### PR TITLE
fix(graphs): issues due to moment-timezone upgrade

### DIFF
--- a/centreon/www/include/views/graphs/javascript/centreon-graph.js
+++ b/centreon/www/include/views/graphs/javascript/centreon-graph.js
@@ -281,6 +281,7 @@
           } else {
               self.chart.load(self.buildMetricData(data[0]).data);
               self.chart.regions(self.buildRegions(data[0]));
+              self.buildLegend(data[0].metrics);
               self.buildExtraLegend(data[0].metrics);
           }
         }
@@ -512,8 +513,8 @@
       if (this.settings.period.startTime === null ||
         this.settings.period.endTime === null) {
 
-        start = moment().tz(this.timezone);
-        end = moment().tz(this.timezone);
+        start = moment.tz(this.timezone);
+        end = moment.tz(this.timezone);
 
         start.subtract(this.interval.number, this.interval.unit);
 
@@ -529,8 +530,9 @@
           myEnd = this.settings.period.endTime * 1000;
         }
 
-        start = moment().tz(myStart, this.timezone);
-        end = moment().tz(myEnd, this.timezone);
+
+        start = moment.tz(myStart, "YYYY-MM-DD HH:mm", this.timezone);
+        end = moment.tz(myEnd, "YYYY-MM-DD HH:mm", this.timezone);
       }
 
       return {
@@ -707,6 +709,9 @@
       var curveId;
       var i;
       var j;
+      // Clear existing legends before building new ones
+      this.legendDiv.empty();
+
       for (i = 0; i < legends.length; i++) {
         legend = legends[i];
         curveId = self.ids[legend.legend];


### PR DESCRIPTION
This pull request introduces improvements to the legend rendering and time handling in the `centreon-graph.js` file. The main focus is on ensuring legends are properly refreshed and displayed, and on correcting the way timezones are handled with the `moment.tz` library.

Legend rendering improvements:

* Ensured existing legends are cleared before building new ones by calling `this.legendDiv.empty()` in the legend-building logic, preventing duplicate or stale legend entries.
* Added a call to `self.buildLegend(data[0].metrics)` to ensure the legend is built whenever new metric data is loaded.

Timezone handling fixes:

* Updated the initialization of `start` and `end` times to use `moment.tz(this.timezone)` instead of chaining `.tz(this.timezone)` on `moment()`, improving timezone accuracy.
* Changed the creation of `start` and `end` times when specific period times are set to use `moment.tz(myStart, "YYYY-MM-DD HH:mm", this.timezone)` and `moment.tz(myEnd, "YYYY-MM-DD HH:mm", this.timezone)`, ensuring correct parsing and timezone handling.