### PR TITLE
script to create host for agent initiated CMA connection

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
@@ -193,7 +193,7 @@ final class CreateHostForAgentConfiguration
         int $agentConfigurationId,
         string $hostName,
         string $address,
-        string $templateName,
+        ?string $templateName,
         int $pollerId,
     ): int {
         $newHost = new NewHost(
@@ -204,7 +204,7 @@ final class CreateHostForAgentConfiguration
         );
         $hostId = $this->writeHostRepository->add($newHost);
 
-        $template = $this->readHostTemplateRepository->findByName($templateName);
+        $template = $templateName !== null ? $this->readHostTemplateRepository->findByName($templateName) : null;
         if ($template === null) {
             CentreonLog::create()->warning(
                 logTypeId: CentreonLog::TYPE_BUSINESS_LOG,

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
@@ -30,7 +30,6 @@ use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Domain\Model\NewHost;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
-use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
 use Core\Service\Domain\Model\NewService;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
@@ -43,7 +42,6 @@ final class CreateHostForAgentConfiguration
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
         private readonly WriteHostRepositoryInterface $writeHostRepository,
-        private readonly ReadServiceRepositoryInterface $readServiceRepository,
         private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
         private readonly WriteServiceRepositoryInterface $writeServiceRepository,
     ) {
@@ -118,7 +116,9 @@ final class CreateHostForAgentConfiguration
             ]
         );
 
-        if ($agentConfiguration->getConfiguration()->getData()['create_host_auto'] === false) {
+        $configData = $agentConfiguration->getConfiguration()->getData();
+        $createHostAuto = $configData['create_host_auto'] ?? false;
+        if ($createHostAuto === false) {
             CentreonLog::create()->info(
                 logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
                 message: '[AC][create_host_auto] Agent configuration is not set to create host automatically. Nothing to do.',
@@ -208,7 +208,7 @@ final class CreateHostForAgentConfiguration
         if ($template === null) {
             CentreonLog::create()->warning(
                 logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-                message: '[AC][create_host_auto] Host template not found.',
+                message: '[AC][create_host_auto] Host template not found or undefined.',
                 customContext: [
                     'agent_configuration_id' => $agentConfigurationId,
                     'host_template_name' => $templateName,
@@ -267,15 +267,22 @@ final class CreateHostForAgentConfiguration
             $serviceTemplates = $this->readServiceTemplateRepository->findByHostId($hostParent['parent_id']);
 
             foreach ($serviceTemplates as $serviceTemplate) {
-                $serviceNames = $this->readServiceRepository->findServiceNamesByHost($hostId);
-                if (
-                    $serviceNames === null
-                    || $serviceNames->contains(new TrimmedString($serviceTemplate->getAlias()))
-                ) {
+                $alias = $serviceTemplate->getAlias();
+                if (array_key_exists($alias, $deployedServices, true)) {
+                    CentreonLog::create()->debug(
+                        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                        message: '[AC][create_host_auto] Service already exists with that name, skipping creation.',
+                        customContext: [
+                            'agent_configuration_id' => $agentConfigurationId,
+                            'host_id' => $hostId,
+                            'service_name' => $alias,
+                        ]
+                    );
+
                     continue;
                 }
                 $service = new NewService(
-                    $serviceTemplate->getAlias(),
+                    $alias,
                     $hostId,
                     null // command line must be inherited from template when you deploy services from a host
                 );
@@ -284,7 +291,7 @@ final class CreateHostForAgentConfiguration
                 $serviceId = $this->writeServiceRepository->add($service);
                 $service = $this->readServiceRepository->findById($serviceId);
                 if ($service !== null) {
-                    $deployedServices[] = $service;
+                    $deployedServices[$alias] = $service;
 
                     CentreonLog::create()->debug(
                         logTypeId: CentreonLog::TYPE_BUSINESS_LOG,

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
@@ -1,0 +1,319 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration;
+
+use CentreonLog;
+use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
+use Core\Common\Domain\TrimmedString;
+use Core\Host\Application\Repository\ReadHostRepositoryInterface;
+use Core\Host\Application\Repository\WriteHostRepositoryInterface;
+use Core\Host\Domain\Model\NewHost;
+use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
+use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
+use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
+use Core\Service\Domain\Model\NewService;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Webmozart\Assert\Assert;
+
+final class CreateHostForAgentConfiguration
+{
+    public function __construct(
+        private readonly ReadAgentConfigurationRepositoryInterface $agentConfigurationRepository,
+        private readonly ReadHostRepositoryInterface $readHostRepository,
+        private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
+        private readonly WriteHostRepositoryInterface $writeHostRepository,
+        private readonly ReadServiceRepositoryInterface $readServiceRepository,
+        private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
+        private readonly WriteServiceRepositoryInterface $writeServiceRepository,
+    ) {
+    }
+
+    /**
+     * @throws \Throwable
+     *
+     * @return array{success: bool, message: string, details: string}
+     */
+    public function __invoke(CreateHostForAgentConfigurationRequest $request): array
+    {
+        $pollerId = $request->pollerId;
+        $hostName = $request->hostName;
+        $address = $request->address;
+        $templateName = $request->templateName;
+        $agentConfiguration = null;
+
+        CentreonLog::create()->debug(
+            logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+            message: '[AC][create_host_auto] Checking arguments.',
+            customContext: [
+                'poller_id' => $pollerId,
+            ]
+        );
+
+        Assert::positiveInteger($pollerId, 'The poller id must be a positive integer.');
+        $agentConfiguration = $this->agentConfigurationRepository->findByPollerId($pollerId);
+        if ($agentConfiguration === null) {
+            CentreonLog::create()->error(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: '[AC][create_host_auto] Poller not linked to any agent configuration.',
+                customContext: [
+                    'poller_id' => $pollerId,
+                ]
+            );
+
+            return [
+                'success' => false,
+                'message' => 'Host creation process failed.',
+                'details' => sprintf('Reason: Agent configuration not found for poller %d.', $pollerId),
+            ];
+        }
+
+        Assert::notEmpty($hostName, 'The host name must not be empty.');
+        if ($this->readHostRepository->existsByName($hostName)) {
+            CentreonLog::create()->error(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: '[AC][create_host_auto] Host name already exists.',
+                customContext: [
+                    'poller_id' => $pollerId,
+                    'agent_configuration_id' => $agentConfiguration->getId(),
+                    'host_name' => $hostName,
+                ]
+            );
+
+            return [
+                'success' => false,
+                'message' => 'Host creation process failed.',
+                'details' => sprintf('Reason: A host with the name "%s" already exists.', $hostName),
+            ];
+        }
+
+        Assert::notEmpty($address, 'The address must not be empty.');
+
+        CentreonLog::create()->debug(
+            logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+            message: '[AC][create_host_auto] Checking agent configuration.',
+            customContext: [
+                'poller_id' => $pollerId,
+                'agent_configuration_id' => $agentConfiguration->getId(),
+            ]
+        );
+
+        if ($agentConfiguration->getConfiguration()->getData()['create_host_auto'] === false) {
+            CentreonLog::create()->info(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: '[AC][create_host_auto] Agent configuration is not set to create host automatically. Nothing to do.',
+                customContext: [
+                    'poller_id' => $pollerId,
+                    'agent_configuration_id' => $agentConfiguration->getId(),
+                ]
+            );
+
+            return [
+                'success' => true,
+                'message' => 'Host creation process skipped.',
+                'details' => 'Reason: Agent configuration is not set to create host automatically.',
+            ];
+        }
+
+        CentreonLog::create()->debug(
+            logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+            message: '[AC][create_host_auto] Creating host.',
+            customContext: [
+                'poller_id' => $pollerId,
+                'agent_configuration_id' => $agentConfiguration->getId(),
+            ]
+        );
+
+        $hostId = $this->deployHost(
+            $agentConfiguration->getId(),
+            $hostName,
+            $address,
+            $templateName,
+            $pollerId,
+        );
+
+        CentreonLog::create()->debug(
+            logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+            message: '[AC][create_host_auto] Creating services.',
+            customContext: [
+                'poller_id' => $pollerId,
+                'agent_configuration_id' => $agentConfiguration->getId(),
+                'host_id' => $hostId,
+            ]
+        );
+
+        $serviceIds = $this->deployServices($agentConfiguration->getId(), $hostId);
+
+        CentreonLog::create()->debug(
+            logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+            message: '[AC][create_host_auto] Host creation process completed successfully.',
+            customContext: [
+                'poller_id' => $pollerId,
+                'agent_configuration_id' => $agentConfiguration->getId(),
+                'host_id' => $hostId,
+                'service_ids' => $serviceIds,
+            ]
+        );
+
+        return [
+            'success' => true,
+            'message' => 'Host creation process completed successfully.',
+            'details' => sprintf(
+                'Host ID: %d, Service IDs: [%s]',
+                $hostId,
+                implode(', ', $serviceIds)
+            ),
+        ];
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    private function deployHost(
+        int $agentConfigurationId,
+        string $hostName,
+        string $address,
+        string $templateName,
+        int $pollerId,
+    ): int {
+        $newHost = new NewHost(
+            monitoringServerId: $pollerId,
+            name: $hostName,
+            address: $address,
+            alias: $hostName,
+        );
+        $hostId = $this->writeHostRepository->add($newHost);
+
+        $template = $this->readHostTemplateRepository->findByName($templateName);
+        if ($template === null) {
+            CentreonLog::create()->warning(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: '[AC][create_host_auto] Host template not found.',
+                customContext: [
+                    'agent_configuration_id' => $agentConfigurationId,
+                    'host_template_name' => $templateName,
+                ]
+            );
+        } else {
+            $this->writeHostRepository->addParent(
+                childId: $hostId,
+                parentId: $template->getId(),
+                order: 1
+            );
+        }
+
+        CentreonLog::create()->debug(
+            logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+            message: '[AC][create_host_auto] Host created successfully.',
+            customContext: [
+                'agent_configuration_id' => $agentConfigurationId,
+                'host_id' => $hostId,
+                'host_name' => $hostName,
+                'template_id' => $template?->getId(),
+                'address' => $address,
+                'poller_id' => $pollerId,
+            ]
+        );
+
+        return $hostId;
+    }
+
+    /**
+     * @throws \Throwable
+     *
+     * @return int[]
+     */
+    private function deployServices(
+        int $agentConfigurationId,
+        int $hostId,
+    ): array {
+        $hostParents = $this->readHostRepository->findParents($hostId);
+        if ($hostParents === []) {
+            CentreonLog::create()->debug(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: '[AC][create_host_auto] No host templates found. No services to deploy.',
+                customContext: [
+                    'agent_configuration_id' => $agentConfigurationId,
+                    'host_id' => $hostId,
+                    'host_parents' => $hostParents,
+                ]
+            );
+
+            return [];
+        }
+
+        $deployedServices = [];
+        foreach ($hostParents as $hostParent) {
+            $serviceTemplates = $this->readServiceTemplateRepository->findByHostId($hostParent['parent_id']);
+
+            foreach ($serviceTemplates as $serviceTemplate) {
+                $serviceNames = $this->readServiceRepository->findServiceNamesByHost($hostId);
+                if (
+                    $serviceNames === null
+                    || $serviceNames->contains(new TrimmedString($serviceTemplate->getAlias()))
+                ) {
+                    continue;
+                }
+                $service = new NewService(
+                    $serviceTemplate->getAlias(),
+                    $hostId,
+                    null // command line must be inherited from template when you deploy services from a host
+                );
+                $service->setServiceTemplateParentId($serviceTemplate->getId());
+                $service->setActivated(true);
+                $serviceId = $this->writeServiceRepository->add($service);
+                $service = $this->readServiceRepository->findById($serviceId);
+                if ($service !== null) {
+                    $deployedServices[] = $service;
+
+                    CentreonLog::create()->debug(
+                        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                        message: '[AC][create_host_auto] Service created successfully.',
+                        customContext: [
+                            'agent_configuration_id' => $agentConfigurationId,
+                            'host_id' => $hostId,
+                            'service_id' => $service->getId(),
+                            'service_name' => $service->getName(),
+                        ]
+                    );
+                }
+            }
+        }
+
+        if ($deployedServices === []) {
+            CentreonLog::create()->debug(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: '[AC][create_host_auto] No service to deploy for the new host.',
+                customContext: [
+                    'agent_configuration_id' => $agentConfigurationId,
+                    'host_id' => $hostId,
+                ]
+            );
+        }
+
+        return array_map(
+            fn ($service) => $service->getId(),
+            $deployedServices
+        );
+    }
+}

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
@@ -25,7 +25,6 @@ namespace Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfigur
 
 use CentreonLog;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
-use Core\Common\Domain\TrimmedString;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Domain\Model\NewHost;

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfiguration.php
@@ -30,6 +30,7 @@ use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Domain\Model\NewHost;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
+use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
 use Core\Service\Domain\Model\NewService;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
@@ -42,6 +43,7 @@ final class CreateHostForAgentConfiguration
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
         private readonly WriteHostRepositoryInterface $writeHostRepository,
+        private readonly ReadServiceRepositoryInterface $readServiceRepository,
         private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
         private readonly WriteServiceRepositoryInterface $writeServiceRepository,
     ) {
@@ -179,7 +181,7 @@ final class CreateHostForAgentConfiguration
             'success' => true,
             'message' => 'Host creation process completed successfully.',
             'details' => sprintf(
-                'Host ID: %d, Service IDs: [%s]',
+                'Host ID: %d, Service IDs: %s',
                 $hostId,
                 implode(', ', $serviceIds)
             ),
@@ -268,7 +270,7 @@ final class CreateHostForAgentConfiguration
 
             foreach ($serviceTemplates as $serviceTemplate) {
                 $alias = $serviceTemplate->getAlias();
-                if (array_key_exists($alias, $deployedServices, true)) {
+                if (array_key_exists($alias, $deployedServices)) {
                     CentreonLog::create()->debug(
                         logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
                         message: '[AC][create_host_auto] Service already exists with that name, skipping creation.',

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationRequest.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration;
+
+final class CreateHostForAgentConfigurationRequest
+{
+    public function __construct(
+        public readonly int $pollerId,
+        public readonly string $hostName,
+        public readonly string $address,
+        public readonly string $templateName,
+    ) {
+    }
+}

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationRequest.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationRequest.php
@@ -29,7 +29,7 @@ final class CreateHostForAgentConfigurationRequest
         public readonly int $pollerId,
         public readonly string $hostName,
         public readonly string $address,
-        public readonly string $templateName,
+        public readonly ?string $templateName,
     ) {
     }
 }

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
@@ -36,18 +36,14 @@ use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
 
 #[AsCommand(name: 'agent-configuration:host:create', description: 'Create a host and deploy services for an agent configuration')]
 final readonly class CreateHostForAgentConfigurationCommand
 {
     public function __construct(
-        private readonly ReadAgentConfigurationRepositoryInterface $agentConfigurationRepository,
-        private readonly ReadHostRepositoryInterface $readHostRepository,
-        private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
-        private readonly WriteHostRepositoryInterface $writeHostRepository,
-        private readonly ReadServiceRepositoryInterface $readServiceRepository,
-        private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
-        private readonly WriteServiceRepositoryInterface $writeServiceRepository,
+        private readonly CreateHostForAgentConfiguration $usecase,
     ) {
     }
 
@@ -57,25 +53,16 @@ final readonly class CreateHostForAgentConfigurationCommand
     ): int {
         try {
             $data = json_decode($jsonArg, true, 512, JSON_THROW_ON_ERROR);
+            $this->validateJsonData($data);
 
             $request = new CreateHostForAgentConfigurationRequest(
-                pollerId: $data['pollerId'] ?? throw new \InvalidArgumentException('pollerId is required'),
-                hostName: $data['hostName'] ?? throw new \InvalidArgumentException('hostName is required'),
-                address: $data['ips'][0] ?? throw new \InvalidArgumentException('ips is required and must contain at least one IP address'),
+                pollerId: $data['pollerId'],
+                hostName: $data['hostName'],
+                address: $data['ips'][0],
                 templateName: $data['hostTemplate'] ?? null,
             );
 
-            $useCase = new CreateHostForAgentConfiguration(
-                agentConfigurationRepository: $this->agentConfigurationRepository,
-                readHostRepository: $this->readHostRepository,
-                readHostTemplateRepository: $this->readHostTemplateRepository,
-                writeHostRepository: $this->writeHostRepository,
-                readServiceRepository: $this->readServiceRepository,
-                readServiceTemplateRepository: $this->readServiceTemplateRepository,
-                writeServiceRepository: $this->writeServiceRepository,
-            );
-
-            $return = ($useCase)($request);
+            $return = ($this->usecase)($request);
 
             if ($return['success'] === true) {
                 $io->success([
@@ -105,5 +92,22 @@ final readonly class CreateHostForAgentConfigurationCommand
         }
 
         return Command::FAILURE;
+    }
+
+    private function validateJsonData(array $data): void
+    {
+        $constraint = new Assert\Collection([
+            'pollerId' => [new Assert\NotBlank(), new Assert\Type('integer')],
+            'hostName' => [new Assert\NotBlank(), new Assert\Type('string')],
+            'ips' => [new Assert\NotBlank(), new Assert\Type('array'), new Assert\Count(min: 1)],
+            'hostTemplate' => new Assert\Optional([new Assert\Type('string')]),
+        ]);
+
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+
+        if (count($violations) > 0) {
+            throw new \InvalidArgumentException((string) $violations);
+        }
     }
 }

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
@@ -53,17 +53,16 @@ final readonly class CreateHostForAgentConfigurationCommand
 
     public function __invoke(
         SymfonyStyle $io,
-        #[Argument] int $pollerId,
-        #[Argument] string $hostName,
-        #[Argument] string $address,
-        #[Argument] string $templateName,
+        #[Argument(description: 'a json containing pollerId, hostName, ips, and hostTemplate')] string $jsonArg,
     ): int {
         try {
+            $data = json_decode($jsonArg, true, 512, JSON_THROW_ON_ERROR);
+
             $request = new CreateHostForAgentConfigurationRequest(
-                pollerId: $pollerId,
-                hostName: $hostName,
-                address: $address,
-                templateName: $templateName,
+                pollerId: $data['pollerId'] ?? throw new \InvalidArgumentException('pollerId is required'),
+                hostName: $data['hostName'] ?? throw new \InvalidArgumentException('hostName is required'),
+                address: $data['ips'][0] ?? throw new \InvalidArgumentException('ips is required and must contain at least one IP address'),
+                templateName: $data['hostTemplate'] ?? null,
             );
 
             $useCase = new CreateHostForAgentConfiguration(

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\AgentConfiguration\Infrastructure\Command;
+
+use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
+use Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfiguration;
+use Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfigurationRequest;
+use Core\Host\Application\Repository\ReadHostRepositoryInterface;
+use Core\Host\Application\Repository\WriteHostRepositoryInterface;
+use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
+use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
+use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'agent-configuration:host:create', description: 'Create a host and deploy services for an agent configuration')]
+final readonly class CreateHostForAgentConfigurationCommand
+{
+    public function __construct(
+        private readonly ReadAgentConfigurationRepositoryInterface $agentConfigurationRepository,
+        private readonly ReadHostRepositoryInterface $readHostRepository,
+        private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
+        private readonly WriteHostRepositoryInterface $writeHostRepository,
+        private readonly ReadServiceRepositoryInterface $readServiceRepository,
+        private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
+        private readonly WriteServiceRepositoryInterface $writeServiceRepository,
+    ) {
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Argument] int $pollerId,
+        #[Argument] string $hostName,
+        #[Argument] string $address,
+        #[Argument] string $templateName,
+    ): int {
+        try {
+            $request = new CreateHostForAgentConfigurationRequest(
+                pollerId: $pollerId,
+                hostName: $hostName,
+                address: $address,
+                templateName: $templateName,
+            );
+
+            $useCase = new CreateHostForAgentConfiguration(
+                agentConfigurationRepository: $this->agentConfigurationRepository,
+                readHostRepository: $this->readHostRepository,
+                readHostTemplateRepository: $this->readHostTemplateRepository,
+                writeHostRepository: $this->writeHostRepository,
+                readServiceRepository: $this->readServiceRepository,
+                readServiceTemplateRepository: $this->readServiceTemplateRepository,
+                writeServiceRepository: $this->writeServiceRepository,
+            );
+
+            $return = ($useCase)($request);
+
+            if ($return['success'] === true) {
+                $io->success([
+                    $return['message'],
+                    $return['details'],
+                ]);
+
+                return Command::SUCCESS;
+            }
+
+            $io->error([
+                $return['message'],
+                $return['details'],
+            ]);
+
+        } catch (\InvalidArgumentException $ex) {
+            $io->error([
+                'Host creation process failed',
+                sprintf('Reason: Invalid argument (%s)', $ex->getMessage()),
+            ]);
+
+        } catch (\Throwable $ex) {
+            $io->error([
+                'Host creation process failed',
+                sprintf('Reason: Unexpected error: %s', $ex->getMessage()),
+            ]);
+        }
+
+        return Command::FAILURE;
+    }
+}

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
@@ -87,6 +87,11 @@ final readonly class CreateHostForAgentConfigurationCommand
         return Command::FAILURE;
     }
 
+    /**
+     * Undocumented function
+     *
+     * @param array<string, mixed> $data
+     */
     private function validateJsonData(array $data): void
     {
         $constraint = new Assert\Collection([

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Command/CreateHostForAgentConfigurationCommand.php
@@ -23,15 +23,8 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Infrastructure\Command;
 
-use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfiguration;
 use Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfigurationRequest;
-use Core\Host\Application\Repository\ReadHostRepositoryInterface;
-use Core\Host\Application\Repository\WriteHostRepositoryInterface;
-use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
-use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
-use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
-use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Configuration/symfony.yaml
@@ -25,7 +25,7 @@ services:
         class: Core\AgentConfiguration\Infrastructure\Repository\DbReadAgentConfigurationRepository
         public: true
 
-    Core\AgentConfiguration\Infrastructure\Command\CreateHostForAgentConfigurationCommand:
+    Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration:
         arguments:
             $readHostTemplateRepository: '@Core\HostTemplate\Infrastructure\Repository\DbReadHostTemplateRepository'
             $readServiceRepository: '@Core\Service\Infrastructure\Repository\DbReadServiceRepository'

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Configuration/symfony.yaml
@@ -24,3 +24,12 @@ services:
     Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface:
         class: Core\AgentConfiguration\Infrastructure\Repository\DbReadAgentConfigurationRepository
         public: true
+
+    Core\AgentConfiguration\Infrastructure\Command\CreateHostForAgentConfigurationCommand:
+        arguments:
+            $readHostTemplateRepository: '@Core\HostTemplate\Infrastructure\Repository\DbReadHostTemplateRepository'
+            $readServiceRepository: '@Core\Service\Infrastructure\Repository\DbReadServiceRepository'
+            $writeServiceRepository: '@Core\Service\Infrastructure\Repository\DbWriteServiceRepository'
+            $readHostRepository: '@Core\Host\Infrastructure\Repository\DbReadHostRepository'
+            $readServiceTemplateRepository: '@Core\ServiceTemplate\Infrastructure\Repository\DbReadServiceTemplateRepository'
+            $writeHostRepository: '@Core\Host\Infrastructure\Repository\DbWriteHostRepository'

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Configuration/symfony.yaml
@@ -25,7 +25,7 @@ services:
         class: Core\AgentConfiguration\Infrastructure\Repository\DbReadAgentConfigurationRepository
         public: true
 
-    Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration:
+    Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfiguration:
         arguments:
             $readHostTemplateRepository: '@Core\HostTemplate\Infrastructure\Repository\DbReadHostTemplateRepository'
             $readServiceRepository: '@Core\Service\Infrastructure\Repository\DbReadServiceRepository'

--- a/centreon/src/Core/HostTemplate/Application/Repository/ReadHostTemplateRepositoryInterface.php
+++ b/centreon/src/Core/HostTemplate/Application/Repository/ReadHostTemplateRepositoryInterface.php
@@ -185,4 +185,15 @@ interface ReadHostTemplateRepositoryInterface
      * @return array<int, int>
      */
     public function findByHostId(int $hostId): array;
+
+    /**
+     * Find host template by its name.
+     *
+     * @param string $hostTemplateName
+     *
+     * @throws \Throwable
+     *
+     * @return HostTemplate|null
+     */
+    public function findByName(string $hostTemplateName): ?HostTemplate;
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
@@ -406,6 +406,78 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
     /**
      * @inheritDoc
      */
+    public function findByName(string $hostTemplateName): ?HostTemplate
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                SELECT
+                    h.host_id,
+                    h.host_name,
+                    h.host_alias,
+                    h.host_snmp_version,
+                    h.host_snmp_community,
+                    h.host_location,
+                    h.command_command_id,
+                    h.command_command_id_arg1,
+                    h.timeperiod_tp_id,
+                    h.host_max_check_attempts,
+                    h.host_check_interval,
+                    h.host_retry_check_interval,
+                    h.host_active_checks_enabled,
+                    h.host_passive_checks_enabled,
+                    h.host_notifications_enabled,
+                    h.host_notification_options,
+                    h.host_notification_interval,
+                    h.timeperiod_tp_id2,
+                    h.cg_additive_inheritance,
+                    h.contact_additive_inheritance,
+                    h.host_first_notification_delay,
+                    h.host_recovery_notification_delay,
+                    h.host_acknowledgement_timeout,
+                    h.host_check_freshness,
+                    h.host_freshness_threshold,
+                    h.host_flap_detection_enabled,
+                    h.host_low_flap_threshold,
+                    h.host_high_flap_threshold,
+                    h.host_event_handler_enabled,
+                    h.command_command_id2,
+                    h.command_command_id_arg2,
+                    h.host_comment,
+                    h.host_locked,
+                    ehi.ehi_notes_url,
+                    ehi.ehi_notes,
+                    ehi.ehi_action_url,
+                    ehi.ehi_icon_image,
+                    ehi.ehi_icon_image_alt,
+                    hc.hc_id AS severity_id
+                FROM `:db`.host h
+                LEFT JOIN `:db`.extended_host_information ehi
+                    ON h.host_id = ehi.host_host_id
+                LEFT JOIN `:db`.hostcategories_relation hcr
+                    ON hcr.host_host_id = h.host_id
+                LEFT JOIN `:db`.hostcategories hc
+                    ON hc.hc_id = hcr.hostcategories_hc_id
+                    AND hc.level IS NOT NULL
+                WHERE h.host_name = :name
+                    AND h.host_register = :host_template_type
+                SQL
+        );
+        $statement = $this->db->prepare($request);
+        $statement->bindValue(':name', $hostTemplateName, \PDO::PARAM_STR);
+        $statement->bindValue(':host_template_type', HostType::Template->value, \PDO::PARAM_STR);
+        $statement->execute();
+
+        if ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            /** @var _HostTemplate $result */
+            return $this->createHostTemplateFromArray($result);
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findByIdAndAccessGroups(int $hostTemplateId, array $accessGroups): ?HostTemplate
     {
         $this->info('Get a host template with ID #' . $hostTemplateId);

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
@@ -1,0 +1,609 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration;
+
+use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
+use Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfiguration;
+use Core\AgentConfiguration\Application\UseCase\CreateHostForAgentConfiguration\CreateHostForAgentConfigurationRequest;
+use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
+use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
+use Core\AgentConfiguration\Domain\Model\Type;
+use Core\Host\Application\Repository\ReadHostRepositoryInterface;
+use Core\Host\Application\Repository\WriteHostRepositoryInterface;
+use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
+use Core\HostTemplate\Domain\Model\HostTemplate;
+use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
+use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
+use Core\Service\Domain\Model\Service;
+use Core\Service\Domain\Model\ServiceNamesByHost;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
+
+beforeEach(function (): void {
+    $this->readAgentConfigurationRepository = $this->createMock(ReadAgentConfigurationRepositoryInterface::class);
+    $this->readHostRepository = $this->createMock(ReadHostRepositoryInterface::class);
+    $this->readHostTemplateRepository = $this->createMock(ReadHostTemplateRepositoryInterface::class);
+    $this->writeHostRepository = $this->createMock(WriteHostRepositoryInterface::class);
+    $this->readServiceRepository = $this->createMock(ReadServiceRepositoryInterface::class);
+    $this->readServiceTemplateRepository = $this->createMock(ReadServiceTemplateRepositoryInterface::class);
+    $this->writeServiceRepository = $this->createMock(WriteServiceRepositoryInterface::class);
+
+    $this->useCase = new CreateHostForAgentConfiguration(
+        agentConfigurationRepository: $this->readAgentConfigurationRepository,
+        readHostRepository: $this->readHostRepository,
+        readHostTemplateRepository: $this->readHostTemplateRepository,
+        writeHostRepository: $this->writeHostRepository,
+        readServiceRepository: $this->readServiceRepository,
+        readServiceTemplateRepository: $this->readServiceTemplateRepository,
+        writeServiceRepository: $this->writeServiceRepository,
+    );
+
+    $this->pollerId = 1;
+    $this->hostName = 'test-host';
+    $this->address = '192.168.1.100';
+    $this->templateName = 'generic-host';
+
+    $this->request = new CreateHostForAgentConfigurationRequest(
+        pollerId: $this->pollerId,
+        hostName: $this->hostName,
+        address: $this->address,
+        templateName: $this->templateName,
+    );
+
+    $this->configurationParameters = new CmaConfigurationParameters([
+        'agent_initiated' => true,
+        'poller_initiated' => true,
+        'otel_public_certificate' => 'cert',
+        'otel_ca_certificate' => 'ca',
+        'otel_private_key' => 'key',
+        'port' => AgentConfiguration::DEFAULT_PORT,
+        'hosts' => [],
+        'tokens' => [
+            [
+                'name' => 'test-token',
+                'creator_id' => 1,
+            ],
+        ],
+        'create_host_auto' => true,
+    ]);
+
+    $this->agentConfiguration = new AgentConfiguration(
+        id: 1,
+        name: 'test-ac',
+        type: Type::CMA,
+        connectionMode: ConnectionModeEnum::SECURE,
+        configuration: $this->configurationParameters,
+    );
+});
+
+it(
+    'should return FAILURE when pollerId is not a positive integer',
+    function (): void {
+        $invalidRequest = new CreateHostForAgentConfigurationRequest(
+            pollerId: 0,
+            hostName: $this->hostName,
+            address: $this->address,
+            templateName: $this->templateName,
+        );
+
+        expect(fn () => ($this->useCase)($invalidRequest))
+            ->toThrow(
+                \InvalidArgumentException::class,
+                'The poller id must be a positive integer.'
+            );
+    }
+);
+
+it(
+    'should return FAILURE when agent configuration is not found for the poller',
+    function (): void {
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->with($this->pollerId)
+            ->willReturn(null);
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => false,
+            'message' => 'Host creation process failed.',
+            'details' => 'Reason: Agent configuration not found for poller 1.',
+        ]);
+    }
+);
+
+it(
+    'should return FAILURE when host name is empty',
+    function (): void {
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->with($this->pollerId)
+            ->willReturn($this->agentConfiguration);
+
+        $invalidRequest = new CreateHostForAgentConfigurationRequest(
+            pollerId: $this->pollerId,
+            hostName: '',
+            address: $this->address,
+            templateName: $this->templateName,
+        );
+
+        expect(fn () => ($this->useCase)($invalidRequest))
+            ->toThrow(
+                \InvalidArgumentException::class,
+                'The host name must not be empty.'
+            );
+    }
+);
+
+it(
+    'should return FAILURE when host name already exists',
+    function (): void {
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willReturn($this->agentConfiguration);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->with($this->hostName)
+            ->willReturn(true);
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => false,
+            'message' => 'Host creation process failed.',
+            'details' => 'Reason: A host with the name "test-host" already exists.',
+        ]);
+    }
+);
+
+it(
+    'should return FAILURE when address is empty',
+    function (): void {
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->with($this->pollerId)
+            ->willReturn($this->agentConfiguration);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->with($this->hostName)
+            ->willReturn(false);
+
+        $invalidRequest = new CreateHostForAgentConfigurationRequest(
+            pollerId: $this->pollerId,
+            hostName: $this->hostName,
+            address: '',
+            templateName: $this->templateName,
+        );
+
+        expect(fn () => ($this->useCase)($invalidRequest))
+            ->toThrow(
+                \InvalidArgumentException::class,
+                'The address must not be empty.'
+            );
+    }
+);
+
+it(
+    'should return SUCCESS and skip host creation when create_host_auto is false',
+    function (): void {
+        $configData = $this->configurationParameters->getData();
+        $configData['create_host_auto'] = false;
+        $configWithAutoCreateDisabled = $this->createMock(ConfigurationParametersInterface::class);
+        $configWithAutoCreateDisabled
+            ->method('getData')
+            ->willReturn($configData);
+
+        $agentConfigWithAutoCreateDisabled = new AgentConfiguration(
+            id: 1,
+            name: 'test-ac',
+            type: Type::CMA,
+            connectionMode: ConnectionModeEnum::SECURE,
+            configuration: $configWithAutoCreateDisabled,
+        );
+
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willReturn($agentConfigWithAutoCreateDisabled);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->willReturn(false);
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => true,
+            'message' => 'Host creation process skipped.',
+            'details' => 'Reason: Agent configuration is not set to create host automatically.',
+        ]);
+    }
+);
+
+it(
+    'should create host and services successfully when all conditions are met',
+    function (): void {
+        $hostId = 10;
+        $serviceId1 = 100;
+        $serviceId2 = 101;
+        $templateId = 5;
+
+        $configData = $this->configurationParameters->getData();
+        $configData['create_host_auto'] = true;
+        $configWithAutoCreateEnabled = $this->createMock(ConfigurationParametersInterface::class);
+        $configWithAutoCreateEnabled
+            ->method('getData')
+            ->willReturn($configData);
+
+        $agentConfigWithAutoCreateEnabled = new AgentConfiguration(
+            id: 1,
+            name: 'test-ac',
+            type: Type::CMA,
+            connectionMode: ConnectionModeEnum::SECURE,
+            configuration: $configWithAutoCreateEnabled,
+        );
+
+        $hostTemplate = new HostTemplate(
+            id: $templateId,
+            name: $this->templateName,
+            alias: 'Generic Host Template',
+        );
+
+        $serviceTemplate1 = new ServiceTemplate(
+            id: 50,
+            name: 'service-template-1',
+            alias: 'Service 1',
+        );
+
+        $serviceTemplate2 = new ServiceTemplate(
+            id: 51,
+            name: 'service-template-2',
+            alias: 'Service 2',
+        );
+
+        $service1 = new Service(
+            id: $serviceId1,
+            name: 'Service 1',
+            hostId: $hostId,
+        );
+
+        $service2 = new Service(
+            id: $serviceId2,
+            name: 'Service 2',
+            hostId: $hostId,
+        );
+
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willReturn($agentConfigWithAutoCreateEnabled);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->with($this->hostName)
+            ->willReturn(false);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('add')
+            ->willReturn($hostId);
+
+        $this->readHostTemplateRepository
+            ->expects($this->once())
+            ->method('findByName')
+            ->with($this->templateName)
+            ->willReturn($hostTemplate);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('addParent')
+            ->with($hostId, $templateId, 1);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findParents')
+            ->with($hostId)
+            ->willReturn([['parent_id' => $templateId]]);
+
+        $this->readServiceTemplateRepository
+            ->expects($this->once())
+            ->method('findByHostId')
+            ->with($templateId)
+            ->willReturn([$serviceTemplate1, $serviceTemplate2]);
+
+        $serviceNames = new ServiceNamesByHost($hostId, []);
+        $this->readServiceRepository
+            ->expects($this->exactly(2))
+            ->method('findServiceNamesByHost')
+            ->with($hostId)
+            ->willReturn($serviceNames);
+
+        $this->writeServiceRepository
+            ->expects($this->exactly(2))
+            ->method('add')
+            ->willReturnOnConsecutiveCalls($serviceId1, $serviceId2);
+
+        $this->readServiceRepository
+            ->expects($this->exactly(2))
+            ->method('findById')
+            ->willReturnOnConsecutiveCalls($service1, $service2);
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => true,
+            'message' => 'Host creation process completed successfully.',
+            'details' => 'Host ID: 10, Service IDs: [100, 101]',
+        ]);
+    }
+);
+
+it(
+    'should create host without template when template is not found',
+    function (): void {
+        $hostId = 10;
+
+        $configData = $this->configurationParameters->getData();
+        $configData['create_host_auto'] = true;
+        $configWithAutoCreateEnabled = $this->createMock(ConfigurationParametersInterface::class);
+        $configWithAutoCreateEnabled
+            ->method('getData')
+            ->willReturn($configData);
+
+        $agentConfigWithAutoCreateEnabled = new AgentConfiguration(
+            id: 1,
+            name: 'test-ac',
+            type: Type::CMA,
+            connectionMode: ConnectionModeEnum::SECURE,
+            configuration: $configWithAutoCreateEnabled,
+        );
+
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willReturn($agentConfigWithAutoCreateEnabled);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->willReturn(false);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('add')
+            ->willReturn($hostId);
+
+        $this->readHostTemplateRepository
+            ->expects($this->once())
+            ->method('findByName')
+            ->with($this->templateName)
+            ->willReturn(null);
+
+        $this->writeHostRepository
+            ->expects($this->never())
+            ->method('addParent');
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findParents')
+            ->with($hostId)
+            ->willReturn([]);
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => true,
+            'message' => 'Host creation process completed successfully.',
+            'details' => 'Host ID: 10, Service IDs: []',
+        ]);
+    }
+);
+
+it(
+    'should not create services when host has no parents',
+    function (): void {
+        $hostId = 10;
+        $templateId = 5;
+
+        $configData = $this->configurationParameters->getData();
+        $configData['create_host_auto'] = true;
+        $configWithAutoCreateEnabled = $this->createMock(ConfigurationParametersInterface::class);
+        $configWithAutoCreateEnabled
+            ->method('getData')
+            ->willReturn($configData);
+
+        $agentConfigWithAutoCreateEnabled = new AgentConfiguration(
+            id: 1,
+            name: 'test-ac',
+            type: Type::CMA,
+            connectionMode: ConnectionModeEnum::SECURE,
+            configuration: $configWithAutoCreateEnabled,
+        );
+
+        $hostTemplate = new HostTemplate(
+            id: $templateId,
+            name: $this->templateName,
+            alias: 'Generic Host Template',
+        );
+
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willReturn($agentConfigWithAutoCreateEnabled);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->willReturn(false);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('add')
+            ->willReturn($hostId);
+
+        $this->readHostTemplateRepository
+            ->expects($this->once())
+            ->method('findByName')
+            ->willReturn($hostTemplate);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('addParent');
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findParents')
+            ->with($hostId)
+            ->willReturn([]);
+
+        $this->readServiceTemplateRepository
+            ->expects($this->never())
+            ->method('findByHostId');
+
+        $this->writeServiceRepository
+            ->expects($this->never())
+            ->method('add');
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => true,
+            'message' => 'Host creation process completed successfully.',
+            'details' => 'Host ID: 10, Service IDs: []',
+        ]);
+    }
+);
+
+it(
+    'should not create duplicate services when service already exists on host',
+    function (): void {
+        $hostId = 10;
+        $templateId = 5;
+        $serviceId = 100;
+
+        $configData = $this->configurationParameters->getData();
+        $configData['create_host_auto'] = true;
+        $configWithAutoCreateEnabled = $this->createMock(ConfigurationParametersInterface::class);
+        $configWithAutoCreateEnabled
+            ->method('getData')
+            ->willReturn($configData);
+
+        $agentConfigWithAutoCreateEnabled = new AgentConfiguration(
+            id: 1,
+            name: 'test-ac',
+            type: Type::CMA,
+            connectionMode: ConnectionModeEnum::SECURE,
+            configuration: $configWithAutoCreateEnabled,
+        );
+
+        $hostTemplate = new HostTemplate(
+            id: $templateId,
+            name: $this->templateName,
+            alias: 'Generic Host Template',
+        );
+
+        $serviceTemplate = new ServiceTemplate(
+            id: 50,
+            name: 'service-template',
+            alias: 'Existing Service',
+        );
+
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willReturn($agentConfigWithAutoCreateEnabled);
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('existsByName')
+            ->willReturn(false);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('add')
+            ->willReturn($hostId);
+
+        $this->readHostTemplateRepository
+            ->expects($this->once())
+            ->method('findByName')
+            ->willReturn($hostTemplate);
+
+        $this->writeHostRepository
+            ->expects($this->once())
+            ->method('addParent');
+
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findParents')
+            ->willReturn([['parent_id' => $templateId]]);
+
+        $this->readServiceTemplateRepository
+            ->expects($this->once())
+            ->method('findByHostId')
+            ->willReturn([$serviceTemplate]);
+
+        $serviceNames = new ServiceNamesByHost($hostId, ['Existing Service']);
+        $this->readServiceRepository
+            ->expects($this->once())
+            ->method('findServiceNamesByHost')
+            ->willReturn($serviceNames);
+
+        $this->writeServiceRepository
+            ->expects($this->never())
+            ->method('add');
+
+        $result = ($this->useCase)($this->request);
+
+        expect($result)->toBe([
+            'success' => true,
+            'message' => 'Host creation process completed successfully.',
+            'details' => 'Host ID: 10, Service IDs: []',
+        ]);
+    }
+);
+
+it(
+    'should return FAILURE when an unexpected exception occurs',
+    function (): void {
+        $this->readAgentConfigurationRepository
+            ->expects($this->once())
+            ->method('findByPollerId')
+            ->willThrowException(new \Exception('Database error'));
+
+        expect(fn () => ($this->useCase)($this->request))
+            ->toThrow(\Exception::class, 'Database error');
+    }
+);

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
@@ -38,7 +38,6 @@ use Core\HostTemplate\Domain\Model\HostTemplate;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
 use Core\Service\Domain\Model\Service;
-use Core\Service\Domain\Model\ServiceNamesByHost;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 
@@ -97,6 +96,10 @@ beforeEach(function (): void {
         connectionMode: ConnectionModeEnum::SECURE,
         configuration: $this->configurationParameters,
     );
+});
+
+afterEach(function (): void {
+    @unlink('centreon-web.log');
 });
 
 it(
@@ -344,13 +347,6 @@ it(
             ->with($templateId)
             ->willReturn([$serviceTemplate1, $serviceTemplate2]);
 
-        $serviceNames = new ServiceNamesByHost($hostId, []);
-        $this->readServiceRepository
-            ->expects($this->exactly(2))
-            ->method('findServiceNamesByHost')
-            ->with($hostId)
-            ->willReturn($serviceNames);
-
         $this->writeServiceRepository
             ->expects($this->exactly(2))
             ->method('add')
@@ -366,7 +362,7 @@ it(
         expect($result)->toBe([
             'success' => true,
             'message' => 'Host creation process completed successfully.',
-            'details' => 'Host ID: 10, Service IDs: [100, 101]',
+            'details' => 'Host ID: 10, Service IDs: 100, 101',
         ]);
     }
 );
@@ -427,7 +423,7 @@ it(
         expect($result)->toBe([
             'success' => true,
             'message' => 'Host creation process completed successfully.',
-            'details' => 'Host ID: 10, Service IDs: []',
+            'details' => 'Host ID: 10, Service IDs: ',
         ]);
     }
 );
@@ -502,13 +498,13 @@ it(
         expect($result)->toBe([
             'success' => true,
             'message' => 'Host creation process completed successfully.',
-            'details' => 'Host ID: 10, Service IDs: []',
+            'details' => 'Host ID: 10, Service IDs: ',
         ]);
     }
 );
 
 it(
-    'should not create duplicate services when service already exists on host',
+    'should not create duplicate services when multiple templates have the same alias',
     function (): void {
         $hostId = 10;
         $templateId = 5;
@@ -535,11 +531,21 @@ it(
             alias: 'Generic Host Template',
         );
 
-        $serviceTemplate = new ServiceTemplate(
+        // Two service templates with the same alias - should only create one service
+        $serviceTemplate1 = new ServiceTemplate(
             id: 50,
-            name: 'service-template',
-            alias: 'Existing Service',
+            name: 'service-template-1',
+            alias: 'Same Alias',
         );
+        $serviceTemplate2 = new ServiceTemplate(
+            id: 51,
+            name: 'service-template-2',
+            alias: 'Same Alias',
+        );
+
+        $service = $this->createMock(Service::class);
+        $service->method('getId')->willReturn($serviceId);
+        $service->method('getName')->willReturn('Same Alias');
 
         $this->readAgentConfigurationRepository
             ->expects($this->once())
@@ -573,24 +579,25 @@ it(
         $this->readServiceTemplateRepository
             ->expects($this->once())
             ->method('findByHostId')
-            ->willReturn([$serviceTemplate]);
+            ->willReturn([$serviceTemplate1, $serviceTemplate2]);
 
-        $serviceNames = new ServiceNamesByHost($hostId, ['Existing Service']);
+        // Only one service should be created (the second template has the same alias)
+        $this->writeServiceRepository
+            ->expects($this->once())
+            ->method('add')
+            ->willReturn($serviceId);
+
         $this->readServiceRepository
             ->expects($this->once())
-            ->method('findServiceNamesByHost')
-            ->willReturn($serviceNames);
-
-        $this->writeServiceRepository
-            ->expects($this->never())
-            ->method('add');
+            ->method('findById')
+            ->willReturn($service);
 
         $result = ($this->useCase)($this->request);
 
         expect($result)->toBe([
             'success' => true,
             'message' => 'Host creation process completed successfully.',
-            'details' => 'Host ID: 10, Service IDs: []',
+            'details' => 'Host ID: 10, Service IDs: 100',
         ]);
     }
 );


### PR DESCRIPTION
## Description

Adds a Symfony console command to create a host (and deploy services from templates) for an agent-initiated CMA connection, backed by a new application use case and repository capability to resolve host templates by name.

Changes:
- Introduce agent-configuration:host:create command that accepts JSON input and triggers host/service deployment.
- Add CreateHostForAgentConfiguration use case + request DTO, including Pest tests.
- Extend host template read repository with findByName() and implement it in the DB repository.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master
