### PR TITLE
enh(media): increade from 2M to 5M upload limit for onPremise

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/help.po
@@ -2685,11 +2685,11 @@ msgstr "Suchtimeout"
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg files. "
 "Multiple images can be uploaded together inside archives like zip, tar, "
 "tar.gz or tar.bz2."
 msgstr ""
-"Wählen Sie eine Datei für den Upload. Es können jpg, png, gif und gd2-"
+"Wählen Sie eine Datei für den Upload. Es können jpg, png, gif, gd2 und svg-"
 "Dateien hochgeladen werden. Mehrere Bilder können in Archiven (zip, tar, "
 "tar.gz, tar.bz2) gleichzeitig hochgeladen werden."
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/help.po
@@ -2691,12 +2691,12 @@ msgstr "Duración máxima de la búsqueda antes de parar."
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg files. "
 "Multiple images can be uploaded together inside archives like zip, tar, "
 "tar.gz or tar.bz2."
 msgstr ""
 "Seleccione un archivo local para enviar. \n"
-"Puede enviar un archivo de tipo jpg, png, gif y gd2. \n"
+"Puede enviar un archivo de tipo jpg, png, gif, gd2 y svg. \n"
 "Se pueden enviar varias imágenes dentro de un archivo de tipo zip, tar, "
 "tar.gz o tar.bz2."
 

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -2766,12 +2766,12 @@ msgstr "Durée maximale de la recherche avant arrêt."
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg files. "
 "Multiple images can be uploaded together inside archives like zip, tar, "
 "tar.gz or tar.bz2."
 msgstr ""
 "Sélectionner un fichier local à envoyer. Vous pouvez envoyer un fichier de "
-"type jpg, png, gif et gd2. Plusieurs images peuvent être envoyées à "
+"type jpg, png, gif, gd2 et svg. Plusieurs images peuvent être envoyées à "
 "l'intérieur d'une archive de type zip, tar, tar.gz ou tar.bz2."
 
 #: centreon/www/include/configuration/configObject/escalation/help.php

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -10599,6 +10599,10 @@ msgstr "Délai maximum de répartition des contrôles initiaux de services"
 msgid "Maximum files size (in bytes)"
 msgstr "Taille maximale des fichiers (en octets)"
 
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Max file size : %s"
+msgstr "Taille de fichier max : %s"
+
 #: centreon/www/include/Administration/parameters/engine/form.php
 msgid "Maximum number of hosts to show"
 msgstr "Nombre maximum d'hôtes à afficher"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -10600,7 +10600,7 @@ msgid "Maximum files size (in bytes)"
 msgstr "Taille maximale des fichiers (en octets)"
 
 #: centreon/www/include/options/media/images/formImg.php
-msgid "Max file size : %s"
+msgid "Max file size: %s"
 msgstr "Taille de fichier max : %s"
 
 #: centreon/www/include/Administration/parameters/engine/form.php

--- a/centreon/lang/help.pot
+++ b/centreon/lang/help.pot
@@ -2147,7 +2147,7 @@ msgstr ""
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg files. "
 "Multiple images can be uploaded together inside archives like zip, tar, "
 "tar.gz or tar.bz2."
 msgstr ""

--- a/centreon/lang/messages.pot
+++ b/centreon/lang/messages.pot
@@ -35,7 +35,7 @@ msgid " Table is not partitioned "
 msgstr ""
 
 #: centreon/www/include/options/media/images/formImg.php
-msgid "Max file size : %s"
+msgid "Max file size: %s"
 msgstr ""
 
 #: centreon/www/include/monitoring/downtime/AddDowntime.php

--- a/centreon/lang/messages.pot
+++ b/centreon/lang/messages.pot
@@ -34,6 +34,10 @@ msgstr ""
 msgid " Table is not partitioned "
 msgstr ""
 
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Max file size : %s"
+msgstr ""
+
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid " The timezone used is configured on your user settings"
 msgstr ""

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/help.po
@@ -2679,12 +2679,12 @@ msgstr "Duração máxima da pesquisa antes de parar."
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg files. "
 "Multiple images can be uploaded together inside archives like zip, tar, "
 "tar.gz or tar.bz2."
 msgstr ""
 "Selecione um arquivo local para enviar. \n"
-"Você pode enviar um arquivo do tipo jpg, png, gif e gd2. \n"
+"Você pode enviar um arquivo do tipo jpg, png, gif, gd2 e svg. \n"
 "Múltiplas imagens podem ser enviadas dentro de um arquivo do tipo zip, tar, "
 "tar.gz ou tar.bz2."
 

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/help.po
@@ -2662,12 +2662,12 @@ msgstr "Duração máxima da pesquisa antes de parar."
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg files. "
 "Multiple images can be uploaded together inside archives like zip, tar, "
 "tar.gz or tar.bz2."
 msgstr ""
 "Selecione um ficheiro local para enviar. \n"
-"Você pode enviar um ficheiro do tipo jpg, png, gif e gd2. \n"
+"Você pode enviar um ficheiro do tipo jpg, png, gif, gd2 e svg. \n"
 "Múltiplas imagens podem ser enviadas dentro de um ficheiro do tipo zip, tar, "
 "tar.gz ou tar.bz2."
 

--- a/centreon/packaging/src/php.ini
+++ b/centreon/packaging/src/php.ini
@@ -4,3 +4,4 @@ session.gc_maxlifetime = 7200
 expose_php = Off
 allow_url_fopen = Off
 memory_limit = 256M
+upload_max_filesize = 5M

--- a/centreon/www/class/centreonImageManager.php
+++ b/centreon/www/class/centreonImageManager.php
@@ -28,11 +28,11 @@ use Pimple\Container;
  */
 class CentreonImageManager extends centreonFileManager
 {
+    private const LEGAL_SIZE = 2000000;
+    private const LEGAL_SIZE_EXTENDED = 5000000;
+
     /** @var string[] */
     protected $legalExtensions = ['jpg', 'jpeg', 'png', 'gif', 'svg'];
-
-    /** @var int */
-    protected $legalSize = 2000000;
 
     /** @var mixed */
     protected $dbConfig;
@@ -45,6 +45,7 @@ class CentreonImageManager extends centreonFileManager
      * @param $basePath
      * @param $destinationDir
      * @param string $comment
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         Container $dependencyInjector,
@@ -52,8 +53,10 @@ class CentreonImageManager extends centreonFileManager
         $basePath,
         $destinationDir,
         $comment = '',
+        bool $isCloudPlatform = false,
     ) {
         parent::__construct($dependencyInjector, $rawFile, $basePath, $destinationDir, $comment);
+        $this->legalSize = $isCloudPlatform ? self::LEGAL_SIZE : self::LEGAL_SIZE_EXTENDED;
         $this->dbConfig = $this->dependencyInjector['configuration_db'];
     }
 

--- a/centreon/www/include/options/media/images/formImg.ihtml
+++ b/centreon/www/include/options/media/images/formImg.ihtml
@@ -35,7 +35,7 @@
 				{else if $o == "w"}
 					{$form.img_path.html}
 				{/if}
-				&nbsp;&nbsp;(Max file size {$max_uploader_file})
+				&nbsp;&nbsp;({$max_uploader_file})
 			</td>
 		</tr>
 		<tr class="list_two">

--- a/centreon/www/include/options/media/images/formImg.php
+++ b/centreon/www/include/options/media/images/formImg.php
@@ -28,7 +28,10 @@ use Core\Common\Domain\Exception\ValueObjectException;
 use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 
 require_once _CENTREON_PATH_ . 'www/class/centreonImageManager.php';
+require_once _CENTREON_PATH_ . 'www/include/common/common-Func.php';
 require_once __DIR__ . '/../../../../../bootstrap.php';
+
+$isCloudPlatform = isCloudPlatform();
 
 const BASE_CENTREON_IMG_DIRECTORY = './img/media';
 
@@ -260,7 +263,8 @@ if ($form->validate()) {
             $_FILES,
             './img/media/',
             $imgPath,
-            $imgComment
+            $imgComment,
+            $isCloudPlatform
         );
         if ($form->getSubmitValue('submitA')) {
             $valid = $oImageUploader->upload();
@@ -282,7 +286,8 @@ if ($form->validate()) {
                 $file,
                 './img/media/',
                 $imgPath,
-                $imgComment
+                $imgComment,
+                $isCloudPlatform
             );
             if ($form->getSubmitValue('submitA')) {
                 $valid = $oImageUploader->uploadFromDirectory('pendingMedia');
@@ -312,7 +317,7 @@ if ($valid) {
     $renderer->setErrorTemplate('<font color="red">{$error}</font><br />{$html}');
     $form->accept($renderer);
     $tpl->assign('form', $renderer->toArray());
-    $tpl->assign('max_uploader_file', ini_get('upload_max_filesize'));
+    $tpl->assign('max_uploader_file', sprintf(_('Max file size : %s'), $isCloudPlatform ? '2M' : '5M'));
     $tpl->assign('o', $o);
     $tpl->display('formImg.ihtml');
 }

--- a/centreon/www/include/options/media/images/formImg.php
+++ b/centreon/www/include/options/media/images/formImg.php
@@ -317,7 +317,7 @@ if ($valid) {
     $renderer->setErrorTemplate('<font color="red">{$error}</font><br />{$html}');
     $form->accept($renderer);
     $tpl->assign('form', $renderer->toArray());
-    $tpl->assign('max_uploader_file', sprintf(_('Max file size : %s'), $isCloudPlatform ? '2M' : '5M'));
+    $tpl->assign('max_uploader_file', sprintf(_('Max file size: %s'), $isCloudPlatform ? '2M' : '5M'));
     $tpl->assign('o', $o);
     $tpl->display('formImg.ihtml');
 }

--- a/centreon/www/include/options/media/images/help.php
+++ b/centreon/www/include/options/media/images/help.php
@@ -28,8 +28,8 @@ $help['img_dir'] = dgettext(
 );
 $help['img_file'] = dgettext(
     'help',
-    'Select a local file to upload. You can upload jpg, png, gif and '
-    . 'gd2 files. Multiple images can be uploaded together inside '
+    'Select a local file to upload. You can upload jpg, png, gif, gd2 and '
+    . 'svg files. Multiple images can be uploaded together inside '
     . 'archives like zip, tar, tar.gz or tar.bz2.'
 );
 


### PR DESCRIPTION
This pull request updates the Centreon image upload functionality to support SVG files and introduces differentiated maximum upload file sizes for cloud and non-cloud platforms. It also improves user-facing help messages and translation files to reflect these changes.

**Image upload enhancements:**

* Added support for uploading `svg` files by including `svg` in the list of allowed image extensions in `centreonImageManager.php` and updating all related help and translation strings. [[1]](diffhunk://#diff-609bb9f577aae34f00c35068487b87e8509277e0638d2272c3bf01876d47c94dR31-L36) [[2]](diffhunk://#diff-c772429557f7fcbaf0daf45cade72b8f06403b39e985d9f720be5a24c1414e9dL31-R32) [[3]](diffhunk://#diff-3d22ed1d9dad8c3f2a1ed9b3eb38621c0051e46e84ea7c87052860aa5e092300L2688-R2692) [[4]](diffhunk://#diff-33c24344db061384a2cb3e92abec63ea838b04a8a34489669c7db84baf2f7dd3L2694-R2699) [[5]](diffhunk://#diff-d97d2614d0ee19c8691fce291afa1a9f43e15ab37d1d3f84e5cc056d74b723e8L2769-R2774) [[6]](diffhunk://#diff-f1ac22dee95d2185dd542f646e64be278702aa0afcf5b097c0fa88a589545974L2150-R2150) [[7]](diffhunk://#diff-f1a110e509e82305f7599fd8e08e3d44746b88239dd2a26d7e575171bd6e6b39L2682-R2687) [[8]](diffhunk://#diff-92ca5c11ef62f83f4eeaf92a4d9c8df5dc4847f48ca77506d585d630781f1f53L2665-R2670)

**Platform-specific upload size limits:**

* Introduced `LEGAL_SIZE` (2MB) and `LEGAL_SIZE_EXTENDED` (5MB) constants in `centreonImageManager.php`, and added logic to set the maximum file size based on whether the platform is cloud or not. [[1]](diffhunk://#diff-609bb9f577aae34f00c35068487b87e8509277e0638d2272c3bf01876d47c94dR31-L36) [[2]](diffhunk://#diff-609bb9f577aae34f00c35068487b87e8509277e0638d2272c3bf01876d47c94dR48-R59)
* Updated the image upload form to pass the `isCloudPlatform` flag and display the correct maximum file size to users (`2M` for cloud, `5M` for non-cloud). [[1]](diffhunk://#diff-0e15d985d0dbe1f17e42b11fb4f7cd3bb3e8ee0af68f3add140e327fdd7fae26R31-R35) [[2]](diffhunk://#diff-0e15d985d0dbe1f17e42b11fb4f7cd3bb3e8ee0af68f3add140e327fdd7fae26L263-R267) [[3]](diffhunk://#diff-0e15d985d0dbe1f17e42b11fb4f7cd3bb3e8ee0af68f3add140e327fdd7fae26L285-R290) [[4]](diffhunk://#diff-0e15d985d0dbe1f17e42b11fb4f7cd3bb3e8ee0af68f3add140e327fdd7fae26L315-R320)

**Configuration update:**

* Set the default PHP `upload_max_filesize` to `5M` in `php.ini` to align with the new maximum for non-cloud platforms.