### PR TITLE
fix(hosts/services): correctly check empty values for commands in mass change

### DIFF
--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1390,8 +1390,7 @@ function updateHost_MC($hostId = null)
             $submittedValues['command_command_id_arg2'] = str_replace("\r", '#R#', $submittedValues['command_command_id_arg2']);
         }
     }
-
-    if (isset($submittedValues['command_command_id'])) {
+    if (! empty($submittedValues['command_command_id'])) {
         $commandRepository = $kernel->getContainer()->get(ReadCommandRepositoryInterface::class);
         $command = $commandRepository->findById((int) $submittedValues['command_command_id']);
         if ($command === null) {

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -1200,7 +1200,7 @@ function updateService_MCForCloud($serviceId = null, $parameters = [])
         $uuid = retrieveServiceSecretUuidFromDatabase($pearDB, $serviceId);
     }
 
-    if (isset($ret['command_command_id'])) {
+    if (! empty($ret['command_command_id'])) {
         $commandRepository = $kernel->getContainer()->get(ReadCommandRepositoryInterface::class);
         $command = $commandRepository->findById((int) $ret['command_command_id']);
         if ($command === null) {
@@ -2704,7 +2704,7 @@ function updateService_MC($service_id = null, $params = [])
         $vaultPath = retrieveServiceVaultPathFromDatabase($pearDB, $service_id);
     }
 
-    if (isset($ret['command_command_id'])) {
+    if (! empty($ret['command_command_id'])) {
         $commandRepository = $kernel->getContainer()->get(ReadCommandRepositoryInterface::class);
         $command = $commandRepository->findById((int) $ret['command_command_id']);
         if ($command === null) {


### PR DESCRIPTION
## Description

This PR intends to fix an issue where Mass Change were broke while not providing check command

**Fixes** # MON-194526

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
