### PR TITLE
fix(SNMP traps): sanitize shell args in CLAPI generatetraps

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonManufacturer.class.php
+++ b/centreon/www/class/centreon-clapi/centreonManufacturer.class.php
@@ -130,8 +130,11 @@ class CentreonManufacturer extends CentreonObject
         }
         copy($mibFile, $tmpMibFile);
         $centreonDir = realpath(__DIR__ . '/../../../');
-        passthru("export MIBS=ALL && {$centreonDir}/bin/snmpttconvertmib --in={$tmpMibFile} --out={$tmpMibFile}.conf");
-        passthru("{$centreonDir}/bin/centFillTrapDB -f {$tmpMibFile}.conf -m {$vendorId}");
+        $escapedMibFile = escapeshellarg($tmpMibFile);
+        $escapedMibConfFile = escapeshellarg($tmpMibFile . '.conf');
+        $escapedVendorId = escapeshellarg((string) $vendorId);
+        passthru("export MIBS=ALL && {$centreonDir}/bin/snmpttconvertmib --in={$escapedMibFile} --out={$escapedMibConfFile}");
+        passthru("{$centreonDir}/bin/centFillTrapDB -f {$escapedMibConfFile} -m {$escapedVendorId}");
         unlink($tmpMibFile);
         if (file_exists($tmpMibFile . '.conf')) {
             unlink($tmpMibFile . '.conf');


### PR DESCRIPTION
## Description

- Fix OS command injection (CWE-78) in the CLAPI `generatetraps` action
- Use `escapeshellarg()` on the MIB file path and vendor ID before passing them to `passthru()` in `centreonManufacturer.class.php`
- `basename()` strips directory traversal but does not neutralize shell metacharacters (`$()`, backticks, `|`, `&`, `;`), which allows arbitrary command execution when a crafted filename is provided

[MON-195221](https://centreon.atlassian.net/browse/MON-195221)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

[MON-195221]: https://centreon.atlassian.net/browse/MON-195221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ