### PR TITLE
Implements internal call HTTP client

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -23,14 +23,82 @@ declare(strict_types=1);
 
 namespace Core\Common\Infrastructure\Api;
 
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
 /**
- * Utility class for converting URLs to localhost for internal API calls.
+ * Client for making internal API calls that stay on localhost.
  * This avoids issues with proxies, load balancers, and HTTPS termination.
  */
 final class InternalApiClient
 {
     private const DEFAULT_LOCAL_HOST = '127.0.0.1';
     private const DEFAULT_LOCAL_SCHEME = 'http';
+
+    private HttpClientInterface $httpClient;
+
+    /**
+     * @param HttpClientInterface|null $httpClient HTTP client (defaults to CurlHttpClient with SSL verification disabled)
+     */
+    public function __construct(?HttpClientInterface $httpClient = null)
+    {
+        $this->httpClient = $httpClient ?? new CurlHttpClient([
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+    }
+
+    /**
+     * Make an internal API request using localhost.
+     *
+     * @param string $url The original URL (will be converted to localhost)
+     * @param string $httpMethod HTTP method (GET, POST, PATCH, PUT, DELETE)
+     * @param string $sessionCookie The session cookie for authentication
+     * @param array<string, mixed> $payload Request body payload (will be JSON encoded)
+     * @param array<string, string> $additionalHeaders Additional headers to include
+     *
+     * @throws TransportExceptionInterface
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws \JsonException
+     *
+     * @return array{status_code: int, content: mixed}
+     */
+    public function request(
+        string $url,
+        string $httpMethod,
+        string $sessionCookie,
+        array $payload = [],
+        array $additionalHeaders = [],
+    ): array {
+        $localUrl = self::convertToLocalUrl($url);
+
+        $headers = array_merge(
+            [
+                'Content-Type' => 'application/json',
+                'Cookie' => $sessionCookie,
+            ],
+            $additionalHeaders
+        );
+
+        $options = ['headers' => $headers];
+
+        if (! empty($payload)) {
+            $options['body'] = json_encode($payload, JSON_THROW_ON_ERROR);
+        }
+
+        $response = $this->httpClient->request($httpMethod, $localUrl, $options);
+
+        return [
+            'status_code' => $response->getStatusCode(),
+            'content' => json_decode($response->getContent(false), true),
+        ];
+    }
 
     /**
      * Convert an external URL to a localhost URL for internal API calls.
@@ -68,19 +136,5 @@ final class InternalApiClient
         }
 
         return $localUrl;
-    }
-
-    /**
-     * Get the default options for internal HTTP client requests.
-     * These options disable SSL verification since we're calling localhost.
-     *
-     * @return array{verify_peer: bool, verify_host: bool}
-     */
-    public static function getDefaultHttpOptions(): array
-    {
-        return [
-            'verify_peer' => false,
-            'verify_host' => false,
-        ];
     }
 }

--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -117,8 +117,10 @@ final class InternalApiClient
             return $url;
         }
 
-        // Rebuild URL with localhost
-        $localUrl = self::DEFAULT_LOCAL_SCHEME . '://' . self::DEFAULT_LOCAL_HOST;
+        $scheme = (isset($parsedUrl['scheme']) && in_array($parsedUrl['scheme'], ['http', 'https'], true))
+            ? $parsedUrl['scheme']
+            : self::DEFAULT_LOCAL_SCHEME;
+        $localUrl = $scheme . '://' . self::DEFAULT_LOCAL_HOST;
 
         // Add path
         if (isset($parsedUrl['path'])) {

--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Common\Infrastructure\Api;
+
+/**
+ * Utility class for converting URLs to localhost for internal API calls.
+ * This avoids issues with proxies, load balancers, and HTTPS termination.
+ */
+final class InternalApiClient
+{
+    private const DEFAULT_LOCAL_HOST = '127.0.0.1';
+    private const DEFAULT_LOCAL_SCHEME = 'http';
+
+    /**
+     * Convert an external URL to a localhost URL for internal API calls.
+     * This ensures the request stays on the local server and doesn't go through
+     * proxies, load balancers, or external network infrastructure.
+     *
+     * @param string $url The original URL (may contain external hostname)
+     *
+     * @return string The localhost URL
+     */
+    public static function convertToLocalUrl(string $url): string
+    {
+        $parsedUrl = parse_url($url);
+
+        if ($parsedUrl === false) {
+            return $url;
+        }
+
+        // Rebuild URL with localhost
+        $localUrl = self::DEFAULT_LOCAL_SCHEME . '://' . self::DEFAULT_LOCAL_HOST;
+
+        // Add path
+        if (isset($parsedUrl['path'])) {
+            $localUrl .= $parsedUrl['path'];
+        }
+
+        // Add query string
+        if (isset($parsedUrl['query'])) {
+            $localUrl .= '?' . $parsedUrl['query'];
+        }
+
+        // Add fragment if present
+        if (isset($parsedUrl['fragment'])) {
+            $localUrl .= '#' . $parsedUrl['fragment'];
+        }
+
+        return $localUrl;
+    }
+
+    /**
+     * Get the default options for internal HTTP client requests.
+     * These options disable SSL verification since we're calling localhost.
+     *
+     * @return array{verify_peer: bool, verify_host: bool}
+     */
+    public static function getDefaultHttpOptions(): array
+    {
+        return [
+            'verify_peer' => false,
+            'verify_host' => false,
+        ];
+    }
+}

--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -88,7 +88,7 @@ final class InternalApiClient
 
         $options = ['headers' => $headers];
 
-        if (! empty($payload)) {
+        if ($payload !== []) {
             $options['body'] = json_encode($payload, JSON_THROW_ON_ERROR);
         }
 

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -204,4 +204,53 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
             ? $this->getBaseUrl() . '/main.php?p=' . $topologyPage
             : $this->getBaseUrl() . '/main.php?p=' . $topologyPage . '&' . http_build_query($options);
     }
+
+    /**
+     * Generate a URL for internal API calls using localhost.
+     * This avoids issues with proxies, load balancers, and HTTPS termination.
+     *
+     * @param string $name Route name
+     * @param array<string, mixed> $parameters Route parameters
+     *
+     * @throws \Exception
+     *
+     * @return string The local URL pointing to 127.0.0.1
+     */
+    public function generateLocalUrl(string $name, array $parameters = []): string
+    {
+        $context = $this->router->getContext();
+
+        // Save original context values
+        $originalHost = $context->getHost();
+        $originalScheme = $context->getScheme();
+        $originalHttpPort = $context->getHttpPort();
+
+        // Force local context for internal calls
+        $context->setHost('127.0.0.1');
+        $context->setScheme('http');
+        $context->setHttpPort(80);
+
+        try {
+            $parameters['base_uri'] ??= $this->getBaseUri();
+            if (! empty($parameters['base_uri'])) {
+                $parameters['base_uri'] .= '/';
+            }
+
+            $generatedRoute = $this->router->generate($name, $parameters, self::ABSOLUTE_URL);
+
+            // Clean up double slashes
+            $generatedRoute = preg_replace('/(?<!:)(\/{2,})/', '/', $generatedRoute);
+
+            if ($generatedRoute === null) {
+                throw new \Exception('Error occurred during regular expression search and replace.');
+            }
+
+            return $generatedRoute;
+        } finally {
+            // Restore original context
+            $context->setHost($originalHost);
+            $context->setScheme($originalScheme);
+            $context->setHttpPort($originalHttpPort);
+        }
+    }
 }

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -236,15 +236,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
                 $parameters['base_uri'] .= '/';
             }
 
-            $generatedRoute = $this->router->generate($name, $parameters, self::ABSOLUTE_URL);
-
-            // Clean up double slashes
-            $generatedRoute = preg_replace('/(?<!:)(\/{2,})/', '/', $generatedRoute);
-
-            if ($generatedRoute === null) {
-                throw new \Exception('Error occurred during regular expression search and replace.');
-            }
-
+            $generatedRoute = $this->generate($name, $parameters, self::ABSOLUTE_URL);
             return $generatedRoute;
         } finally {
             // Restore original context

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -236,8 +236,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
                 $parameters['base_uri'] .= '/';
             }
 
-            $generatedRoute = $this->generate($name, $parameters, self::ABSOLUTE_URL);
-            return $generatedRoute;
+            return $this->generate($name, $parameters, self::ABSOLUTE_URL);
         } finally {
             // Restore original context
             $context->setHost($originalHost);

--- a/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
@@ -192,7 +192,7 @@ class InternalApiClientTest extends TestCase
             ->method('request')
             ->with(
                 'GET',
-                $this->callback(fn($url) => str_contains($url, '127.0.0.1')),
+                $this->callback(fn ($url) => str_contains($url, '127.0.0.1')),
                 $this->anything()
             )
             ->willReturn($mockResponse);
@@ -240,9 +240,7 @@ class InternalApiClientTest extends TestCase
             ->with(
                 'POST',
                 $this->anything(),
-                $this->callback(function ($options) use ($payload) {
-                    return isset($options['body']) && $options['body'] === json_encode($payload);
-                })
+                $this->callback(fn ($options) => isset($options['body']) && $options['body'] === json_encode($payload))
             )
             ->willReturn($mockResponse);
 
@@ -262,7 +260,7 @@ class InternalApiClientTest extends TestCase
             ->with(
                 'GET',
                 $this->anything(),
-                $this->callback(fn($options) => !isset($options['body']))
+                $this->callback(fn ($options) => ! isset($options['body']))
             )
             ->willReturn($mockResponse);
 
@@ -282,10 +280,8 @@ class InternalApiClientTest extends TestCase
             ->with(
                 $this->anything(),
                 $this->anything(),
-                $this->callback(function ($options) {
-                    return isset($options['headers']['Content-Type'])
-                        && $options['headers']['Content-Type'] === 'application/json';
-                })
+                $this->callback(fn ($options) => isset($options['headers']['Content-Type'])
+                        && $options['headers']['Content-Type'] === 'application/json')
             )
             ->willReturn($mockResponse);
 
@@ -305,10 +301,8 @@ class InternalApiClientTest extends TestCase
             ->with(
                 $this->anything(),
                 $this->anything(),
-                $this->callback(function ($options) {
-                    return isset($options['headers']['Cookie'])
-                        && $options['headers']['Cookie'] === self::TEST_SESSION_COOKIE;
-                })
+                $this->callback(fn ($options) => isset($options['headers']['Cookie'])
+                        && $options['headers']['Cookie'] === self::TEST_SESSION_COOKIE)
             )
             ->willReturn($mockResponse);
 

--- a/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Common\Infrastructure\Api;
+
+use Core\Common\Infrastructure\Api\InternalApiClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Core\Common\Infrastructure\Api\InternalApiClient
+ */
+class InternalApiClientTest extends TestCase
+{
+    /**
+     * @dataProvider provideUrlsToConvert
+     *
+     * @param string $inputUrl The original URL
+     * @param string $expectedUrl The expected localhost URL
+     */
+    public function testConvertToLocalUrl(string $inputUrl, string $expectedUrl): void
+    {
+        $result = InternalApiClient::convertToLocalUrl($inputUrl);
+
+        $this->assertSame($expectedUrl, $result);
+    }
+
+    /**
+     * @return iterable<string, array{inputUrl: string, expectedUrl: string}>
+     */
+    public static function provideUrlsToConvert(): iterable
+    {
+        yield 'simple HTTPS URL' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield 'simple HTTP URL' => [
+            'inputUrl' => 'http://centreon.example.com/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield 'URL with query string' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts?limit=10&page=1',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts?limit=10&page=1',
+        ];
+
+        yield 'URL with fragment' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts#section',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts#section',
+        ];
+
+        yield 'URL with query string and fragment' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts?id=5#details',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts?id=5#details',
+        ];
+
+        yield 'URL with port number' => [
+            'inputUrl' => 'https://centreon.example.com:8443/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield 'localhost URL should remain localhost' => [
+            'inputUrl' => 'http://localhost/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield '127.0.0.1 URL should remain unchanged' => [
+            'inputUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield 'URL with IP address' => [
+            'inputUrl' => 'https://192.168.1.100/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield 'URL with subdomain' => [
+            'inputUrl' => 'https://monitoring.centreon.example.com/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        ];
+
+        yield 'URL with complex path' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/configuration/hosts/123/templates',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/configuration/hosts/123/templates',
+        ];
+
+        yield 'URL without path' => [
+            'inputUrl' => 'https://centreon.example.com',
+            'expectedUrl' => 'http://127.0.0.1',
+        ];
+
+        yield 'URL with only query string' => [
+            'inputUrl' => 'https://centreon.example.com?search=test',
+            'expectedUrl' => 'http://127.0.0.1?search=test',
+        ];
+
+        yield 'URL with encoded characters in query' => [
+            'inputUrl' => 'https://centreon.example.com/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
+            'expectedUrl' => 'http://127.0.0.1/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
+        ];
+    }
+
+    public function testConvertToLocalUrlWithInvalidUrlReturnsOriginal(): void
+    {
+        // An extremely malformed URL that parse_url cannot handle
+        $malformedUrl = 'http:///example.com';
+
+        $result = InternalApiClient::convertToLocalUrl($malformedUrl);
+
+        // parse_url returns false for severely malformed URLs,
+        // so the original URL should be returned
+        // Note: parse_url is quite permissive, so this tests the fallback behavior
+        $this->assertIsString($result);
+    }
+
+    public function testGetDefaultHttpOptionsReturnsCorrectStructure(): void
+    {
+        $options = InternalApiClient::getDefaultHttpOptions();
+
+        $this->assertIsArray($options);
+        $this->assertArrayHasKey('verify_peer', $options);
+        $this->assertArrayHasKey('verify_host', $options);
+    }
+
+    public function testGetDefaultHttpOptionsDisablesSslVerification(): void
+    {
+        $options = InternalApiClient::getDefaultHttpOptions();
+
+        $this->assertFalse($options['verify_peer']);
+        $this->assertFalse($options['verify_host']);
+    }
+
+    public function testConvertToLocalUrlAlwaysUsesHttp(): void
+    {
+        $httpsUrl = 'https://secure.example.com/api/test';
+
+        $result = InternalApiClient::convertToLocalUrl($httpsUrl);
+
+        $this->assertStringStartsWith('http://', $result);
+        $this->assertStringNotContainsString('https://', $result);
+    }
+
+    public function testConvertToLocalUrlAlwaysUsesLocalhost(): void
+    {
+        $externalUrl = 'https://external-server.example.com/api/test';
+
+        $result = InternalApiClient::convertToLocalUrl($externalUrl);
+
+        $this->assertStringContainsString('127.0.0.1', $result);
+        $this->assertStringNotContainsString('external-server.example.com', $result);
+    }
+
+    public function testConvertToLocalUrlPreservesPathIntegrity(): void
+    {
+        $url = 'https://example.com/centreon/api/latest/configuration/hosts/42';
+
+        $result = InternalApiClient::convertToLocalUrl($url);
+
+        $this->assertStringContainsString('/centreon/api/latest/configuration/hosts/42', $result);
+    }
+
+    public function testConvertToLocalUrlPreservesQueryParametersIntegrity(): void
+    {
+        $url = 'https://example.com/api?param1=value1&param2=value2&param3=value3';
+
+        $result = InternalApiClient::convertToLocalUrl($url);
+
+        $this->assertStringContainsString('param1=value1', $result);
+        $this->assertStringContainsString('param2=value2', $result);
+        $this->assertStringContainsString('param3=value3', $result);
+    }
+}

--- a/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
@@ -55,7 +55,7 @@ class InternalApiClientTest extends TestCase
     {
         yield 'simple HTTPS URL' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
         ];
 
         yield 'simple HTTP URL' => [
@@ -65,22 +65,22 @@ class InternalApiClientTest extends TestCase
 
         yield 'URL with query string' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts?limit=10&page=1',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts?limit=10&page=1',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts?limit=10&page=1',
         ];
 
         yield 'URL with fragment' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts#section',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts#section',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts#section',
         ];
 
         yield 'URL with query string and fragment' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts?id=5#details',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts?id=5#details',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts?id=5#details',
         ];
 
         yield 'URL with port number' => [
             'inputUrl' => 'https://centreon.example.com:8443/centreon/api/latest/hosts',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
         ];
 
         yield 'localhost URL should remain localhost' => [
@@ -95,32 +95,32 @@ class InternalApiClientTest extends TestCase
 
         yield 'URL with IP address' => [
             'inputUrl' => 'https://192.168.1.100/centreon/api/latest/hosts',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
         ];
 
         yield 'URL with subdomain' => [
             'inputUrl' => 'https://monitoring.centreon.example.com/centreon/api/latest/hosts',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
         ];
 
         yield 'URL with complex path' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/configuration/hosts/123/templates',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/configuration/hosts/123/templates',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/configuration/hosts/123/templates',
         ];
 
         yield 'URL without path' => [
             'inputUrl' => 'https://centreon.example.com',
-            'expectedUrl' => 'http://127.0.0.1',
+            'expectedUrl' => 'https://127.0.0.1',
         ];
 
         yield 'URL with only query string' => [
             'inputUrl' => 'https://centreon.example.com?search=test',
-            'expectedUrl' => 'http://127.0.0.1?search=test',
+            'expectedUrl' => 'https://127.0.0.1?search=test',
         ];
 
         yield 'URL with encoded characters in query' => [
             'inputUrl' => 'https://centreon.example.com/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
-            'expectedUrl' => 'http://127.0.0.1/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
+            'expectedUrl' => 'https://127.0.0.1/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
         ];
     }
 
@@ -135,16 +135,6 @@ class InternalApiClientTest extends TestCase
         // so the original URL should be returned
         // Note: parse_url is quite permissive, so this tests the fallback behavior
         $this->assertIsString($result);
-    }
-
-    public function testConvertToLocalUrlAlwaysUsesHttp(): void
-    {
-        $httpsUrl = 'https://secure.example.com/api/test';
-
-        $result = InternalApiClient::convertToLocalUrl($httpsUrl);
-
-        $this->assertStringStartsWith('http://', $result);
-        $this->assertStringNotContainsString('https://', $result);
     }
 
     public function testConvertToLocalUrlAlwaysUsesLocalhost(): void

--- a/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
@@ -25,12 +25,16 @@ namespace Tests\Core\Common\Infrastructure\Api;
 
 use Core\Common\Infrastructure\Api\InternalApiClient;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @covers \Core\Common\Infrastructure\Api\InternalApiClient
  */
 class InternalApiClientTest extends TestCase
 {
+    private const TEST_SESSION_COOKIE = 'PHPSESSID=test-session-id-12345';
+
     /**
      * @dataProvider provideUrlsToConvert
      *
@@ -133,23 +137,6 @@ class InternalApiClientTest extends TestCase
         $this->assertIsString($result);
     }
 
-    public function testGetDefaultHttpOptionsReturnsCorrectStructure(): void
-    {
-        $options = InternalApiClient::getDefaultHttpOptions();
-
-        $this->assertIsArray($options);
-        $this->assertArrayHasKey('verify_peer', $options);
-        $this->assertArrayHasKey('verify_host', $options);
-    }
-
-    public function testGetDefaultHttpOptionsDisablesSslVerification(): void
-    {
-        $options = InternalApiClient::getDefaultHttpOptions();
-
-        $this->assertFalse($options['verify_peer']);
-        $this->assertFalse($options['verify_host']);
-    }
-
     public function testConvertToLocalUrlAlwaysUsesHttp(): void
     {
         $httpsUrl = 'https://secure.example.com/api/test';
@@ -188,5 +175,250 @@ class InternalApiClientTest extends TestCase
         $this->assertStringContainsString('param1=value1', $result);
         $this->assertStringContainsString('param2=value2', $result);
         $this->assertStringContainsString('param3=value3', $result);
+    }
+
+    // =========================================================================
+    // Tests for request() method
+    // =========================================================================
+
+    public function testRequestConvertsUrlToLocalhost(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn('{"success": true}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                $this->callback(fn($url) => str_contains($url, '127.0.0.1')),
+                $this->anything()
+            )
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('https://external.example.com/api/test', 'GET', self::TEST_SESSION_COOKIE);
+
+        $this->assertEquals(200, $result['status_code']);
+        $this->assertEquals(['success' => true], $result['content']);
+    }
+
+    public function testRequestSetsCorrectHttpMethod(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(201);
+        $mockResponse->method('getContent')->willReturn('{}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                $this->anything(),
+                $this->anything()
+            )
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/test', 'POST', self::TEST_SESSION_COOKIE);
+
+        $this->assertEquals(201, $result['status_code']);
+    }
+
+    public function testRequestEncodesPayloadAsJson(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn('{}');
+
+        $payload = ['name' => 'test-host', 'address' => '192.168.1.1'];
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                $this->anything(),
+                $this->callback(function ($options) use ($payload) {
+                    return isset($options['body']) && $options['body'] === json_encode($payload);
+                })
+            )
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $client->request('http://localhost/api/test', 'POST', self::TEST_SESSION_COOKIE, $payload);
+    }
+
+    public function testRequestDoesNotSetBodyForEmptyPayload(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn('{}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                $this->anything(),
+                $this->callback(fn($options) => !isset($options['body']))
+            )
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
+    }
+
+    public function testRequestSetsContentTypeHeader(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn('{}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(function ($options) {
+                    return isset($options['headers']['Content-Type'])
+                        && $options['headers']['Content-Type'] === 'application/json';
+                })
+            )
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
+    }
+
+    public function testRequestSetsCookieHeader(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn('{}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(function ($options) {
+                    return isset($options['headers']['Cookie'])
+                        && $options['headers']['Cookie'] === self::TEST_SESSION_COOKIE;
+                })
+            )
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
+    }
+
+    public function testRequestParsesJsonResponse(): void
+    {
+        $responseData = ['id' => 42, 'name' => 'test', 'active' => true];
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn(json_encode($responseData));
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->method('request')->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
+
+        $this->assertEquals($responseData, $result['content']);
+    }
+
+    public function testRequestReturnsNullForInvalidJson(): void
+    {
+        $invalidJson = 'This is not JSON';
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn($invalidJson);
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->method('request')->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
+
+        // json_decode returns null for invalid JSON
+        $this->assertNull($result['content']);
+    }
+
+    public function testRequestWithDeleteMethod(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(204);
+        $mockResponse->method('getContent')->willReturn('');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with('DELETE', $this->anything(), $this->anything())
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/hosts/42', 'DELETE', self::TEST_SESSION_COOKIE);
+
+        $this->assertEquals(204, $result['status_code']);
+    }
+
+    public function testRequestWithPatchMethod(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(200);
+        $mockResponse->method('getContent')->willReturn('{"updated": true}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->expects($this->once())
+            ->method('request')
+            ->with('PATCH', $this->anything(), $this->anything())
+            ->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/hosts/42', 'PATCH', self::TEST_SESSION_COOKIE, ['name' => 'new-name']);
+
+        $this->assertEquals(200, $result['status_code']);
+    }
+
+    // =========================================================================
+    // Tests for error scenarios
+    // =========================================================================
+
+    public function testRequestHandles4xxStatusCodes(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(404);
+        $mockResponse->method('getContent')->willReturn('{"error": "Not found"}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->method('request')->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/hosts/9999', 'GET', self::TEST_SESSION_COOKIE);
+
+        $this->assertEquals(404, $result['status_code']);
+        $this->assertEquals(['error' => 'Not found'], $result['content']);
+    }
+
+    public function testRequestHandles5xxStatusCodes(): void
+    {
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockResponse->method('getStatusCode')->willReturn(500);
+        $mockResponse->method('getContent')->willReturn('{"error": "Internal server error"}');
+
+        $mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $mockHttpClient->method('request')->willReturn($mockResponse);
+
+        $client = new InternalApiClient($mockHttpClient);
+        $result = $client->request('http://localhost/api/test', 'POST', self::TEST_SESSION_COOKIE);
+
+        $this->assertEquals(500, $result['status_code']);
     }
 }

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -1303,11 +1303,8 @@ class CentreonConfigCentreonBroker
         /** @var Core\Infrastructure\Common\Api\Router $router */
         $router = $kernel->getContainer()->get(Core\Infrastructure\Common\Api\Router::class)
         ?? throw new LogicException('Router not found in container');
-        $client = new Symfony\Component\HttpClient\CurlHttpClient();
-        $headers = [
-            'Content-Type' => 'application/json',
-            'Cookie' => CentreonSession::resolveSessionCookie(),
-        ];
+        $client = new InternalApiClient();
+        $sessionCookie = CentreonSession::resolveSessionCookie();
         $parameters = ['brokerId' => $configId];
         if ($basePath) {
             $parameters['base_uri'] = $basePath;
@@ -1321,26 +1318,14 @@ class CentreonConfigCentreonBroker
                 Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
             );
 
-            // Convert URL to localhost to avoid proxy/load balancer issues
-            $url = InternalApiClient::convertToLocalUrl($url);
-
             foreach ($groups as $group) {
                 $payload = $this->buildPayload($group);
-                $response = $client->request(
-                    'POST',
-                    $url,
-                    [
-                        'headers' => $headers,
-                        'body' => json_encode($payload),
-                        // Skip SSL verification for localhost calls
-                        'verify_peer' => false,
-                        'verify_host' => false,
-                    ],
-                );
-                if ($response->getStatusCode() !== 201) {
-                    $content = json_decode($response->getContent(false));
+                $response = $client->request($url, 'POST', $sessionCookie, $payload);
 
-                    throw new Exception($content->message ?? 'Unexpected return status');
+                if ($response['status_code'] !== 201) {
+                    $message = $response['content']['message'] ?? 'Unexpected return status';
+
+                    throw new Exception($message);
                 }
             }
         }

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -24,6 +24,7 @@ use Centreon\Domain\Log\Logger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
@@ -1320,6 +1321,9 @@ class CentreonConfigCentreonBroker
                 Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
             );
 
+            // Convert URL to localhost to avoid proxy/load balancer issues
+            $url = InternalApiClient::convertToLocalUrl($url);
+
             foreach ($groups as $group) {
                 $payload = $this->buildPayload($group);
                 $response = $client->request(
@@ -1328,6 +1332,9 @@ class CentreonConfigCentreonBroker
                     [
                         'headers' => $headers,
                         'body' => json_encode($payload),
+                        // Skip SSL verification for localhost calls
+                        'verify_peer' => false,
+                        'verify_host' => false,
                     ],
                 );
                 if ($response->getStatusCode() !== 201) {

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -40,7 +40,6 @@ use Core\Host\Application\Converter\HostEventConverter;
 use Core\Infrastructure\Common\Api\Router;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
-use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -2968,36 +2968,20 @@ function updateByApi(array $formData, bool $isCloudPlatform, string $basePath, b
  */
 function callHostApi(string $url, string $httpMethod, array $payload): array
 {
-    // Convert URL to localhost to avoid proxy/load balancer issues
-    $url = InternalApiClient::convertToLocalUrl($url);
+    $client = new InternalApiClient();
+    $response = $client->request($url, $httpMethod, CentreonSession::resolveSessionCookie(), $payload);
 
-    $client = new CurlHttpClient();
-    $response = $client->request(
-        $httpMethod,
-        $url,
-        [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Cookie' => CentreonSession::resolveSessionCookie(),
-            ],
-            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
-            // Skip SSL verification for localhost calls
-            'verify_peer' => false,
-            'verify_host' => false,
-        ],
-    );
-
-    $status = $response->getStatusCode();
+    $status = $response['status_code'];
     if (
         ($httpMethod === 'POST' && $status !== 201)
         || ($httpMethod === 'PATCH' && $status !== 204)
     ) {
-        $content = json_decode(json: $response->getContent(false), flags: JSON_THROW_ON_ERROR);
+        $message = $response['content']['message'] ?? 'Unexpected return status';
 
-        throw new Exception($content->message ?? 'Unexpected return status');
+        throw new Exception($message);
     }
 
-    return ['status_code' => $status, 'content' => json_decode($response->getContent(false), true)];
+    return $response;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -34,6 +34,7 @@ use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Infrastructure\Common\Api\Router;
@@ -2967,6 +2968,9 @@ function updateByApi(array $formData, bool $isCloudPlatform, string $basePath, b
  */
 function callHostApi(string $url, string $httpMethod, array $payload): array
 {
+    // Convert URL to localhost to avoid proxy/load balancer issues
+    $url = InternalApiClient::convertToLocalUrl($url);
+
     $client = new CurlHttpClient();
     $response = $client->request(
         $httpMethod,
@@ -2977,6 +2981,9 @@ function callHostApi(string $url, string $httpMethod, array $payload): array
                 'Cookie' => CentreonSession::resolveSessionCookie(),
             ],
             'body' => json_encode($payload, JSON_THROW_ON_ERROR),
+            // Skip SSL verification for localhost calls
+            'verify_peer' => false,
+            'verify_host' => false,
         ],
     );
 

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -31,6 +31,7 @@ use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Infrastructure\Common\Api\Router;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
@@ -4422,6 +4423,9 @@ function deleteServiceTemplateByApi(array $serviceTemplates = []): void
  */
 function callApi(string $url, string $httpMethod, array $payload): array
 {
+    // Convert URL to localhost to avoid proxy/load balancer issues
+    $url = InternalApiClient::convertToLocalUrl($url);
+
     $client = new CurlHttpClient();
     $response = $client->request(
         $httpMethod,
@@ -4432,6 +4436,9 @@ function callApi(string $url, string $httpMethod, array $payload): array
                 'Cookie' => CentreonSession::resolveSessionCookie(),
             ],
             'body' => json_encode($payload),
+            // Skip SSL verification for localhost calls
+            'verify_peer' => false,
+            'verify_host' => false,
         ]
     );
 

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -4423,27 +4423,7 @@ function deleteServiceTemplateByApi(array $serviceTemplates = []): void
  */
 function callApi(string $url, string $httpMethod, array $payload): array
 {
-    // Convert URL to localhost to avoid proxy/load balancer issues
-    $url = InternalApiClient::convertToLocalUrl($url);
+    $client = new InternalApiClient();
 
-    $client = new CurlHttpClient();
-    $response = $client->request(
-        $httpMethod,
-        $url,
-        [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Cookie' => CentreonSession::resolveSessionCookie(),
-            ],
-            'body' => json_encode($payload),
-            // Skip SSL verification for localhost calls
-            'verify_peer' => false,
-            'verify_host' => false,
-        ]
-    );
-
-    $status = $response->getStatusCode();
-    $content = json_decode($response->getContent(false), true);
-
-    return ['status_code' => $status, 'content' => $content];
+    return $client->request($url, $httpMethod, CentreonSession::resolveSessionCookie(), $payload);
 }

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -38,7 +38,6 @@ use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryI
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
-use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;

--- a/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -28,7 +28,6 @@ if (! isset($centreon)) {
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Infrastructure\Common\Api\Router;
-use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 function includeExcludeTimeperiods($tpId, $includeTab = [], $excludeTab = [])

--- a/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -26,6 +26,7 @@ if (! isset($centreon)) {
 }
 
 use Core\ActionLog\Domain\Model\ActionLog;
+use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Infrastructure\Common\Api\Router;
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -432,6 +433,9 @@ function insertTimeperiodByApi(array $formData, string $basePath): int
         UrlGeneratorInterface::ABSOLUTE_URL,
     );
 
+    // Convert URL to localhost to avoid proxy/load balancer issues
+    $url = InternalApiClient::convertToLocalUrl($url);
+
     $headers = [
         'Content-Type' => 'application/json',
         'Cookie' => CentreonSession::resolveSessionCookie(),
@@ -442,6 +446,9 @@ function insertTimeperiodByApi(array $formData, string $basePath): int
         [
             'headers' => $headers,
             'body' => json_encode(value: $payload, flags: JSON_THROW_ON_ERROR),
+            // Skip SSL verification for localhost calls
+            'verify_peer' => false,
+            'verify_host' => false,
         ],
     );
 
@@ -515,6 +522,9 @@ function updateTimeperiodByApi(array $formData, string $basePath): void
         UrlGeneratorInterface::ABSOLUTE_URL,
     );
 
+    // Convert URL to localhost to avoid proxy/load balancer issues
+    $url = InternalApiClient::convertToLocalUrl($url);
+
     $headers = [
         'Content-Type' => 'application/json',
         'Cookie' => CentreonSession::resolveSessionCookie(),
@@ -525,6 +535,9 @@ function updateTimeperiodByApi(array $formData, string $basePath): void
         [
             'headers' => $headers,
             'body' => json_encode(value: $payload, flags: JSON_THROW_ON_ERROR),
+            // Skip SSL verification for localhost calls
+            'verify_peer' => false,
+            'verify_host' => false,
         ],
     );
 
@@ -587,7 +600,19 @@ function deleteTimePeriodByAPI(string $basePath, array $timePeriodIds): void
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
 
-        $response = $client->request('DELETE', $url, ['headers' => $headers]);
+        // Convert URL to localhost to avoid proxy/load balancer issues
+        $url = InternalApiClient::convertToLocalUrl($url);
+
+        $response = $client->request(
+            'DELETE',
+            $url,
+            [
+                'headers' => $headers,
+                // Skip SSL verification for localhost calls
+                'verify_peer' => false,
+                'verify_host' => false,
+            ]
+        );
 
         if ($response->getStatusCode() !== 204) {
             $content = json_decode($response->getContent(false), true);

--- a/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -424,7 +424,6 @@ function insertTimeperiodByApi(array $formData, string $basePath): int
     $kernel = Kernel::createForWeb();
     /** @var Router $router */
     $router = $kernel->getContainer()->get(Router::class);
-    $client = new CurlHttpClient();
 
     $payload = getPayloadForTimePeriod($formData);
     $url = $router->generate(
@@ -433,35 +432,17 @@ function insertTimeperiodByApi(array $formData, string $basePath): int
         UrlGeneratorInterface::ABSOLUTE_URL,
     );
 
-    // Convert URL to localhost to avoid proxy/load balancer issues
-    $url = InternalApiClient::convertToLocalUrl($url);
+    $client = new InternalApiClient();
+    $response = $client->request($url, 'POST', CentreonSession::resolveSessionCookie(), $payload);
 
-    $headers = [
-        'Content-Type' => 'application/json',
-        'Cookie' => CentreonSession::resolveSessionCookie(),
-    ];
-    $response = $client->request(
-        'POST',
-        $url,
-        [
-            'headers' => $headers,
-            'body' => json_encode(value: $payload, flags: JSON_THROW_ON_ERROR),
-            // Skip SSL verification for localhost calls
-            'verify_peer' => false,
-            'verify_host' => false,
-        ],
-    );
+    if ($response['status_code'] !== 201) {
+        $message = $response['content']['message'] ?? 'Unexpected return status';
 
-    if ($response->getStatusCode() !== 201) {
-        $content = json_decode(json: $response->getContent(false), flags: JSON_THROW_ON_ERROR);
-
-        throw new Exception($content->message ?? 'Unexpected return status');
+        throw new Exception($message);
     }
 
-    $data = $response->toArray();
-
-    /** @var array{id:int} $data */
-    return $data['id'];
+    /** @var array{id:int} $response['content'] */
+    return $response['content']['id'];
 }
 
 /**
@@ -513,7 +494,6 @@ function updateTimeperiodByApi(array $formData, string $basePath): void
     $kernel = Kernel::createForWeb();
     /** @var Router $router */
     $router = $kernel->getContainer()->get(Router::class);
-    $client = new CurlHttpClient();
 
     $payload = getPayloadForTimePeriod($formData);
     $url = $router->generate(
@@ -522,29 +502,13 @@ function updateTimeperiodByApi(array $formData, string $basePath): void
         UrlGeneratorInterface::ABSOLUTE_URL,
     );
 
-    // Convert URL to localhost to avoid proxy/load balancer issues
-    $url = InternalApiClient::convertToLocalUrl($url);
+    $client = new InternalApiClient();
+    $response = $client->request($url, 'PUT', CentreonSession::resolveSessionCookie(), $payload);
 
-    $headers = [
-        'Content-Type' => 'application/json',
-        'Cookie' => CentreonSession::resolveSessionCookie(),
-    ];
-    $response = $client->request(
-        'PUT',
-        $url,
-        [
-            'headers' => $headers,
-            'body' => json_encode(value: $payload, flags: JSON_THROW_ON_ERROR),
-            // Skip SSL verification for localhost calls
-            'verify_peer' => false,
-            'verify_host' => false,
-        ],
-    );
+    if ($response['status_code'] !== 204) {
+        $message = $response['content']['message'] ?? 'Unexpected return status';
 
-    if ($response->getStatusCode() !== 204) {
-        $content = json_decode(json: $response->getContent(false), flags: JSON_THROW_ON_ERROR);
-
-        throw new Exception($content->message ?? 'Unexpected return status');
+        throw new Exception($message);
     }
 }
 
@@ -586,12 +550,8 @@ function deleteTimePeriodByAPI(string $basePath, array $timePeriodIds): void
     $kernel = Kernel::createForWeb();
     /** @var Router $router */
     $router = $kernel->getContainer()->get(Router::class);
-    $client = new CurlHttpClient();
-
-    $headers = [
-        'Content-Type' => 'application/json',
-        'Cookie' => CentreonSession::resolveSessionCookie(),
-    ];
+    $client = new InternalApiClient();
+    $sessionCookie = CentreonSession::resolveSessionCookie();
 
     foreach ($timePeriodIds as $id) {
         $url = $router->generate(
@@ -600,23 +560,10 @@ function deleteTimePeriodByAPI(string $basePath, array $timePeriodIds): void
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
 
-        // Convert URL to localhost to avoid proxy/load balancer issues
-        $url = InternalApiClient::convertToLocalUrl($url);
+        $response = $client->request($url, 'DELETE', $sessionCookie);
 
-        $response = $client->request(
-            'DELETE',
-            $url,
-            [
-                'headers' => $headers,
-                // Skip SSL verification for localhost calls
-                'verify_peer' => false,
-                'verify_host' => false,
-            ]
-        );
-
-        if ($response->getStatusCode() !== 204) {
-            $content = json_decode($response->getContent(false), true);
-            $message = $content['message'] ?? 'Unknown error';
+        if ($response['status_code'] !== 204) {
+            $message = $response['content']['message'] ?? 'Unknown error';
 
             CentreonLog::create()->error(
                 logTypeId: CentreonLog::TYPE_BUSINESS_LOG,


### PR DESCRIPTION
## Pull request overview

Implements a mechanism for “internal” HTTP API calls by rewriting generated absolute URLs to `127.0.0.1` and adjusting HTTP client options to avoid issues with proxies/load balancers.

**Changes:**
- Added `Core\Common\Infrastructure\Api\InternalApiClient` (URL rewriting + default HTTP options) and PHPUnit coverage.
- Updated several legacy configuration DB helper functions to route API calls through the localhost URL and disable TLS verification.
- Added `Router::generateLocalUrl()` as an alternative way to generate localhost absolute URLs.
