### PR TITLE
fix(contact): api real time selection is wrong

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1004,6 +1004,10 @@ function insertContact(array $ret = []): int
         $ret['reach_api_rt']['reach_api_rt'] = '1';
     }
 
+    if (! $centreon->user->admin) {
+        $ret = filterNonAdminFields($ret);
+    }
+
     try {
         $bindParams = sanitizeFormContactParameters($ret);
     } catch (InvalidArgumentException $exception) {
@@ -1121,10 +1125,6 @@ function updateContact(int $contactId): void
         && $ret['contact_oreon']['contact_oreon'] === '1'
     ) {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
-    }
-
-    if (! $centreon->user->admin) {
-        $ret = filterNonAdminFields($ret);
     }
 
     try {

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1002,6 +1002,8 @@ function insertContact(array $ret = []): int
         && $ret['contact_oreon']['contact_oreon'] === '1'
     ) {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
+    } else {
+        $ret['reach_api_rt']['reach_api_rt'] = '0';
     }
 
     if (! $centreon->user->admin) {
@@ -1118,6 +1120,20 @@ function updateContact(int $contactId): void
     // Remove illegal chars in data sent by the user
     $ret['contact_name'] = CentreonUtils::escapeSecure($ret['contact_name'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
     $ret['contact_alias'] = CentreonUtils::escapeSecure($ret['contact_alias'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
+
+    // Set reach_api_rt according to reach front end value
+    if (
+        isset($ret['contact_oreon']['contact_oreon'])
+        && $ret['contact_oreon']['contact_oreon'] === '1'
+    ) {
+        $ret['reach_api_rt']['reach_api_rt'] = '1';
+    } else {
+        $ret['reach_api_rt']['reach_api_rt'] = '0';
+    }
+
+    if (! $centreon->user->admin) {
+        $ret = filterNonAdminFields($ret);
+    }
 
     try {
         $bindParams = sanitizeFormContactParameters($ret);

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1004,10 +1004,6 @@ function insertContact(array $ret = []): int
         $ret['reach_api_rt']['reach_api_rt'] = '1';
     }
 
-    if (! $centreon->user->admin) {
-        $ret = filterNonAdminFields($ret);
-    }
-
     try {
         $bindParams = sanitizeFormContactParameters($ret);
     } catch (InvalidArgumentException $exception) {

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1002,8 +1002,6 @@ function insertContact(array $ret = []): int
         && $ret['contact_oreon']['contact_oreon'] === '1'
     ) {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
-    } else {
-        $ret['reach_api_rt']['reach_api_rt'] = '0';
     }
 
     if (! $centreon->user->admin) {
@@ -1127,8 +1125,6 @@ function updateContact(int $contactId): void
         && $ret['contact_oreon']['contact_oreon'] === '1'
     ) {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
-    } else {
-        $ret['reach_api_rt']['reach_api_rt'] = '0';
     }
 
     if (! $centreon->user->admin) {

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -1,3 +1,12 @@
+<style>
+{literal}
+    /* Si l'input interne est disabled (géré par votre PHP), le parent md-radio se grise tout seul */
+    .md-radio:has(input[disabled]) {
+        opacity: 0.5;
+        pointer-events: none;
+    }
+{/literal}
+</style>
 {$form.javascript}
 <form {$form.attributes}>
 <div class="headerTabContainer">
@@ -277,3 +286,43 @@
     {$form.hidden}
 </form>
 {$helptext}
+<script type="text/javascript">
+{literal}
+    function handleReachRealTimeChange() {
+        var frontEndYes = document.getElementById('contact_oreon_yes');
+
+        var radioYes = document.getElementById('reach_api_rt_yes');
+        var radioNo = document.getElementById('reach_api_rt_no');
+
+        console.log("Checkbox trouvée ?", !!frontEndYes);
+        if (frontEndYes) {
+            if (frontEndYes.checked) {
+                console.log("Checkbox cochée ?", frontEndYes.checked);
+                radioYes.checked = true;
+                radioYes.disabled = true;
+                radioNo.disabled = true;
+
+                radioYes.parentElement.style.opacity = "0.5";
+                radioNo.parentElement.style.opacity = "0.5";
+            } else {
+                console.log("Tentative de réactivation...");
+                radioYes.disabled = false;
+                radioNo.disabled = false;
+                radioYes.removeAttribute('disabled');
+                radioNo.removeAttribute('disabled');
+
+                radioYes.parentElement.style.opacity = "1";
+                radioNo.parentElement.style.opacity = "1";
+            }
+        }
+    }
+
+    window.addEventListener('load', (event) => {
+        var frontEndYes = document.getElementById('contact_oreon_yes');
+        var frontEndNo = document.getElementById('contact_oreon_no');
+
+        if (frontEndYes) frontEndYes.addEventListener('click', handleReachRealTimeChange);
+        if (frontEndNo) frontEndNo.addEventListener('click', handleReachRealTimeChange);
+    });
+{/literal}
+</script>

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -294,10 +294,8 @@
         var radioYes = document.getElementById('reach_api_rt_yes');
         var radioNo = document.getElementById('reach_api_rt_no');
 
-        console.log("Checkbox trouvée ?", !!frontEndYes);
         if (frontEndYes) {
             if (frontEndYes.checked) {
-                console.log("Checkbox cochée ?", frontEndYes.checked);
                 radioYes.checked = true;
                 radioYes.disabled = true;
                 radioNo.disabled = true;
@@ -305,9 +303,7 @@
                 radioYes.parentElement.style.opacity = "0.5";
                 radioNo.parentElement.style.opacity = "0.5";
             } else {
-                console.log("Tentative de réactivation...");
-                radioYes.disabled = false;
-                radioNo.disabled = false;
+                radioNo.checked = true;
                 radioYes.removeAttribute('disabled');
                 radioNo.removeAttribute('disabled');
 

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -294,7 +294,7 @@
         var radioYes = document.getElementById('reach_api_rt_yes');
         var radioNo = document.getElementById('reach_api_rt_no');
 
-        if (frontEndYes) {
+        if (frontEndYes && radioYes && radioNo) {
             if (frontEndYes.checked) {
                 radioYes.checked = true;
                 radioYes.disabled = true;

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -739,6 +739,16 @@ $form->addElement(
 );
 
 if ($centreon->user->admin) {
+    if (!isset($cct['contact_oreon'])) {
+        $cct['contact_oreon'] = '1';
+    }
+    $useFrontend = (isset($cct['contact_oreon']) && $cct['contact_oreon'] === '1');
+    $reachApiRtYes = ['id' => 'reach_api_rt_yes', 'data-testid' => 'reach_api_rt_yes'];
+    $reachApiRtNo = ['id' => 'reach_api_rt_no', 'data-testid' => 'reach_api_rt_no'];
+    if ($useFrontend) {
+        $reachApiRtYes['disabled'] = 'disabled';
+        $reachApiRtNo['disabled'] = 'disabled';
+    }
     $tab = [];
     $tab[] = $form->createElement(
         'radio',
@@ -784,7 +794,7 @@ if ($centreon->user->admin) {
         null,
         _('Yes'),
         '1',
-        ['id' => 'reach_api_rt_yes', 'data-testid' => 'reach_api_rt_yes']
+        $reachApiRtYes
     );
     $tab[] = $form->createElement(
         'radio',
@@ -792,7 +802,7 @@ if ($centreon->user->admin) {
         null,
         _('No'),
         '0',
-        ['id' => 'reach_api_rt_no', 'data-testid' => 'reach_api_rt_no']
+        $reachApiRtNo
     );
     $form->addGroup($tab, 'reach_api_rt', _('Reach API Realtime'), '&nbsp;');
 }
@@ -862,7 +872,7 @@ if ($o != MASSIVE_CHANGE) {
         'contact_oreon' => ['contact_oreon' => '1'],
         'contact_admin' => ['contact_admin' => '0'],
         'reach_api' => ['reach_api' => '0'],
-        'reach_api_rt' => ['reach_api_rt' => '0'],
+        'reach_api_rt' => ['reach_api_rt' => '1'],
     ]);
 }
 $form->addElement(

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -739,7 +739,7 @@ $form->addElement(
 );
 
 if ($centreon->user->admin) {
-    if (!isset($cct['contact_oreon'])) {
+    if (! isset($cct['contact_oreon'])) {
         $cct['contact_oreon'] = '1';
     }
     $useFrontend = (isset($cct['contact_oreon']) && $cct['contact_oreon'] === '1');


### PR DESCRIPTION
## Description

This PR intends to fix behaviour of the reach real time api in the contacts form according to the front end : 
- When useFrontend: true, reachApiRealtime must be disabled and set to true
- When useFrontend : false, reachApiRealtime must be editable and set to false

[MON-191024](https://centreon.atlassian.net/browse/MON-191024)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-191024]: https://centreon.atlassian.net/browse/MON-191024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ