### PR TITLE
fix(CustomView): rename of CV not working for users under ACL

### DIFF
--- a/centreon/www/class/centreonWidget.class.php
+++ b/centreon/www/class/centreonWidget.class.php
@@ -1000,11 +1000,8 @@ class CentreonWidget
                                 AND cvur.locked = 0
                                 AND (
                                         cvur.user_id = :userId
-                                        {$groupClause}
-                                    )
-                            )
-                        )
                 SQL;
+            $updateSql .= "{$groupClause})))";
         }
         try {
             $params = [


### PR DESCRIPTION
## Description

rename of a custom view not working for users under ACL

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Check [Ticket](https://centreon.atlassian.net/browse/MON-193314)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
