### PR TITLE
fix(widgets): correctly escape config database name in widgets

### DIFF
--- a/centreon/www/widgets/hostgroup-monitoring/src/export.php
+++ b/centreon/www/widgets/hostgroup-monitoring/src/export.php
@@ -102,13 +102,13 @@ try {
         $accessGroupsList = implode(',', $accessGroups->getIds());
         $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
         $baseQuery .= <<<SQL
-                INNER JOIN {$configurationDatabaseName}.acl_resources_hg_relations arhr
+                INNER JOIN `{$configurationDatabaseName}`.acl_resources_hg_relations arhr
                     ON hostgroups.hostgroup_id = arhr.hg_hg_id
-                INNER JOIN {$configurationDatabaseName}.acl_resources res
+                INNER JOIN `{$configurationDatabaseName}`.acl_resources res
                     ON arhr.acl_res_id = res.acl_res_id
-                INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+                INNER JOIN `{$configurationDatabaseName}`.acl_res_group_relations argr
                     ON res.acl_res_id = argr.acl_res_id
-                INNER JOIN {$configurationDatabaseName}.acl_groups ag
+                INNER JOIN `{$configurationDatabaseName}`.acl_groups ag
                     ON argr.acl_group_id = ag.acl_group_id
                     AND ag.acl_group_id IN ({$accessGroupsList})
             SQL;

--- a/centreon/www/widgets/hostgroup-monitoring/src/index.php
+++ b/centreon/www/widgets/hostgroup-monitoring/src/index.php
@@ -159,13 +159,13 @@ try {
             $accessGroupsList = implode(',', $accessGroups->getIds());
             $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
             $baseQuery .= <<<SQL
-                    INNER JOIN {$configurationDatabaseName}.acl_resources_hg_relations arhr
+                    INNER JOIN `{$configurationDatabaseName}`.acl_resources_hg_relations arhr
                         ON hostgroups.hostgroup_id = arhr.hg_hg_id
-                    INNER JOIN {$configurationDatabaseName}.acl_resources res
+                    INNER JOIN `{$configurationDatabaseName}`.acl_resources res
                         ON arhr.acl_res_id = res.acl_res_id
-                    INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+                    INNER JOIN `{$configurationDatabaseName}`.acl_res_group_relations argr
                         ON res.acl_res_id = argr.acl_res_id
-                    INNER JOIN {$configurationDatabaseName}.acl_groups ag
+                    INNER JOIN `{$configurationDatabaseName}`.acl_groups ag
                         ON argr.acl_group_id = ag.acl_group_id
                         AND ag.acl_group_id IN ({$accessGroupsList})
                 SQL;

--- a/centreon/www/widgets/servicegroup-monitoring/src/export.php
+++ b/centreon/www/widgets/servicegroup-monitoring/src/export.php
@@ -90,13 +90,13 @@ if (! $centreon->user->admin) {
 
     $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
     $baseQuery .= <<<SQL
-            INNER JOIN {$configurationDatabaseName}.acl_resources_sg_relations arsr
+            INNER JOIN `{$configurationDatabaseName}`.acl_resources_sg_relations arsr
                 ON servicegroups.servicegroup_id = arsr.sg_id
-            INNER JOIN {$configurationDatabaseName}.acl_resources res
+            INNER JOIN `{$configurationDatabaseName}`.acl_resources res
                 ON arsr.acl_res_id = res.acl_res_id
-            INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+            INNER JOIN `{$configurationDatabaseName}`.acl_res_group_relations argr
                 ON res.acl_res_id = argr.acl_res_id
-            INNER JOIN {$configurationDatabaseName}.acl_groups ag
+            INNER JOIN `{$configurationDatabaseName}`.acl_groups ag
                 ON argr.acl_group_id = ag.acl_group_id
             WHERE ag.acl_group_id IN ({$accessGroupList})
         SQL;

--- a/centreon/www/widgets/servicegroup-monitoring/src/index.php
+++ b/centreon/www/widgets/servicegroup-monitoring/src/index.php
@@ -135,13 +135,13 @@ if (! $centreon->user->admin) {
 
     $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
     $baseQuery .= <<<SQL
-            INNER JOIN {$configurationDatabaseName}.acl_resources_sg_relations arsr
+            INNER JOIN `{$configurationDatabaseName}`.acl_resources_sg_relations arsr
                 ON servicegroups.servicegroup_id = arsr.sg_id
-            INNER JOIN {$configurationDatabaseName}.acl_resources res
+            INNER JOIN `{$configurationDatabaseName}`.acl_resources res
                 ON arsr.acl_res_id = res.acl_res_id
-            INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+            INNER JOIN `{$configurationDatabaseName}`.acl_res_group_relations argr
                 ON res.acl_res_id = argr.acl_res_id
-            INNER JOIN {$configurationDatabaseName}.acl_groups ag
+            INNER JOIN `{$configurationDatabaseName}`.acl_groups ag
                 ON argr.acl_group_id = ag.acl_group_id
             WHERE ag.acl_group_id IN ({$accessGroupList})
         SQL;


### PR DESCRIPTION
This pull request updates SQL queries in several files to enclose dynamic database names in backticks. This change improves compatibility with MySQL and prevents potential SQL syntax errors when database names contain special characters.

**SQL query improvements for database name handling:**

* Enclosed `{$configurationDatabaseName}` in backticks in all relevant `INNER JOIN` statements in `hostgroup-monitoring/src/export.php` to ensure correct SQL syntax.
* Applied the same backtick enclosure for `{$configurationDatabaseName}` in `INNER JOIN` statements in `hostgroup-monitoring/src/index.php`.
* Updated `servicegroup-monitoring/src/export.php` to use backticks around `{$configurationDatabaseName}` in all `INNER JOIN` statements.
* Made corresponding updates in `servicegroup-monitoring/src/index.php` to enclose `{$configurationDatabaseName}` in backticks in all `INNER JOIN` statements.