### PR TITLE
fix(dependencies): use prepared statements in dependency DB-Func files

### DIFF
--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -1,25 +1,39 @@
 <?php
-
 /*
- * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Copyright 2005-2015 Centreon
+ * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
  *
  * For more information : contact@centreon.com
  *
  */
 
-if (! isset($oreon)) {
+if (!isset($oreon)) {
     exit();
 }
 
@@ -34,8 +48,8 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
-    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
     if ($dep === false) {
@@ -61,16 +75,15 @@ function testCycle($childs = null)
             return false;
         }
     }
-
     return true;
 }
 
 function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
-    $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+    $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
     foreach (array_keys($dependencies) as $key) {
-        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $statement->execute();
     }
 }
@@ -79,36 +92,36 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB;
     $selectStmt = $pearDB->prepare(
-        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+        "SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
                 notification_failure_criteria, dep_comment
-        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1"
     );
     $insertStmt = $pearDB->prepare(
-        'INSERT INTO dependency
+        "INSERT INTO dependency
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-         :notification_failure_criteria, :dep_comment)'
+         :notification_failure_criteria, :dep_comment)"
     );
     $selectParentStmt = $pearDB->prepare(
-        'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
-        . 'WHERE dependency_dep_id = :dep_id'
+        "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation "
+        . "WHERE dependency_dep_id = :dep_id"
     );
     $insertParentStmt = $pearDB->prepare(
-        'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
-        . 'VALUES (:depId, :metaId)'
+        "INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) "
+        . "VALUES (:depId, :metaId)"
     );
     $selectChildStmt = $pearDB->prepare(
-        'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
-        . 'WHERE dependency_dep_id = :dep_id'
+        "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation "
+        . "WHERE dependency_dep_id = :dep_id"
     );
     $insertChildStmt = $pearDB->prepare(
-        'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
-        . 'VALUES (:depId, :metaId)'
+        "INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) "
+        . "VALUES (:depId, :metaId)"
     );
 
     foreach (array_keys($dependencies) as $key) {
-        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $selectStmt->execute();
         $row = $selectStmt->fetch();
         if ($row === false) {
@@ -117,28 +130,28 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {
-                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_name', $dep_name, \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], \PDO::PARAM_STR);
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {
-                    $selectParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectParentStmt->execute();
                     while ($ms = $selectParentStmt->fetch()) {
-                        $insertParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
-                        $insertParentStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], \PDO::PARAM_INT);
                         $insertParentStmt->execute();
                     }
                     $selectParentStmt->closeCursor();
-                    $selectChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectChildStmt->execute();
                     while ($ms = $selectChildStmt->fetch()) {
-                        $insertChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
-                        $insertChildStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], \PDO::PARAM_INT);
                         $insertChildStmt->execute();
                     }
                     $selectChildStmt->closeCursor();
@@ -150,7 +163,7 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 
 function updateMetaServiceDependencyInDB($dep_id = null)
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     updateMetaServiceDependency($dep_id);
@@ -163,8 +176,7 @@ function insertMetaServiceDependencyInDB()
     $dep_id = insertMetaServiceDependency();
     updateMetaServiceDependencyMetaServiceParents($dep_id);
     updateMetaServiceDependencyMetaServiceChilds($dep_id);
-
-    return $dep_id;
+    return ($dep_id);
 }
 
 /**
@@ -178,29 +190,29 @@ function insertMetaServiceDependency(): int
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
 
     $statement = $pearDB->prepare(
-        'INSERT INTO `dependency`
+        "INSERT INTO `dependency`
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:depName, :depDescription, :inheritsParent, :executionFailure,
-                :notificationFailure, :depComment)'
+                :notificationFailure, :depComment)"
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
     $statement->execute();
 
     $depId = (int) $pearDB->lastInsertId();
 
-    // Prepare value for changelog
+    /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        'metaservice dependency',
+        "metaservice dependency",
         $depId,
-        $resourceValues['dep_name'],
-        'a',
+        $resourceValues["dep_name"],
+        "a",
         $fields
     );
 
@@ -214,38 +226,38 @@ function insertMetaServiceDependency(): int
  */
 function updateMetaServiceDependency($depId = null): void
 {
-    if (! $depId) {
+    if (!$depId) {
         exit();
     }
     global $form, $pearDB, $centreon;
 
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
     $statement = $pearDB->prepare(
-        'UPDATE `dependency`
+        "UPDATE `dependency`
         SET dep_name = :depName,
         dep_description = :depDescription,
         inherits_parent = :inheritsParent,
         execution_failure_criteria = :executionFailure,
         notification_failure_criteria = :notificationFailure,
         dep_comment = :depComment
-        WHERE dep_id = :depId'
+        WHERE dep_id = :depId"
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
-    $statement->bindValue(':depId', $depId, PDO::PARAM_INT);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
+    $statement->bindValue(':depId', $depId, \PDO::PARAM_INT);
     $statement->execute();
 
-    // Prepare value for changelog
+    /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        'metaservice dependency',
+        "metaservice dependency",
         $depId,
-        $resourceValues['dep_name'],
-        'c',
+        $resourceValues["dep_name"],
+        "c",
         $fields
     );
 }
@@ -259,82 +271,82 @@ function updateMetaServiceDependency($depId = null): void
 function sanitizeResourceParameters(array $resources): array
 {
     $sanitizedParameters = [];
-    $sanitizedParameters['dep_name'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
+    $sanitizedParameters['dep_name'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
     if (empty($sanitizedParameters['dep_name'])) {
         throw new InvalidArgumentException(_("Dependency name can't be empty"));
     }
 
-    $sanitizedParameters['dep_description'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
+    $sanitizedParameters['dep_description'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
     if (empty($sanitizedParameters['dep_description'])) {
         throw new InvalidArgumentException(_("Dependency description can't be empty"));
     }
 
-    $resources['inherits_parent']['inherits_parent'] == 1
-        ? $sanitizedParameters['inherits_parent'] = '1'
-        : $sanitizedParameters['inherits_parent'] = '0';
+    $resources["inherits_parent"]["inherits_parent"] == 1
+        ? $sanitizedParameters["inherits_parent"] = '1'
+        : $sanitizedParameters["inherits_parent"] = '0';
 
-    $sanitizedParameters['execution_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['execution_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ',',
-            array_keys($resources['execution_failure_criteria'])
+            ",",
+            array_keys($resources["execution_failure_criteria"])
         )
     );
 
-    $sanitizedParameters['notification_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['notification_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ',',
-            array_keys($resources['notification_failure_criteria'])
+            ",",
+            array_keys($resources["notification_failure_criteria"])
         )
     );
-    $sanitizedParameters['dep_comment'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
+    $sanitizedParameters['dep_comment'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
 
     return $sanitizedParameters;
 }
 
 function updateMetaServiceDependencyMetaServiceParents($dep_id = null)
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    $statement = $pearDB->prepare('DELETE FROM dependency_metaserviceParent_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_metaserviceParent_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
     $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msParents');
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id)
-        VALUES (:dep_id, :meta_id)'
+        "INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)"
     );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-        $statement->bindValue(':meta_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();
     }
 }
 
 function updateMetaServiceDependencyMetaServiceChilds($dep_id = null)
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    $statement = $pearDB->prepare('DELETE FROM dependency_metaserviceChild_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_metaserviceChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
     $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msChilds');
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id)
-        VALUES (:dep_id, :meta_id)'
+        "INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)"
     );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-        $statement->bindValue(':meta_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -1,39 +1,25 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
- * GPL Licence 2.0.
- * 
- * This program is free software; you can redistribute it and/or modify it under 
- * the terms of the GNU General Public License as published by the Free Software 
- * Foundation ; either version 2 of the License.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with 
- * this program; if not, see <http://www.gnu.org/licenses>.
- * 
- * Linking this program statically or dynamically with other modules is making a 
- * combined work based on this program. Thus, the terms and conditions of the GNU 
- * General Public License cover the whole combination.
- * 
- * As a special exception, the copyright holders of this program give Centreon 
- * permission to link this program with independent modules to produce an executable, 
- * regardless of the license terms of these independent modules, and to copy and 
- * distribute the resulting executable under terms of Centreon choice, provided that 
- * Centreon also meet, for each linked independent module, the terms  and conditions 
- * of the license of that module. An independent module is a module which is not 
- * derived from this program. If you modify this program, you may extend this 
- * exception to your version of the program, but you are not obliged to do so. If you
- * do not wish to do so, delete this exception statement from your version.
- * 
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  * For more information : contact@centreon.com
- * 
+ *
  */
 
-if (!isset($oreon)) {
+if (! isset($oreon)) {
     exit();
 }
 
@@ -48,19 +34,15 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '" .
-        htmlentities($name, ENT_QUOTES, "UTF-8") . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
-    #Modif case
-    if ($dbResult->rowCount() >= 1 && $dep["dep_id"] == $id) {
-        return true;
-    } #Duplicate entry
-    elseif ($dbResult->rowCount() >= 1 && $dep["dep_id"] != $id) {
-        return false;
-    } else {
+    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
+    if ($dep === false) {
         return true;
     }
+
+    return $dep['dep_id'] == $id;
 }
 
 function testCycle($childs = null)
@@ -79,64 +61,87 @@ function testCycle($childs = null)
             return false;
         }
     }
+
     return true;
 }
 
 function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
-    foreach ($dependencies as $key => $value) {
-        $dbResult = $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+    $statement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+    foreach (array_keys($dependencies) as $key) {
+        $statement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
 function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
-        global $pearDB;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row["dep_id"] = null;
+    global $pearDB;
+    $selectStmt = $pearDB->prepare(
+        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+    );
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)'
+    );
+    $selectParentStmt = $pearDB->prepare(
+        'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertParentStmt = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) '
+        . 'VALUES (:depId, :metaId)'
+    );
+    $selectChildStmt = $pearDB->prepare(
+        'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) '
+        . 'VALUES (:depId, :metaId)'
+    );
+
+    foreach (array_keys($dependencies) as $key) {
+        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        if ($row === false) {
+            continue;
+        }
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == "dep_name") {
-                    $dep_name = $value2 . "_" . $i;
-                    $value2 = $value2 . "_" . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
-            }
+            $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {
-                $rq = $val ? "INSERT INTO dependency VALUES (" . $val . ")" : null;
-                $pearDB->query($rq);
-                $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-                $maxId = $dbResult->fetch();
-                if (isset($maxId["MAX(dep_id)"])) {
-                    $query = "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $statement = $pearDB->prepare("INSERT INTO dependency_metaserviceParent_relation " .
-                        "VALUES (:maxId, :metaId)");
-                    while ($ms = $dbResult->fetch()) {
-                        $statement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);
-                        $statement->execute();
+                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->execute();
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectParentStmt->execute();
+                    while ($ms = $selectParentStmt->fetch()) {
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
+                        $insertParentStmt->execute();
                     }
-                    $dbResult->closeCursor();
-                    $query = "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $childStatement = $pearDB->prepare("INSERT INTO dependency_metaserviceChild_relation " .
-                        "VALUES (:maxId, :metaId)");
-                    while ($ms = $dbResult->fetch()) {
-                        $childStatement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $childStatement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);
-                        $childStatement->execute();
+                    $selectParentStmt->closeCursor();
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectChildStmt->execute();
+                    while ($ms = $selectChildStmt->fetch()) {
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], PDO::PARAM_INT);
+                        $insertChildStmt->execute();
                     }
-                    $dbResult->closeCursor();
+                    $selectChildStmt->closeCursor();
                 }
             }
         }
@@ -145,7 +150,7 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 
 function updateMetaServiceDependencyInDB($dep_id = null)
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     updateMetaServiceDependency($dep_id);
@@ -158,7 +163,8 @@ function insertMetaServiceDependencyInDB()
     $dep_id = insertMetaServiceDependency();
     updateMetaServiceDependencyMetaServiceParents($dep_id);
     updateMetaServiceDependencyMetaServiceChilds($dep_id);
-    return ($dep_id);
+
+    return $dep_id;
 }
 
 /**
@@ -172,33 +178,33 @@ function insertMetaServiceDependency(): int
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
 
     $statement = $pearDB->prepare(
-        "INSERT INTO `dependency`
+        'INSERT INTO `dependency`
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:depName, :depDescription, :inheritsParent, :executionFailure,
-                :notificationFailure, :depComment)"
+                :notificationFailure, :depComment)'
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
-    /* Prepare value for changelog */
+    // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        "metaservice dependency",
-        $depId["MAX(dep_id)"],
-        $resourceValues["dep_name"],
-        "a",
+        'metaservice dependency',
+        $depId,
+        $resourceValues['dep_name'],
+        'a',
         $fields
     );
-    return ((int) $depId["MAX(dep_id)"]);
+
+    return $depId;
 }
 
 /**
@@ -208,38 +214,38 @@ function insertMetaServiceDependency(): int
  */
 function updateMetaServiceDependency($depId = null): void
 {
-    if (!$depId) {
+    if (! $depId) {
         exit();
     }
     global $form, $pearDB, $centreon;
 
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
     $statement = $pearDB->prepare(
-        "UPDATE `dependency`
+        'UPDATE `dependency`
         SET dep_name = :depName,
         dep_description = :depDescription,
         inherits_parent = :inheritsParent,
         execution_failure_criteria = :executionFailure,
         notification_failure_criteria = :notificationFailure,
         dep_comment = :depComment
-        WHERE dep_id = :depId"
+        WHERE dep_id = :depId'
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
-    $statement->bindValue(':depId', $depId, \PDO::PARAM_INT);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
+    $statement->bindValue(':depId', $depId, PDO::PARAM_INT);
     $statement->execute();
 
-    /* Prepare value for changelog */
+    // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        "metaservice dependency",
+        'metaservice dependency',
         $depId,
-        $resourceValues["dep_name"],
-        "c",
+        $resourceValues['dep_name'],
+        'c',
         $fields
     );
 }
@@ -253,78 +259,82 @@ function updateMetaServiceDependency($depId = null): void
 function sanitizeResourceParameters(array $resources): array
 {
     $sanitizedParameters = [];
-    $sanitizedParameters['dep_name'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
+    $sanitizedParameters['dep_name'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
     if (empty($sanitizedParameters['dep_name'])) {
         throw new InvalidArgumentException(_("Dependency name can't be empty"));
     }
 
-    $sanitizedParameters['dep_description'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
+    $sanitizedParameters['dep_description'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
     if (empty($sanitizedParameters['dep_description'])) {
         throw new InvalidArgumentException(_("Dependency description can't be empty"));
     }
 
-    $resources["inherits_parent"]["inherits_parent"] == 1
-        ? $sanitizedParameters["inherits_parent"] = '1'
-        : $sanitizedParameters["inherits_parent"] = '0';
+    $resources['inherits_parent']['inherits_parent'] == 1
+        ? $sanitizedParameters['inherits_parent'] = '1'
+        : $sanitizedParameters['inherits_parent'] = '0';
 
-    $sanitizedParameters['execution_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['execution_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ",",
-            array_keys($resources["execution_failure_criteria"])
+            ',',
+            array_keys($resources['execution_failure_criteria'])
         )
     );
 
-    $sanitizedParameters['notification_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['notification_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ",",
-            array_keys($resources["notification_failure_criteria"])
+            ',',
+            array_keys($resources['notification_failure_criteria'])
         )
     );
-    $sanitizedParameters['dep_comment'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
+    $sanitizedParameters['dep_comment'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
 
     return $sanitizedParameters;
 }
 
 function updateMetaServiceDependencyMetaServiceParents($dep_id = null)
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    $rq = "DELETE FROM dependency_metaserviceParent_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_metaserviceParent_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msParents');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = "INSERT INTO dependency_metaserviceParent_relation ";
-        $rq .= "(dependency_dep_id, meta_service_meta_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
 function updateMetaServiceDependencyMetaServiceChilds($dep_id = null)
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    $rq = "DELETE FROM dependency_metaserviceChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare('DELETE FROM dependency_metaserviceChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
     $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msChilds');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = "INSERT INTO dependency_metaserviceChild_relation ";
-        $rq .= "(dependency_dep_id, meta_service_meta_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -1,42 +1,25 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
- * GPL Licence 2.0.
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation ; either version 2 of the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Linking this program statically or dynamically with other modules is making a
- * combined work based on this program. Thus, the terms and conditions of the GNU
- * General Public License cover the whole combination.
- *
- * As a special exception, the copyright holders of this program give Centreon
- * permission to link this program with independent modules to produce an executable,
- * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of Centreon choice, provided that
- * Centreon also meet, for each linked independent module, the terms  and conditions
- * of the license of that module. An independent module is a module which is not
- * derived from this program. If you modify this program, you may extend this
- * exception to your version of the program, but you are not obliged to do so. If you
- * do not wish to do so, delete this exception statement from your version.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * For more information : contact@centreon.com
  *
- * SVN : $URL$
- * SVN : $Id$
- *
  */
 
-if (!isset($oreon)) {
+if (! isset($oreon)) {
     exit();
 }
 
@@ -51,19 +34,15 @@ function testServiceDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '" .
-        htmlentities($name, ENT_QUOTES, "UTF-8") . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
-    #Modif case
-    if ($dbResult->rowCount() >= 1 && $dep["dep_id"] == $id) {
-        return true;
-    } #Duplicate entry
-    elseif ($dbResult->rowCount() >= 1 && $dep["dep_id"] != $id) {
-        return false;
-    } else {
+    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
+    if ($dep === false) {
         return true;
     }
+
+    return $dep['dep_id'] == $id;
 }
 
 function testCycleH($childs = null)
@@ -82,106 +61,138 @@ function testCycleH($childs = null)
             return false;
         }
     }
+
     return true;
 }
 
 function deleteServiceDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
-    foreach ($dependencies as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT dep_name FROM `dependency` WHERE `dep_id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+    $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
+    $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+    foreach (array_keys($dependencies) as $key) {
+        $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStatement->execute();
+        $row = $selectStatement->fetch();
+        if ($row === false) {
+            continue;
+        }
 
-        $dbResult = $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
-        $oreon->CentreonLogAction->insertLog("service dependency", $key, $row['dep_name'], "d");
+        $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $deleteStatement->execute();
+        $oreon->CentreonLogAction->insertLog('service dependency', $key, $row['dep_name'], 'd');
     }
 }
 
 function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
-        global $pearDB, $oreon;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row["dep_id"] = null;
-        for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == "dep_name") {
-                    $dep_name = $value2 . "_" . $i;
-                    $value2 = $value2 . "_" . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
-                if ($key2 != "dep_id") {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($dep_name)) {
-                    $fields["dep_name"] = $dep_name;
-                }
-            }
-            if (isset($dep_name) && testServiceDependencyExistence($dep_name)) {
-                $rq = $val ? "INSERT INTO dependency VALUES (" . $val . ")" : null;
-                $pearDB->query($rq);
-                $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-                $maxId = $dbResult->fetch();
-                if (isset($maxId["MAX(dep_id)"])) {
-                    $query = "SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_hostPar"] = "";
-                    $query = "INSERT INTO dependency_hostChild_relation VALUES (:dep_id, :host_host_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($host = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':host_host_id', (int) $host["host_host_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_hostPar"] .= $host["host_host_id"] . ",";
-                    }
-                    $fields["dep_hostPar"] = trim($fields["dep_hostPar"], ",");
+    global $pearDB, $oreon;
+    $selectStmt = $pearDB->prepare(
+        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+    );
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)'
+    );
+    $selectHostChildStmt = $pearDB->prepare(
+        'SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id'
+    );
+    $insertHostChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:depId, :hostId)'
+    );
+    $selectServiceParentStmt = $pearDB->prepare(
+        'SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
+        WHERE dependency_dep_id = :dep_id'
+    );
+    $insertServiceParentStmt = $pearDB->prepare(
+        'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)'
+    );
+    $selectServiceChildStmt = $pearDB->prepare(
+        'SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
+        WHERE dependency_dep_id = :dep_id'
+    );
+    $insertServiceChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)'
+    );
 
-                    $query = "SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_hSvPar"] = "";
-                    $query = "INSERT INTO dependency_serviceParent_relation 
-                        VALUES (:dep_id, :service_service_id, :host_host_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($service = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(
-                            ':service_service_id',
-                            (int) $service["service_service_id"],
-                            \PDO::PARAM_INT
-                        );
-                        $statement->bindValue(':host_host_id', (int) $service["host_host_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_hSvPar"] .= $service["service_service_id"] . ",";
+    foreach (array_keys($dependencies) as $key) {
+        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            continue;
+        }
+        for ($i = 1; $i <= $nbrDup[$key]; $i++) {
+            $dep_name = $row['dep_name'] . '_' . $i;
+            $fields = [];
+            foreach ($row as $key2 => $value2) {
+                $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
+            }
+            if (testServiceDependencyExistence($dep_name)) {
+                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->execute();
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
+                    $selectHostChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectHostChildStmt->execute();
+                    $fields['dep_hostPar'] = '';
+                    while ($host = $selectHostChildStmt->fetch()) {
+                        $insertHostChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertHostChildStmt->bindValue(':hostId', (int) $host['host_host_id'], PDO::PARAM_INT);
+                        $insertHostChildStmt->execute();
+                        $fields['dep_hostPar'] .= $host['host_host_id'] . ',';
                     }
-                    $fields["dep_hSvPar"] = trim($fields["dep_hSvPar"], ",");
-                    $query = "SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_hSvChi"] = "";
-                    $query = "INSERT INTO dependency_serviceChild_relation 
-                        VALUES (:dep_id, :service_service_id, :host_host_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($service = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(
-                            ':service_service_id',
-                            (int) $service["service_service_id"],
-                            \PDO::PARAM_INT
+                    $fields['dep_hostPar'] = trim($fields['dep_hostPar'], ',');
+
+                    $selectServiceParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectServiceParentStmt->execute();
+                    $fields['dep_hSvPar'] = '';
+                    while ($service = $selectServiceParentStmt->fetch()) {
+                        $insertServiceParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertServiceParentStmt->bindValue(
+                            ':serviceId',
+                            (int) $service['service_service_id'],
+                            PDO::PARAM_INT
                         );
-                        $statement->bindValue(':host_host_id', (int) $service["host_host_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_hSvChi"] .= $service["service_service_id"] . ",";
+                        $insertServiceParentStmt->bindValue(':hostId', (int) $service['host_host_id'], PDO::PARAM_INT);
+                        $insertServiceParentStmt->execute();
+                        $fields['dep_hSvPar'] .= $service['service_service_id'] . ',';
                     }
-                    $fields["dep_hSvChi"] = trim($fields["dep_hSvChi"], ",");
+                    $fields['dep_hSvPar'] = trim($fields['dep_hSvPar'], ',');
+
+                    $selectServiceChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectServiceChildStmt->execute();
+                    $fields['dep_hSvChi'] = '';
+                    while ($service = $selectServiceChildStmt->fetch()) {
+                        $insertServiceChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertServiceChildStmt->bindValue(
+                            ':serviceId',
+                            (int) $service['service_service_id'],
+                            PDO::PARAM_INT
+                        );
+                        $insertServiceChildStmt->bindValue(':hostId', (int) $service['host_host_id'], PDO::PARAM_INT);
+                        $insertServiceChildStmt->execute();
+                        $fields['dep_hSvChi'] .= $service['service_service_id'] . ',';
+                    }
+                    $fields['dep_hSvChi'] = trim($fields['dep_hSvChi'], ',');
                     $oreon->CentreonLogAction->insertLog(
-                        "service dependency",
-                        $maxId["MAX(dep_id)"],
+                        'service dependency',
+                        $lastId,
                         $dep_name,
-                        "a",
+                        'a',
                         $fields
                     );
                 }
@@ -192,7 +203,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 
 function updateServiceDependencyInDB($dep_id = null)
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     updateServiceDependency($dep_id);
@@ -207,7 +218,8 @@ function insertServiceDependencyInDB($ret = [])
     updateServiceDependencyServiceParents($dep_id, $ret);
     updateServiceDependencyServiceChilds($dep_id, $ret);
     updateServiceDependencyHostChildren($dep_id, $ret);
-    return ($dep_id);
+
+    return $dep_id;
 }
 
 /**
@@ -219,46 +231,46 @@ function insertServiceDependencyInDB($ret = [])
 function insertServiceDependency($ret = []): int
 {
     global $form, $pearDB, $centreon;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
 
     $resourceValues = sanitizeResourceParameters($ret);
     $statement = $pearDB->prepare(
-        "INSERT INTO `dependency`
+        'INSERT INTO `dependency`
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:depName, :depDescription, :inheritsParent, :executionFailure,
-                :notificationFailure, :depComment)"
+                :notificationFailure, :depComment)'
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
     $statement->bindValue(
         ':executionFailure',
         $resourceValues['execution_failure_criteria'] ?? null,
-        \PDO::PARAM_STR
+        PDO::PARAM_STR
     );
     $statement->bindValue(
         ':notificationFailure',
         $resourceValues['notification_failure_criteria'] ?? null,
-        \PDO::PARAM_STR
+        PDO::PARAM_STR
     );
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     $fields = CentreonLogAction::prepareChanges($ret);
     $centreon->CentreonLogAction->insertLog(
-        "service dependency",
-        $depId["MAX(dep_id)"],
-        $resourceValues["dep_name"],
-        "a",
+        'service dependency',
+        $depId,
+        $resourceValues['dep_name'],
+        'a',
         $fields
     );
-    return ((int) $depId["MAX(dep_id)"]);
+
+    return $depId;
 }
 
 /**
@@ -268,46 +280,46 @@ function insertServiceDependency($ret = []): int
  */
 function updateServiceDependency($depId = null): void
 {
-    if (!$depId) {
+    if (! $depId) {
         exit();
     }
     global $form, $pearDB, $centreon;
 
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
     $statement = $pearDB->prepare(
-        "UPDATE `dependency`
+        'UPDATE `dependency`
         SET dep_name = :depName,
         dep_description = :depDescription,
         inherits_parent = :inheritsParent,
         execution_failure_criteria = :executionFailure,
         notification_failure_criteria = :notificationFailure,
         dep_comment = :depComment
-        WHERE dep_id = :depId"
+        WHERE dep_id = :depId'
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
     $statement->bindValue(
         ':executionFailure',
         $resourceValues['execution_failure_criteria'] ?? null,
-        \PDO::PARAM_STR
+        PDO::PARAM_STR
     );
     $statement->bindValue(
         ':notificationFailure',
         $resourceValues['notification_failure_criteria'] ?? null,
-        \PDO::PARAM_STR
+        PDO::PARAM_STR
     );
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
-    $statement->bindValue(':depId', $depId, \PDO::PARAM_INT);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
+    $statement->bindValue(':depId', $depId, PDO::PARAM_INT);
     $statement->execute();
 
-    /* Prepare value for changelog */
+    // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        "service dependency",
+        'service dependency',
         $depId,
-        $resourceValues["dep_name"],
-        "c",
+        $resourceValues['dep_name'],
+        'c',
         $fields
     );
 }
@@ -321,123 +333,133 @@ function updateServiceDependency($depId = null): void
 function sanitizeResourceParameters(array $resources): array
 {
     $sanitizedParameters = [];
-    $sanitizedParameters['dep_name'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
+    $sanitizedParameters['dep_name'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
     if (empty($sanitizedParameters['dep_name'])) {
         throw new InvalidArgumentException(_("Dependency name can't be empty"));
     }
 
-    $sanitizedParameters['dep_description'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
+    $sanitizedParameters['dep_description'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
     if (empty($sanitizedParameters['dep_description'])) {
         throw new InvalidArgumentException(_("Dependency description can't be empty"));
     }
 
-    $resources["inherits_parent"]["inherits_parent"] == 1
-        ? $sanitizedParameters["inherits_parent"] = '1'
-        : $sanitizedParameters["inherits_parent"] = '0';
+    $resources['inherits_parent']['inherits_parent'] == 1
+        ? $sanitizedParameters['inherits_parent'] = '1'
+        : $sanitizedParameters['inherits_parent'] = '0';
 
-    if (isset($resources["execution_failure_criteria"]) && is_array($resources["execution_failure_criteria"])) {
-        $sanitizedParameters['execution_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
+    if (isset($resources['execution_failure_criteria']) && is_array($resources['execution_failure_criteria'])) {
+        $sanitizedParameters['execution_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
             implode(
-                ",",
-                array_keys($resources["execution_failure_criteria"])
+                ',',
+                array_keys($resources['execution_failure_criteria'])
             )
         );
     }
 
-    if (isset($resources["notification_failure_criteria"]) && is_array($resources["notification_failure_criteria"])) {
-        $sanitizedParameters['notification_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
+    if (isset($resources['notification_failure_criteria']) && is_array($resources['notification_failure_criteria'])) {
+        $sanitizedParameters['notification_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
             implode(
-                ",",
-                array_keys($resources["notification_failure_criteria"])
+                ',',
+                array_keys($resources['notification_failure_criteria'])
             )
         );
     }
-    $sanitizedParameters['dep_comment'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
+    $sanitizedParameters['dep_comment'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
 
     return $sanitizedParameters;
 }
 
 function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_serviceParent_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
-    $ret1 = $ret["dep_hSvPar"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvPar");
+    $statement = $pearDB->prepare('DELETE FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
+    $ret1 = $ret['dep_hSvPar'] ?? CentreonUtils::mergeWithInitialValues($form, 'dep_hSvPar');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)'
+    );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $exp = explode("-", $ret1[$i]);
+        $exp = explode('-', $ret1[$i]);
         if (count($exp) == 2) {
-            $rq = "INSERT INTO dependency_serviceParent_relation ";
-            $rq .= "(dependency_dep_id, service_service_id, host_host_id) ";
-            $rq .= "VALUES ";
-            $rq .= "('" . $dep_id . "', '" . $exp[1] . "', '" . $exp[0] . "')";
-            $dbResult = $pearDB->query($rq);
+            $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 }
 
 function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_serviceChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
-    $ret1 = $ret["dep_hSvChi"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvChi");
+    $statement = $pearDB->prepare('DELETE FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
+    $ret1 = $ret['dep_hSvChi'] ?? CentreonUtils::mergeWithInitialValues($form, 'dep_hSvChi');
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)'
+    );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $exp = explode("-", $ret1[$i]);
+        $exp = explode('-', $ret1[$i]);
         if (count($exp) == 2) {
-            $rq = "INSERT INTO dependency_serviceChild_relation ";
-            $rq .= "(dependency_dep_id, service_service_id, host_host_id) ";
-            $rq .= "VALUES ";
-            $rq .= "('" . $dep_id . "', '" . $exp[1] . "', '" . $exp[0] . "')";
-            $dbResult = $pearDB->query($rq);
+            $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 }
 
 /**
  * Update Service Dependency Host Children
+ * @param null|mixed $dep_id
+ * @param mixed $ret
  */
 function updateServiceDependencyHostChildren($dep_id = null, $ret = [])
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_hostChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
-    if (isset($ret["dep_hHostChi"])) {
-        $ret1 = $ret["dep_hHostChi"];
+    $statement = $pearDB->prepare('DELETE FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
+    if (isset($ret['dep_hHostChi'])) {
+        $ret1 = $ret['dep_hHostChi'];
     } else {
-        $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hHostChi");
+        $ret1 = CentreonUtils::mergeWithInitialValues($form, 'dep_hHostChi');
     }
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:dep_id, :host_id)'
+    );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = "INSERT INTO dependency_hostChild_relation ";
-        $rq .= "(dependency_dep_id, host_host_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret1[$i] . "')";
-        $dbResult = $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':host_id', (int) $ret1[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -1,25 +1,42 @@
 <?php
-
 /*
- * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Copyright 2005-2015 Centreon
+ * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
  *
  * For more information : contact@centreon.com
  *
+ * SVN : $URL$
+ * SVN : $Id$
+ *
  */
 
-if (! isset($oreon)) {
+if (!isset($oreon)) {
     exit();
 }
 
@@ -34,8 +51,8 @@ function testServiceDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
-    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
     if ($dep === false) {
@@ -61,26 +78,25 @@ function testCycleH($childs = null)
             return false;
         }
     }
-
     return true;
 }
 
 function deleteServiceDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
-    $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
-    $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+    $selectStatement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+    $deleteStatement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
     foreach (array_keys($dependencies) as $key) {
-        $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $selectStatement->execute();
         $row = $selectStatement->fetch();
         if ($row === false) {
             continue;
         }
 
-        $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $deleteStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $deleteStatement->execute();
-        $oreon->CentreonLogAction->insertLog('service dependency', $key, $row['dep_name'], 'd');
+        $oreon->CentreonLogAction->insertLog("service dependency", $key, $row['dep_name'], "d");
     }
 }
 
@@ -88,45 +104,45 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB, $oreon;
     $selectStmt = $pearDB->prepare(
-        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+        "SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
                 notification_failure_criteria, dep_comment
-        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1"
     );
     $insertStmt = $pearDB->prepare(
-        'INSERT INTO dependency
+        "INSERT INTO dependency
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-         :notification_failure_criteria, :dep_comment)'
+         :notification_failure_criteria, :dep_comment)"
     );
     $selectHostChildStmt = $pearDB->prepare(
-        'SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id'
+        "SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id"
     );
     $insertHostChildStmt = $pearDB->prepare(
-        'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
-        VALUES (:depId, :hostId)'
+        "INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:depId, :hostId)"
     );
     $selectServiceParentStmt = $pearDB->prepare(
-        'SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
-        WHERE dependency_dep_id = :dep_id'
+        "SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
+        WHERE dependency_dep_id = :dep_id"
     );
     $insertServiceParentStmt = $pearDB->prepare(
-        'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
-        VALUES (:depId, :serviceId, :hostId)'
+        "INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)"
     );
     $selectServiceChildStmt = $pearDB->prepare(
-        'SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
-        WHERE dependency_dep_id = :dep_id'
+        "SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
+        WHERE dependency_dep_id = :dep_id"
     );
     $insertServiceChildStmt = $pearDB->prepare(
-        'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
-        VALUES (:depId, :serviceId, :hostId)'
+        "INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)"
     );
 
     foreach (array_keys($dependencies) as $key) {
-        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $selectStmt->execute();
-        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
+        $row = $selectStmt->fetch(\PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }
@@ -137,62 +153,62 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
                 $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceDependencyExistence($dep_name)) {
-                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_name', $dep_name, \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], \PDO::PARAM_STR);
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {
-                    $selectHostChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectHostChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectHostChildStmt->execute();
                     $fields['dep_hostPar'] = '';
                     while ($host = $selectHostChildStmt->fetch()) {
-                        $insertHostChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
-                        $insertHostChildStmt->bindValue(':hostId', (int) $host['host_host_id'], PDO::PARAM_INT);
+                        $insertHostChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertHostChildStmt->bindValue(':hostId', (int) $host['host_host_id'], \PDO::PARAM_INT);
                         $insertHostChildStmt->execute();
                         $fields['dep_hostPar'] .= $host['host_host_id'] . ',';
                     }
-                    $fields['dep_hostPar'] = trim($fields['dep_hostPar'], ',');
+                    $fields["dep_hostPar"] = trim($fields["dep_hostPar"], ",");
 
-                    $selectServiceParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectServiceParentStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectServiceParentStmt->execute();
                     $fields['dep_hSvPar'] = '';
                     while ($service = $selectServiceParentStmt->fetch()) {
-                        $insertServiceParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertServiceParentStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
                         $insertServiceParentStmt->bindValue(
                             ':serviceId',
                             (int) $service['service_service_id'],
-                            PDO::PARAM_INT
+                            \PDO::PARAM_INT
                         );
-                        $insertServiceParentStmt->bindValue(':hostId', (int) $service['host_host_id'], PDO::PARAM_INT);
+                        $insertServiceParentStmt->bindValue(':hostId', (int) $service['host_host_id'], \PDO::PARAM_INT);
                         $insertServiceParentStmt->execute();
                         $fields['dep_hSvPar'] .= $service['service_service_id'] . ',';
                     }
-                    $fields['dep_hSvPar'] = trim($fields['dep_hSvPar'], ',');
+                    $fields["dep_hSvPar"] = trim($fields["dep_hSvPar"], ",");
 
-                    $selectServiceChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectServiceChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectServiceChildStmt->execute();
                     $fields['dep_hSvChi'] = '';
                     while ($service = $selectServiceChildStmt->fetch()) {
-                        $insertServiceChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertServiceChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
                         $insertServiceChildStmt->bindValue(
                             ':serviceId',
                             (int) $service['service_service_id'],
-                            PDO::PARAM_INT
+                            \PDO::PARAM_INT
                         );
-                        $insertServiceChildStmt->bindValue(':hostId', (int) $service['host_host_id'], PDO::PARAM_INT);
+                        $insertServiceChildStmt->bindValue(':hostId', (int) $service['host_host_id'], \PDO::PARAM_INT);
                         $insertServiceChildStmt->execute();
                         $fields['dep_hSvChi'] .= $service['service_service_id'] . ',';
                     }
-                    $fields['dep_hSvChi'] = trim($fields['dep_hSvChi'], ',');
+                    $fields["dep_hSvChi"] = trim($fields["dep_hSvChi"], ",");
                     $oreon->CentreonLogAction->insertLog(
-                        'service dependency',
+                        "service dependency",
                         $lastId,
                         $dep_name,
-                        'a',
+                        "a",
                         $fields
                     );
                 }
@@ -203,7 +219,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 
 function updateServiceDependencyInDB($dep_id = null)
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     updateServiceDependency($dep_id);
@@ -218,8 +234,7 @@ function insertServiceDependencyInDB($ret = [])
     updateServiceDependencyServiceParents($dep_id, $ret);
     updateServiceDependencyServiceChilds($dep_id, $ret);
     updateServiceDependencyHostChildren($dep_id, $ret);
-
-    return $dep_id;
+    return ($dep_id);
 }
 
 /**
@@ -231,45 +246,44 @@ function insertServiceDependencyInDB($ret = [])
 function insertServiceDependency($ret = []): int
 {
     global $form, $pearDB, $centreon;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
 
     $resourceValues = sanitizeResourceParameters($ret);
     $statement = $pearDB->prepare(
-        'INSERT INTO `dependency`
+        "INSERT INTO `dependency`
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:depName, :depDescription, :inheritsParent, :executionFailure,
-                :notificationFailure, :depComment)'
+                :notificationFailure, :depComment)"
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
     $statement->bindValue(
         ':executionFailure',
         $resourceValues['execution_failure_criteria'] ?? null,
-        PDO::PARAM_STR
+        \PDO::PARAM_STR
     );
     $statement->bindValue(
         ':notificationFailure',
         $resourceValues['notification_failure_criteria'] ?? null,
-        PDO::PARAM_STR
+        \PDO::PARAM_STR
     );
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
     $statement->execute();
 
     $depId = (int) $pearDB->lastInsertId();
 
     $fields = CentreonLogAction::prepareChanges($ret);
     $centreon->CentreonLogAction->insertLog(
-        'service dependency',
+        "service dependency",
         $depId,
-        $resourceValues['dep_name'],
-        'a',
+        $resourceValues["dep_name"],
+        "a",
         $fields
     );
-
     return $depId;
 }
 
@@ -280,46 +294,46 @@ function insertServiceDependency($ret = []): int
  */
 function updateServiceDependency($depId = null): void
 {
-    if (! $depId) {
+    if (!$depId) {
         exit();
     }
     global $form, $pearDB, $centreon;
 
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
     $statement = $pearDB->prepare(
-        'UPDATE `dependency`
+        "UPDATE `dependency`
         SET dep_name = :depName,
         dep_description = :depDescription,
         inherits_parent = :inheritsParent,
         execution_failure_criteria = :executionFailure,
         notification_failure_criteria = :notificationFailure,
         dep_comment = :depComment
-        WHERE dep_id = :depId'
+        WHERE dep_id = :depId"
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
     $statement->bindValue(
         ':executionFailure',
         $resourceValues['execution_failure_criteria'] ?? null,
-        PDO::PARAM_STR
+        \PDO::PARAM_STR
     );
     $statement->bindValue(
         ':notificationFailure',
         $resourceValues['notification_failure_criteria'] ?? null,
-        PDO::PARAM_STR
+        \PDO::PARAM_STR
     );
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
-    $statement->bindValue(':depId', $depId, PDO::PARAM_INT);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
+    $statement->bindValue(':depId', $depId, \PDO::PARAM_INT);
     $statement->execute();
 
-    // Prepare value for changelog
+    /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        'service dependency',
+        "service dependency",
         $depId,
-        $resourceValues['dep_name'],
-        'c',
+        $resourceValues["dep_name"],
+        "c",
         $fields
     );
 }
@@ -333,67 +347,67 @@ function updateServiceDependency($depId = null): void
 function sanitizeResourceParameters(array $resources): array
 {
     $sanitizedParameters = [];
-    $sanitizedParameters['dep_name'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
+    $sanitizedParameters['dep_name'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
     if (empty($sanitizedParameters['dep_name'])) {
         throw new InvalidArgumentException(_("Dependency name can't be empty"));
     }
 
-    $sanitizedParameters['dep_description'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
+    $sanitizedParameters['dep_description'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
     if (empty($sanitizedParameters['dep_description'])) {
         throw new InvalidArgumentException(_("Dependency description can't be empty"));
     }
 
-    $resources['inherits_parent']['inherits_parent'] == 1
-        ? $sanitizedParameters['inherits_parent'] = '1'
-        : $sanitizedParameters['inherits_parent'] = '0';
+    $resources["inherits_parent"]["inherits_parent"] == 1
+        ? $sanitizedParameters["inherits_parent"] = '1'
+        : $sanitizedParameters["inherits_parent"] = '0';
 
-    if (isset($resources['execution_failure_criteria']) && is_array($resources['execution_failure_criteria'])) {
-        $sanitizedParameters['execution_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
+    if (isset($resources["execution_failure_criteria"]) && is_array($resources["execution_failure_criteria"])) {
+        $sanitizedParameters['execution_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
             implode(
-                ',',
-                array_keys($resources['execution_failure_criteria'])
+                ",",
+                array_keys($resources["execution_failure_criteria"])
             )
         );
     }
 
-    if (isset($resources['notification_failure_criteria']) && is_array($resources['notification_failure_criteria'])) {
-        $sanitizedParameters['notification_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
+    if (isset($resources["notification_failure_criteria"]) && is_array($resources["notification_failure_criteria"])) {
+        $sanitizedParameters['notification_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
             implode(
-                ',',
-                array_keys($resources['notification_failure_criteria'])
+                ",",
+                array_keys($resources["notification_failure_criteria"])
             )
         );
     }
-    $sanitizedParameters['dep_comment'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
+    $sanitizedParameters['dep_comment'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
 
     return $sanitizedParameters;
 }
 
 function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $statement = $pearDB->prepare('DELETE FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    $ret1 = $ret['dep_hSvPar'] ?? CentreonUtils::mergeWithInitialValues($form, 'dep_hSvPar');
+    $ret1 = $ret["dep_hSvPar"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvPar");
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
-        VALUES (:dep_id, :service_id, :host_id)'
+        "INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)"
     );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $exp = explode('-', $ret1[$i]);
+        $exp = explode("-", $ret1[$i]);
         if (count($exp) == 2) {
-            $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-            $statement->bindValue(':service_id', (int) $exp[1], PDO::PARAM_INT);
-            $statement->bindValue(':host_id', (int) $exp[0], PDO::PARAM_INT);
+            $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], \PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], \PDO::PARAM_INT);
             $statement->execute();
         }
     }
@@ -401,29 +415,29 @@ function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
 
 function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $statement = $pearDB->prepare('DELETE FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    $ret1 = $ret['dep_hSvChi'] ?? CentreonUtils::mergeWithInitialValues($form, 'dep_hSvChi');
+    $ret1 = $ret["dep_hSvChi"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvChi");
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
-        VALUES (:dep_id, :service_id, :host_id)'
+        "INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)"
     );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $exp = explode('-', $ret1[$i]);
+        $exp = explode("-", $ret1[$i]);
         if (count($exp) == 2) {
-            $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-            $statement->bindValue(':service_id', (int) $exp[1], PDO::PARAM_INT);
-            $statement->bindValue(':host_id', (int) $exp[0], PDO::PARAM_INT);
+            $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], \PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], \PDO::PARAM_INT);
             $statement->execute();
         }
     }
@@ -436,30 +450,30 @@ function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
  */
 function updateServiceDependencyHostChildren($dep_id = null, $ret = [])
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $statement = $pearDB->prepare('DELETE FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    if (isset($ret['dep_hHostChi'])) {
-        $ret1 = $ret['dep_hHostChi'];
+    if (isset($ret["dep_hHostChi"])) {
+        $ret1 = $ret["dep_hHostChi"];
     } else {
-        $ret1 = CentreonUtils::mergeWithInitialValues($form, 'dep_hHostChi');
+        $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hHostChi");
     }
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
-        VALUES (:dep_id, :host_id)'
+        "INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:dep_id, :host_id)"
     );
     $counter = count($ret1);
     for ($i = 0; $i < $counter; $i++) {
-        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-        $statement->bindValue(':host_id', (int) $ret1[$i], PDO::PARAM_INT);
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':host_id', (int) $ret1[$i], \PDO::PARAM_INT);
         $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -1,42 +1,25 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
- * GPL Licence 2.0.
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation ; either version 2 of the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, see <http://www.gnu.org/licenses>.
- *
- * Linking this program statically or dynamically with other modules is making a
- * combined work based on this program. Thus, the terms and conditions of the GNU
- * General Public License cover the whole combination.
- *
- * As a special exception, the copyright holders of this program give Centreon
- * permission to link this program with independent modules to produce an executable,
- * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of Centreon choice, provided that
- * Centreon also meet, for each linked independent module, the terms  and conditions
- * of the license of that module. An independent module is a module which is not
- * derived from this program. If you modify this program, you may extend this
- * exception to your version of the program, but you are not obliged to do so. If you
- * do not wish to do so, delete this exception statement from your version.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * For more information : contact@centreon.com
  *
- * SVN : $URL$
- * SVN : $Id$
- *
  */
 
-if (!isset($oreon)) {
+if (! isset($oreon)) {
     exit();
 }
 
@@ -51,19 +34,15 @@ function testServiceGroupDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '" .
-        htmlentities($name, ENT_QUOTES, "UTF-8") . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
-    #Modif case
-    if ($dbResult->rowCount() >= 1 && $dep["dep_id"] == $id) {
-        return true;
-    } #Duplicate entry
-    elseif ($dbResult->rowCount() >= 1 && $dep["dep_id"] != $id) {
-        return false;
-    } else {
+    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
+    if ($dep === false) {
         return true;
     }
+
+    return $dep['dep_id'] == $id;
 }
 
 function testServiceGroupDependencyCycle($childs = null)
@@ -82,89 +61,113 @@ function testServiceGroupDependencyCycle($childs = null)
             return false;
         }
     }
+
     return true;
 }
 
 function deleteServiceGroupDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
-    foreach ($dependencies as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT dep_name FROM `dependency` WHERE `dep_id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+    $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
+    $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+    foreach (array_keys($dependencies) as $key) {
+        $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStatement->execute();
+        $row = $selectStatement->fetch();
+        if ($row === false) {
+            continue;
+        }
 
-        $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
-        $oreon->CentreonLogAction->insertLog("servicegroup dependency", $key, $row['dep_name'], "d");
+        $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $deleteStatement->execute();
+        $oreon->CentreonLogAction->insertLog('servicegroup dependency', $key, $row['dep_name'], 'd');
     }
 }
 
 function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
-        global $pearDB, $oreon;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row["dep_id"] = null;
+    global $pearDB, $oreon;
+    $selectStmt = $pearDB->prepare(
+        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+    );
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)'
+    );
+    $selectParentStmt = $pearDB->prepare(
+        'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertParentStmt = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
+        . 'VALUES (:depId, :servicegroupId)'
+    );
+    $selectChildStmt = $pearDB->prepare(
+        'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
+        . 'WHERE dependency_dep_id = :dep_id'
+    );
+    $insertChildStmt = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
+        . 'VALUES (:depId, :servicegroupId)'
+    );
+
+    foreach (array_keys($dependencies) as $key) {
+        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            continue;
+        }
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
+            $dep_name = $row['dep_name'] . '_' . $i;
+            $fields = [];
             foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == "dep_name") {
-                    $dep_name = $value2 . "_" . $i;
-                    $value2 = $value2 . "_" . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
-                if ($key2 != "dep_id") {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($dep_name)) {
-                    $fields["dep_name"] = $dep_name;
-                }
+                $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
-            if (isset($dep_name) && testServiceGroupDependencyExistence($dep_name)) {
-                $rq = $val ? "INSERT INTO dependency VALUES (" . $val . ")" : null;
-                $pearDB->query($rq);
-                $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-                $maxId = $dbResult->fetch();
-                if (isset($maxId["MAX(dep_id)"])) {
-                    $query = "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_sgParents"] = "";
-                    $query = "INSERT INTO dependency_servicegroupParent_relation " .
-                             "VALUES (:dep_id, :servicegroup_sg_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($sg = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':servicegroup_sg_id', (int) $sg["servicegroup_sg_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_sgParents"] .= $sg["servicegroup_sg_id"] . ",";
+            if (testServiceGroupDependencyExistence($dep_name)) {
+                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->execute();
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectParentStmt->execute();
+                    $fields['dep_sgParents'] = '';
+                    while ($sg = $selectParentStmt->fetch()) {
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
+                        $insertParentStmt->execute();
+                        $fields['dep_sgParents'] .= $sg['servicegroup_sg_id'] . ',';
                     }
-                    $fields["dep_sgParents"] = trim($fields["dep_sgParents"], ",");
-                    $dbResult->closeCursor();
-                    $query = "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_sgChilds"] = "";
-                    $query = "INSERT INTO dependency_servicegroupChild_relation " .
-                             "VALUES (:dep_id, :servicegroup_sg_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($sg = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':servicegroup_sg_id', (int) $sg["servicegroup_sg_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_sgChilds"] .= $sg["servicegroup_sg_id"] . ",";
+                    $fields['dep_sgParents'] = trim($fields['dep_sgParents'], ',');
+                    $selectParentStmt->closeCursor();
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectChildStmt->execute();
+                    $fields['dep_sgChilds'] = '';
+                    while ($sg = $selectChildStmt->fetch()) {
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
+                        $insertChildStmt->execute();
+                        $fields['dep_sgChilds'] .= $sg['servicegroup_sg_id'] . ',';
                     }
-                    $fields["dep_sgChilds"] = trim($fields["dep_sgChilds"], ",");
+                    $selectChildStmt->closeCursor();
+                    $fields['dep_sgChilds'] = trim($fields['dep_sgChilds'], ',');
                     $oreon->CentreonLogAction->insertLog(
-                        "servicegroup dependency",
-                        $maxId["MAX(dep_id)"],
+                        'servicegroup dependency',
+                        $lastId,
                         $dep_name,
-                        "a",
+                        'a',
                         $fields
                     );
-                    $dbResult->closeCursor();
                 }
             }
         }
@@ -173,7 +176,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 
 function updateServiceGroupDependencyInDB($dep_id = null)
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     updateServiceGroupDependency($dep_id);
@@ -186,7 +189,8 @@ function insertServiceGroupDependencyInDB($ret = [])
     $dep_id = insertServiceGroupDependency($ret);
     updateServiceGroupDependencyServiceGroupParents($dep_id, $ret);
     updateServiceGroupDependencyServiceGroupChilds($dep_id, $ret);
-    return ($dep_id);
+
+    return $dep_id;
 }
 
 /**
@@ -198,39 +202,39 @@ function insertServiceGroupDependencyInDB($ret = [])
 function insertServiceGroupDependency($ret = []): int
 {
     global $form, $pearDB, $centreon;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
 
     $resourceValues = sanitizeResourceParameters($ret);
     $statement = $pearDB->prepare(
-        "INSERT INTO `dependency`
+        'INSERT INTO `dependency`
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:depName, :depDescription, :inheritsParent, :executionFailure,
-                :notificationFailure, :depComment)"
+                :notificationFailure, :depComment)'
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
-    /* Prepare value for changelog */
+    // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        "servicegroup dependency",
-        $depId["MAX(dep_id)"],
-        $resourceValues["dep_name"],
-        "a",
+        'servicegroup dependency',
+        $depId,
+        $resourceValues['dep_name'],
+        'a',
         $fields
     );
-    return ((int) $depId["MAX(dep_id)"]);
+
+    return $depId;
 }
 
 /**
@@ -240,38 +244,38 @@ function insertServiceGroupDependency($ret = []): int
  */
 function updateServiceGroupDependency($depId = null): void
 {
-    if (!$depId) {
+    if (! $depId) {
         exit();
     }
     global $form, $pearDB, $centreon;
 
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
     $statement = $pearDB->prepare(
-        "UPDATE `dependency`
+        'UPDATE `dependency`
         SET dep_name = :depName,
         dep_description = :depDescription,
         inherits_parent = :inheritsParent,
         execution_failure_criteria = :executionFailure,
         notification_failure_criteria = :notificationFailure,
         dep_comment = :depComment
-        WHERE dep_id = :depId"
+        WHERE dep_id = :depId'
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
-    $statement->bindValue(':depId', $depId, \PDO::PARAM_INT);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
+    $statement->bindValue(':depId', $depId, PDO::PARAM_INT);
     $statement->execute();
 
-    /* Prepare value for changelog */
+    // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        "servicegroup dependency",
+        'servicegroup dependency',
         $depId,
-        $resourceValues["dep_name"],
-        "c",
+        $resourceValues['dep_name'],
+        'c',
         $fields
     );
 }
@@ -285,90 +289,94 @@ function updateServiceGroupDependency($depId = null): void
 function sanitizeResourceParameters(array $resources): array
 {
     $sanitizedParameters = [];
-    $sanitizedParameters['dep_name'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
+    $sanitizedParameters['dep_name'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
     if (empty($sanitizedParameters['dep_name'])) {
         throw new InvalidArgumentException(_("Dependency name can't be empty"));
     }
 
-    $sanitizedParameters['dep_description'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
+    $sanitizedParameters['dep_description'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
     if (empty($sanitizedParameters['dep_description'])) {
         throw new InvalidArgumentException(_("Dependency description can't be empty"));
     }
 
-    $resources["inherits_parent"]["inherits_parent"] == 1
-        ? $sanitizedParameters["inherits_parent"] = '1'
-        : $sanitizedParameters["inherits_parent"] = '0';
+    $resources['inherits_parent']['inherits_parent'] == 1
+        ? $sanitizedParameters['inherits_parent'] = '1'
+        : $sanitizedParameters['inherits_parent'] = '0';
 
-    $sanitizedParameters['execution_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['execution_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ",",
-            array_keys($resources["execution_failure_criteria"])
+            ',',
+            array_keys($resources['execution_failure_criteria'])
         )
     );
 
-    $sanitizedParameters['notification_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['notification_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ",",
-            array_keys($resources["notification_failure_criteria"])
+            ',',
+            array_keys($resources['notification_failure_criteria'])
         )
     );
-    $sanitizedParameters['dep_comment'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
+    $sanitizedParameters['dep_comment'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
 
     return $sanitizedParameters;
 }
 
 function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = [])
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_servicegroupParent_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
-    if (isset($ret["dep_sgParents"])) {
-        $ret = $ret["dep_sgParents"];
+    $statement = $pearDB->prepare('DELETE FROM dependency_servicegroupParent_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
+    if (isset($ret['dep_sgParents'])) {
+        $ret = $ret['dep_sgParents'];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgParents');
     }
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = "INSERT INTO dependency_servicegroupParent_relation ";
-        $rq .= "(dependency_dep_id, servicegroup_sg_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
 function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = [])
 {
-    if (!$dep_id) {
+    if (! $dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (!count($ret)) {
+    if (! count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_servicegroupChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
-    if (isset($ret["dep_sgChilds"])) {
-        $ret = $ret["dep_sgChilds"];
+    $statement = $pearDB->prepare('DELETE FROM dependency_servicegroupChild_relation WHERE dependency_dep_id = :dep_id');
+    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement->execute();
+    if (isset($ret['dep_sgChilds'])) {
+        $ret = $ret['dep_sgChilds'];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgChilds');
     }
+    $statement = $pearDB->prepare(
+        'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)'
+    );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $rq = "INSERT INTO dependency_servicegroupChild_relation ";
-        $rq .= "(dependency_dep_id, servicegroup_sg_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -1,25 +1,42 @@
 <?php
-
 /*
- * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Copyright 2005-2015 Centreon
+ * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
  *
  * For more information : contact@centreon.com
  *
+ * SVN : $URL$
+ * SVN : $Id$
+ *
  */
 
-if (! isset($oreon)) {
+if (!isset($oreon)) {
     exit();
 }
 
@@ -34,8 +51,8 @@ function testServiceGroupDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $statement = $pearDB->prepare('SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name');
-    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
     $statement->execute();
     $dep = $statement->fetch();
     if ($dep === false) {
@@ -61,26 +78,25 @@ function testServiceGroupDependencyCycle($childs = null)
             return false;
         }
     }
-
     return true;
 }
 
 function deleteServiceGroupDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
-    $selectStatement = $pearDB->prepare('SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1');
-    $deleteStatement = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+    $selectStatement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+    $deleteStatement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
     foreach (array_keys($dependencies) as $key) {
-        $selectStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $selectStatement->execute();
         $row = $selectStatement->fetch();
         if ($row === false) {
             continue;
         }
 
-        $deleteStatement->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $deleteStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $deleteStatement->execute();
-        $oreon->CentreonLogAction->insertLog('servicegroup dependency', $key, $row['dep_name'], 'd');
+        $oreon->CentreonLogAction->insertLog("servicegroup dependency", $key, $row['dep_name'], "d");
     }
 }
 
@@ -88,38 +104,38 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB, $oreon;
     $selectStmt = $pearDB->prepare(
-        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+        "SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
                 notification_failure_criteria, dep_comment
-        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1"
     );
     $insertStmt = $pearDB->prepare(
-        'INSERT INTO dependency
+        "INSERT INTO dependency
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-         :notification_failure_criteria, :dep_comment)'
+         :notification_failure_criteria, :dep_comment)"
     );
     $selectParentStmt = $pearDB->prepare(
-        'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
-        . 'WHERE dependency_dep_id = :dep_id'
+        "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation "
+        . "WHERE dependency_dep_id = :dep_id"
     );
     $insertParentStmt = $pearDB->prepare(
-        'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) '
-        . 'VALUES (:depId, :servicegroupId)'
+        "INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) "
+        . "VALUES (:depId, :servicegroupId)"
     );
     $selectChildStmt = $pearDB->prepare(
-        'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation '
-        . 'WHERE dependency_dep_id = :dep_id'
+        "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation "
+        . "WHERE dependency_dep_id = :dep_id"
     );
     $insertChildStmt = $pearDB->prepare(
-        'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) '
-        . 'VALUES (:depId, :servicegroupId)'
+        "INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) "
+        . "VALUES (:depId, :servicegroupId)"
     );
 
     foreach (array_keys($dependencies) as $key) {
-        $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
         $selectStmt->execute();
-        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
+        $row = $selectStmt->fetch(\PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }
@@ -130,42 +146,42 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
                 $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceGroupDependencyExistence($dep_name)) {
-                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_name', $dep_name, \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], \PDO::PARAM_STR);
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {
-                    $selectParentStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectParentStmt->execute();
-                    $fields['dep_sgParents'] = '';
+                    $fields["dep_sgParents"] = "";
                     while ($sg = $selectParentStmt->fetch()) {
-                        $insertParentStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
-                        $insertParentStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], \PDO::PARAM_INT);
                         $insertParentStmt->execute();
-                        $fields['dep_sgParents'] .= $sg['servicegroup_sg_id'] . ',';
+                        $fields["dep_sgParents"] .= $sg['servicegroup_sg_id'] . ",";
                     }
-                    $fields['dep_sgParents'] = trim($fields['dep_sgParents'], ',');
+                    $fields["dep_sgParents"] = trim($fields["dep_sgParents"], ",");
                     $selectParentStmt->closeCursor();
-                    $selectChildStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
                     $selectChildStmt->execute();
-                    $fields['dep_sgChilds'] = '';
+                    $fields["dep_sgChilds"] = "";
                     while ($sg = $selectChildStmt->fetch()) {
-                        $insertChildStmt->bindValue(':depId', (int) $lastId, PDO::PARAM_INT);
-                        $insertChildStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], \PDO::PARAM_INT);
                         $insertChildStmt->execute();
-                        $fields['dep_sgChilds'] .= $sg['servicegroup_sg_id'] . ',';
+                        $fields["dep_sgChilds"] .= $sg['servicegroup_sg_id'] . ",";
                     }
                     $selectChildStmt->closeCursor();
-                    $fields['dep_sgChilds'] = trim($fields['dep_sgChilds'], ',');
+                    $fields["dep_sgChilds"] = trim($fields["dep_sgChilds"], ",");
                     $oreon->CentreonLogAction->insertLog(
-                        'servicegroup dependency',
+                        "servicegroup dependency",
                         $lastId,
                         $dep_name,
-                        'a',
+                        "a",
                         $fields
                     );
                 }
@@ -176,7 +192,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 
 function updateServiceGroupDependencyInDB($dep_id = null)
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     updateServiceGroupDependency($dep_id);
@@ -189,8 +205,7 @@ function insertServiceGroupDependencyInDB($ret = [])
     $dep_id = insertServiceGroupDependency($ret);
     updateServiceGroupDependencyServiceGroupParents($dep_id, $ret);
     updateServiceGroupDependencyServiceGroupChilds($dep_id, $ret);
-
-    return $dep_id;
+    return ($dep_id);
 }
 
 /**
@@ -202,38 +217,37 @@ function insertServiceGroupDependencyInDB($ret = [])
 function insertServiceGroupDependency($ret = []): int
 {
     global $form, $pearDB, $centreon;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
 
     $resourceValues = sanitizeResourceParameters($ret);
     $statement = $pearDB->prepare(
-        'INSERT INTO `dependency`
+        "INSERT INTO `dependency`
         (dep_name, dep_description, inherits_parent, execution_failure_criteria,
          notification_failure_criteria, dep_comment)
         VALUES (:depName, :depDescription, :inheritsParent, :executionFailure,
-                :notificationFailure, :depComment)'
+                :notificationFailure, :depComment)"
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
     $statement->execute();
 
     $depId = (int) $pearDB->lastInsertId();
 
-    // Prepare value for changelog
+    /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        'servicegroup dependency',
+        "servicegroup dependency",
         $depId,
-        $resourceValues['dep_name'],
-        'a',
+        $resourceValues["dep_name"],
+        "a",
         $fields
     );
-
     return $depId;
 }
 
@@ -244,38 +258,38 @@ function insertServiceGroupDependency($ret = []): int
  */
 function updateServiceGroupDependency($depId = null): void
 {
-    if (! $depId) {
+    if (!$depId) {
         exit();
     }
     global $form, $pearDB, $centreon;
 
     $resourceValues = sanitizeResourceParameters($form->getSubmitValues());
     $statement = $pearDB->prepare(
-        'UPDATE `dependency`
+        "UPDATE `dependency`
         SET dep_name = :depName,
         dep_description = :depDescription,
         inherits_parent = :inheritsParent,
         execution_failure_criteria = :executionFailure,
         notification_failure_criteria = :notificationFailure,
         dep_comment = :depComment
-        WHERE dep_id = :depId'
+        WHERE dep_id = :depId"
     );
-    $statement->bindValue(':depName', $resourceValues['dep_name'], PDO::PARAM_STR);
-    $statement->bindValue(':depDescription', $resourceValues['dep_description'], PDO::PARAM_STR);
-    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], PDO::PARAM_STR);
-    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], PDO::PARAM_STR);
-    $statement->bindValue(':depComment', $resourceValues['dep_comment'], PDO::PARAM_STR);
-    $statement->bindValue(':depId', $depId, PDO::PARAM_INT);
+    $statement->bindValue(':depName', $resourceValues['dep_name'], \PDO::PARAM_STR);
+    $statement->bindValue(':depDescription', $resourceValues['dep_description'], \PDO::PARAM_STR);
+    $statement->bindValue(':inheritsParent', $resourceValues['inherits_parent'], \PDO::PARAM_STR);
+    $statement->bindValue(':executionFailure', $resourceValues['execution_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':notificationFailure', $resourceValues['notification_failure_criteria'], \PDO::PARAM_STR);
+    $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
+    $statement->bindValue(':depId', $depId, \PDO::PARAM_INT);
     $statement->execute();
 
-    // Prepare value for changelog
+    /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
-        'servicegroup dependency',
+        "servicegroup dependency",
         $depId,
-        $resourceValues['dep_name'],
-        'c',
+        $resourceValues["dep_name"],
+        "c",
         $fields
     );
 }
@@ -289,94 +303,94 @@ function updateServiceGroupDependency($depId = null): void
 function sanitizeResourceParameters(array $resources): array
 {
     $sanitizedParameters = [];
-    $sanitizedParameters['dep_name'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
+    $sanitizedParameters['dep_name'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_name']);
     if (empty($sanitizedParameters['dep_name'])) {
         throw new InvalidArgumentException(_("Dependency name can't be empty"));
     }
 
-    $sanitizedParameters['dep_description'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
+    $sanitizedParameters['dep_description'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_description']);
     if (empty($sanitizedParameters['dep_description'])) {
         throw new InvalidArgumentException(_("Dependency description can't be empty"));
     }
 
-    $resources['inherits_parent']['inherits_parent'] == 1
-        ? $sanitizedParameters['inherits_parent'] = '1'
-        : $sanitizedParameters['inherits_parent'] = '0';
+    $resources["inherits_parent"]["inherits_parent"] == 1
+        ? $sanitizedParameters["inherits_parent"] = '1'
+        : $sanitizedParameters["inherits_parent"] = '0';
 
-    $sanitizedParameters['execution_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['execution_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ',',
-            array_keys($resources['execution_failure_criteria'])
+            ",",
+            array_keys($resources["execution_failure_criteria"])
         )
     );
 
-    $sanitizedParameters['notification_failure_criteria'] = HtmlAnalyzer::sanitizeAndRemoveTags(
+    $sanitizedParameters['notification_failure_criteria'] = \HtmlAnalyzer::sanitizeAndRemoveTags(
         implode(
-            ',',
-            array_keys($resources['notification_failure_criteria'])
+            ",",
+            array_keys($resources["notification_failure_criteria"])
         )
     );
-    $sanitizedParameters['dep_comment'] = HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
+    $sanitizedParameters['dep_comment'] = \HtmlAnalyzer::sanitizeAndRemoveTags($resources['dep_comment']);
 
     return $sanitizedParameters;
 }
 
 function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = [])
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $statement = $pearDB->prepare('DELETE FROM dependency_servicegroupParent_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_servicegroupParent_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    if (isset($ret['dep_sgParents'])) {
-        $ret = $ret['dep_sgParents'];
+    if (isset($ret["dep_sgParents"])) {
+        $ret = $ret["dep_sgParents"];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgParents');
     }
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id)
-        VALUES (:dep_id, :sg_id)'
+        "INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)"
     );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-        $statement->bindValue(':sg_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();
     }
 }
 
 function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = [])
 {
-    if (! $dep_id) {
+    if (!$dep_id) {
         exit();
     }
     global $form;
     global $pearDB;
-    if (! count($ret)) {
+    if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $statement = $pearDB->prepare('DELETE FROM dependency_servicegroupChild_relation WHERE dependency_dep_id = :dep_id');
-    $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
+    $statement = $pearDB->prepare("DELETE FROM dependency_servicegroupChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    if (isset($ret['dep_sgChilds'])) {
-        $ret = $ret['dep_sgChilds'];
+    if (isset($ret["dep_sgChilds"])) {
+        $ret = $ret["dep_sgChilds"];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgChilds');
     }
     $statement = $pearDB->prepare(
-        'INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id)
-        VALUES (:dep_id, :sg_id)'
+        "INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)"
     );
     $counter = count($ret);
     for ($i = 0; $i < $counter; $i++) {
-        $statement->bindValue(':dep_id', (int) $dep_id, PDO::PARAM_INT);
-        $statement->bindValue(':sg_id', (int) $ret[$i], PDO::PARAM_INT);
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();
     }
 }


### PR DESCRIPTION
## Description

Backport of #9693 to hotfix-24.10-next.

- Fix SQL injection (CWE-89) in service, metaservice, and servicegroup dependency `DB-Func.php` files
- Replace all raw SQL string concatenation with prepared statements using `bindValue()`

[MON-195277](https://centreon.atlassian.net/browse/MON-195277)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

[MON-195277]: https://centreon.atlassian.net/browse/MON-195277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ