### PR TITLE
fix(open-tickets): sanitize file paths in upload and remove actions

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/removeFile.php
@@ -24,6 +24,52 @@ $resultat = array(
     "msg" => 'ok',
 );
 
-$temp_dir = sys_get_temp_dir();
-unlink($temp_dir . '/opentickets/' . $get_information['uniqId'] . '__' . $get_information['filename']);
-unset($_SESSION['ot_upload_files'][$get_information['uniqId']]);
+if (! isset($_SESSION['centreon'])) {
+    $resultat = ['code' => 1, 'msg' => 'Unauthorized.'];
+
+    return;
+}
+
+$uniq_id = $get_information['uniqId'] ?? '';
+$filename = basename($get_information['filename'] ?? '');
+
+if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/D', $uniq_id) || $filename === '') {
+    $resultat = ['code' => 1, 'msg' => 'Invalid parameters.'];
+
+    return;
+}
+
+$target_dir = sys_get_temp_dir() . '/opentickets';
+$file_path = $target_dir . '/' . $uniq_id . '__' . $filename;
+
+$real_target_dir = realpath($target_dir);
+$real_file_path = realpath($file_path);
+if (
+    $real_target_dir === false
+    || $real_file_path === false
+    || ! str_starts_with($real_file_path, $real_target_dir . '/')
+) {
+    $resultat = ['code' => 1, 'msg' => 'File not found.'];
+
+    return;
+}
+
+if (! isset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path])
+    && ! isset($_SESSION['ot_upload_files'][$uniq_id][$file_path])
+) {
+    $resultat = ['code' => 1, 'msg' => 'Unauthorized file access.'];
+
+    return;
+}
+
+if (! unlink($real_file_path)) {
+    $resultat = ['code' => 1, 'msg' => 'Failed to delete file.'];
+
+    return;
+}
+
+unset($_SESSION['ot_upload_files'][$uniq_id][$real_file_path], $_SESSION['ot_upload_files'][$uniq_id][$file_path]);
+
+if (empty($_SESSION['ot_upload_files'][$uniq_id])) {
+    unset($_SESSION['ot_upload_files'][$uniq_id]);
+}

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/uploadFile.php
@@ -19,24 +19,66 @@
  * limitations under the License.
  */
 
-$resultat = array(
-    "code" => 0,
-    "msg" => 'ok',
-);
+$resultat = ["code" => 0, "msg" => 'ok'];
 
-$uniq_id = $_REQUEST['uniqId'];
+if (! isset($_SESSION['centreon'])) {
+    $resultat = ['code' => 1, 'msg' => 'Unauthorized.'];
+
+    return;
+}
+
+$uniq_id = $_REQUEST['uniqId'] ?? '';
+if (! preg_match('/^[a-f0-9]{13}(\.[0-9]{8})?$/D', $uniq_id)) {
+    $resultat = ['code' => 1, 'msg' => 'Invalid uniqId format.'];
+
+    return;
+}
+
+$target_dir = sys_get_temp_dir() . '/opentickets';
+// Second is_dir() handles the race where another request created it between the first check and mkdir().
+if (! is_dir($target_dir) && ! mkdir($target_dir, 0750) && ! is_dir($target_dir)) {
+    $resultat = ['code' => 1, 'msg' => 'Failed to create upload directory.'];
+
+    return;
+}
+
+$real_target_dir = realpath($target_dir);
+
 foreach ($_FILES as $file) {
-    $dir = dirname($file['tmp_name']);
-    $file_dst = $dir . '/opentickets/' . $uniq_id . '__' . $file['name'];
-    @mkdir($dir . '/opentickets', 0750);
-    if (rename($file['tmp_name'], $file_dst)) {
-        if (!isset($_SESSION['ot_upload_files'])) {
-            $_SESSION['ot_upload_files'] = array();
-        }
-        if (!isset($_SESSION['ot_upload_files'][$uniq_id])) {
-            $_SESSION['ot_upload_files'][$uniq_id] = array();
-        }
+    $safe_filename = basename($file['name']);
+    if (
+        $safe_filename === ''
+        || $safe_filename === '.'
+        || $safe_filename === '..'
+        || preg_match('/[\x00-\x1f\x7f]/', $safe_filename)
+        || strlen($safe_filename) > 200
+    ) {
+        $resultat = ['code' => 1, 'msg' => 'Invalid filename.'];
 
-        $_SESSION['ot_upload_files'][$uniq_id][$file_dst] = 1;
+        return;
     }
+
+    $file_dst = $target_dir . '/' . $uniq_id . '__' . $safe_filename;
+
+    $real_dst_dir = realpath(dirname($file_dst));
+    if ($real_target_dir === false || $real_dst_dir === false || $real_dst_dir !== $real_target_dir) {
+        $resultat = ['code' => 1, 'msg' => 'Invalid file path.'];
+
+        return;
+    }
+
+    if (! move_uploaded_file($file['tmp_name'], $file_dst)) {
+        $resultat = ['code' => 1, 'msg' => 'Failed to save uploaded file.'];
+
+        return;
+    }
+
+    if (! isset($_SESSION['ot_upload_files'])) {
+        $_SESSION['ot_upload_files'] = [];
+    }
+    if (! isset($_SESSION['ot_upload_files'][$uniq_id])) {
+        $_SESSION['ot_upload_files'][$uniq_id] = [];
+    }
+
+    $_SESSION['ot_upload_files'][$uniq_id][$file_dst] = 1;
 }


### PR DESCRIPTION
## Description

Backport of #9676 to `hotfix-24.04-next`.

### Fixed
* Path traversal vulnerability (CWE-22) in `uploadFile.php` allowing arbitrary file write via crafted `uniqId` or filename
* Path traversal vulnerability in `removeFile.php` allowing arbitrary file deletion via crafted parameters
* Missing session authentication in both action files

### How
* Add session authentication checks to both files
* Validate `uniqId` with strict regex (`/^[a-f0-9]+$/`)
* Apply `basename()` to filenames to strip directory traversal sequences
* Verify resolved paths with `realpath()` stay within the expected temp directory
* Reject filenames with control characters or exceeding 200 characters
* Enforce session-based authorization in `removeFile.php`
* Use `sys_get_temp_dir()` consistently for temp path resolution
* Replace error-suppressed `@mkdir()` with proper error handling

**Fixes** [MON-195255](https://centreon.atlassian.net/browse/MON-195255)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Target serie

- [x] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the [coding style guidelines](https://github.com/centreon/centreon/blob/master/CONTRIBUTING.md#coding-style) provided by Centreon
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have rebased my development branch on the base branch

[MON-195255]: https://centreon.atlassian.net/browse/MON-195255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ