### PR TITLE
fix: guiding lines graph

### DIFF
--- a/centreon/packages/ui/src/Graph/Chart/BasicComponents/Lines/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/BasicComponents/Lines/index.tsx
@@ -2,6 +2,7 @@ import type { ScaleLinear } from 'd3-scale';
 import { isNil } from 'ramda';
 import type { MutableRefObject } from 'react';
 
+import { Axis, AxisYRight } from '../../../common/Axes/models';
 import {
   getDates,
   getTimeSeriesForLines,
@@ -40,6 +41,12 @@ interface Props extends GlobalAreaLines {
   lineStyle: LineStyle | Array<LineStyle>;
   hasSecondUnit?: boolean;
   maxLeftAxisCharacters: number;
+  firstUnit?: string;
+  secondUnit?: string;
+  axis?: {
+    axisYLeft?: Axis;
+    axisYRight?: AxisYRight;
+  };
 }
 
 const Lines = ({
@@ -58,7 +65,10 @@ const Lines = ({
   scaleLogarithmicBase,
   lineStyle,
   hasSecondUnit,
-  maxLeftAxisCharacters
+  maxLeftAxisCharacters,
+  firstUnit,
+  secondUnit,
+  axis
 }: Props): JSX.Element => {
   const { stackedLinesData, invertedStackedLinesData } = useStackedLines({
     lines: displayedLines,
@@ -84,6 +94,15 @@ const Lines = ({
     maxLeftAxisCharacters,
     xScale
   };
+  const leftScale = yScalesPerUnit[axis?.axisYLeft?.unit ?? firstUnit];
+  const rightScale = yScalesPerUnit[axis?.axisYRight?.unit ?? secondUnit];
+  const hasUnitDisplayed =
+    Boolean(firstUnit || secondUnit) ||
+    Boolean(
+      axis?.axisYLeft?.unit ||
+        axis?.axisYLeft?.displayUnit ||
+        (axis?.axisYRight?.unit && axis?.axisYRight?.displayUnit)
+    );
 
   return (
     <g>
@@ -91,6 +110,12 @@ const Lines = ({
         <GuidingLines
           graphHeight={height}
           graphWidth={width}
+          hasSecondUnit={hasSecondUnit}
+          hasUnit={hasUnitDisplayed}
+          leftScale={leftScale}
+          lines={displayedLines}
+          maxLeftAxisCharacters={maxLeftAxisCharacters}
+          rightScale={rightScale}
           timeSeries={timeSeries}
           xScale={xScale}
         />

--- a/centreon/packages/ui/src/Graph/Chart/Chart.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/Chart.tsx
@@ -339,8 +339,10 @@ const Chart = ({
                 )}
                 {!isEmpty(linesDisplayedAsLine) && (
                   <Lines
+                    axis={axis}
                     displayAnchor={displayAnchor}
                     displayedLines={linesDisplayedAsLine}
+                    firstUnit={firstUnit}
                     graphSvgRef={graphSvgRef}
                     hasSecondUnit={hasSecondUnit}
                     height={graphHeight - marginTop}
@@ -348,6 +350,7 @@ const Chart = ({
                     maxLeftAxisCharacters={maxLeftAxisCharacters}
                     scale={axis?.scale}
                     scaleLogarithmicBase={axis?.scaleLogarithmicBase}
+                    secondUnit={secondUnit}
                     timeSeries={timeSeries}
                     width={graphWidth}
                     xScale={xScale}

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/GuidingLines.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/GuidingLines.tsx
@@ -1,6 +1,7 @@
 import { grey } from '@mui/material/colors';
 
 import { Shape } from '@visx/visx';
+import { ReactElement } from 'react';
 
 import type { GuidingLines as GuidingLinesModel } from './models';
 import useTickGraph from './useTickGraph';
@@ -9,9 +10,23 @@ const GuidingLines = ({
   timeSeries,
   xScale,
   graphHeight,
-  graphWidth
-}: GuidingLinesModel): JSX.Element | null => {
-  const { positionX, positionY, guidingLinesRef } = useTickGraph({
+  graphWidth,
+  maxLeftAxisCharacters,
+  hasSecondUnit,
+  lines,
+  leftScale,
+  rightScale,
+  hasUnit
+}: GuidingLinesModel): ReactElement | null => {
+  const { positionX, positionY } = useTickGraph({
+    graphHeight,
+    graphWidth,
+    hasSecondUnit,
+    hasUnit,
+    leftScale,
+    lines,
+    maxLeftAxisCharacters,
+    rightScale,
     timeSeries,
     xScale
   });
@@ -20,7 +35,7 @@ const GuidingLines = ({
   }
 
   return (
-    <g ref={guidingLinesRef}>
+    <>
       <Shape.Line
         fill="dotted"
         from={{ x: positionX, y: 0 }}
@@ -38,7 +53,7 @@ const GuidingLines = ({
         strokeWidth={1}
         to={{ x: graphWidth, y: positionY }}
       />
-    </g>
+    </>
   );
 };
 

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/GuidingLines.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/GuidingLines.tsx
@@ -19,8 +19,6 @@ const GuidingLines = ({
   hasUnit
 }: GuidingLinesModel): ReactElement | null => {
   const { positionX, positionY } = useTickGraph({
-    graphHeight,
-    graphWidth,
     hasSecondUnit,
     hasUnit,
     leftScale,

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/models.ts
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/models.ts
@@ -1,5 +1,6 @@
 import type { ScaleLinear, ScaleTime } from 'd3-scale';
 
+import { Axis, AxisYRight } from '../../../common/Axes/models';
 import type { Line, TimeValue } from '../../../common/timeSeries/models';
 
 interface AnchorPoint {
@@ -29,6 +30,12 @@ export interface GuidingLines {
   graphWidth: number;
   timeSeries: Array<TimeValue>;
   xScale: ScaleLinear<number, number>;
+  maxLeftAxisCharacters: number;
+  hasSecondUnit?: boolean;
+  leftScale?: ScaleLinear<number, number>;
+  lines: Array<Line>;
+  rightScale?: ScaleLinear<number, number>;
+  hasUnit?: boolean;
 }
 
 export interface GetYAnchorPoint {

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/models.ts
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/models.ts
@@ -1,6 +1,5 @@
 import type { ScaleLinear, ScaleTime } from 'd3-scale';
 
-import { Axis, AxisYRight } from '../../../common/Axes/models';
 import type { Line, TimeValue } from '../../../common/timeSeries/models';
 
 interface AnchorPoint {

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/useTickGraph.ts
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/useTickGraph.ts
@@ -8,6 +8,7 @@ import {
   useState
 } from 'react';
 
+import { Axis, AxisYRight } from '../../../common/Axes/models';
 import useAxisY from '../../../common/Axes/useAxisY';
 import { getTimeValue } from '../../../common/timeSeries';
 import type { Line, TimeValue } from '../../../common/timeSeries/models';
@@ -15,7 +16,6 @@ import {
   computeGElementMarginLeft,
   computPixelsToShiftMouse
 } from '../../../common/utils';
-import { margin } from '../../common';
 import { mousePositionAtom } from '../interactionWithGraphAtoms';
 
 interface AnchorPointResult {
@@ -36,6 +36,7 @@ interface Props {
   xScale: ScaleLinear<number, number>;
   hasSecondUnit?: boolean;
   maxLeftAxisCharacters: number;
+  hasUnit?: boolean;
 }
 
 const useTickGraph = ({
@@ -46,9 +47,9 @@ const useTickGraph = ({
   lines = [],
   baseAxis = 1000,
   hasSecondUnit,
-  maxLeftAxisCharacters
+  maxLeftAxisCharacters,
+  hasUnit
 }: Props): AnchorPointResult => {
-  const guidingLinesRef = useRef<SVGGElement | null>(null);
   const [tickAxisBottom, setTickAxisBottom] = useState<Date | null>(null);
   const [tickAxisLeft, setTickAxisLeft] = useState<string | null>(null);
   const [tickAxisRight, setTickAxisRight] = useState<string | null>(null);
@@ -57,19 +58,16 @@ const useTickGraph = ({
 
   const mousePosition = useAtomValue(mousePositionAtom);
 
-  const paddingLeftString = useMemo(
-    () =>
-      (
-        guidingLinesRef.current?.parentElement?.parentElement?.attributes
-          ?.transform.value || ''
-      ).match(/translate\(([0-9.]+), ([0-9.]+)\)/)?.[1] || '0',
-    []
-  );
-
   const positionX = mousePosition
-    ? mousePosition[0] - Number(paddingLeftString) - 1
+    ? mousePosition[0] -
+      computeGElementMarginLeft({
+        hasSecondUnit,
+        maxCharacters: maxLeftAxisCharacters
+      })
     : undefined;
-  const positionY = mousePosition ? mousePosition[1] - margin.top : undefined;
+  const positionY = mousePosition
+    ? mousePosition[1] - (hasUnit ? 29 : 4)
+    : undefined;
 
   useEffect(() => {
     if (!mousePosition) {
@@ -113,7 +111,6 @@ const useTickGraph = ({
   }, [mousePosition]);
 
   return {
-    guidingLinesRef,
     positionX,
     positionY,
     tickAxisBottom,

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/useTickGraph.ts
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/useTickGraph.ts
@@ -1,14 +1,7 @@
 import type { ScaleLinear } from 'd3-scale';
 import { useAtomValue } from 'jotai';
-import {
-  type MutableRefObject,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { type MutableRefObject, useEffect, useState } from 'react';
 
-import { Axis, AxisYRight } from '../../../common/Axes/models';
 import useAxisY from '../../../common/Axes/useAxisY';
 import { getTimeValue } from '../../../common/timeSeries';
 import type { Line, TimeValue } from '../../../common/timeSeries/models';


### PR DESCRIPTION
## Description

This fixes guiding lines in graph.

Before:
<img width="173" height="109" alt="Screenshot 2026-02-05 at 4 48 36 PM" src="https://github.com/user-attachments/assets/79113c9d-4ccc-4467-bd23-f75164ab754b" />

After:
<img width="217" height="101" alt="Screenshot 2026-02-05 at 4 50 49 PM" src="https://github.com/user-attachments/assets/0adb100b-dfe0-4dd8-9673-79d96d05ea25" />

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
