### PR TITLE
fix(dependencies): use prepared statements in dependency DB-Func files

### DIFF
--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -77,8 +77,8 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
 
 function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
+    global $pearDB;
     foreach (array_keys($dependencies) as $key) {
-        global $pearDB;
         $statement = $pearDB->prepare(
             'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
                     notification_failure_criteria, dep_comment
@@ -90,16 +90,32 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
         if ($row === false) {
             continue;
         }
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO dependency
+            (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+             notification_failure_criteria, dep_comment)
+            VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+             :notification_failure_criteria, :dep_comment)'
+        );
+        $selectParentStmt = $pearDB->prepare(
+            'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
+            . 'WHERE dependency_dep_id = :dep_id'
+        );
+        $insertParentStmt = $pearDB->prepare(
+            'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
+            . 'VALUES (:depId, :metaId)'
+        );
+        $selectChildStmt = $pearDB->prepare(
+            'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
+            . 'WHERE dependency_dep_id = :dep_id'
+        );
+        $insertChildStmt = $pearDB->prepare(
+            'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
+            . 'VALUES (:depId, :metaId)'
+        );
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {
-                $insertStmt = $pearDB->prepare(
-                    'INSERT INTO dependency
-                    (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                     notification_failure_criteria, dep_comment)
-                    VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-                     :notification_failure_criteria, :dep_comment)'
-                );
                 $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
                 $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
                 $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
@@ -109,30 +125,22 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {
-                    $selectStatement = $pearDB->prepare('SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
-                        . 'WHERE dependency_dep_id = :dep_id');
-                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $selectStatement->execute();
-                    $statement = $pearDB->prepare('INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
-                        . 'VALUES (:maxId, :metaId)');
-                    while ($ms = $selectStatement->fetch()) {
-                        $statement->bindValue(':maxId', (int) $lastId, PDO::PARAM_INT);
-                        $statement->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectParentStmt->execute();
+                    while ($ms = $selectParentStmt->fetch()) {
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
+                        $insertParentStmt->execute();
                     }
-                    $selectStatement->closeCursor();
-                    $selectStatement = $pearDB->prepare('SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
-                        . 'WHERE dependency_dep_id = :dep_id');
-                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $selectStatement->execute();
-                    $childStatement = $pearDB->prepare('INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
-                        . 'VALUES (:maxId, :metaId)');
-                    while ($ms = $selectStatement->fetch()) {
-                        $childStatement->bindValue(':maxId', (int) $lastId, PDO::PARAM_INT);
-                        $childStatement->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
-                        $childStatement->execute();
+                    $selectParentStmt->closeCursor();
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectChildStmt->execute();
+                    while ($ms = $selectChildStmt->fetch()) {
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
+                        $insertChildStmt->execute();
                     }
-                    $selectStatement->closeCursor();
+                    $selectChildStmt->closeCursor();
                 }
             }
         }

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -34,7 +34,7 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
     $statement->bindValue(':name', $name, PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
@@ -70,7 +70,7 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
     foreach ($dependencies as $key => $value) {
-        $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+        $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
     }
@@ -80,7 +80,7 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach ($dependencies as $key => $value) {
         global $pearDB;
-        $statement = $pearDB->prepare("SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1");
+        $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -34,16 +34,16 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '"
-        . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
     // Modif case
-    if ($dbResult->rowCount() >= 1 && $dep['dep_id'] == $id) {
+    if ($statement->rowCount() >= 1 && $dep['dep_id'] == $id) {
         return true;
     } // Duplicate entry
 
-    return ! ($dbResult->rowCount() >= 1 && $dep['dep_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $dep['dep_id'] != $id);
 }
 
 function testCycle($childs = null)
@@ -86,20 +86,22 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
         $row = $statement->fetch();
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'dep_name') {
-                    $dep_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-            }
+            $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {
-                $rq = $val ? 'INSERT INTO dependency VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO dependency
+                    (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                     notification_failure_criteria, dep_comment)
+                    VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+                     :notification_failure_criteria, :dep_comment)'
+                );
+                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->execute();
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
@@ -284,18 +286,20 @@ function updateMetaServiceDependencyMetaServiceParents($dep_id = null)
     }
     global $form;
     global $pearDB;
-    $rq = 'DELETE FROM dependency_metaserviceParent_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_metaserviceParent_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msParents');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO dependency_metaserviceParent_relation ';
-        $rq .= '(dependency_dep_id, meta_service_meta_id) ';
-        $rq .= 'VALUES ';
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
@@ -306,17 +310,19 @@ function updateMetaServiceDependencyMetaServiceChilds($dep_id = null)
     }
     global $form;
     global $pearDB;
-    $rq = 'DELETE FROM dependency_metaserviceChild_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_metaserviceChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msChilds');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO dependency_metaserviceChild_relation ';
-        $rq .= '(dependency_dep_id, meta_service_meta_id) ';
-        $rq .= 'VALUES ';
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -79,14 +79,17 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach (array_keys($dependencies) as $key) {
         global $pearDB;
-        $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
+        $statement = $pearDB->prepare(
+            'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                    notification_failure_criteria, dep_comment
+            FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+        );
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
         if ($row === false) {
             continue;
         }
-        $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -70,7 +70,9 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
     foreach ($dependencies as $key => $value) {
-        $dbResult = $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+        $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
@@ -78,8 +80,10 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach ($dependencies as $key => $value) {
         global $pearDB;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
+        $statement = $pearDB->prepare("SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
+        $row = $statement->fetch();
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $val = null;
@@ -99,28 +103,30 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
-                    $query = 'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
-                        . "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectStatement = $pearDB->prepare('SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
+                        . 'WHERE dependency_dep_id = :dep_id');
+                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectStatement->execute();
                     $statement = $pearDB->prepare('INSERT INTO dependency_metaserviceParent_relation '
                         . 'VALUES (:maxId, :metaId)');
-                    while ($ms = $dbResult->fetch()) {
+                    while ($ms = $selectStatement->fetch()) {
                         $statement->bindValue(':maxId', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
                         $statement->execute();
                     }
-                    $dbResult->closeCursor();
-                    $query = 'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
-                        . "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectStatement->closeCursor();
+                    $selectStatement = $pearDB->prepare('SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
+                        . 'WHERE dependency_dep_id = :dep_id');
+                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectStatement->execute();
                     $childStatement = $pearDB->prepare('INSERT INTO dependency_metaserviceChild_relation '
                         . 'VALUES (:maxId, :metaId)');
-                    while ($ms = $dbResult->fetch()) {
+                    while ($ms = $selectStatement->fetch()) {
                         $childStatement->bindValue(':maxId', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $childStatement->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
                         $childStatement->execute();
                     }
-                    $dbResult->closeCursor();
+                    $selectStatement->closeCursor();
                 }
             }
         }

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -78,41 +78,42 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
 function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB;
+    $selectStmt = $pearDB->prepare(
+        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+    );
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)'
+    );
+    $selectParentStmt = $pearDB->prepare(
+        'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertParentStmt = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
+        . 'VALUES (:depId, :metaId)'
+    );
+    $selectChildStmt = $pearDB->prepare(
+        'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
+        . 'VALUES (:depId, :metaId)'
+    );
+
     foreach (array_keys($dependencies) as $key) {
-        $statement = $pearDB->prepare(
-            'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                    notification_failure_criteria, dep_comment
-            FROM dependency WHERE dep_id = :dep_id LIMIT 1'
-        );
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
-        $row = $statement->fetch();
+        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         if ($row === false) {
             continue;
         }
-        $insertStmt = $pearDB->prepare(
-            'INSERT INTO dependency
-            (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-             notification_failure_criteria, dep_comment)
-            VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-             :notification_failure_criteria, :dep_comment)'
-        );
-        $selectParentStmt = $pearDB->prepare(
-            'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
-            . 'WHERE dependency_dep_id = :dep_id'
-        );
-        $insertParentStmt = $pearDB->prepare(
-            'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
-            . 'VALUES (:depId, :metaId)'
-        );
-        $selectChildStmt = $pearDB->prepare(
-            'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
-            . 'WHERE dependency_dep_id = :dep_id'
-        );
-        $insertChildStmt = $pearDB->prepare(
-            'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
-            . 'VALUES (:depId, :metaId)'
-        );
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -38,12 +38,11 @@ function testExistence($name = null)
     $statement->bindValue(':name', $name, PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
-    // Modif case
-    if ($statement->rowCount() >= 1 && $dep['dep_id'] == $id) {
+    if ($dep === false) {
         return true;
-    } // Duplicate entry
+    }
 
-    return ! ($statement->rowCount() >= 1 && $dep['dep_id'] != $id);
+    return $dep['dep_id'] == $id;
 }
 
 function testCycle($childs = null)
@@ -69,8 +68,8 @@ function testCycle($childs = null)
 function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
+    $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
     foreach ($dependencies as $key => $value) {
-        $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
     }
@@ -102,17 +101,16 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
                 $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
                 $insertStmt->execute();
-                $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
-                $maxId = $dbResult->fetch();
-                if (isset($maxId['MAX(dep_id)'])) {
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
                     $selectStatement = $pearDB->prepare('SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
                         . 'WHERE dependency_dep_id = :dep_id');
                     $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $selectStatement->execute();
-                    $statement = $pearDB->prepare('INSERT INTO dependency_metaserviceParent_relation '
+                    $statement = $pearDB->prepare('INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
                         . 'VALUES (:maxId, :metaId)');
                     while ($ms = $selectStatement->fetch()) {
-                        $statement->bindValue(':maxId', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $statement->bindValue(':maxId', (int) $lastId, PDO::PARAM_INT);
                         $statement->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
                         $statement->execute();
                     }
@@ -121,10 +119,10 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
                         . 'WHERE dependency_dep_id = :dep_id');
                     $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $selectStatement->execute();
-                    $childStatement = $pearDB->prepare('INSERT INTO dependency_metaserviceChild_relation '
+                    $childStatement = $pearDB->prepare('INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
                         . 'VALUES (:maxId, :metaId)');
                     while ($ms = $selectStatement->fetch()) {
-                        $childStatement->bindValue(':maxId', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $childStatement->bindValue(':maxId', (int) $lastId, PDO::PARAM_INT);
                         $childStatement->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
                         $childStatement->execute();
                     }
@@ -179,20 +177,19 @@ function insertMetaServiceDependency(): int
     $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
         'metaservice dependency',
-        $depId['MAX(dep_id)'],
+        $depId,
         $resourceValues['dep_name'],
         'a',
         $fields
     );
 
-    return (int) $depId['MAX(dep_id)'];
+    return $depId;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -69,7 +69,7 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
     $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
-    foreach ($dependencies as $key => $value) {
+    foreach (array_keys($dependencies) as $key) {
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
     }
@@ -77,12 +77,15 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
 
 function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
+    foreach (array_keys($dependencies) as $key) {
         global $pearDB;
         $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
+        if ($row === false) {
+            continue;
+        }
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -34,16 +34,16 @@ function testServiceDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '"
-        . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
     // Modif case
-    if ($dbResult->rowCount() >= 1 && $dep['dep_id'] == $id) {
+    if ($statement->rowCount() >= 1 && $dep['dep_id'] == $id) {
         return true;
     } // Duplicate entry
 
-    return ! ($dbResult->rowCount() >= 1 && $dep['dep_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $dep['dep_id'] != $id);
 }
 
 function testCycleH($childs = null)
@@ -92,26 +92,28 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
         $row = $statement->fetch();
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
+            $dep_name = $row['dep_name'] . '_' . $i;
+            $fields = [];
             foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'dep_name') {
-                    $dep_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
                 if ($key2 != 'dep_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($dep_name)) {
-                    $fields['dep_name'] = $dep_name;
+                    $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
                 }
             }
-            if (isset($dep_name) && testServiceDependencyExistence($dep_name)) {
-                $rq = $val ? 'INSERT INTO dependency VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+            if (testServiceDependencyExistence($dep_name)) {
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO dependency
+                    (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                     notification_failure_criteria, dep_comment)
+                    VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+                     :notification_failure_criteria, :dep_comment)'
+                );
+                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->execute();
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
@@ -359,19 +361,22 @@ function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
     if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = 'DELETE FROM dependency_serviceParent_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     $ret1 = $ret['dep_hSvPar'] ?? CentreonUtils::mergeWithInitialValues($form, 'dep_hSvPar');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)'
+    );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
         $exp = explode('-', $ret1[$i]);
         if (count($exp) == 2) {
-            $rq = 'INSERT INTO dependency_serviceParent_relation ';
-            $rq .= '(dependency_dep_id, service_service_id, host_host_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $dep_id . "', '" . $exp[1] . "', '" . $exp[0] . "')";
-            $dbResult = $pearDB->query($rq);
+            $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 }
@@ -386,19 +391,22 @@ function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
     if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = 'DELETE FROM dependency_serviceChild_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     $ret1 = $ret['dep_hSvChi'] ?? CentreonUtils::mergeWithInitialValues($form, 'dep_hSvChi');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)'
+    );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
         $exp = explode('-', $ret1[$i]);
         if (count($exp) == 2) {
-            $rq = 'INSERT INTO dependency_serviceChild_relation ';
-            $rq .= '(dependency_dep_id, service_service_id, host_host_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $dep_id . "', '" . $exp[1] . "', '" . $exp[0] . "')";
-            $dbResult = $pearDB->query($rq);
+            $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 }
@@ -418,20 +426,22 @@ function updateServiceDependencyHostChildren($dep_id = null, $ret = [])
     if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = 'DELETE FROM dependency_hostChild_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     if (isset($ret['dep_hHostChi'])) {
         $ret1 = $ret['dep_hHostChi'];
     } else {
         $ret1 = CentreonUtils::mergeWithInitialValues($form, 'dep_hHostChi');
     }
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:dep_id, :host_id)'
+    );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO dependency_hostChild_relation ';
-        $rq .= '(dependency_dep_id, host_host_id) ';
-        $rq .= 'VALUES ';
-        $rq .= "('" . $dep_id . "', '" . $ret1[$i] . "')";
-        $dbResult = $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':host_id', (int) $ret1[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -34,7 +34,7 @@ function testServiceDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
     $statement->bindValue(':name', $name, PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
@@ -70,12 +70,12 @@ function deleteServiceDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
     foreach ($dependencies as $key => $value) {
-        $statement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+        $statement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
 
-        $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+        $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $oreon->CentreonLogAction->insertLog('service dependency', $key, $row['dep_name'], 'd');
@@ -86,7 +86,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach ($dependencies as $key => $value) {
         global $pearDB, $oreon;
-        $statement = $pearDB->prepare("SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1");
+        $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
@@ -117,7 +117,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
-                    $statement2 = $pearDB->prepare("SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id");
+                    $statement2 = $pearDB->prepare('SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id');
                     $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $statement2->execute();
                     $fields['dep_hostPar'] = '';
@@ -131,7 +131,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                     }
                     $fields['dep_hostPar'] = trim($fields['dep_hostPar'], ',');
 
-                    $statement2 = $pearDB->prepare("SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id");
+                    $statement2 = $pearDB->prepare('SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id');
                     $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $statement2->execute();
                     $fields['dep_hSvPar'] = '';
@@ -150,7 +150,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                         $fields['dep_hSvPar'] .= $service['service_service_id'] . ',';
                     }
                     $fields['dep_hSvPar'] = trim($fields['dep_hSvPar'], ',');
-                    $statement2 = $pearDB->prepare("SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id");
+                    $statement2 = $pearDB->prepare('SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id');
                     $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $statement2->execute();
                     $fields['dep_hSvChi'] = '';

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -70,10 +70,14 @@ function deleteServiceDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
     foreach ($dependencies as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT dep_name FROM `dependency` WHERE `dep_id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+        $statement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
+        $row = $statement->fetch();
 
-        $dbResult = $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+        $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
         $oreon->CentreonLogAction->insertLog('service dependency', $key, $row['dep_name'], 'd');
     }
 }
@@ -82,8 +86,10 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach ($dependencies as $key => $value) {
         global $pearDB, $oreon;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
+        $statement = $pearDB->prepare("SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
+        $row = $statement->fetch();
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $val = null;
@@ -109,12 +115,13 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
-                    $query = "SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $statement2 = $pearDB->prepare("SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id");
+                    $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $statement2->execute();
                     $fields['dep_hostPar'] = '';
                     $query = 'INSERT INTO dependency_hostChild_relation VALUES (:dep_id, :host_host_id)';
                     $statement = $pearDB->prepare($query);
-                    while ($host = $dbResult->fetch()) {
+                    while ($host = $statement2->fetch()) {
                         $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':host_host_id', (int) $host['host_host_id'], PDO::PARAM_INT);
                         $statement->execute();
@@ -122,13 +129,14 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                     }
                     $fields['dep_hostPar'] = trim($fields['dep_hostPar'], ',');
 
-                    $query = "SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $statement2 = $pearDB->prepare("SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id");
+                    $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $statement2->execute();
                     $fields['dep_hSvPar'] = '';
-                    $query = 'INSERT INTO dependency_serviceParent_relation 
+                    $query = 'INSERT INTO dependency_serviceParent_relation
                         VALUES (:dep_id, :service_service_id, :host_host_id)';
                     $statement = $pearDB->prepare($query);
-                    while ($service = $dbResult->fetch()) {
+                    while ($service = $statement2->fetch()) {
                         $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $statement->bindValue(
                             ':service_service_id',
@@ -140,13 +148,14 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                         $fields['dep_hSvPar'] .= $service['service_service_id'] . ',';
                     }
                     $fields['dep_hSvPar'] = trim($fields['dep_hSvPar'], ',');
-                    $query = "SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $statement2 = $pearDB->prepare("SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id");
+                    $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $statement2->execute();
                     $fields['dep_hSvChi'] = '';
-                    $query = 'INSERT INTO dependency_serviceChild_relation 
+                    $query = 'INSERT INTO dependency_serviceChild_relation
                         VALUES (:dep_id, :service_service_id, :host_host_id)';
                     $statement = $pearDB->prepare($query);
-                    while ($service = $dbResult->fetch()) {
+                    while ($service = $statement2->fetch()) {
                         $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $statement->bindValue(
                             ':service_service_id',

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -88,21 +88,22 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach (array_keys($dependencies) as $key) {
         global $pearDB, $oreon;
-        $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
+        $statement = $pearDB->prepare(
+            'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                    notification_failure_criteria, dep_comment
+            FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+        );
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
         if ($row === false) {
             continue;
         }
-        $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             $fields = [];
             foreach ($row as $key2 => $value2) {
-                if ($key2 != 'dep_id') {
-                    $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
-                }
+                $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceDependencyExistence($dep_name)) {
                 $insertStmt = $pearDB->prepare(

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -86,8 +86,8 @@ function deleteServiceDependencyInDB($dependencies = [])
 
 function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
+    global $pearDB, $oreon;
     foreach (array_keys($dependencies) as $key) {
-        global $pearDB, $oreon;
         $statement = $pearDB->prepare(
             'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
                     notification_failure_criteria, dep_comment
@@ -99,6 +99,36 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
         if ($row === false) {
             continue;
         }
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO dependency
+            (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+             notification_failure_criteria, dep_comment)
+            VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+             :notification_failure_criteria, :dep_comment)'
+        );
+        $selectHostChildStmt = $pearDB->prepare(
+            'SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id'
+        );
+        $insertHostChildStmt = $pearDB->prepare(
+            'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+            VALUES (:depId, :hostId)'
+        );
+        $selectServiceParentStmt = $pearDB->prepare(
+            'SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
+            WHERE dependency_dep_id = :dep_id'
+        );
+        $insertServiceParentStmt = $pearDB->prepare(
+            'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+            VALUES (:depId, :serviceId, :hostId)'
+        );
+        $selectServiceChildStmt = $pearDB->prepare(
+            'SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
+            WHERE dependency_dep_id = :dep_id'
+        );
+        $insertServiceChildStmt = $pearDB->prepare(
+            'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+            VALUES (:depId, :serviceId, :hostId)'
+        );
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             $fields = [];
@@ -106,13 +136,6 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceDependencyExistence($dep_name)) {
-                $insertStmt = $pearDB->prepare(
-                    'INSERT INTO dependency
-                    (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                     notification_failure_criteria, dep_comment)
-                    VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-                     :notification_failure_criteria, :dep_comment)'
-                );
                 $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
                 $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
                 $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
@@ -122,55 +145,45 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {
-                    $statement2 = $pearDB->prepare('SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id');
-                    $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $statement2->execute();
+                    $selectHostChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectHostChildStmt->execute();
                     $fields['dep_hostPar'] = '';
-                    $query = 'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id) VALUES (:dep_id, :host_host_id)';
-                    $statement = $pearDB->prepare($query);
-                    while ($host = $statement2->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
-                        $statement->bindValue(':host_host_id', (int) $host['host_host_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                    while ($host = $selectHostChildStmt->fetch()) {
+                        $insertHostChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertHostChildStmt->bindValue(':hostId', (int) $host['host_host_id'], PDO::PARAM_INT);
+                        $insertHostChildStmt->execute();
                         $fields['dep_hostPar'] .= $host['host_host_id'] . ',';
                     }
                     $fields['dep_hostPar'] = trim($fields['dep_hostPar'], ',');
 
-                    $statement2 = $pearDB->prepare('SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id');
-                    $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $statement2->execute();
+                    $selectServiceParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectServiceParentStmt->execute();
                     $fields['dep_hSvPar'] = '';
-                    $query = 'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
-                        VALUES (:dep_id, :service_service_id, :host_host_id)';
-                    $statement = $pearDB->prepare($query);
-                    while ($service = $statement2->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
-                        $statement->bindValue(
-                            ':service_service_id',
+                    while ($service = $selectServiceParentStmt->fetch()) {
+                        $insertServiceParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertServiceParentStmt->bindValue(
+                            ':serviceId',
                             (int) $service['service_service_id'],
                             PDO::PARAM_INT
                         );
-                        $statement->bindValue(':host_host_id', (int) $service['host_host_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                        $insertServiceParentStmt->bindValue(':hostId', (int) $service['host_host_id'], PDO::PARAM_INT);
+                        $insertServiceParentStmt->execute();
                         $fields['dep_hSvPar'] .= $service['service_service_id'] . ',';
                     }
                     $fields['dep_hSvPar'] = trim($fields['dep_hSvPar'], ',');
-                    $statement2 = $pearDB->prepare('SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id');
-                    $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $statement2->execute();
+
+                    $selectServiceChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectServiceChildStmt->execute();
                     $fields['dep_hSvChi'] = '';
-                    $query = 'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
-                        VALUES (:dep_id, :service_service_id, :host_host_id)';
-                    $statement = $pearDB->prepare($query);
-                    while ($service = $statement2->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
-                        $statement->bindValue(
-                            ':service_service_id',
+                    while ($service = $selectServiceChildStmt->fetch()) {
+                        $insertServiceChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertServiceChildStmt->bindValue(
+                            ':serviceId',
                             (int) $service['service_service_id'],
                             PDO::PARAM_INT
                         );
-                        $statement->bindValue(':host_host_id', (int) $service['host_host_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                        $insertServiceChildStmt->bindValue(':hostId', (int) $service['host_host_id'], PDO::PARAM_INT);
+                        $insertServiceChildStmt->execute();
                         $fields['dep_hSvChi'] .= $service['service_service_id'] . ',';
                     }
                     $fields['dep_hSvChi'] = trim($fields['dep_hSvChi'], ',');

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -87,48 +87,49 @@ function deleteServiceDependencyInDB($dependencies = [])
 function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB, $oreon;
+    $selectStmt = $pearDB->prepare(
+        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+    );
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)'
+    );
+    $selectHostChildStmt = $pearDB->prepare(
+        'SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id'
+    );
+    $insertHostChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:depId, :hostId)'
+    );
+    $selectServiceParentStmt = $pearDB->prepare(
+        'SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
+        WHERE dependency_dep_id = :dep_id'
+    );
+    $insertServiceParentStmt = $pearDB->prepare(
+        'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)'
+    );
+    $selectServiceChildStmt = $pearDB->prepare(
+        'SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
+        WHERE dependency_dep_id = :dep_id'
+    );
+    $insertServiceChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)'
+    );
+
     foreach (array_keys($dependencies) as $key) {
-        $statement = $pearDB->prepare(
-            'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                    notification_failure_criteria, dep_comment
-            FROM dependency WHERE dep_id = :dep_id LIMIT 1'
-        );
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
-        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }
-        $insertStmt = $pearDB->prepare(
-            'INSERT INTO dependency
-            (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-             notification_failure_criteria, dep_comment)
-            VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-             :notification_failure_criteria, :dep_comment)'
-        );
-        $selectHostChildStmt = $pearDB->prepare(
-            'SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id'
-        );
-        $insertHostChildStmt = $pearDB->prepare(
-            'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
-            VALUES (:depId, :hostId)'
-        );
-        $selectServiceParentStmt = $pearDB->prepare(
-            'SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
-            WHERE dependency_dep_id = :dep_id'
-        );
-        $insertServiceParentStmt = $pearDB->prepare(
-            'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
-            VALUES (:depId, :serviceId, :hostId)'
-        );
-        $selectServiceChildStmt = $pearDB->prepare(
-            'SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
-            WHERE dependency_dep_id = :dep_id'
-        );
-        $insertServiceChildStmt = $pearDB->prepare(
-            'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
-            VALUES (:depId, :serviceId, :hostId)'
-        );
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             $fields = [];

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -70,10 +70,13 @@ function deleteServiceDependencyInDB($dependencies = [])
     global $pearDB, $oreon;
     $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
     $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
-    foreach ($dependencies as $key => $value) {
+    foreach (array_keys($dependencies) as $key) {
         $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $selectStatement->execute();
         $row = $selectStatement->fetch();
+        if ($row === false) {
+            continue;
+        }
 
         $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $deleteStatement->execute();
@@ -83,12 +86,15 @@ function deleteServiceDependencyInDB($dependencies = [])
 
 function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
+    foreach (array_keys($dependencies) as $key) {
         global $pearDB, $oreon;
         $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
+        if ($row === false) {
+            continue;
+        }
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -95,7 +95,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
         );
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
-        $row = $statement->fetch();
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -38,12 +38,11 @@ function testServiceDependencyExistence($name = null)
     $statement->bindValue(':name', $name, PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
-    // Modif case
-    if ($statement->rowCount() >= 1 && $dep['dep_id'] == $id) {
+    if ($dep === false) {
         return true;
-    } // Duplicate entry
+    }
 
-    return ! ($statement->rowCount() >= 1 && $dep['dep_id'] != $id);
+    return $dep['dep_id'] == $id;
 }
 
 function testCycleH($childs = null)
@@ -69,15 +68,15 @@ function testCycleH($childs = null)
 function deleteServiceDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
+    $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
+    $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
     foreach ($dependencies as $key => $value) {
-        $statement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
-        $row = $statement->fetch();
+        $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStatement->execute();
+        $row = $selectStatement->fetch();
 
-        $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
+        $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $deleteStatement->execute();
         $oreon->CentreonLogAction->insertLog('service dependency', $key, $row['dep_name'], 'd');
     }
 }
@@ -114,17 +113,16 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
                 $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
                 $insertStmt->execute();
-                $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
-                $maxId = $dbResult->fetch();
-                if (isset($maxId['MAX(dep_id)'])) {
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
                     $statement2 = $pearDB->prepare('SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id');
                     $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $statement2->execute();
                     $fields['dep_hostPar'] = '';
-                    $query = 'INSERT INTO dependency_hostChild_relation VALUES (:dep_id, :host_host_id)';
+                    $query = 'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id) VALUES (:dep_id, :host_host_id)';
                     $statement = $pearDB->prepare($query);
                     while ($host = $statement2->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
                         $statement->bindValue(':host_host_id', (int) $host['host_host_id'], PDO::PARAM_INT);
                         $statement->execute();
                         $fields['dep_hostPar'] .= $host['host_host_id'] . ',';
@@ -135,11 +133,11 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                     $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $statement2->execute();
                     $fields['dep_hSvPar'] = '';
-                    $query = 'INSERT INTO dependency_serviceParent_relation
+                    $query = 'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
                         VALUES (:dep_id, :service_service_id, :host_host_id)';
                     $statement = $pearDB->prepare($query);
                     while ($service = $statement2->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
                         $statement->bindValue(
                             ':service_service_id',
                             (int) $service['service_service_id'],
@@ -154,11 +152,11 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                     $statement2->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $statement2->execute();
                     $fields['dep_hSvChi'] = '';
-                    $query = 'INSERT INTO dependency_serviceChild_relation
+                    $query = 'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
                         VALUES (:dep_id, :service_service_id, :host_host_id)';
                     $statement = $pearDB->prepare($query);
                     while ($service = $statement2->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
                         $statement->bindValue(
                             ':service_service_id',
                             (int) $service['service_service_id'],
@@ -171,7 +169,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                     $fields['dep_hSvChi'] = trim($fields['dep_hSvChi'], ',');
                     $oreon->CentreonLogAction->insertLog(
                         'service dependency',
-                        $maxId['MAX(dep_id)'],
+                        $lastId,
                         $dep_name,
                         'a',
                         $fields
@@ -240,19 +238,18 @@ function insertServiceDependency($ret = []): int
     $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     $fields = CentreonLogAction::prepareChanges($ret);
     $centreon->CentreonLogAction->insertLog(
         'service dependency',
-        $depId['MAX(dep_id)'],
+        $depId,
         $resourceValues['dep_name'],
         'a',
         $fields
     );
 
-    return (int) $depId['MAX(dep_id)'];
+    return $depId;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -95,7 +95,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
         );
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
-        $row = $statement->fetch();
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }
@@ -158,6 +158,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                         $insertChildStmt->execute();
                         $fields['dep_sgChilds'] .= $sg['servicegroup_sg_id'] . ',';
                     }
+                    $selectChildStmt->closeCursor();
                     $fields['dep_sgChilds'] = trim($fields['dep_sgChilds'], ',');
                     $oreon->CentreonLogAction->insertLog(
                         'servicegroup dependency',
@@ -166,7 +167,6 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                         'a',
                         $fields
                     );
-                    $selectChildStmt->closeCursor();
                 }
             }
         }

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -87,41 +87,42 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
 function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB, $oreon;
+    $selectStmt = $pearDB->prepare(
+        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+    );
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)'
+    );
+    $selectParentStmt = $pearDB->prepare(
+        'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertParentStmt = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
+        . 'VALUES (:depId, :servicegroupId)'
+    );
+    $selectChildStmt = $pearDB->prepare(
+        'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
+        . 'VALUES (:depId, :servicegroupId)'
+    );
+
     foreach (array_keys($dependencies) as $key) {
-        $statement = $pearDB->prepare(
-            'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                    notification_failure_criteria, dep_comment
-            FROM dependency WHERE dep_id = :dep_id LIMIT 1'
-        );
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
-        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }
-        $insertStmt = $pearDB->prepare(
-            'INSERT INTO dependency
-            (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-             notification_failure_criteria, dep_comment)
-            VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-             :notification_failure_criteria, :dep_comment)'
-        );
-        $selectParentStmt = $pearDB->prepare(
-            'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
-            . 'WHERE dependency_dep_id = :dep_id'
-        );
-        $insertParentStmt = $pearDB->prepare(
-            'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
-            . 'VALUES (:depId, :servicegroupId)'
-        );
-        $selectChildStmt = $pearDB->prepare(
-            'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
-            . 'WHERE dependency_dep_id = :dep_id'
-        );
-        $insertChildStmt = $pearDB->prepare(
-            'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
-            . 'VALUES (:depId, :servicegroupId)'
-        );
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             $fields = [];

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -70,10 +70,13 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
     global $pearDB, $oreon;
     $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
     $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
-    foreach ($dependencies as $key => $value) {
+    foreach (array_keys($dependencies) as $key) {
         $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $selectStatement->execute();
         $row = $selectStatement->fetch();
+        if ($row === false) {
+            continue;
+        }
 
         $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $deleteStatement->execute();
@@ -83,12 +86,15 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
 
 function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
+    foreach (array_keys($dependencies) as $key) {
         global $pearDB, $oreon;
         $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
+        if ($row === false) {
+            continue;
+        }
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -88,21 +88,22 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach (array_keys($dependencies) as $key) {
         global $pearDB, $oreon;
-        $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
+        $statement = $pearDB->prepare(
+            'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                    notification_failure_criteria, dep_comment
+            FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+        );
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
         if ($row === false) {
             continue;
         }
-        $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             $fields = [];
             foreach ($row as $key2 => $value2) {
-                if ($key2 != 'dep_id') {
-                    $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
-                }
+                $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceGroupDependencyExistence($dep_name)) {
                 $insertStmt = $pearDB->prepare(

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -70,10 +70,14 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
     foreach ($dependencies as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT dep_name FROM `dependency` WHERE `dep_id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+        $statement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
+        $row = $statement->fetch();
 
-        $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+        $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
         $oreon->CentreonLogAction->insertLog('servicegroup dependency', $key, $row['dep_name'], 'd');
     }
 }
@@ -82,8 +86,10 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach ($dependencies as $key => $value) {
         global $pearDB, $oreon;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
+        $statement = $pearDB->prepare("SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1");
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
+        $row = $statement->fetch();
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $val = null;
@@ -109,29 +115,31 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
-                    $query = 'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
-                        . "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectStatement = $pearDB->prepare('SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
+                        . 'WHERE dependency_dep_id = :dep_id');
+                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectStatement->execute();
                     $fields['dep_sgParents'] = '';
                     $query = 'INSERT INTO dependency_servicegroupParent_relation '
                              . 'VALUES (:dep_id, :servicegroup_sg_id)';
                     $statement = $pearDB->prepare($query);
-                    while ($sg = $dbResult->fetch()) {
+                    while ($sg = $selectStatement->fetch()) {
                         $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':servicegroup_sg_id', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
                         $statement->execute();
                         $fields['dep_sgParents'] .= $sg['servicegroup_sg_id'] . ',';
                     }
                     $fields['dep_sgParents'] = trim($fields['dep_sgParents'], ',');
-                    $dbResult->closeCursor();
-                    $query = 'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
-                        . "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectStatement->closeCursor();
+                    $selectStatement = $pearDB->prepare('SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
+                        . 'WHERE dependency_dep_id = :dep_id');
+                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectStatement->execute();
                     $fields['dep_sgChilds'] = '';
                     $query = 'INSERT INTO dependency_servicegroupChild_relation '
                              . 'VALUES (:dep_id, :servicegroup_sg_id)';
                     $statement = $pearDB->prepare($query);
-                    while ($sg = $dbResult->fetch()) {
+                    while ($sg = $selectStatement->fetch()) {
                         $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':servicegroup_sg_id', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
                         $statement->execute();
@@ -145,7 +153,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                         'a',
                         $fields
                     );
-                    $dbResult->closeCursor();
+                    $selectStatement->closeCursor();
                 }
             }
         }

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -34,16 +34,16 @@ function testServiceGroupDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '"
-        . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
     // Modif case
-    if ($dbResult->rowCount() >= 1 && $dep['dep_id'] == $id) {
+    if ($statement->rowCount() >= 1 && $dep['dep_id'] == $id) {
         return true;
     } // Duplicate entry
 
-    return ! ($dbResult->rowCount() >= 1 && $dep['dep_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $dep['dep_id'] != $id);
 }
 
 function testServiceGroupDependencyCycle($childs = null)
@@ -92,26 +92,28 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
         $row = $statement->fetch();
         $row['dep_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
+            $dep_name = $row['dep_name'] . '_' . $i;
+            $fields = [];
             foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'dep_name') {
-                    $dep_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
                 if ($key2 != 'dep_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($dep_name)) {
-                    $fields['dep_name'] = $dep_name;
+                    $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
                 }
             }
-            if (isset($dep_name) && testServiceGroupDependencyExistence($dep_name)) {
-                $rq = $val ? 'INSERT INTO dependency VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+            if (testServiceGroupDependencyExistence($dep_name)) {
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO dependency
+                    (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                     notification_failure_criteria, dep_comment)
+                    VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+                     :notification_failure_criteria, :dep_comment)'
+                );
+                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->execute();
                 $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
                 $maxId = $dbResult->fetch();
                 if (isset($maxId['MAX(dep_id)'])) {
@@ -318,21 +320,23 @@ function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = 
     if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = 'DELETE FROM dependency_servicegroupParent_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_servicegroupParent_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     if (isset($ret['dep_sgParents'])) {
         $ret = $ret['dep_sgParents'];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgParents');
     }
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO dependency_servicegroupParent_relation ';
-        $rq .= '(dependency_dep_id, servicegroup_sg_id) ';
-        $rq .= 'VALUES ';
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
@@ -346,20 +350,22 @@ function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = [
     if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = 'DELETE FROM dependency_servicegroupChild_relation ';
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_servicegroupChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     if (isset($ret['dep_sgChilds'])) {
         $ret = $ret['dep_sgChilds'];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgChilds');
     }
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO dependency_servicegroupChild_relation ';
-        $rq .= '(dependency_dep_id, servicegroup_sg_id) ';
-        $rq .= 'VALUES ';
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -34,7 +34,7 @@ function testServiceGroupDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
     $statement->bindValue(':name', $name, PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
@@ -70,12 +70,12 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
     foreach ($dependencies as $key => $value) {
-        $statement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+        $statement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();
 
-        $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+        $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $oreon->CentreonLogAction->insertLog('servicegroup dependency', $key, $row['dep_name'], 'd');
@@ -86,7 +86,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
     foreach ($dependencies as $key => $value) {
         global $pearDB, $oreon;
-        $statement = $pearDB->prepare("SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1");
+        $statement = $pearDB->prepare('SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1');
         $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetch();

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -38,12 +38,11 @@ function testServiceGroupDependencyExistence($name = null)
     $statement->bindValue(':name', $name, PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
-    // Modif case
-    if ($statement->rowCount() >= 1 && $dep['dep_id'] == $id) {
+    if ($dep === false) {
         return true;
-    } // Duplicate entry
+    }
 
-    return ! ($statement->rowCount() >= 1 && $dep['dep_id'] != $id);
+    return $dep['dep_id'] == $id;
 }
 
 function testServiceGroupDependencyCycle($childs = null)
@@ -69,15 +68,15 @@ function testServiceGroupDependencyCycle($childs = null)
 function deleteServiceGroupDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
+    $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
+    $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
     foreach ($dependencies as $key => $value) {
-        $statement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
-        $row = $statement->fetch();
+        $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStatement->execute();
+        $row = $selectStatement->fetch();
 
-        $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-        $statement->execute();
+        $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $deleteStatement->execute();
         $oreon->CentreonLogAction->insertLog('servicegroup dependency', $key, $row['dep_name'], 'd');
     }
 }
@@ -114,19 +113,18 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                 $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
                 $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
                 $insertStmt->execute();
-                $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
-                $maxId = $dbResult->fetch();
-                if (isset($maxId['MAX(dep_id)'])) {
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
                     $selectStatement = $pearDB->prepare('SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
                         . 'WHERE dependency_dep_id = :dep_id');
                     $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $selectStatement->execute();
                     $fields['dep_sgParents'] = '';
-                    $query = 'INSERT INTO dependency_servicegroupParent_relation '
+                    $query = 'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
                              . 'VALUES (:dep_id, :servicegroup_sg_id)';
                     $statement = $pearDB->prepare($query);
                     while ($sg = $selectStatement->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
                         $statement->bindValue(':servicegroup_sg_id', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
                         $statement->execute();
                         $fields['dep_sgParents'] .= $sg['servicegroup_sg_id'] . ',';
@@ -138,11 +136,11 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                     $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
                     $selectStatement->execute();
                     $fields['dep_sgChilds'] = '';
-                    $query = 'INSERT INTO dependency_servicegroupChild_relation '
+                    $query = 'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
                              . 'VALUES (:dep_id, :servicegroup_sg_id)';
                     $statement = $pearDB->prepare($query);
                     while ($sg = $selectStatement->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId['MAX(dep_id)'], PDO::PARAM_INT);
+                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
                         $statement->bindValue(':servicegroup_sg_id', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
                         $statement->execute();
                         $fields['dep_sgChilds'] .= $sg['servicegroup_sg_id'] . ',';
@@ -150,7 +148,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                     $fields['dep_sgChilds'] = trim($fields['dep_sgChilds'], ',');
                     $oreon->CentreonLogAction->insertLog(
                         'servicegroup dependency',
-                        $maxId['MAX(dep_id)'],
+                        $lastId,
                         $dep_name,
                         'a',
                         $fields
@@ -210,20 +208,19 @@ function insertServiceGroupDependency($ret = []): int
     $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query('SELECT MAX(dep_id) FROM dependency');
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
         'servicegroup dependency',
-        $depId['MAX(dep_id)'],
+        $depId,
         $resourceValues['dep_name'],
         'a',
         $fields
     );
 
-    return (int) $depId['MAX(dep_id)'];
+    return $depId;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -86,8 +86,8 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
 
 function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
+    global $pearDB, $oreon;
     foreach (array_keys($dependencies) as $key) {
-        global $pearDB, $oreon;
         $statement = $pearDB->prepare(
             'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
                     notification_failure_criteria, dep_comment
@@ -99,6 +99,29 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
         if ($row === false) {
             continue;
         }
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO dependency
+            (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+             notification_failure_criteria, dep_comment)
+            VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+             :notification_failure_criteria, :dep_comment)'
+        );
+        $selectParentStmt = $pearDB->prepare(
+            'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
+            . 'WHERE dependency_dep_id = :dep_id'
+        );
+        $insertParentStmt = $pearDB->prepare(
+            'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
+            . 'VALUES (:depId, :servicegroupId)'
+        );
+        $selectChildStmt = $pearDB->prepare(
+            'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
+            . 'WHERE dependency_dep_id = :dep_id'
+        );
+        $insertChildStmt = $pearDB->prepare(
+            'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
+            . 'VALUES (:depId, :servicegroupId)'
+        );
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             $fields = [];
@@ -106,13 +129,6 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                 $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceGroupDependencyExistence($dep_name)) {
-                $insertStmt = $pearDB->prepare(
-                    'INSERT INTO dependency
-                    (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                     notification_failure_criteria, dep_comment)
-                    VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-                     :notification_failure_criteria, :dep_comment)'
-                );
                 $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
                 $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
                 $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
@@ -122,34 +138,24 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {
-                    $selectStatement = $pearDB->prepare('SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
-                        . 'WHERE dependency_dep_id = :dep_id');
-                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $selectStatement->execute();
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectParentStmt->execute();
                     $fields['dep_sgParents'] = '';
-                    $query = 'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
-                             . 'VALUES (:dep_id, :servicegroup_sg_id)';
-                    $statement = $pearDB->prepare($query);
-                    while ($sg = $selectStatement->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
-                        $statement->bindValue(':servicegroup_sg_id', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                    while ($sg = $selectParentStmt->fetch()) {
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
+                        $insertParentStmt->execute();
                         $fields['dep_sgParents'] .= $sg['servicegroup_sg_id'] . ',';
                     }
                     $fields['dep_sgParents'] = trim($fields['dep_sgParents'], ',');
-                    $selectStatement->closeCursor();
-                    $selectStatement = $pearDB->prepare('SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
-                        . 'WHERE dependency_dep_id = :dep_id');
-                    $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
-                    $selectStatement->execute();
+                    $selectParentStmt->closeCursor();
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectChildStmt->execute();
                     $fields['dep_sgChilds'] = '';
-                    $query = 'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
-                             . 'VALUES (:dep_id, :servicegroup_sg_id)';
-                    $statement = $pearDB->prepare($query);
-                    while ($sg = $selectStatement->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $lastId, PDO::PARAM_INT);
-                        $statement->bindValue(':servicegroup_sg_id', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                    while ($sg = $selectChildStmt->fetch()) {
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
+                        $insertChildStmt->execute();
                         $fields['dep_sgChilds'] .= $sg['servicegroup_sg_id'] . ',';
                     }
                     $fields['dep_sgChilds'] = trim($fields['dep_sgChilds'], ',');
@@ -160,7 +166,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                         'a',
                         $fields
                     );
-                    $selectStatement->closeCursor();
+                    $selectChildStmt->closeCursor();
                 }
             }
         }


### PR DESCRIPTION
## Description

- Fix SQL injection (CWE-89) in service, metaservice, and servicegroup dependency `DB-Func.php` files
- Replace all raw SQL string concatenation with prepared statements using `bindValue()`
- Convert `testExistence()` functions from `htmlentities()` to parameterized queries
- Convert `update*Parents/Childs()` functions to parameterize `$dep_id` and form values
- Replace the duplicate pattern (`$val` string building from DB rows) with explicit prepared INSERT

[MON-195224](https://centreon.atlassian.net/browse/MON-195224)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

[MON-195224]: https://centreon.atlassian.net/browse/MON-195224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ