### PR TITLE
fix close ticket with webservice not finding ticket if service has been moved from one host to another

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -288,7 +288,11 @@ class Automatic
         }
 
         $service['service_state'] = $service['state'];
-        $service['state_str'] = $params['service_state'];
+
+        if (isset($params['service_state'])) {
+            $service['state_str'] = $params['service_state'];
+        }
+        
         $service['last_state_change_duration'] = CentreonDuration::toString(
             time() - $service['last_state_change']
         );
@@ -736,14 +740,17 @@ class Automatic
      */
     protected function getServiceTicket($params, $macroName)
     {
-        $stmt = $this->dbCentstorage->prepare(
-            'SELECT SQL_CALC_FOUND_ROWS mot.ticket_value AS ticket_id 
-            FROM services s 
-            LEFT JOIN customvariables cv ON ( cv.service_id = :service_id AND cv.name = :macro_name)
-            LEFT JOIN mod_open_tickets mot ON cv.value = mot.ticket_value 
-            WHERE s.service_id = :service_id'
-        );
+        $query =<<<SQL
+            SELECT cv.value AS ticket_id
+            FROM customvariables cv
+            WHERE service_id = :service_id
+                AND host_id = :host_id
+                AND cv.name = :macro_name
+        SQL;
+
+        $stmt = $this->dbCentstorage->prepare($query);
         $stmt->bindParam(':service_id', $params['service_id'], PDO::PARAM_INT);
+        $stmt->bindParam(':host_id', $params['host_id'], PDO::PARAM_INT);
         $stmt->bindParam(':macro_name', $macroName, PDO::PARAM_STR);
 
         $stmt->execute();

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -292,7 +292,7 @@ class Automatic
         if (isset($params['service_state'])) {
             $service['state_str'] = $params['service_state'];
         }
-        
+
         $service['last_state_change_duration'] = CentreonDuration::toString(
             time() - $service['last_state_change']
         );
@@ -741,7 +741,7 @@ class Automatic
     protected function getServiceTicket($params, $macroName)
     {
         $query =<<<SQL
-            SELECT cv.value AS ticket_id
+            SELECT SQL_CALC_FOUND_ROWS cv.value AS ticket_id
             FROM customvariables cv
             WHERE service_id = :service_id
                 AND host_id = :host_id

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -349,7 +349,9 @@ class Automatic
         }
 
         $host['host_state'] = $host['state'];
-        $host['state_str'] = $params['host_state'];
+        if (isset($params['host_state'])) {
+            $host['state_str'] = $params['host_state'];
+        }
         $host['last_state_change_duration'] = CentreonDuration::toString(
             time() - $host['last_state_change']
         );
@@ -714,12 +716,12 @@ class Automatic
     protected function getHostTicket($params, $macroName)
     {
         $stmt = $this->dbCentstorage->prepare(
-            'SELECT SQL_CALC_FOUND_ROWS mot.ticket_value AS ticket_id 
-            FROM hosts h 
-            LEFT JOIN customvariables cv ON (h.host_id = cv.host_id 
-            AND (cv.service_id IS NULL or cv.service_id = 0) 
+            'SELECT mot.ticket_value AS ticket_id
+            FROM hosts h
+            LEFT JOIN customvariables cv ON (h.host_id = cv.host_id
+            AND (cv.service_id IS NULL or cv.service_id = 0)
             AND cv.name = :macro_name)
-            LEFT JOIN mod_open_tickets mot ON cv.value = mot.ticket_value 
+            LEFT JOIN mod_open_tickets mot ON cv.value = mot.ticket_value
             WHERE h.host_id = :host_id'
         );
         $stmt->bindParam(':macro_name', $macroName, PDO::PARAM_STR);
@@ -741,10 +743,11 @@ class Automatic
     protected function getServiceTicket($params, $macroName)
     {
         $query = <<<'SQL'
-                SELECT SQL_CALC_FOUND_ROWS cv.value AS ticket_id
+                SELECT mot.ticket_value AS ticket_id
                 FROM customvariables cv
-                WHERE service_id = :service_id
-                    AND host_id = :host_id
+                LEFT JOIN mod_open_tickets mot ON cv.value = mot.ticket_value
+                WHERE cv.service_id = :service_id
+                    AND cv.host_id = :host_id
                     AND cv.name = :macro_name
             SQL;
 

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -740,13 +740,13 @@ class Automatic
      */
     protected function getServiceTicket($params, $macroName)
     {
-        $query =<<<SQL
-            SELECT SQL_CALC_FOUND_ROWS cv.value AS ticket_id
-            FROM customvariables cv
-            WHERE service_id = :service_id
-                AND host_id = :host_id
-                AND cv.name = :macro_name
-        SQL;
+        $query = <<<'SQL'
+                SELECT SQL_CALC_FOUND_ROWS cv.value AS ticket_id
+                FROM customvariables cv
+                WHERE service_id = :service_id
+                    AND host_id = :host_id
+                    AND cv.name = :macro_name
+            SQL;
 
         $stmt = $this->dbCentstorage->prepare($query);
         $stmt->bindParam(':service_id', $params['service_id'], PDO::PARAM_INT);


### PR DESCRIPTION
## Description

for some reason, if you move a service from one host to another and you open a ticket on said service and try to close it from the open ticket webservice. It will either fail because it doesn't find any ticket or try to close the wrong ticket (if you opened a ticket a while ago on the service before moving it)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added SQL_CALC_FOUND_ROWS to improve result counting in queries

**🐛 Bugfixes**
* Fixed ticket closure lookup to correctly find moved service tickets

**🔧 Refactors**
* Fixed heredoc indentation to comply with backend linting rules


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92172135?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->