### PR TITLE
fix: change order for input (#9348)

### DIFF
--- a/centreon/www/front_src/src/Authentication/SAML/Form/inputs.ts
+++ b/centreon/www/front_src/src/Authentication/SAML/Form/inputs.ts
@@ -285,7 +285,7 @@ export const inputs: Array<InputProps> = [
     group: labelIdentityProvider,
     hideInput: (values: FormikValues): boolean => !values.requestedAuthnContext,
     label: labelRequestedAuthnContextComparison,
-    required: true,
+    required: false,
     type: InputType.Custom
   },
   {


### PR DESCRIPTION
dev-25.10.x backport of [MON-194781](https://centreon.atlassian.net/browse/MON-194781)

[MON-194781]: https://centreon.atlassian.net/browse/MON-194781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ