### PR TITLE
fix(open-tickets): sanitize file paths in upload and remove actions

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
@@ -65,8 +65,8 @@ if (! unlink($real_file_path)) {
     return;
 }
 
-unset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path]);
-unset($_SESSION['ot_upload_files'][$uniq_id][$file_path]);
+unset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path], $_SESSION['ot_upload_files'][$uniq_id][$file_path]);
+
 if (empty($_SESSION['ot_upload_files'][$uniq_id])) {
     unset($_SESSION['ot_upload_files'][$uniq_id]);
 }

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
@@ -21,6 +21,43 @@
 
 $resultat = ['code' => 0, 'msg' => 'ok'];
 
-$temp_dir = sys_get_temp_dir();
-unlink($temp_dir . '/opentickets/' . $get_information['uniqId'] . '__' . $get_information['filename']);
-unset($_SESSION['ot_upload_files'][$get_information['uniqId']]);
+if (! isset($_SESSION['centreon'])) {
+    $resultat = ['code' => 1, 'msg' => 'Unauthorized.'];
+
+    return;
+}
+
+$uniq_id = $get_information['uniqId'] ?? '';
+$filename = basename($get_information['filename'] ?? '');
+
+if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/', $uniq_id) || $filename === '') {
+    $resultat = ['code' => 1, 'msg' => 'Invalid parameters.'];
+
+    return;
+}
+
+$target_dir = sys_get_temp_dir() . '/opentickets';
+$file_path = $target_dir . '/' . $uniq_id . '__' . $filename;
+
+$real_target_dir = realpath($target_dir);
+$real_file_path = realpath($file_path);
+if (
+    $real_target_dir === false
+    || $real_file_path === false
+    || strpos($real_file_path, $real_target_dir . '/') !== 0
+) {
+    $resultat = ['code' => 1, 'msg' => 'File not found.'];
+
+    return;
+}
+
+if (! isset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path])
+    && ! isset($_SESSION['ot_upload_files'][$uniq_id][$file_path])
+) {
+    $resultat = ['code' => 1, 'msg' => 'Unauthorized file access.'];
+
+    return;
+}
+
+unlink($real_file_path);
+unset($_SESSION['ot_upload_files'][$uniq_id]);

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
@@ -30,7 +30,7 @@ if (! isset($_SESSION['centreon'])) {
 $uniq_id = $get_information['uniqId'] ?? '';
 $filename = basename($get_information['filename'] ?? '');
 
-if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/', $uniq_id) || $filename === '') {
+if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/D', $uniq_id) || $filename === '') {
     $resultat = ['code' => 1, 'msg' => 'Invalid parameters.'];
 
     return;

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
@@ -60,4 +60,8 @@ if (! isset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path])
 }
 
 unlink($real_file_path);
-unset($_SESSION['ot_upload_files'][$uniq_id]);
+unset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path]);
+unset($_SESSION['ot_upload_files'][$uniq_id][$file_path]);
+if (empty($_SESSION['ot_upload_files'][$uniq_id])) {
+    unset($_SESSION['ot_upload_files'][$uniq_id]);
+}

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
@@ -44,7 +44,7 @@ $real_file_path = realpath($file_path);
 if (
     $real_target_dir === false
     || $real_file_path === false
-    || strpos($real_file_path, $real_target_dir . '/') !== 0
+    || ! str_starts_with($real_file_path, $real_target_dir . '/')
 ) {
     $resultat = ['code' => 1, 'msg' => 'File not found.'];
 
@@ -59,7 +59,12 @@ if (! isset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path])
     return;
 }
 
-unlink($real_file_path);
+if (! unlink($real_file_path)) {
+    $resultat = ['code' => 1, 'msg' => 'Failed to delete file.'];
+
+    return;
+}
+
 unset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path]);
 unset($_SESSION['ot_upload_files'][$uniq_id][$file_path]);
 if (empty($_SESSION['ot_upload_files'][$uniq_id])) {

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -51,7 +51,8 @@ foreach ($_FILES as $file) {
         || strlen($safe_filename) > 200
     ) {
         $resultat = ['code' => 1, 'msg' => 'Invalid filename.'];
-        continue;
+
+        return;
     }
 
     $file_dst = $target_dir . '/' . $uniq_id . '__' . $safe_filename;
@@ -60,12 +61,14 @@ foreach ($_FILES as $file) {
     $real_dst_dir = realpath(dirname($file_dst));
     if ($real_target_dir === false || $real_dst_dir === false || $real_dst_dir !== $real_target_dir) {
         $resultat = ['code' => 1, 'msg' => 'Invalid file path.'];
-        continue;
+
+        return;
     }
 
     if (! move_uploaded_file($file['tmp_name'], $file_dst)) {
         $resultat = ['code' => 1, 'msg' => 'Failed to save uploaded file.'];
-        continue;
+
+        return;
     }
 
     if (! isset($_SESSION['ot_upload_files'])) {

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -21,11 +21,48 @@
 
 $resultat = ['code' => 0, 'msg' => 'ok'];
 
-$uniq_id = $_REQUEST['uniqId'];
+if (! isset($_SESSION['centreon'])) {
+    $resultat = ['code' => 1, 'msg' => 'Unauthorized.'];
+
+    return;
+}
+
+$uniq_id = $_REQUEST['uniqId'] ?? '';
+if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/', $uniq_id)) {
+    $resultat = ['code' => 1, 'msg' => 'Invalid uniqId format.'];
+
+    return;
+}
+
+$target_dir = sys_get_temp_dir() . '/opentickets';
+if (! is_dir($target_dir) && ! mkdir($target_dir, 0750)) {
+    $resultat = ['code' => 1, 'msg' => 'Failed to create upload directory.'];
+
+    return;
+}
+
 foreach ($_FILES as $file) {
-    $dir = dirname($file['tmp_name']);
-    $file_dst = $dir . '/opentickets/' . $uniq_id . '__' . $file['name'];
-    @mkdir($dir . '/opentickets', 0750);
+    $safe_filename = basename($file['name']);
+    if (
+        $safe_filename === ''
+        || $safe_filename === '.'
+        || $safe_filename === '..'
+        || preg_match('/[\x00-\x1f\x7f]/', $safe_filename)
+        || strlen($safe_filename) > 200
+    ) {
+        $resultat = ['code' => 1, 'msg' => 'Invalid filename.'];
+        continue;
+    }
+
+    $file_dst = $target_dir . '/' . $uniq_id . '__' . $safe_filename;
+
+    $real_target_dir = realpath($target_dir);
+    $real_dst_dir = realpath(dirname($file_dst));
+    if ($real_target_dir === false || $real_dst_dir === false || $real_dst_dir !== $real_target_dir) {
+        $resultat = ['code' => 1, 'msg' => 'Invalid file path.'];
+        continue;
+    }
+
     if (rename($file['tmp_name'], $file_dst)) {
         if (! isset($_SESSION['ot_upload_files'])) {
             $_SESSION['ot_upload_files'] = [];

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -63,14 +63,17 @@ foreach ($_FILES as $file) {
         continue;
     }
 
-    if (rename($file['tmp_name'], $file_dst)) {
-        if (! isset($_SESSION['ot_upload_files'])) {
-            $_SESSION['ot_upload_files'] = [];
-        }
-        if (! isset($_SESSION['ot_upload_files'][$uniq_id])) {
-            $_SESSION['ot_upload_files'][$uniq_id] = [];
-        }
-
-        $_SESSION['ot_upload_files'][$uniq_id][$file_dst] = 1;
+    if (! move_uploaded_file($file['tmp_name'], $file_dst)) {
+        $resultat = ['code' => 1, 'msg' => 'Failed to save uploaded file.'];
+        continue;
     }
+
+    if (! isset($_SESSION['ot_upload_files'])) {
+        $_SESSION['ot_upload_files'] = [];
+    }
+    if (! isset($_SESSION['ot_upload_files'][$uniq_id])) {
+        $_SESSION['ot_upload_files'][$uniq_id] = [];
+    }
+
+    $_SESSION['ot_upload_files'][$uniq_id][$file_dst] = 1;
 }

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -28,7 +28,7 @@ if (! isset($_SESSION['centreon'])) {
 }
 
 $uniq_id = $_REQUEST['uniqId'] ?? '';
-if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/', $uniq_id)) {
+if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/D', $uniq_id)) {
     $resultat = ['code' => 1, 'msg' => 'Invalid uniqId format.'];
 
     return;

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -42,6 +42,8 @@ if (! is_dir($target_dir) && ! mkdir($target_dir, 0750) && ! is_dir($target_dir)
     return;
 }
 
+$real_target_dir = realpath($target_dir);
+
 foreach ($_FILES as $file) {
     $safe_filename = basename($file['name']);
     if (
@@ -58,7 +60,6 @@ foreach ($_FILES as $file) {
 
     $file_dst = $target_dir . '/' . $uniq_id . '__' . $safe_filename;
 
-    $real_target_dir = realpath($target_dir);
     $real_dst_dir = realpath(dirname($file_dst));
     if ($real_target_dir === false || $real_dst_dir === false || $real_dst_dir !== $real_target_dir) {
         $resultat = ['code' => 1, 'msg' => 'Invalid file path.'];

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -35,7 +35,8 @@ if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/', $uniq_id)) {
 }
 
 $target_dir = sys_get_temp_dir() . '/opentickets';
-if (! is_dir($target_dir) && ! mkdir($target_dir, 0750)) {
+// Second is_dir() handles the race where another request created it between the first check and mkdir().
+if (! is_dir($target_dir) && ! mkdir($target_dir, 0750) && ! is_dir($target_dir)) {
     $resultat = ['code' => 1, 'msg' => 'Failed to create upload directory.'];
 
     return;


### PR DESCRIPTION
## Description

### Fixed

* Path traversal vulnerability (CWE-22) in `uploadFile.php` allowing arbitrary file write via unsanitized `$_FILES['name']` and `$_REQUEST['uniqId']`
* Path traversal vulnerability in `removeFile.php` allowing arbitrary file deletion via unsanitized `uniqId` and `filename` parameters
* Missing session authentication in both action files — they were directly accessible without authentication since the Apache configuration allows direct access to any PHP file under `www/`

### How

* Add session authentication checks (`$_SESSION['centreon']`) to both action files so they no longer rely solely on `call.php` being the entry point
* Validate `uniqId` with a strict regex matching PHP `uniqid()` output format
* Apply `basename()` to all user-supplied filenames to strip path components
* Verify resolved paths stay within the target directory using `realpath()`
* Reject filenames containing control characters or exceeding 200 characters on upload
* Enforce session-based authorization in `removeFile.php` to ensure only files uploaded by the current session can be deleted
* Use `sys_get_temp_dir()` consistently instead of `dirname($file['tmp_name'])`
* Replace error-suppressed `@mkdir()` with proper error handling

**Fixes** [MON-170734](https://centreon.atlassian.net/browse/MON-170734), [PG-4](https://centreon.atlassian.net/browse/PG-4)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-170734]: https://centreon.atlassian.net/browse/MON-170734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ