### PR TITLE
fix(ha): add support for MySQL

### DIFF
--- a/centreon-ha/bin/centreondb-smooth-backup.sh
+++ b/centreon-ha/bin/centreondb-smooth-backup.sh
@@ -106,10 +106,16 @@ get_current_logbin_file() {
 		mysqladmin --user="$DBROOTUSER" --password="$DBROOTPASSWORD" flush-logs
 	fi
 
-	if [ -z "$DBROOTPASSWORD" ] ; then
-		file=$(mysql -B -u "$DBROOTUSER" -e 'SHOW MASTER STATUS\G' 2>&1 | grep 'File:' | awk '{ print $2 }')
+	if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
+		_show_status="SHOW MASTER STATUS"
 	else
-		file=$(mysql -B -u "$DBROOTUSER" -p"$DBROOTPASSWORD" -e 'SHOW MASTER STATUS\G' 2>&1 | grep 'File:' | awk '{ print $2 }')
+		_show_status="SHOW BINARY LOG STATUS"
+	fi
+
+	if [ -z "$DBROOTPASSWORD" ] ; then
+		file=$(mysql -B -u "$DBROOTUSER" -e "$_show_status\G" 2>&1 | grep 'File:' | awk '{ print $2 }')
+	else
+		file=$(mysql -B -u "$DBROOTUSER" -p"$DBROOTPASSWORD" -e "$_show_status\G" 2>&1 | grep 'File:' | awk '{ print $2 }')
 	fi
 	if [ "$?" -ne "0" ] ; then
 		output_log "ERROR: connection MySQL to get index file." 1

--- a/centreon-ha/bin/centreondb-smooth-backup.sh
+++ b/centreon-ha/bin/centreondb-smooth-backup.sh
@@ -57,6 +57,16 @@ sql_fetch_db_binary
 sql_fetch_systemd_service
 sql_fetch_db_config
 
+if [ -z "$SQL_DB_BINARY" ] ; then
+    echo "ERROR: Cannot find MariaDB/MySQL binary." >&2
+    exit 1
+fi
+
+if [ -z "$SQL_SYSTEMD_SERVICE" ] ; then
+    echo "ERROR: Cannot find MariaDB/MySQL systemd service." >&2
+    exit 1
+fi
+
 logbin_activated=1
 
 #####

--- a/centreon-ha/bin/centreondb-smooth-backup.sh
+++ b/centreon-ha/bin/centreondb-smooth-backup.sh
@@ -9,6 +9,7 @@
 #
 ###################################################
 
+source /usr/share/centreon-ha/lib/mysql-functions.sh
 source /etc/centreon-ha/mysql-resources.sh
 
 OPT_TOTAL=1
@@ -50,10 +51,12 @@ MYSQL_CNF="/etc/my.cnf.d/server.cnf"
 READONLY_CHECK=1
 
 ###
-# Check MySQL launch
+# Get DB parameters
 ###
-process=$(ps -o args --no-headers -C mysqld)
-started=1
+sql_fetch_db_binary
+sql_fetch_systemd_service
+sql_fetch_db_config
+
 logbin_activated=1
 
 #####
@@ -120,53 +123,22 @@ output_log() {
 }
 
 ###
-# Find datadir AND logbin 
+# Find datadir AND logbin
 ###
-if [ -n "$process" ] ; then
-	datadir=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
-	etc_file=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-	logbin=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $1 }')
-	logbin_path=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $2 }')
-	pidname=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--pid-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-    if [ -n "$etc_file" ] ; then
-		MYSQL_CNF="$etc_file"
-	fi
-fi
+datadir="$SQL_CONF_DATADIR"
 
-if [ -z "$datadir" ] ; then
-	datadir=$(cat "$MYSQL_CNF" | grep -E '^datadir' | awk -F\= '{ print $2 }')
-fi
 if [ -z "$datadir" ] ; then
 	output_log "ERROR: Can't find MySQL datadir." 1
 	exit 1
 fi
-### Avoid datadir is a symlink (get the absolute path)
-datadir=$(cd "$datadir"; pwd -P)
 
-if [ -z "$pidname" ] ; then
-	pidname=$(cat "$MYSQL_CNF" | grep -E '^pid-file' | awk -F\= '{ print $2 }')
-fi
-if [ -z "$pidname" ] ; then
-	pidname=$(hostname | cut -d '.' -f 1)
-else
-	pidname=$(basename "$pidname" | cut -d '.' -f 1)
-fi
-
-if [ -z "$logbin" ] ; then
-	logbin=$(cat "$MYSQL_CNF" | grep -E '^log-bin' | awk -F\= '{ print $1 }')
-	logbin_path=$(cat "$MYSQL_CNF" | grep -E '^log-bin' | awk -F\= '{ print $2 }')
-fi
-if [ -z "$logbin" ] ; then
+if [ -z "$SQL_CONF_LOG_BIN_ARG" ] ; then
 	output_log "'log-bin' option not found. Can't do an incremental backup."
 	logbin_activated=0
 	OPT_INCR=0
 else
-	if [ -n "$logbin_path" ] ; then
-		logbin_files=$(basename "$logbin_path")
-		logbin_loc=$(dirname "$logbin_path")
-	else
-		logbin_files="$pidname-bin"
-	fi
+	logbin_files=$(basename "$SQL_CONF_LOG_BIN")
+	logbin_loc=$(dirname "$SQL_CONF_LOG_BIN")
 	if [ -z "$logbin_loc" ] || [ "$logbin_loc" = "." ] ; then
 		logbin_loc="$datadir"
 	fi
@@ -347,9 +319,9 @@ if [ "$PACEMAKER_ON" = "1" ] ; then
 	pcs resource unmanage "$PACEMAKER_RSC_MYSQL"
 fi
 i=0
-output_log "Stopping mysqld:" 0 1
-mysqladmin --user="$DBROOTUSER" --password="$DBROOTPASSWORD"  shutdown 
-while ps -o args --no-headers -C mysqld >/dev/null; do
+output_log "Stopping $SQL_DB_BINARY:" 0 1
+mysqladmin --user="$DBROOTUSER" --password="$DBROOTPASSWORD"  shutdown
+while ps -o args --no-headers -C "$SQL_DB_BINARY" >/dev/null; do
 	if [ "$i" -gt "$STOP_TIMEOUT" ] ; then
 		output_log ""
 		output_log "ERROR: Can't stop MySQL Server" 1
@@ -372,8 +344,8 @@ lvcreate -l $free_pe -s -n dbbackup $lv_name
 ###
 # Start server
 ###
-output_log "Start mysqld:"
-systemctl start mariadb
+output_log "Start $SQL_DB_BINARY:"
+systemctl start "$SQL_SYSTEMD_SERVICE"
 
 set_readonly
 

--- a/centreon-ha/bin/mysql-check-status.sh
+++ b/centreon-ha/bin/mysql-check-status.sh
@@ -12,6 +12,11 @@
 
 sql_fetch_db_binary
 
+if [ -z "$SQL_DB_BINARY" ] ; then
+	echo "ERROR: Cannot find MariaDB/MySQL binary." >&2
+	exit 1
+fi
+
 if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
 	SQL_SHOW_REPLICA_STATUS="SHOW SLAVE STATUS"
 	SQL_SHOW_PRIMARY_STATUS="SHOW MASTER STATUS"

--- a/centreon-ha/bin/mysql-check-status.sh
+++ b/centreon-ha/bin/mysql-check-status.sh
@@ -10,6 +10,23 @@
 . /usr/share/centreon-ha/lib/mysql-functions.sh
 . /etc/centreon-ha/mysql-resources.sh
 
+sql_fetch_db_binary
+
+if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
+	SQL_SHOW_REPLICA_STATUS="SHOW SLAVE STATUS"
+	SQL_SHOW_PRIMARY_STATUS="SHOW MASTER STATUS"
+	SQL_FIELD_IO_RUNNING="Slave_IO_Running"
+	SQL_FIELD_SQL_RUNNING="Slave_SQL_Running"
+	SQL_FIELD_LOG_FILE="Master_Log_File"
+	SQL_FIELD_LOG_POS="Read_Master_Log_Pos"
+else
+	SQL_SHOW_REPLICA_STATUS="SHOW REPLICA STATUS"
+	SQL_SHOW_PRIMARY_STATUS="SHOW BINARY LOG STATUS"
+	SQL_FIELD_IO_RUNNING="Replica_IO_Running"
+	SQL_FIELD_SQL_RUNNING="Replica_SQL_Running"
+	SQL_FIELD_LOG_FILE="Source_Log_File"
+	SQL_FIELD_LOG_POS="Read_Source_Log_Pos"
+fi
 
 append_error_msg()
 {
@@ -85,9 +102,9 @@ replication_status()
 	slave_status_error_append=""
 	slave_address=""
 	if [ "$connexion_status_server1" -eq 0 ] ; then
-		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMEMASTER" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -qi 'Slave_IO_Running: Yes'
+		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMEMASTER" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -qi "${SQL_FIELD_IO_RUNNING}: Yes"
 		status_io_thread1=$?
-		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMEMASTER" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -qi 'Slave_SQL_Running: Yes'
+		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMEMASTER" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -qi "${SQL_FIELD_SQL_RUNNING}: Yes"
 		status_sql_thread1=$?
 	else
 		status_io_thread1=100
@@ -95,9 +112,9 @@ replication_status()
 	fi
 	
 	if [ "$connexion_status_server2" -eq 0 ] ; then
-		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMESLAVE" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -qi 'Slave_IO_Running: Yes'
+		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMESLAVE" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -qi "${SQL_FIELD_IO_RUNNING}: Yes"
 		status_io_thread2=$?
-		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMESLAVE" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -qi 'Slave_SQL_Running: Yes'
+		mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMESLAVE" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -qi "${SQL_FIELD_SQL_RUNNING}: Yes"
 		status_sql_thread2=$?
 	else
 		status_io_thread2=100
@@ -117,7 +134,7 @@ replication_status()
 
 			# Cas ou le thread SQL est arrete a cause d'une erreur
 			if [ "$status_sql_thread1" -ne 0 ] ; then
-				last_error=$(mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMEMASTER" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -i 'Last_Error' | awk '{ for (i = 2; i < NF; i++) { myerror = myerror " " $i } } END { print myerror } ')
+				last_error=$(mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMEMASTER" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -i 'Last_Error' | awk '{ for (i = 2; i < NF; i++) { myerror = myerror " " $i } } END { print myerror } ')
 				if [ -n "$last_error" ] ; then
 					slave_status=1
 					append_error_msg "slave_status_error" "SQL Thread is stopped because of an error (error='$last_error')." "slave_status_error_append"
@@ -130,7 +147,7 @@ replication_status()
 
 			# Cas ou le thread SQL est arrete a cause d'une erreur
 			if [ "$status_sql_thread2" -ne 0 ] ; then
-				last_error=$(mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMESLAVE" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -i 'Last_Error' | awk '{ for (i = 2; i < NF; i++) { myerror = myerror " " $i } } END { print myerror }')
+				last_error=$(mysql -f -u "$DBROOTUSER" -h "$DBHOSTNAMESLAVE" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -i 'Last_Error' | awk '{ for (i = 2; i < NF; i++) { myerror = myerror " " $i } } END { print myerror }')
 				if [ -n "$last_error" ] ; then
 					slave_status=1
 					append_error_msg "slave_status_error" "SQL Thread is stopped because of an error (error='$last_error')." "slave_status_error_append"
@@ -180,14 +197,14 @@ replication_status()
 			append_error_msg "position_status_error" "Can't get master position on '$master_address'." "position_status_error_append"	
 		else
 			# get master position
-			temp_read=$(mysql -f -u "$DBROOTUSER" -h "$master_address" "-p$DBROOTPASSWORD" -e 'SHOW MASTER STATUS\G' | grep -iE 'File|Position')
+			temp_read=$(mysql -f -u "$DBROOTUSER" -h "$master_address" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_PRIMARY_STATUS\G" | grep -iE 'File|Position')
 			master_file=$(echo "$temp_read" | grep -i 'File' | awk '{ print $2 }')
 			master_position=$(echo "$temp_read" | grep -i 'Position' | awk '{ print $2 }')
 
 			# get slave position (pas besoin de verifier)
-			temp_read=$(mysql -f -u "$DBROOTUSER" -h "$slave_address" "-p$DBROOTPASSWORD" -e 'SHOW SLAVE STATUS\G' | grep -iE '[^a-zA-Z_]Master_Log_File|Read_Master_Log_Pos')
-			slave_file=$(echo "$temp_read" | grep -i 'Master_Log_File' | awk '{ print $2 }')
-			slave_position=$(echo "$temp_read" | grep -i 'Read_Master_Log_Pos' | awk '{ print $2 }')
+			temp_read=$(mysql -f -u "$DBROOTUSER" -h "$slave_address" "-p$DBROOTPASSWORD" -e "$SQL_SHOW_REPLICA_STATUS\G" | grep -iE "[^a-zA-Z_]${SQL_FIELD_LOG_FILE}|${SQL_FIELD_LOG_POS}")
+			slave_file=$(echo "$temp_read" | grep -i "${SQL_FIELD_LOG_FILE}" | awk '{ print $2 }')
+			slave_position=$(echo "$temp_read" | grep -i "${SQL_FIELD_LOG_POS}" | awk '{ print $2 }')
 
 			# Slave I/O thread wrong
 

--- a/centreon-ha/bin/mysql-sync-bigdb.sh
+++ b/centreon-ha/bin/mysql-sync-bigdb.sh
@@ -181,7 +181,11 @@ fi
 ############# END SANITY CHECK
 #############
 
-gtid_current_pos=$(mysql -B -N -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e 'SET GLOBAL read_only = ON; SELECT @@gtid_current_pos')
+if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
+    gtid_current_pos=$(mysql -B -N -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e 'SET GLOBAL read_only = ON; SELECT @@gtid_current_pos')
+else
+    gtid_current_pos=$(mysql -B -N -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e 'SET GLOBAL read_only = ON; SELECT @@gtid_executed')
+fi
 if ! echo "$gtid_current_pos" | grep -qE '[0-9]+-[0-9]+-[0-9]+' ; then
     mysql -B -N -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e 'SET GLOBAL read_only = OFF;'
     echo "ERROR: cannot get gtid current pos"
@@ -312,15 +316,28 @@ echo "OK"
 # Demarrer la replication
 ###
 echo "Start Replication"
-mysql -f -u "$DBROOTUSER" -h "$slave_hostname" -p"$DBROOTPASSWORD" << EOF
+if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
+    mysql -f -u "$DBROOTUSER" -h "$slave_hostname" -p"$DBROOTPASSWORD" << EOF
 RESET MASTER;
 STOP SLAVE;
 RESET SLAVE;
 SET GLOBAL gtid_slave_pos = '$gtid_current_pos';
 CHANGE MASTER TO MASTER_HOST='$master_hostname', MASTER_USER='$DBREPLUSER', MASTER_PASSWORD='$DBREPLPASSWORD', master_use_gtid=slave_pos;
 START SLAVE;
-show processlist;
+SHOW PROCESSLIST;
 quit
 EOF
+else
+    mysql -f -u "$DBROOTUSER" -h "$slave_hostname" -p"$DBROOTPASSWORD" << EOF
+RESET MASTER;
+STOP REPLICA;
+RESET REPLICA ALL;
+SET GLOBAL gtid_purged = '$gtid_current_pos';
+CHANGE REPLICATION SOURCE TO SOURCE_HOST='$master_hostname', SOURCE_USER='$DBREPLUSER', SOURCE_PASSWORD='$DBREPLPASSWORD', SOURCE_AUTO_POSITION=1;
+START REPLICA;
+SHOW PROCESSLIST;
+quit
+EOF
+fi
 
 exit 0

--- a/centreon-ha/bin/mysql-sync-bigdb.sh
+++ b/centreon-ha/bin/mysql-sync-bigdb.sh
@@ -186,7 +186,12 @@ if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
 else
     gtid_current_pos=$(mysql -B -N -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e 'SET GLOBAL read_only = ON; SELECT @@gtid_executed')
 fi
-if ! echo "$gtid_current_pos" | grep -qE '[0-9]+-[0-9]+-[0-9]+' ; then
+if [ "$SQL_IS_MARIADB" -eq 1 ] ; then
+    _gtid_pattern='[0-9]+-[0-9]+-[0-9]+'
+else
+    _gtid_pattern='[0-9a-fA-F-]+:[0-9]+'
+fi
+if ! echo "$gtid_current_pos" | grep -qE "$_gtid_pattern" ; then
     mysql -B -N -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e 'SET GLOBAL read_only = OFF;'
     echo "ERROR: cannot get gtid current pos"
     exit 1

--- a/centreon-ha/bin/mysql-sync-bigdb.sh
+++ b/centreon-ha/bin/mysql-sync-bigdb.sh
@@ -166,6 +166,8 @@ fi
 
 slave_hostname=$(get_other_db_hostname)
 master_hostname=$(get_other_db_hostname $slave_hostname)
+# Note: SQL_DB_BINARY and SQL_SYSTEMD_SERVICE are detected locally.
+# Both HA nodes are assumed to run the same database engine.
 echo "Connection to slave Server (verify mysql stopped): $slave_hostname"
 result=$($USER_SUDO ssh -p $SSH_PORT $slave_hostname 'if ps --no-headers -C '"$SQL_DB_BINARY"' >/dev/null; then echo "yes" ; else echo "no"; fi')
 if [ "$result" != "no" ] ; then

--- a/centreon-ha/bin/mysql-sync-bigdb.sh
+++ b/centreon-ha/bin/mysql-sync-bigdb.sh
@@ -334,7 +334,7 @@ quit
 EOF
 else
     mysql -f -u "$DBROOTUSER" -h "$slave_hostname" -p"$DBROOTPASSWORD" << EOF
-RESET MASTER;
+RESET BINARY LOGS AND GTIDS;
 STOP REPLICA;
 RESET REPLICA ALL;
 SET GLOBAL gtid_purged = '$gtid_current_pos';

--- a/centreon-ha/bin/mysql-sync-bigdb.sh
+++ b/centreon-ha/bin/mysql-sync-bigdb.sh
@@ -38,9 +38,7 @@ STOP_TIMEOUT=60
 SNAPSHOT_MOUNT_PATH="/mnt/"
 USER="mysql"
 USER_SUDO="sudo -u $USER"
-MYSQLBINARY="mariadbd"
 MYSQLADMIN="mysqladmin"
-MYSQL_START="systemctl start mariadb"
 SUDO_MYSQL_START_SLAVE="sudo"
 SSH_PORT="22"
 RSYNC_EXTRA_OPTIONS="--checksum"
@@ -61,91 +59,45 @@ if [ "$?" -ne "0" ] ; then
 fi
 
 ###
-# Check MySQL launch
+# Get DB parameters
 ###
-process=$(ps -o args --no-headers -C ${MYSQLBINARY})
-started=0
+sql_fetch_db_binary
+sql_fetch_systemd_service
+sql_fetch_db_config
 
-###
-# Find datadir
-###
-if [ -n "$process" ] ; then
-    datadir=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
-    etc_file=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-    logbin=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $1 }')
-    logbin_path=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $2 }')
-    pidname=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--pid-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-    relaylog=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--relay-log")) { print $i } } }' | awk -F\= '{ print $1 }')
-    relaylog_path=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--relay-log")) { print $i } } }' | awk -F\= '{ print $2 }')
-    started=1
+if [ -z "$SQL_DB_BINARY" ] ; then
+    echo "Cannot find MariaDB/MySQL binary." >&2
+    exit 1
 fi
 
-if [ -n "$etc_file" ] ; then
-    mariadbd_options=$($MYSQLBINARY --print-defaults --defaults-file="$etc_file")
-else
-    mariadbd_options=$($MYSQLBINARY --print-defaults)
-fi
-mariadbd_options=$(echo $mariadbd_options | awk '{ for (i = 1; i < NF; i++) { print $i } }')
-
-if [ -z "$datadir" ] ; then
-    datadir=$(echo "$mariadbd_options" | grep -E '^--datadir=' | awk -F\= '{ print $2; exit 0 }')
+if [ -z "$SQL_SYSTEMD_SERVICE" ] ; then
+    echo "Cannot find MariaDB/MySQL systemd service." >&2
+    exit 1
 fi
 
-if [ -z "$datadir" ] ; then
+if [ -z "$SQL_CONF_DATADIR" ] ; then
     echo "ERROR: Can't find MySQL datadir." >&2
     exit 1
 fi
-### Avoid datadir is a symlink (get the absolute path)
-datadir=$(cd "$datadir"; pwd -P)
 
-if [ -z "$pidname" ] ; then
-    pidname=$(echo "$mariadbd_options" | grep -E '^--pid-file=' | awk -F\= '{ print $2; exit 0 }')
-fi
-if [ -z "$pidname" ] ; then
-    pidname=$(hostname | cut -d '.' -f 1)
-else
-    pidname=$(basename "$pidname" | cut -d '.' -f 1)
-fi
-
-if [ -z "$logbin" ] ; then
-    logbin=$(echo "$mariadbd_options" | grep -E '^--log-bin=' | awk -F\= '{ print $1 }')
-    logbin_path=$(echo "$mariadbd_options" | grep -E '^--log-bin=' | awk -F\= '{ print $2 }')
-fi
-if [ -z "$logbin" ] ; then
-    echo "'log-bin' option not found. Can't sync."
+if [ -z "$SQL_CONF_LOG_BIN_ARG" ] ; then
+    echo "'log-bin' option not found. Can't sync." >&2
     exit 1
-else
-    if [ -n "$logbin_path" ] ; then
-        logbin_files=$(basename "$logbin_path")
-        logbin_loc=$(dirname "$logbin_path")
-    else
-        logbin_files="$pidname-bin"
-    fi
-    if [ -z "$logbin_loc" ] || [ "$logbin_loc" = "." ] ; then
-        logbin_loc="$datadir"
-    fi
 fi
 
-if [ -z "$relaylog" ] ; then
-    relaylog=$(echo "$mariadbd_options" | grep -E '^--relay-log=' | awk -F\= '{ print $1 }')
-    relaylog_path=$(echo "$mariadbd_options" | grep -E '^--relay-log=' | awk -F\= '{ print $2 }')
-fi
-if [ -z "$relaylog" ] ; then
-    relaylog_loc="$datadir"
-    relaylog_files="$pidname-relay-bin"
-else
-    if [ -n "$relaylog_path" ] ; then
-        relaylog_files=$(basename "$relaylog_path")
-        relaylog_loc=$(dirname "$relaylog_path")
-    else
-        relaylog_files="$pidname-relay-bin" 
-    fi
-    if [ -z "$relaylog_loc" ] ; then
-        relaylog_loc="$datadir"
-    fi
+logbin_files=$(basename "$SQL_CONF_LOG_BIN")
+logbin_loc=$(dirname "$SQL_CONF_LOG_BIN")
+if [ -z "$logbin_loc" ] || [ "$logbin_loc" = "." ] ; then
+    logbin_loc="$SQL_CONF_DATADIR"
 fi
 
-echo "MySQL datadir found: $datadir"
+relaylog_files=$(basename "$SQL_CONF_RELAY_LOG")
+relaylog_loc=$(dirname "$SQL_CONF_RELAY_LOG")
+if [ -z "$relaylog_loc" ] || [ "$relaylog_loc" = "." ] ; then
+    relaylog_loc="$SQL_CONF_DATADIR"
+fi
+
+echo "MySQL datadir found: $SQL_CONF_DATADIR"
 echo "MySQL logbin files: $logbin_files"
 echo "MySQL logbin localisation: $logbin_loc"
 echo "MySQL relaylog files: $relaylog_files"
@@ -154,8 +106,8 @@ echo "MySQL relaylog localisation: $relaylog_loc"
 ###
 # Get mount datadir
 ###
-mount_device=$(df -P "$datadir" | tail -1 | awk '{ print $1 }')
-mount_point=$(df -P "$datadir" | tail -1 | awk '{ print $6 }')
+mount_device=$(df -P "$SQL_CONF_DATADIR" | tail -1 | awk '{ print $1 }')
+mount_point=$(df -P "$SQL_CONF_DATADIR" | tail -1 | awk '{ print $6 }')
 if [ -z "$mount_device" ] ; then
     echo "ERROR: Can't get mount device for datadir." >&2
     exit 1
@@ -215,12 +167,12 @@ fi
 slave_hostname=$(get_other_db_hostname)
 master_hostname=$(get_other_db_hostname $slave_hostname)
 echo "Connection to slave Server (verify mysql stopped): $slave_hostname"
-result=$($USER_SUDO ssh -p $SSH_PORT $slave_hostname 'if ps --no-headers -C '"$MYSQLBINARY"' >/dev/null; then echo "yes" ; else echo "no"; fi')
+result=$($USER_SUDO ssh -p $SSH_PORT $slave_hostname 'if ps --no-headers -C '"$SQL_DB_BINARY"' >/dev/null; then echo "yes" ; else echo "no"; fi')
 if [ "$result" != "no" ] ; then
     echo "ERROR: MySQL is launched or problem to connect to the server." >&2
     exit 1
 fi
-if [ "$started" -eq 0 ] ; then
+if [ "$SQL_IS_RUNNING" -eq 0 ] ; then
     echo "ERROR: MySQL master is not started." >&2
     exit 1
 fi
@@ -239,9 +191,9 @@ fi
 echo "gtid_current_pos = " $gtid_current_pos
 
 i=0
-echo -n "Stopping $MYSQLBINARY:"
+echo -n "Stopping $SQL_DB_BINARY:"
 $MYSQLADMIN -f -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" shutdown
-while ps -o args --no-headers -C $MYSQLBINARY >/dev/null; do
+while ps -o args --no-headers -C "$SQL_DB_BINARY" >/dev/null; do
     if [ "$i" -gt "$STOP_TIMEOUT" ] ; then
         echo ""
         echo "ERROR: Can't stop MySQL Server" >&2
@@ -267,8 +219,8 @@ fi
 ###
 # Start server
 ###
-echo "Start $MYSQLBINARY: ($MYSQL_START)"
-$MYSQL_START &
+echo "Start $SQL_DB_BINARY: (systemctl start $SQL_SYSTEMD_SERVICE)"
+systemctl start "$SQL_SYSTEMD_SERVICE" &
 i=0
 until mysqlshow -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" > /dev/null 2>&1; do
     if [ "$i" -gt "$STOP_TIMEOUT" ] ; then
@@ -296,11 +248,11 @@ mysql -f -u "$DBROOTUSER" -h "$master_hostname" -p"$DBROOTPASSWORD" -e "SET GLOB
 echo "Mount LVM snapshot"
 SNAPSHOT_DATADIR_MOUNT="$SNAPSHOT_MOUNT_PATH/snap-dbbackupdatadir"
 mkdir -p "$SNAPSHOT_DATADIR_MOUNT"
-TYPEFS_BACKUP=$(df -T "$datadir" | tail -1 | awk -F' ' '{print $(NF-5)}')
+TYPEFS_BACKUP=$(df -T "$SQL_CONF_DATADIR" | tail -1 | awk -F' ' '{print $(NF-5)}')
 [ "$TYPEFS_BACKUP"  = "xfs" ] && MNTOPTIONS="-o nouuid"
 mount $MNTOPTIONS /dev/$vg_name/dbbackupdatadir "$SNAPSHOT_DATADIR_MOUNT"
 
-concat_datadir=$(echo "$datadir" | sed "s#^${mount_point}##")
+concat_datadir=$(echo "$SQL_CONF_DATADIR" | sed "s#^${mount_point}##")
 
 ###
 # Delete from other side
@@ -314,7 +266,7 @@ $USER_SUDO ssh -p $SSH_PORT $slave_hostname "rm -f \"${logbin_loc}/${logbin_file
 ###
 
 echo "Rsync in progress (exclude MySQL, ${logbin_files}, ${relaylog_files})"
-rsync -av $RSYNC_EXTRA_OPTIONS --delete --progress --exclude="mysql" --exclude="${pidname}.pid" --exclude="${logbin_files}*" --exclude="${relaylog_files}*" --exclude="auto.cnf" --exclude=".ssh/*" "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/" -e "$USER_SUDO ssh -p $SSH_PORT" $slave_hostname:$datadir/
+rsync -av $RSYNC_EXTRA_OPTIONS --delete --progress --exclude="mysql" --exclude="${SQL_CONF_PID_FILE}.pid" --exclude="${logbin_files}*" --exclude="${relaylog_files}*" --exclude="auto.cnf" --exclude=".ssh/*" "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/" -e "$USER_SUDO ssh -p $SSH_PORT" $slave_hostname:$SQL_CONF_DATADIR/
 
 mysql_ibd_system=''
 for file in $(ls "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/mysql/"*.ibd); do
@@ -322,12 +274,12 @@ for file in $(ls "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/mysql/"*.ibd); do
     mysql_ibd_system="$mysql_ibd_system \"$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/mysql/$filename.ibd\" \"$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/mysql/$filename.frm\""
 done
 if [ -n "$mysql_ibd_system" ] ; then
-    eval rsync -av $RSYNC_EXTRA_OPTIONS --progress $mysql_ibd_system -e \"\$USER_SUDO ssh -p $SSH_PORT\" \$slave_hostname:\"\$datadir/mysql/\"
+    eval rsync -av $RSYNC_EXTRA_OPTIONS --progress $mysql_ibd_system -e \"\$USER_SUDO ssh -p $SSH_PORT\" \$slave_hostname:\"\$SQL_CONF_DATADIR/mysql/\"
 fi
 
 # Mode Fastest. Uncomment this and comment line above
-#rsync -av --delete --progress --exclude="*.MYI" --exclude="*.MYD" --exclude="mysql" --exclude="${pidname}.pid" --exclude="${logbin_files}*" --exclude="${relaylog_files}*" --exclude=".ssh/*" "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/" -e "$USER_SUDO ssh -p $SSH_PORT" $slave_hostname:$datadir/
-#rsync -av --size-only --delete --progress --include='*/' --exclude="mysql" --include='*.MYI' --include='*.MYD' --exclude='*' --exclude=".ssh/*" "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/" -e "ssh -i /var/lib/mysql/.ssh/id_rsa -p $SSH_PORT" $USER@$slave_hostname:$datadir/
+#rsync -av --delete --progress --exclude="*.MYI" --exclude="*.MYD" --exclude="mysql" --exclude="${SQL_CONF_PID_FILE}.pid" --exclude="${logbin_files}*" --exclude="${relaylog_files}*" --exclude=".ssh/*" "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/" -e "$USER_SUDO ssh -p $SSH_PORT" $slave_hostname:$SQL_CONF_DATADIR/
+#rsync -av --size-only --delete --progress --include='*/' --exclude="mysql" --include='*.MYI' --include='*.MYD' --exclude='*' --exclude=".ssh/*" "$SNAPSHOT_DATADIR_MOUNT/$concat_datadir/" -e "ssh -i /var/lib/mysql/.ssh/id_rsa -p $SSH_PORT" $USER@$slave_hostname:$SQL_CONF_DATADIR/
 
 ###
 # Suppression du snapshot
@@ -342,7 +294,7 @@ lvremove -f /dev/$vg_name/dbbackupdatadir
 ###
 
 echo "Start MySQL Slave"
-$USER_SUDO ssh -p $SSH_PORT $slave_hostname -- "$SUDO_MYSQL_START_SLAVE $MYSQL_START &"
+$USER_SUDO ssh -p $SSH_PORT $slave_hostname -- "$SUDO_MYSQL_START_SLAVE systemctl start '$SQL_SYSTEMD_SERVICE' &"
 i=0
 until mysqlshow -u "$DBROOTUSER" -h "$slave_hostname" -p"$DBROOTPASSWORD" > /dev/null 2>&1; do
         if [ "$i" -gt "$STOP_TIMEOUT" ] ; then

--- a/centreon-ha/bin/purge_mysql_parts.sh
+++ b/centreon-ha/bin/purge_mysql_parts.sh
@@ -1,32 +1,22 @@
 #!/bin/bash
 
+source /usr/share/centreon-ha/lib/mysql-functions.sh
+
 PARTITION_NAME="centreon_storage/data_bin"
 DB_ROOT_USER="root"
 DB_ROOT_PASSWORD=""
 
-process=$(ps -o args --no-headers -C mysqld)
-started=0
+sql_fetch_db_binary
+sql_fetch_db_config
 
 ####
 # Find DATADIR
 ####
-if [ -n "$process" ] ; then
-	datadir=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
-	etc_file=$(echo "$process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-	started=1
-fi
-if [ -z "$etc_file" ] ; then
-	etc_file="/etc/my.cnf"
-fi
-if [ -z "$datadir" ] ; then
-	datadir=$(cat "$etc_file" | grep -E '^datadir' | awk -F\= '{ print $2 }')
-fi
+datadir="$SQL_CONF_DATADIR"
 if [ -z "$datadir" ] ; then
 	echo "ERROR: Can't find MySQL datadir." >&2
 	exit 1
 fi
-### Avoid datadir is a symlink (get the absolute path)
-datadir=$(cd "$datadir"; pwd -P)
 
 echo "MySQL datadir found: $datadir"
 
@@ -50,7 +40,7 @@ for partition in $PARTITION_NAME; do
 	else
 		result=$(mysql -B -u "$DB_ROOT_USER" -p"$DB_ROOT_PASSWORD" -e "$request")
 	fi
-	
+
 	for file in "$datadir/$partition#P#"* ; do
 		partition_part=$(basename "$file" | perl -p -e "s/$tmp_table#P#(.*?)\..*/\1/;")
 		if [ -n "$partition_part" ] ; then

--- a/centreon-ha/lib/mysql-functions.sh
+++ b/centreon-ha/lib/mysql-functions.sh
@@ -25,6 +25,7 @@ sql_fetch_db_binary()
     fi
 
     # order is important as mariadb installs a mysqld symlink
+    local _test_binary
     for _test_binary in mariadbd mysqld; do
         command -v "$_test_binary" &>/dev/null
         if [ $? -eq 0 ]; then
@@ -46,6 +47,7 @@ sql_fetch_systemd_service()
     fi
 
     # order is important as mariadb installs symlinks
+    local _test_service
     for _test_service in mariadb mysql; do
         if systemctl list-unit-files "$_test_service.service" 2>/dev/null | grep -q "$_test_service.service"; then
             SQL_SYSTEMD_SERVICE="$_test_service"
@@ -64,6 +66,7 @@ sql_fetch_db_running()
         return 1
     fi
 
+    local _process
     _process=$(ps -o args --no-headers -C "${SQL_DB_BINARY}" | head -1)
 
     if [ -n "$_process" ] ; then
@@ -81,15 +84,16 @@ sql_fetch_db_config()
         return 1
     fi
 
+    local _process _options
     _process=$(ps -o args --no-headers -C "${SQL_DB_BINARY}" | head -1)
 
     if [ -n "$_process" ] ; then
-        SQL_CONF_DATADIR=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_DEFAULTS_FILE=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_LOG_BIN_ARG=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $1 }')
-        SQL_CONF_LOG_BIN=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_PID_FILE=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--pid-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_RELAY_LOG=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--relay-log")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_DATADIR=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "^--datadir=")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_DEFAULTS_FILE=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "^--defaults-file=")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_LOG_BIN_ARG=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "^--log-bin=")) { print $i } } }' | awk -F\= '{ print $1 }')
+        SQL_CONF_LOG_BIN=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "^--log-bin=")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_PID_FILE=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "^--pid-file=")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_RELAY_LOG=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "^--relay-log=")) { print $i } } }' | awk -F\= '{ print $2 }')
         SQL_IS_RUNNING=1
     else
         SQL_IS_RUNNING=0

--- a/centreon-ha/lib/mysql-functions.sh
+++ b/centreon-ha/lib/mysql-functions.sh
@@ -4,6 +4,132 @@
 # bash common functions for mysql replication management scripts #
 ##################################################################
 
+SQL_DB_BINARY=
+SQL_SYSTEMD_SERVICE=
+SQL_IS_RUNNING=0
+
+SQL_CONF_DATADIR=
+SQL_CONF_DEFAULTS_FILE=
+SQL_CONF_LOG_BIN_ARG=
+SQL_CONF_LOG_BIN=
+SQL_CONF_PID_FILE=
+SQL_CONF_RELAY_LOG=
+
+SQL_OPTIONS=
+
+sql_fetch_db_binary()
+{
+    if [ -n "$SQL_DB_BINARY" ] ; then
+        return 0
+    fi
+
+    # order is important as mariadb installs a mysqld symlink
+    for _test_binary in mariadbd mysqld; do
+        command -v "$_test_binary" &>/dev/null
+        if [ $? -eq 0 ]; then
+            SQL_DB_BINARY="$_test_binary"
+            break
+        fi
+    done
+}
+
+sql_fetch_systemd_service()
+{
+    if [ -n "$SQL_SYSTEMD_SERVICE" ] ; then
+        return 0
+    fi
+
+    # order is important as mariadb installs symlinks
+    for _test_service in mariadb mysql; do
+        if systemctl list-unit-files "$_test_service.service" 2>/dev/null | grep -q "$_test_service.service"; then
+            SQL_SYSTEMD_SERVICE="$_test_service"
+            break
+        fi
+    done
+}
+
+sql_fetch_db_running()
+{
+    sql_fetch_db_binary
+
+    if [ -z "$SQL_DB_BINARY" ] ; then
+        return 1
+    fi
+
+    _process=$(ps -o args --no-headers -C ${SQL_DB_BINARY})
+
+    if [ -n "$_process" ] ; then
+        SQL_IS_RUNNING=1
+    else
+        SQL_IS_RUNNING=0
+    fi
+}
+
+sql_fetch_db_config()
+{
+    sql_fetch_db_binary
+
+    if [ -z "$SQL_DB_BINARY" ] ; then
+        return 1
+    fi
+
+    _process=$(ps -o args --no-headers -C "${SQL_DB_BINARY}")
+
+    if [ -n "$_process" ] ; then
+        SQL_CONF_DATADIR=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_DEFAULTS_FILE=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_LOG_BIN_ARG=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $1 }')
+        SQL_CONF_LOG_BIN=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_PID_FILE=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--pid-file")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_RELAY_LOG=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--relay-log")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_IS_RUNNING=1
+    else
+        SQL_IS_RUNNING=0
+    fi
+
+    _defaults_file_arg=
+    if [ -n "$SQL_CONF_DEFAULTS_FILE" ] ; then
+        _defaults_file_arg="--defaults-file=\"$SQL_CONF_DEFAULTS_FILE\""
+    fi
+    _options=$($SQL_DB_BINARY --print-defaults $_defaults_file_arg | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i < NF; i++) { print $i } }')
+
+    if [ -z "$SQL_CONF_DATADIR" ] ; then
+        SQL_CONF_DATADIR=$(echo "$_options" | grep -E '^--datadir=' | awk -F\= '{ print $2 }')
+    fi
+    if [ -z "$SQL_CONF_DATADIR" ] ; then
+        SQL_CONF_DATADIR="/var/lib/mysql"
+    fi
+
+    ### Avoid datadir is a symlink (get the absolute path)
+    SQL_CONF_DATADIR=$(realpath "$SQL_CONF_DATADIR")
+
+    if [ -z "$SQL_CONF_PID_FILE" ] ; then
+        SQL_CONF_PID_FILE=$(echo "$_options" | grep -E '^--pid-file=' | awk -F\= '{ print $2 }')
+    fi
+    if [ -z "$SQL_CONF_PID_FILE" ] ; then
+        SQL_CONF_PID_FILE=$(hostname -s)
+    else
+        SQL_CONF_PID_FILE=$(basename "$SQL_CONF_PID_FILE" | cut -d '.' -f 1)
+    fi
+
+    if [ -z "$SQL_CONF_LOG_BIN_ARG" ] ; then
+        SQL_CONF_LOG_BIN_ARG=$(echo "$_options" | grep -E '^--log-bin=' | awk -F\= '{ print $1 }')
+        SQL_CONF_LOG_BIN=$(echo "$_options" | grep -E '^--log-bin=' | awk -F\= '{ print $2 }')
+    fi
+
+    if [ -z "$SQL_CONF_LOG_BIN" ] ; then
+        SQL_CONF_LOG_BIN="$SQL_CONF_DATADIR/$SQL_CONF_PID_FILE-bin"
+    fi
+
+    if [ -z "$SQL_CONF_RELAY_LOG" ] ; then
+        SQL_CONF_RELAY_LOG=$(echo "$_options" | grep -E '^--relay-log=' | awk -F\= '{ print $2 }')
+    fi
+
+    if [ -z "$SQL_CONF_RELAY_LOG" ] ; then
+        SQL_CONF_RELAY_LOG="$SQL_CONF_DATADIR/$SQL_CONF_PID_FILE-relay-bin"
+    fi
+}
+
 get_other_db_hostname()
 {
 	if [ -z "$1" ] ; then

--- a/centreon-ha/lib/mysql-functions.sh
+++ b/centreon-ha/lib/mysql-functions.sh
@@ -100,13 +100,13 @@ sql_fetch_db_config()
     fi
 
     if [ -n "$SQL_CONF_DEFAULTS_FILE" ] ; then
-        _options=$($SQL_DB_BINARY --print-defaults "--defaults-file=$SQL_CONF_DEFAULTS_FILE" | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i <= NF; i++) { print $i } }')
+        _options=$($SQL_DB_BINARY "--defaults-file=$SQL_CONF_DEFAULTS_FILE" --print-defaults | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i <= NF; i++) { print $i } }')
     else
         _options=$($SQL_DB_BINARY --print-defaults | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i <= NF; i++) { print $i } }')
     fi
 
     if [ -z "$SQL_CONF_DATADIR" ] ; then
-        SQL_CONF_DATADIR=$(echo "$_options" | grep -E '^--datadir=' | awk -F\= '{ print $2 }')
+        SQL_CONF_DATADIR=$(echo "$_options" | grep -E '^--datadir=' | tail -1 | awk -F\= '{ print $2 }')
     fi
     if [ -z "$SQL_CONF_DATADIR" ] ; then
         SQL_CONF_DATADIR="/var/lib/mysql"
@@ -116,7 +116,7 @@ sql_fetch_db_config()
     SQL_CONF_DATADIR=$(realpath "$SQL_CONF_DATADIR")
 
     if [ -z "$SQL_CONF_PID_FILE" ] ; then
-        SQL_CONF_PID_FILE=$(echo "$_options" | grep -E '^--pid-file=' | awk -F\= '{ print $2 }')
+        SQL_CONF_PID_FILE=$(echo "$_options" | grep -E '^--pid-file=' | tail -1 | awk -F\= '{ print $2 }')
     fi
     if [ -z "$SQL_CONF_PID_FILE" ] ; then
         SQL_CONF_PID_FILE=$(hostname -s)
@@ -125,8 +125,8 @@ sql_fetch_db_config()
     fi
 
     if [ -z "$SQL_CONF_LOG_BIN_ARG" ] ; then
-        SQL_CONF_LOG_BIN_ARG=$(echo "$_options" | grep -E '^--log-bin=' | awk -F\= '{ print $1 }')
-        SQL_CONF_LOG_BIN=$(echo "$_options" | grep -E '^--log-bin=' | awk -F\= '{ print $2 }')
+        SQL_CONF_LOG_BIN_ARG=$(echo "$_options" | grep -E '^--log-bin=' | tail -1 | awk -F\= '{ print $1 }')
+        SQL_CONF_LOG_BIN=$(echo "$_options" | grep -E '^--log-bin=' | tail -1 | awk -F\= '{ print $2 }')
     fi
 
     if [ -z "$SQL_CONF_LOG_BIN" ] ; then
@@ -134,7 +134,7 @@ sql_fetch_db_config()
     fi
 
     if [ -z "$SQL_CONF_RELAY_LOG" ] ; then
-        SQL_CONF_RELAY_LOG=$(echo "$_options" | grep -E '^--relay-log=' | awk -F\= '{ print $2 }')
+        SQL_CONF_RELAY_LOG=$(echo "$_options" | grep -E '^--relay-log=' | tail -1 | awk -F\= '{ print $2 }')
     fi
 
     if [ -z "$SQL_CONF_RELAY_LOG" ] ; then

--- a/centreon-ha/lib/mysql-functions.sh
+++ b/centreon-ha/lib/mysql-functions.sh
@@ -5,6 +5,7 @@
 ##################################################################
 
 SQL_DB_BINARY=
+SQL_IS_MARIADB=0
 SQL_SYSTEMD_SERVICE=
 SQL_IS_RUNNING=0
 
@@ -28,9 +29,14 @@ sql_fetch_db_binary()
         command -v "$_test_binary" &>/dev/null
         if [ $? -eq 0 ]; then
             SQL_DB_BINARY="$_test_binary"
-            break
+            if [ "$_test_binary" = "mariadbd" ] ; then
+                SQL_IS_MARIADB=1
+            fi
+            return 0
         fi
     done
+
+    return 1
 }
 
 sql_fetch_systemd_service()
@@ -43,9 +49,11 @@ sql_fetch_systemd_service()
     for _test_service in mariadb mysql; do
         if systemctl list-unit-files "$_test_service.service" 2>/dev/null | grep -q "$_test_service.service"; then
             SQL_SYSTEMD_SERVICE="$_test_service"
-            break
+            return 0
         fi
     done
+
+    return 1
 }
 
 sql_fetch_db_running()
@@ -56,7 +64,7 @@ sql_fetch_db_running()
         return 1
     fi
 
-    _process=$(ps -o args --no-headers -C ${SQL_DB_BINARY})
+    _process=$(ps -o args --no-headers -C "${SQL_DB_BINARY}" | head -1)
 
     if [ -n "$_process" ] ; then
         SQL_IS_RUNNING=1
@@ -73,25 +81,25 @@ sql_fetch_db_config()
         return 1
     fi
 
-    _process=$(ps -o args --no-headers -C "${SQL_DB_BINARY}")
+    _process=$(ps -o args --no-headers -C "${SQL_DB_BINARY}" | head -1)
 
     if [ -n "$_process" ] ; then
-        SQL_CONF_DATADIR=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_DEFAULTS_FILE=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_LOG_BIN_ARG=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $1 }')
-        SQL_CONF_LOG_BIN=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_PID_FILE=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--pid-file")) { print $i } } }' | awk -F\= '{ print $2 }')
-        SQL_CONF_RELAY_LOG=$(echo "$_process" | awk '{ for (i = 1; i < NF; i++) { if (match($i, "--relay-log")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_DATADIR=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--datadir")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_DEFAULTS_FILE=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--defaults-file")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_LOG_BIN_ARG=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $1 }')
+        SQL_CONF_LOG_BIN=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--log-bin")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_PID_FILE=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--pid-file")) { print $i } } }' | awk -F\= '{ print $2 }')
+        SQL_CONF_RELAY_LOG=$(echo "$_process" | awk '{ for (i = 1; i <= NF; i++) { if (match($i, "--relay-log")) { print $i } } }' | awk -F\= '{ print $2 }')
         SQL_IS_RUNNING=1
     else
         SQL_IS_RUNNING=0
     fi
 
-    _defaults_file_arg=
     if [ -n "$SQL_CONF_DEFAULTS_FILE" ] ; then
-        _defaults_file_arg="--defaults-file=\"$SQL_CONF_DEFAULTS_FILE\""
+        _options=$($SQL_DB_BINARY --print-defaults "--defaults-file=$SQL_CONF_DEFAULTS_FILE" | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i <= NF; i++) { print $i } }')
+    else
+        _options=$($SQL_DB_BINARY --print-defaults | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i <= NF; i++) { print $i } }')
     fi
-    _options=$($SQL_DB_BINARY --print-defaults $_defaults_file_arg | grep -v "would have been started with the following argument" | awk '{ for (i = 1; i < NF; i++) { print $i } }')
 
     if [ -z "$SQL_CONF_DATADIR" ] ; then
         SQL_CONF_DATADIR=$(echo "$_options" | grep -E '^--datadir=' | awk -F\= '{ print $2 }')

--- a/centreon-ha/ocf-scripts/mariadb-centreon
+++ b/centreon-ha/ocf-scripts/mariadb-centreon
@@ -352,7 +352,12 @@ set_gtid() {
     fi
 
     # Ensure that we got something like a valid GTID
-    if ! echo $gtid | grep -q '-'; then
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        _gtid_valid=$(echo $gtid | grep -cE '[0-9]+-[0-9]+-[0-9]+')
+    else
+        _gtid_valid=$(echo $gtid | grep -cE '[0-9a-fA-F-]+:[0-9]+')
+    fi
+    if [ "$_gtid_valid" -eq 0 ]; then
         ocf_exit_reason "Unable to read GTID from $_DB_NAME"
         ocf_log err "Unable to read GTID from $_DB_NAME"
         return $OCF_ERR_GENERIC
@@ -868,6 +873,8 @@ mysql_start() {
     fi
 
     # Enable semi-sync
+    # Note: the MySQL branch uses variable names introduced in MySQL 8.0.26
+    # (rpl_semi_sync_source_*, sync_source_info). MySQL < 8.0.26 is not supported.
     if [ "$_is_mariadb" -eq 1 ] ; then
         ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
                 -e "SET GLOBAL rpl_semi_sync_slave_enabled='OFF', \

--- a/centreon-ha/ocf-scripts/mariadb-centreon
+++ b/centreon-ha/ocf-scripts/mariadb-centreon
@@ -49,13 +49,53 @@ OCF_RESKEY_node_list_default=""
 : ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
 . ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
 . ${OCF_FUNCTIONS_DIR}/mariadb-centreon-common.sh
+
+#######################################################################
+# Detect MariaDB vs MySQL
+_is_mariadb=0
+_DB_NAME="MySQL"
+if command -v mariadbd &>/dev/null; then
+    _is_mariadb=1
+    _DB_NAME="MariaDB"
+fi
+
+# SQL command and field name compatibility
+if [ "$_is_mariadb" -eq 1 ] ; then
+    _SQL_SHOW_REPLICA_STATUS="SHOW SLAVE STATUS"
+    _SQL_START_REPLICA="START SLAVE"
+    _SQL_STOP_REPLICA="STOP SLAVE"
+    _SQL_STOP_REPLICA_IO="STOP SLAVE IO_THREAD"
+    _SQL_RESET_REPLICA_ALL="RESET SLAVE /*!50516 ALL */"
+    _SQL_FIELD_HOST="Master_Host"
+    _SQL_FIELD_USER="Master_User"
+    _SQL_FIELD_PORT="Master_Port"
+    _SQL_FIELD_LOG_FILE="Master_Log_File"
+    _SQL_FIELD_USING_GTID="Using_Gtid"
+    _SQL_FIELD_SQL_RUNNING="Slave_SQL_Running"
+    _SQL_FIELD_IO_RUNNING="Slave_IO_Running"
+    _SQL_FIELD_SECS_BEHIND="Seconds_Behind_Master"
+else
+    _SQL_SHOW_REPLICA_STATUS="SHOW REPLICA STATUS"
+    _SQL_START_REPLICA="START REPLICA"
+    _SQL_STOP_REPLICA="STOP REPLICA"
+    _SQL_STOP_REPLICA_IO="STOP REPLICA IO_THREAD"
+    _SQL_RESET_REPLICA_ALL="RESET REPLICA ALL"
+    _SQL_FIELD_HOST="Source_Host"
+    _SQL_FIELD_USER="Source_User"
+    _SQL_FIELD_PORT="Source_Port"
+    _SQL_FIELD_LOG_FILE="Source_Log_File"
+    _SQL_FIELD_USING_GTID="Auto_Position"
+    _SQL_FIELD_SQL_RUNNING="Replica_SQL_Running"
+    _SQL_FIELD_IO_RUNNING="Replica_IO_Running"
+    _SQL_FIELD_SECS_BEHIND="Seconds_Behind_Source"
+fi
 #######################################################################
 
 usage() {
   cat <<UEND
 usage: $0 (start|stop|validate-all|meta-data|monitor|promote|demote|notify)
 
-$0 manages a MariaDB Database as an HA resource.
+$0 manages a MariaDB/MySQL Database as an HA resource.
 
 The 'start' operation starts the database.
 The 'stop' operation stops the database.
@@ -76,14 +116,14 @@ meta_data() {
 <version>1.0</version>
 
 <longdesc lang="en">
-Resource script for MariaDB.
+Resource script for MariaDB/MySQL.
 
 Manages a complete master/slave replication setup with GTID, for simpler
 uses look at the mysql resource agent which supports older replication
 forms which mysql and mariadb have in common.
 
 The resource must be setup to use notifications. Set 'notify=true' in the metadata
-attributes when defining a MariaDB master/slave instance.
+attributes when defining a MariaDB/MySQL master/slave instance.
 
 The default behavior is to use uname -n values in the change master to command.
 Other IPs can be specified manually by adding a node attribute
@@ -91,22 +131,22 @@ Other IPs can be specified manually by adding a node attribute
 For example, if the mariadb primitive you are using is p_mariadb, the
 attribute to set will be p_mariadb_mysql_master_IP.
 </longdesc>
-<shortdesc lang="en">Manages a MariaDB master/slave instance</shortdesc>
+<shortdesc lang="en">Manages a MariaDB/MySQL master/slave instance</shortdesc>
 <parameters>
 
 <parameter name="binary" unique="0" required="0">
 <longdesc lang="en">
-Location of the MariaDB server binary
+Location of the MariaDB/MySQL server binary
 </longdesc>
-<shortdesc lang="en">MariaDB server binary</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL server binary</shortdesc>
 <content type="string" default="${OCF_RESKEY_binary_default}" />
 </parameter>
 
 <parameter name="client_binary" unique="0" required="0">
 <longdesc lang="en">
-Location of the MariaDB client binary
+Location of the MariaDB/MySQL client binary
 </longdesc>
-<shortdesc lang="en">MariaDB client binary</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL client binary</shortdesc>
 <content type="string" default="${OCF_RESKEY_client_binary_default}" />
 </parameter>
 
@@ -114,7 +154,7 @@ Location of the MariaDB client binary
 <longdesc lang="en">
 Configuration file
 </longdesc>
-<shortdesc lang="en">MariaDB config</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL config</shortdesc>
 <content type="string" default="${OCF_RESKEY_config_default}" />
 </parameter>
 
@@ -122,23 +162,23 @@ Configuration file
 <longdesc lang="en">
 Directory containing databases
 </longdesc>
-<shortdesc lang="en">MariaDB datadir</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL datadir</shortdesc>
 <content type="string" default="${OCF_RESKEY_datadir_default}" />
 </parameter>
 
 <parameter name="user" unique="0" required="0">
 <longdesc lang="en">
-User running MariaDB daemon
+User running MariaDB/MySQL daemon
 </longdesc>
-<shortdesc lang="en">MariaDB user</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL user</shortdesc>
 <content type="string" default="${OCF_RESKEY_user_default}" />
 </parameter>
 
 <parameter name="group" unique="0" required="0">
 <longdesc lang="en">
-Group running MariaDB daemon (for logfile and directory permissions)
+Group running MariaDB/MySQL daemon (for logfile and directory permissions)
 </longdesc>
-<shortdesc lang="en">MariaDB group</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL group</shortdesc>
 <content type="string" default="${OCF_RESKEY_group_default}"/>
 </parameter>
 
@@ -146,7 +186,7 @@ Group running MariaDB daemon (for logfile and directory permissions)
 <longdesc lang="en">
 The logfile to be used for mysqld.
 </longdesc>
-<shortdesc lang="en">MariaDB log file</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL log file</shortdesc>
 <content type="string" default="${OCF_RESKEY_log_default}"/>
 </parameter>
 
@@ -164,7 +204,7 @@ This is required for the master selection to function.
 <longdesc lang="en">
 The pidfile to be used for mysqld.
 </longdesc>
-<shortdesc lang="en">MariaDB pid file</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL pid file</shortdesc>
 <content type="string" default="${OCF_RESKEY_pid_default}"/>
 </parameter>
 
@@ -172,7 +212,7 @@ The pidfile to be used for mysqld.
 <longdesc lang="en">
 The socket to be used for mysqld.
 </longdesc>
-<shortdesc lang="en">MariaDB socket</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL socket</shortdesc>
 <content type="string" default="${OCF_RESKEY_socket_default}"/>
 </parameter>
 
@@ -180,29 +220,29 @@ The socket to be used for mysqld.
 <longdesc lang="en">
 Table to be tested in monitor statement (in database.table notation)
 </longdesc>
-<shortdesc lang="en">MariaDB test table</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL test table</shortdesc>
 <content type="string" default="${OCF_RESKEY_test_table_default}" />
 </parameter>
 
 <parameter name="test_user" unique="0" required="0">
 <longdesc lang="en">
-MariaDB test user, must have select privilege on test_table
+MariaDB/MySQL test user, must have select privilege on test_table
 </longdesc>
-<shortdesc lang="en">MariaDB test user</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL test user</shortdesc>
 <content type="string" default="${OCF_RESKEY_test_user_default}" />
 </parameter>
 
 <parameter name="test_passwd" unique="0" required="0">
 <longdesc lang="en">
-MariaDB test user password
+MariaDB/MySQL test user password
 </longdesc>
-<shortdesc lang="en">MariaDB test user password</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL test user password</shortdesc>
 <content type="string" default="${OCF_RESKEY_test_passwd_default}" />
 </parameter>
 
 <parameter name="enable_creation" unique="0" required="0">
 <longdesc lang="en">
-If the MariaDB database does not exist, it will be created
+If the MariaDB/MySQL database does not exist, it will be created
 </longdesc>
 <shortdesc lang="en">Create the database if it does not exist</shortdesc>
 <content type="boolean" default="${OCF_RESKEY_enable_creation_default}"/>
@@ -219,31 +259,31 @@ Additional parameters which are passed to the mysqld on startup.
 
 <parameter name="replication_user" unique="0" required="0">
 <longdesc lang="en">
-MariaDB replication user. This user is used for starting and stopping
-MariaDB replication, for setting and resetting the master host, and for
+MariaDB/MySQL replication user. This user is used for starting and stopping
+MariaDB/MySQL replication, for setting and resetting the master host, and for
 setting and unsetting read-only mode. Because of that, this user must
 have SUPER, REPLICATION SLAVE, REPLICATION CLIENT, PROCESS and RELOAD
 privileges on all nodes within the cluster. Mandatory if you define a
 master-slave resource.
 </longdesc>
-<shortdesc lang="en">MariaDB replication user</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL replication user</shortdesc>
 <content type="string" default="${OCF_RESKEY_replication_user_default}" />
 </parameter>
 
 <parameter name="replication_passwd" unique="0" required="0">
 <longdesc lang="en">
-MariaDB replication password. Used for replication client and slave.
+MariaDB/MySQL replication password. Used for replication client and slave.
 Mandatory if you define a master-slave resource.
 </longdesc>
-<shortdesc lang="en">MariaDB replication user password</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL replication user password</shortdesc>
 <content type="string" default="${OCF_RESKEY_replication_passwd_default}" />
 </parameter>
 
 <parameter name="replication_port" unique="0" required="0">
 <longdesc lang="en">
-The port on which the Master MariaDB instance is listening.
+The port on which the Master MariaDB/MySQL instance is listening.
 </longdesc>
-<shortdesc lang="en">MariaDB replication port</shortdesc>
+<shortdesc lang="en">MariaDB/MySQL replication port</shortdesc>
 <content type="string" default="${OCF_RESKEY_replication_port_default}" />
 </parameter>
 
@@ -282,8 +322,18 @@ greater_than_equal_long()
 
 greater_than_gtid()
 {
-    local gtid1_transaction_id=$(echo $1 | cut -d - -f 3)
-    local gtid2_transaction_id=$(echo $2 | cut -d - -f 3)
+    local gtid1_transaction_id
+    local gtid2_transaction_id
+
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        # MariaDB GTID format: domain-server-sequence
+        gtid1_transaction_id=$(echo $1 | cut -d - -f 3)
+        gtid2_transaction_id=$(echo $2 | cut -d - -f 3)
+    else
+        # MySQL GTID format: uuid:1-N (extract N, the last transaction number)
+        gtid1_transaction_id=$(echo $1 | grep -oE '[0-9]+$')
+        gtid2_transaction_id=$(echo $2 | grep -oE '[0-9]+$')
+    fi
 
     greater_than_equal_long $gtid1_transaction_id $gtid2_transaction_id
     return $?
@@ -292,13 +342,19 @@ greater_than_gtid()
 set_gtid() {
     # Sets the GTID in CIB using attrd_updater for this node.
 
-    local gtid=$($MYSQL $MYSQL_OPTIONS_REPL \
+    local gtid
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        gtid=$($MYSQL $MYSQL_OPTIONS_REPL \
                         -s -N -e "show global variables like 'gtid_current_pos'" | cut -f 2)
+    else
+        gtid=$($MYSQL $MYSQL_OPTIONS_REPL \
+                        -s -N -e "SELECT @@gtid_executed")
+    fi
 
-    # Ensure that we got somethine like a valid GTID
+    # Ensure that we got something like a valid GTID
     if ! echo $gtid | grep -q '-'; then
-        ocf_exit_reason "Unable to read GTID from MariaDB"
-        ocf_log err "Unable to read GTID from MariaDB"
+        ocf_exit_reason "Unable to read GTID from $_DB_NAME"
+        ocf_log err "Unable to read GTID from $_DB_NAME"
         return $OCF_ERR_GENERIC
     fi
 
@@ -499,22 +555,22 @@ get_slave_info() {
         local tmpfile=$(mktemp ${HA_RSCTMP}/check_slave.${OCF_RESOURCE_INSTANCE}.XXXXXX)
 
         $MYSQL $MYSQL_OPTIONS_REPL \
-        -e 'SHOW SLAVE STATUS\G' > $tmpfile
+        -e "$_SQL_SHOW_REPLICA_STATUS\G" > $tmpfile
 
         if [ -s $tmpfile ]; then
-            master_host=$(parse_slave_info Master_Host $tmpfile)
-            master_user=$(parse_slave_info Master_User $tmpfile)
-            master_port=$(parse_slave_info Master_Port $tmpfile)
-            master_using_gtid=$(parse_slave_info Using_Gtid $tmpfile)
-            master_log_file=$(parse_slave_info Master_Log_File $tmpfile)
-            slave_sql=$(parse_slave_info Slave_SQL_Running $tmpfile)
-            slave_io=$(parse_slave_info Slave_IO_Running $tmpfile)
+            master_host=$(parse_slave_info $_SQL_FIELD_HOST $tmpfile)
+            master_user=$(parse_slave_info $_SQL_FIELD_USER $tmpfile)
+            master_port=$(parse_slave_info $_SQL_FIELD_PORT $tmpfile)
+            master_using_gtid=$(parse_slave_info $_SQL_FIELD_USING_GTID $tmpfile)
+            master_log_file=$(parse_slave_info $_SQL_FIELD_LOG_FILE $tmpfile)
+            slave_sql=$(parse_slave_info $_SQL_FIELD_SQL_RUNNING $tmpfile)
+            slave_io=$(parse_slave_info $_SQL_FIELD_IO_RUNNING $tmpfile)
             last_errno=$(parse_slave_info Last_Errno $tmpfile)
             last_error=$(parse_slave_info Last_Error $tmpfile)
-            secs_behind=$(parse_slave_info Seconds_Behind_Master $tmpfile)
+            secs_behind=$(parse_slave_info $_SQL_FIELD_SECS_BEHIND $tmpfile)
             last_io_errno=$(parse_slave_info Last_IO_Errno $tmpfile)
             last_io_error=$(parse_slave_info Last_IO_Error $tmpfile)
-            ocf_log debug "MariaDB instance running as a replication slave"
+            ocf_log debug "$_DB_NAME instance running as a replication slave"
             rm "$tmpfile"
         else
             # Instance produced an empty "SHOW SLAVE STATUS" output --
@@ -538,27 +594,27 @@ check_slave() {
 
         # Check normal errors
         if [ $last_errno -ne 0 ]; then
-            ocf_exit_reason "MariaDB slave replication has failed ($last_errno): $last_error"
+            ocf_exit_reason "$_DB_NAME slave replication has failed ($last_errno): $last_error"
 
             exit $OCF_ERR_GENERIC
         fi
 
         # Check IO Errors, ignore 2003 which indicates a connection failure to the master
         if [ $last_io_errno -ne 0 ] && [ $last_io_errno -ne 2003 ]; then
-            ocf_exit_reason "MariaDB slave io has failed ($last_io_errno): $last_io_error"
+            ocf_exit_reason "$_DB_NAME slave io has failed ($last_io_errno): $last_io_error"
 
             exit $OCF_ERR_GENERIC
         fi
 
         if [ $last_io_errno -eq 2003 ]; then
-            ocf_log warn "MariaDB master not reachable from slave"
+            ocf_log warn "$_DB_NAME master not reachable from slave"
         fi
         
         if [ "$slave_io" != 'Yes' ]; then
             # Not necessarily a bad thing. The master may have
             # temporarily shut down, and the slave may just be
             # reconnecting. A warning can't hurt, though.
-            ocf_log warn "MariaDB Slave IO threads currently not running."
+            ocf_log warn "$_DB_NAME Slave IO threads currently not running."
 
             # Sanity check, are we at least on the right master
             new_master=$($CRM_ATTR_REPL_INFO --query  -q)
@@ -576,20 +632,20 @@ check_slave() {
             # We don't have a replication SQL thread running. Not a
             # good thing. Try to recoved by restarting the SQL thread
             # and remove reader vip.  Prevent MariaDB restart.
-            ocf_exit_reason "MariaDB Slave SQL threads currently not running."
+            ocf_exit_reason "$_DB_NAME Slave SQL threads currently not running."
 
             # Remove reader vip
             set_reader_attr 0
 
-            # try to restart slave
+            # try to restart replica
             ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-                -e "START SLAVE"
+                -e "$_SQL_START_REPLICA"
 
             # Return success to prevent a restart
             exit $OCF_SUCCESS
         fi
 
-        ocf_log debug "MariaDB instance running as a replication slave"
+        ocf_log debug "$_DB_NAME instance running as a replication slave"
     else
         # Instance produced an empty "SHOW SLAVE STATUS" output --
         # instance is not a slave
@@ -607,14 +663,23 @@ set_master() {
     # name of the new master host. The master must either be unchanged
     # from the laste master the slave replicated from, or freshly
     # reset with RESET MASTER.
-    ocf_log info "Changing MariaDB configuration to replicate from $new_master."
+    ocf_log info "Changing $_DB_NAME configuration to replicate from $new_master."
 
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
-        MASTER_PORT=$OCF_RESKEY_replication_port, \
-        MASTER_USER='$OCF_RESKEY_replication_user', \
-        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd', \
-        MASTER_USE_GTID=current_pos";
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+            -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
+            MASTER_PORT=$OCF_RESKEY_replication_port, \
+            MASTER_USER='$OCF_RESKEY_replication_user', \
+            MASTER_PASSWORD='$OCF_RESKEY_replication_passwd', \
+            MASTER_USE_GTID=current_pos";
+    else
+        ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+            -e "CHANGE REPLICATION SOURCE TO SOURCE_HOST='$new_master', \
+            SOURCE_PORT=$OCF_RESKEY_replication_port, \
+            SOURCE_USER='$OCF_RESKEY_replication_user', \
+            SOURCE_PASSWORD='$OCF_RESKEY_replication_passwd', \
+            SOURCE_AUTO_POSITION=1";
+    fi
 }
 
 unset_master(){
@@ -633,9 +698,9 @@ unset_master(){
     # Stop the slave I/O thread and wait for relay log
     # processing to complete
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE IO_THREAD"
+        -e "$_SQL_STOP_REPLICA_IO"
     if [ $? -gt 0 ]; then
-        ocf_exit_reason "Error stopping slave IO thread"
+        ocf_exit_reason "Error stopping replica IO thread"
         exit $OCF_ERR_GENERIC
     fi
 
@@ -644,30 +709,30 @@ unset_master(){
         $MYSQL $MYSQL_OPTIONS_REPL \
             -e 'SHOW PROCESSLIST\G' > $tmpfile
         if grep -i 'Has read all relay log' $tmpfile >/dev/null; then
-            ocf_log info "MariaDB slave has finished processing relay log"
+            ocf_log info "$_DB_NAME slave has finished processing relay log"
             break
         fi
         if ! grep -q 'system user' $tmpfile; then
             ocf_log info "Slave not runnig - not waiting to finish"
             break
         fi
-        ocf_log info "Waiting for MariaDB slave to finish processing relay log"
+        ocf_log info "Waiting for $_DB_NAME slave to finish processing relay log"
         sleep 1
     done
     rm -f $tmpfile
 
-    # Now, stop all slave activity and unset the master host
+    # Now, stop all replica activity and unset the master host
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE"
+        -e "$_SQL_STOP_REPLICA"
     if [ $? -gt 0 ]; then
-        ocf_exit_reason "Error stopping rest slave threads"
+        ocf_exit_reason "Error stopping rest replica threads"
         exit $OCF_ERR_GENERIC
     fi
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "RESET SLAVE /*!50516 ALL */;"
+        -e "$_SQL_RESET_REPLICA_ALL;"
     if [ $? -gt 0 ]; then
-        ocf_exit_reason "Failed to reset slave"
+        ocf_exit_reason "Failed to reset replica"
         exit $OCF_ERR_GENERIC
     fi
 }
@@ -675,7 +740,7 @@ unset_master(){
 # Start replication as slave
 start_slave() {
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "START SLAVE"
+        -e "$_SQL_START_REPLICA"
 }
 
 # Set the attribute controlling the readers VIP
@@ -769,10 +834,10 @@ mysql_monitor() {
     fi
     
     if ! get_read_only; then
-        ocf_log debug "MariaDB monitor succeeded (master)";
+        ocf_log debug "$_DB_NAME monitor succeeded (master)";
         return $OCF_RUNNING_MASTER
     else
-        ocf_log debug "MariaDB monitor succeeded";
+        ocf_log debug "$_DB_NAME monitor succeeded";
         return $OCF_SUCCESS
     fi
 }
@@ -790,7 +855,7 @@ mysql_start() {
 
     mysql_common_status info
     if [ $? = $OCF_SUCCESS ]; then
-        ocf_log info "MariaDB already running"
+        ocf_log info "$_DB_NAME already running"
         return $OCF_SUCCESS
     fi
 
@@ -803,14 +868,24 @@ mysql_start() {
     fi
 
     # Enable semi-sync
-    ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
-            -e "SET GLOBAL rpl_semi_sync_slave_enabled='OFF', \
-                           rpl_semi_sync_master_enabled='ON', \
-                           rpl_semi_sync_master_wait_no_slave='OFF', \
-                           rpl_semi_sync_master_wait_point='AFTER_SYNC', \
-                           gtid_strict_mode='ON', \
-                           sync_binlog=1, \
-                           sync_master_info=1;"
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+                -e "SET GLOBAL rpl_semi_sync_slave_enabled='OFF', \
+                               rpl_semi_sync_master_enabled='ON', \
+                               rpl_semi_sync_master_wait_no_slave='OFF', \
+                               rpl_semi_sync_master_wait_point='AFTER_SYNC', \
+                               gtid_strict_mode='ON', \
+                               sync_binlog=1, \
+                               sync_master_info=1;"
+    else
+        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+                -e "SET GLOBAL rpl_semi_sync_replica_enabled='OFF', \
+                               rpl_semi_sync_source_enabled='ON', \
+                               rpl_semi_sync_source_wait_no_replica='OFF', \
+                               rpl_semi_sync_source_wait_point='AFTER_SYNC', \
+                               sync_binlog=1, \
+                               sync_source_info=1;"
+    fi
     rc=$?
     if [ $rc -ne 0 ]; then
         ocf_exit_reason "Failed to enable semi-sync and set variables";
@@ -836,7 +911,7 @@ mysql_start() {
             return $OCF_ERR_GENERIC
         fi
     else
-        ocf_log info "No MariaDB master present - clearing replication state, setting gtid in attrd, waiting for first master"
+        ocf_log info "No $_DB_NAME master present - clearing replication state, setting gtid in attrd, waiting for first master"
         unset_master
         set_waiting_for_first_master
     fi
@@ -853,7 +928,7 @@ mysql_start() {
         return $rc
     fi
 
-    ocf_log info "MariaDB started"
+    ocf_log info "$_DB_NAME started"
     return $OCF_SUCCESS
 }
 
@@ -874,12 +949,17 @@ mysql_promote() {
         return $OCF_NOT_RUNNING
     fi
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE"
+        -e "$_SQL_STOP_REPLICA"
 
     set_read_only off || return $OCF_ERR_GENERIC
     # Force the master to wait for timeout period on slave disconnect
-    ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
-            -e "SET GLOBAL rpl_semi_sync_master_wait_no_slave='ON';"
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+                -e "SET GLOBAL rpl_semi_sync_master_wait_no_slave='ON';"
+    else
+        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+                -e "SET GLOBAL rpl_semi_sync_source_wait_no_replica='ON';"
+    fi
     
     # Set Master Info in CIB, cluster level attribute
     master_info="$(get_local_ip)"
@@ -900,8 +980,13 @@ mysql_demote() {
     fi
 
     # Return to default no wait setting.
-    ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
-            -e "SET GLOBAL rpl_semi_sync_master_wait_no_slave='OFF';"
+    if [ "$_is_mariadb" -eq 1 ] ; then
+        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+                -e "SET GLOBAL rpl_semi_sync_master_wait_no_slave='OFF';"
+    else
+        ocf_run -q $MYSQL $MYSQL_OPTIONS_TEST \
+                -e "SET GLOBAL rpl_semi_sync_source_wait_no_replica='OFF';"
+    fi
 
     # Return master preference to default, so the cluster manager gets
     # a chance to select a new master

--- a/centreon-ha/ocf-scripts/mariadb-centreon-common.sh
+++ b/centreon-ha/ocf-scripts/mariadb-centreon-common.sh
@@ -239,7 +239,9 @@ mysql_common_start()
     local pid
     local service_name
 
-    # Auto-detect the systemd service name
+    # Auto-detect the systemd service name.
+    # This duplicates logic from mysql-functions.sh because this OCF script
+    # runs under Pacemaker with #!/bin/sh and must remain self-contained.
     for service_name in mariadb mysql; do
         if systemctl list-unit-files "$service_name.service" 2>/dev/null | grep -q "$service_name.service"; then
             break

--- a/centreon-ha/ocf-scripts/mariadb-centreon-common.sh
+++ b/centreon-ha/ocf-scripts/mariadb-centreon-common.sh
@@ -237,8 +237,21 @@ mysql_common_start()
 {
     local mysql_extra_params="$1"
     local pid
+    local service_name
 
-    systemctl start mariadb
+    # Auto-detect the systemd service name
+    for service_name in mariadb mysql; do
+        if systemctl list-unit-files "$service_name.service" 2>/dev/null | grep -q "$service_name.service"; then
+            break
+        fi
+        service_name=""
+    done
+    if [ -z "$service_name" ]; then
+        ocf_exit_reason "Cannot find MariaDB/MySQL systemd service"
+        return $OCF_ERR_INSTALLED
+    fi
+
+    systemctl start "$service_name"
     pid=$(cat $OCF_RESKEY_pid)
 
     # Spin waiting for the server to come up.


### PR DESCRIPTION
## Description

**Fixes** [MON-169377](https://centreon.atlassian.net/browse/MON-169377)

The Centreon HA shell scripts hardcode MariaDB-specific binary names (`mariadbd`) and service names (`systemctl start mariadb`), causing failures when MySQL is used instead.

This PR introduces shared auto-detection functions in `lib/mysql-functions.sh` and updates all HA scripts to use them:

* `sql_fetch_db_binary()` — detects `mariadbd` or `mysqld`
* `sql_fetch_systemd_service()` — detects `mariadb` or `mysql` systemd service
* `sql_fetch_db_config()` — reads datadir, log-bin, pid-file, relay-log from the running process or config defaults

Updated scripts:
* `bin/mysql-sync-bigdb.sh` — uses shared functions instead of hardcoded values
* `bin/centreondb-smooth-backup.sh` — uses shared functions instead of hardcoded `ps -C mysqld` and `systemctl start mariadb`
* `bin/purge_mysql_parts.sh` — uses shared functions instead of hardcoded `ps -C mysqld` and duplicated datadir detection
* `ocf-scripts/mariadb-centreon-common.sh` — auto-detects systemd service name in `mysql_common_start()`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. On a Centreon HA setup using **MariaDB**: verify that `mysql-sync-bigdb.sh`, `centreondb-smooth-backup.sh`, and `purge_mysql_parts.sh` detect and use the MariaDB binary and service correctly.
2. On a Centreon HA setup using **MySQL**: verify the same scripts detect and use the MySQL binary and service correctly.
3. Verify `mariadb-centreon-common.sh` OCF resource starts the correct service via `systemctl`.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-169377]: https://centreon.atlassian.net/browse/MON-169377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ