### PR TITLE
fix(dependencies): use prepared statements in dependency DB-Func files

### DIFF
--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -63,8 +63,8 @@ function testCycle($childs = null)
 {
     global $pearDB;
     global $form;
-    $parents = [];
-    $childs = [];
+    $parents = array();
+    $childs = array();
     if (isset($form)) {
         $parents = $form->getSubmitValue('dep_msParents');
         $childs = $form->getSubmitValue('dep_msChilds');
@@ -78,7 +78,7 @@ function testCycle($childs = null)
     return true;
 }
 
-function deleteMetaServiceDependencyInDB($dependencies = [])
+function deleteMetaServiceDependencyInDB($dependencies = array())
 {
     global $pearDB;
     $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
@@ -88,7 +88,7 @@ function deleteMetaServiceDependencyInDB($dependencies = [])
     }
 }
 
-function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
+function multipleMetaServiceDependencyInDB($dependencies = array(), $nbrDup = array())
 {
     global $pearDB;
     $selectStmt = $pearDB->prepare(
@@ -313,14 +313,13 @@ function updateMetaServiceDependencyMetaServiceParents($dep_id = null)
     $statement = $pearDB->prepare("DELETE FROM dependency_metaserviceParent_relation WHERE dependency_dep_id = :dep_id");
     $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    $ret = [];
+    $ret = array();
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msParents');
     $statement = $pearDB->prepare(
         "INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id)
         VALUES (:dep_id, :meta_id)"
     );
-    $counter = count($ret);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret); $i++) {
         $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
         $statement->bindValue(':meta_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();
@@ -337,14 +336,13 @@ function updateMetaServiceDependencyMetaServiceChilds($dep_id = null)
     $statement = $pearDB->prepare("DELETE FROM dependency_metaserviceChild_relation WHERE dependency_dep_id = :dep_id");
     $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    $ret = [];
+    $ret = array();
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msChilds');
     $statement = $pearDB->prepare(
         "INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id)
         VALUES (:dep_id, :meta_id)"
     );
-    $counter = count($ret);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret); $i++) {
         $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
         $statement->bindValue(':meta_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -3,34 +3,34 @@
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
- * 
- * This program is free software; you can redistribute it and/or modify it under 
- * the terms of the GNU General Public License as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
  * Foundation ; either version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with 
+ *
+ * You should have received a copy of the GNU General Public License along with
  * this program; if not, see <http://www.gnu.org/licenses>.
- * 
- * Linking this program statically or dynamically with other modules is making a 
- * combined work based on this program. Thus, the terms and conditions of the GNU 
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
- * 
- * As a special exception, the copyright holders of this program give Centreon 
- * permission to link this program with independent modules to produce an executable, 
- * regardless of the license terms of these independent modules, and to copy and 
- * distribute the resulting executable under terms of Centreon choice, provided that 
- * Centreon also meet, for each linked independent module, the terms  and conditions 
- * of the license of that module. An independent module is a module which is not 
- * derived from this program. If you modify this program, you may extend this 
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
  * do not wish to do so, delete this exception statement from your version.
- * 
+ *
  * For more information : contact@centreon.com
- * 
+ *
  */
 
 if (!isset($oreon)) {
@@ -48,27 +48,23 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '" .
-        htmlentities($name, ENT_QUOTES, "UTF-8") . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
-    #Modif case
-    if ($dbResult->rowCount() >= 1 && $dep["dep_id"] == $id) {
-        return true;
-    } #Duplicate entry
-    elseif ($dbResult->rowCount() >= 1 && $dep["dep_id"] != $id) {
-        return false;
-    } else {
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
+    if ($dep === false) {
         return true;
     }
+
+    return $dep['dep_id'] == $id;
 }
 
 function testCycle($childs = null)
 {
     global $pearDB;
     global $form;
-    $parents = array();
-    $childs = array();
+    $parents = [];
+    $childs = [];
     if (isset($form)) {
         $parents = $form->getSubmitValue('dep_msParents');
         $childs = $form->getSubmitValue('dep_msChilds');
@@ -82,58 +78,83 @@ function testCycle($childs = null)
     return true;
 }
 
-function deleteMetaServiceDependencyInDB($dependencies = array())
+function deleteMetaServiceDependencyInDB($dependencies = [])
 {
     global $pearDB;
-    foreach ($dependencies as $key => $value) {
-        $dbResult = $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+    $statement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+    foreach (array_keys($dependencies) as $key) {
+        $statement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
-function multipleMetaServiceDependencyInDB($dependencies = array(), $nbrDup = array())
+function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
-        global $pearDB;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row["dep_id"] = null;
+    global $pearDB;
+    $selectStmt = $pearDB->prepare(
+        "SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1"
+    );
+    $insertStmt = $pearDB->prepare(
+        "INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)"
+    );
+    $selectParentStmt = $pearDB->prepare(
+        "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation "
+        . "WHERE dependency_dep_id = :dep_id"
+    );
+    $insertParentStmt = $pearDB->prepare(
+        "INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id) "
+        . "VALUES (:depId, :metaId)"
+    );
+    $selectChildStmt = $pearDB->prepare(
+        "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation "
+        . "WHERE dependency_dep_id = :dep_id"
+    );
+    $insertChildStmt = $pearDB->prepare(
+        "INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id) "
+        . "VALUES (:depId, :metaId)"
+    );
+
+    foreach (array_keys($dependencies) as $key) {
+        $selectStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        if ($row === false) {
+            continue;
+        }
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                $key2 == "dep_name" ? ($dep_name = $value2 = $value2 . "_" . $i) : null;
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
-            }
+            $dep_name = $row['dep_name'] . '_' . $i;
             if (testExistence($dep_name)) {
-                $val ? $rq = "INSERT INTO dependency VALUES (" . $val . ")" : $rq = null;
-                $pearDB->query($rq);
-                $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-                $maxId = $dbResult->fetch();
-                if (isset($maxId["MAX(dep_id)"])) {
-                    $query = "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $statement = $pearDB->prepare("INSERT INTO dependency_metaserviceParent_relation " .
-                        "VALUES (:maxId, :metaId)");
-                    while ($ms = $dbResult->fetch()) {
-                        $statement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);
-                        $statement->execute();
+                $insertStmt->bindValue(':dep_name', $dep_name, \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], \PDO::PARAM_STR);
+                $insertStmt->execute();
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectParentStmt->execute();
+                    while ($ms = $selectParentStmt->fetch()) {
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], \PDO::PARAM_INT);
+                        $insertParentStmt->execute();
                     }
-                    $dbResult->closeCursor();
-                    $query = "SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceChild_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $childStatement = $pearDB->prepare("INSERT INTO dependency_metaserviceChild_relation " .
-                        "VALUES (:maxId, :metaId)");
-                    while ($ms = $dbResult->fetch()) {
-                        $childStatement->bindValue(':maxId', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $childStatement->bindValue(':metaId', (int) $ms["meta_service_meta_id"], \PDO::PARAM_INT);
-                        $childStatement->execute();
+                    $selectParentStmt->closeCursor();
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectChildStmt->execute();
+                    while ($ms = $selectChildStmt->fetch()) {
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':metaId', (int) $ms['meta_service_meta_id'], \PDO::PARAM_INT);
+                        $insertChildStmt->execute();
                     }
-                    $dbResult->closeCursor();
+                    $selectChildStmt->closeCursor();
                 }
             }
         }
@@ -183,19 +204,19 @@ function insertMetaServiceDependency(): int
     $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
         "metaservice dependency",
-        $depId["MAX(dep_id)"],
+        $depId,
         $resourceValues["dep_name"],
         "a",
         $fields
     );
-    return ((int) $depId["MAX(dep_id)"]);
+
+    return $depId;
 }
 
 /**
@@ -289,17 +310,20 @@ function updateMetaServiceDependencyMetaServiceParents($dep_id = null)
     }
     global $form;
     global $pearDB;
-    $rq = "DELETE FROM dependency_metaserviceParent_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
-    $ret = array();
+    $statement = $pearDB->prepare("DELETE FROM dependency_metaserviceParent_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
+    $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msParents');
-    for ($i = 0; $i < count($ret); $i++) {
-        $rq = "INSERT INTO dependency_metaserviceParent_relation ";
-        $rq .= "(dependency_dep_id, meta_service_meta_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_metaserviceParent_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)"
+    );
+    $counter = count($ret);
+    for ($i = 0; $i < $counter; $i++) {
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], \PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
@@ -310,16 +334,19 @@ function updateMetaServiceDependencyMetaServiceChilds($dep_id = null)
     }
     global $form;
     global $pearDB;
-    $rq = "DELETE FROM dependency_metaserviceChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
-    $ret = array();
+    $statement = $pearDB->prepare("DELETE FROM dependency_metaserviceChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
+    $ret = [];
     $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_msChilds');
-    for ($i = 0; $i < count($ret); $i++) {
-        $rq = "INSERT INTO dependency_metaserviceChild_relation ";
-        $rq .= "(dependency_dep_id, meta_service_meta_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_metaserviceChild_relation (dependency_dep_id, meta_service_meta_id)
+        VALUES (:dep_id, :meta_id)"
+    );
+    $counter = count($ret);
+    for ($i = 0; $i < $counter; $i++) {
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':meta_id', (int) $ret[$i], \PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -66,8 +66,8 @@ function testCycleH($childs = null)
 {
     global $pearDB;
     global $form;
-    $parents = [];
-    $childs = [];
+    $parents = array();
+    $childs = array();
     if (isset($form)) {
         $parents = $form->getSubmitValue('dep_hSvPar');
         $childs = $form->getSubmitValue('dep_hSvChi');
@@ -81,7 +81,7 @@ function testCycleH($childs = null)
     return true;
 }
 
-function deleteServiceDependencyInDB($dependencies = [])
+function deleteServiceDependencyInDB($dependencies = array())
 {
     global $pearDB, $oreon;
     $selectStatement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
@@ -100,7 +100,7 @@ function deleteServiceDependencyInDB($dependencies = [])
     }
 }
 
-function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
+function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array())
 {
     global $pearDB, $oreon;
     $selectStmt = $pearDB->prepare(
@@ -228,7 +228,7 @@ function updateServiceDependencyInDB($dep_id = null)
     updateServiceDependencyHostChildren($dep_id);
 }
 
-function insertServiceDependencyInDB($ret = [])
+function insertServiceDependencyInDB($ret = array())
 {
     $dep_id = insertServiceDependency($ret);
     updateServiceDependencyServiceParents($dep_id, $ret);
@@ -243,7 +243,7 @@ function insertServiceDependencyInDB($ret = [])
  * @param array<string, mixed> $ret
  * @return int
  */
-function insertServiceDependency($ret = []): int
+function insertServiceDependency($ret = array()): int
 {
     global $form, $pearDB, $centreon;
     if (!count($ret)) {
@@ -383,7 +383,7 @@ function sanitizeResourceParameters(array $resources): array
     return $sanitizedParameters;
 }
 
-function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
+function updateServiceDependencyServiceParents($dep_id = null, $ret = array())
 {
     if (!$dep_id) {
         exit();
@@ -396,13 +396,16 @@ function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
     $statement = $pearDB->prepare("DELETE FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id");
     $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    $ret1 = $ret["dep_hSvPar"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvPar");
+    if (isset($ret["dep_hSvPar"])) {
+        $ret1 = $ret["dep_hSvPar"];
+    } else {
+        $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hSvPar");
+    }
     $statement = $pearDB->prepare(
         "INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
         VALUES (:dep_id, :service_id, :host_id)"
     );
-    $counter = count($ret1);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret1); $i++) {
         $exp = explode("-", $ret1[$i]);
         if (count($exp) == 2) {
             $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
@@ -413,7 +416,7 @@ function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
     }
 }
 
-function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
+function updateServiceDependencyServiceChilds($dep_id = null, $ret = array())
 {
     if (!$dep_id) {
         exit();
@@ -426,13 +429,16 @@ function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
     $statement = $pearDB->prepare("DELETE FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id");
     $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
     $statement->execute();
-    $ret1 = $ret["dep_hSvChi"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvChi");
+    if (isset($ret["dep_hSvChi"])) {
+        $ret1 = $ret["dep_hSvChi"];
+    } else {
+        $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hSvChi");
+    }
     $statement = $pearDB->prepare(
         "INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
         VALUES (:dep_id, :service_id, :host_id)"
     );
-    $counter = count($ret1);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret1); $i++) {
         $exp = explode("-", $ret1[$i]);
         if (count($exp) == 2) {
             $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
@@ -448,7 +454,7 @@ function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
  * @param null|mixed $dep_id
  * @param mixed $ret
  */
-function updateServiceDependencyHostChildren($dep_id = null, $ret = [])
+function updateServiceDependencyHostChildren($dep_id = null, $ret = array())
 {
     if (!$dep_id) {
         exit();
@@ -470,8 +476,7 @@ function updateServiceDependencyHostChildren($dep_id = null, $ret = [])
         "INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
         VALUES (:dep_id, :host_id)"
     );
-    $counter = count($ret1);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret1); $i++) {
         $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
         $statement->bindValue(':host_id', (int) $ret1[$i], \PDO::PARAM_INT);
         $statement->execute();

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -51,27 +51,23 @@ function testServiceDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '" .
-        htmlentities($name, ENT_QUOTES, "UTF-8") . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
-    #Modif case
-    if ($dbResult->rowCount() >= 1 && $dep["dep_id"] == $id) {
-        return true;
-    } #Duplicate entry
-    elseif ($dbResult->rowCount() >= 1 && $dep["dep_id"] != $id) {
-        return false;
-    } else {
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
+    if ($dep === false) {
         return true;
     }
+
+    return $dep['dep_id'] == $id;
 }
 
 function testCycleH($childs = null)
 {
     global $pearDB;
     global $form;
-    $parents = array();
-    $childs = array();
+    $parents = [];
+    $childs = [];
     if (isset($form)) {
         $parents = $form->getSubmitValue('dep_hSvPar');
         $childs = $form->getSubmitValue('dep_hSvChi');
@@ -85,98 +81,132 @@ function testCycleH($childs = null)
     return true;
 }
 
-function deleteServiceDependencyInDB($dependencies = array())
+function deleteServiceDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
-    foreach ($dependencies as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT dep_name FROM `dependency` WHERE `dep_id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+    $selectStatement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+    $deleteStatement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+    foreach (array_keys($dependencies) as $key) {
+        $selectStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $selectStatement->execute();
+        $row = $selectStatement->fetch();
+        if ($row === false) {
+            continue;
+        }
 
-        $dbResult = $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+        $deleteStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $deleteStatement->execute();
         $oreon->CentreonLogAction->insertLog("service dependency", $key, $row['dep_name'], "d");
     }
 }
 
-function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array())
+function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
-        global $pearDB, $oreon;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row["dep_id"] = null;
+    global $pearDB, $oreon;
+    $selectStmt = $pearDB->prepare(
+        "SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1"
+    );
+    $insertStmt = $pearDB->prepare(
+        "INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)"
+    );
+    $selectHostChildStmt = $pearDB->prepare(
+        "SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id"
+    );
+    $insertHostChildStmt = $pearDB->prepare(
+        "INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:depId, :hostId)"
+    );
+    $selectServiceParentStmt = $pearDB->prepare(
+        "SELECT service_service_id, host_host_id FROM dependency_serviceParent_relation
+        WHERE dependency_dep_id = :dep_id"
+    );
+    $insertServiceParentStmt = $pearDB->prepare(
+        "INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)"
+    );
+    $selectServiceChildStmt = $pearDB->prepare(
+        "SELECT service_service_id, host_host_id FROM dependency_serviceChild_relation
+        WHERE dependency_dep_id = :dep_id"
+    );
+    $insertServiceChildStmt = $pearDB->prepare(
+        "INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:depId, :serviceId, :hostId)"
+    );
+
+    foreach (array_keys($dependencies) as $key) {
+        $selectStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch(\PDO::FETCH_ASSOC);
+        if ($row === false) {
+            continue;
+        }
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
+            $dep_name = $row['dep_name'] . '_' . $i;
+            $fields = [];
             foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                $key2 == "dep_name" ? ($dep_name = $value2 = $value2 . "_" . $i) : null;
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
-                if ($key2 != "dep_id") {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($dep_name)) {
-                    $fields["dep_name"] = $dep_name;
-                }
+                $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
-            if (isset($dep_name) && testServiceDependencyExistence($dep_name)) {
-                $val ? $rq = "INSERT INTO dependency VALUES (" . $val . ")" : $rq = null;
-                $pearDB->query($rq);
-                $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-                $maxId = $dbResult->fetch();
-                if (isset($maxId["MAX(dep_id)"])) {
-                    $query = "SELECT * FROM dependency_hostChild_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_hostPar"] = "";
-                    $query = "INSERT INTO dependency_hostChild_relation VALUES (:dep_id, :host_host_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($host = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':host_host_id', (int) $host["host_host_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_hostPar"] .= $host["host_host_id"] . ",";
+            if (testServiceDependencyExistence($dep_name)) {
+                $insertStmt->bindValue(':dep_name', $dep_name, \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], \PDO::PARAM_STR);
+                $insertStmt->execute();
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
+                    $selectHostChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectHostChildStmt->execute();
+                    $fields['dep_hostPar'] = '';
+                    while ($host = $selectHostChildStmt->fetch()) {
+                        $insertHostChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertHostChildStmt->bindValue(':hostId', (int) $host['host_host_id'], \PDO::PARAM_INT);
+                        $insertHostChildStmt->execute();
+                        $fields['dep_hostPar'] .= $host['host_host_id'] . ',';
                     }
                     $fields["dep_hostPar"] = trim($fields["dep_hostPar"], ",");
 
-                    $query = "SELECT * FROM dependency_serviceParent_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_hSvPar"] = "";
-                    $query = "INSERT INTO dependency_serviceParent_relation 
-                        VALUES (:dep_id, :service_service_id, :host_host_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($service = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(
-                            ':service_service_id',
-                            (int) $service["service_service_id"],
+                    $selectServiceParentStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectServiceParentStmt->execute();
+                    $fields['dep_hSvPar'] = '';
+                    while ($service = $selectServiceParentStmt->fetch()) {
+                        $insertServiceParentStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertServiceParentStmt->bindValue(
+                            ':serviceId',
+                            (int) $service['service_service_id'],
                             \PDO::PARAM_INT
                         );
-                        $statement->bindValue(':host_host_id', (int) $service["host_host_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_hSvPar"] .= $service["service_service_id"] . ",";
+                        $insertServiceParentStmt->bindValue(':hostId', (int) $service['host_host_id'], \PDO::PARAM_INT);
+                        $insertServiceParentStmt->execute();
+                        $fields['dep_hSvPar'] .= $service['service_service_id'] . ',';
                     }
                     $fields["dep_hSvPar"] = trim($fields["dep_hSvPar"], ",");
-                    $query = "SELECT * FROM dependency_serviceChild_relation WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
-                    $fields["dep_hSvChi"] = "";
-                    $query = "INSERT INTO dependency_serviceChild_relation 
-                        VALUES (:dep_id, :service_service_id, :host_host_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($service = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(
-                            ':service_service_id',
-                            (int) $service["service_service_id"],
+
+                    $selectServiceChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectServiceChildStmt->execute();
+                    $fields['dep_hSvChi'] = '';
+                    while ($service = $selectServiceChildStmt->fetch()) {
+                        $insertServiceChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertServiceChildStmt->bindValue(
+                            ':serviceId',
+                            (int) $service['service_service_id'],
                             \PDO::PARAM_INT
                         );
-                        $statement->bindValue(':host_host_id', (int) $service["host_host_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_hSvChi"] .= $service["service_service_id"] . ",";
+                        $insertServiceChildStmt->bindValue(':hostId', (int) $service['host_host_id'], \PDO::PARAM_INT);
+                        $insertServiceChildStmt->execute();
+                        $fields['dep_hSvChi'] .= $service['service_service_id'] . ',';
                     }
                     $fields["dep_hSvChi"] = trim($fields["dep_hSvChi"], ",");
                     $oreon->CentreonLogAction->insertLog(
                         "service dependency",
-                        $maxId["MAX(dep_id)"],
+                        $lastId,
                         $dep_name,
                         "a",
                         $fields
@@ -198,7 +228,7 @@ function updateServiceDependencyInDB($dep_id = null)
     updateServiceDependencyHostChildren($dep_id);
 }
 
-function insertServiceDependencyInDB($ret = array())
+function insertServiceDependencyInDB($ret = [])
 {
     $dep_id = insertServiceDependency($ret);
     updateServiceDependencyServiceParents($dep_id, $ret);
@@ -213,7 +243,7 @@ function insertServiceDependencyInDB($ret = array())
  * @param array<string, mixed> $ret
  * @return int
  */
-function insertServiceDependency($ret = array()): int
+function insertServiceDependency($ret = []): int
 {
     global $form, $pearDB, $centreon;
     if (!count($ret)) {
@@ -244,18 +274,17 @@ function insertServiceDependency($ret = array()): int
     $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     $fields = CentreonLogAction::prepareChanges($ret);
     $centreon->CentreonLogAction->insertLog(
         "service dependency",
-        $depId["MAX(dep_id)"],
+        $depId,
         $resourceValues["dep_name"],
         "a",
         $fields
     );
-    return ((int) $depId["MAX(dep_id)"]);
+    return $depId;
 }
 
 /**
@@ -354,7 +383,7 @@ function sanitizeResourceParameters(array $resources): array
     return $sanitizedParameters;
 }
 
-function updateServiceDependencyServiceParents($dep_id = null, $ret = array())
+function updateServiceDependencyServiceParents($dep_id = null, $ret = [])
 {
     if (!$dep_id) {
         exit();
@@ -364,27 +393,27 @@ function updateServiceDependencyServiceParents($dep_id = null, $ret = array())
     if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_serviceParent_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
-    if (isset($ret["dep_hSvPar"])) {
-        $ret1 = $ret["dep_hSvPar"];
-    } else {
-        $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hSvPar");
-    }
-    for ($i = 0; $i < count($ret1); $i++) {
+    $statement = $pearDB->prepare("DELETE FROM dependency_serviceParent_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
+    $ret1 = $ret["dep_hSvPar"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvPar");
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_serviceParent_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)"
+    );
+    $counter = count($ret1);
+    for ($i = 0; $i < $counter; $i++) {
         $exp = explode("-", $ret1[$i]);
         if (count($exp) == 2) {
-            $rq = "INSERT INTO dependency_serviceParent_relation ";
-            $rq .= "(dependency_dep_id, service_service_id, host_host_id) ";
-            $rq .= "VALUES ";
-            $rq .= "('" . $dep_id . "', '" . $exp[1] . "', '" . $exp[0] . "')";
-            $dbResult = $pearDB->query($rq);
+            $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], \PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], \PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 }
 
-function updateServiceDependencyServiceChilds($dep_id = null, $ret = array())
+function updateServiceDependencyServiceChilds($dep_id = null, $ret = [])
 {
     if (!$dep_id) {
         exit();
@@ -394,30 +423,32 @@ function updateServiceDependencyServiceChilds($dep_id = null, $ret = array())
     if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_serviceChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
-    if (isset($ret["dep_hSvChi"])) {
-        $ret1 = $ret["dep_hSvChi"];
-    } else {
-        $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hSvChi");
-    }
-    for ($i = 0; $i < count($ret1); $i++) {
+    $statement = $pearDB->prepare("DELETE FROM dependency_serviceChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
+    $ret1 = $ret["dep_hSvChi"] ?? CentreonUtils::mergeWithInitialValues($form, "dep_hSvChi");
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_serviceChild_relation (dependency_dep_id, service_service_id, host_host_id)
+        VALUES (:dep_id, :service_id, :host_id)"
+    );
+    $counter = count($ret1);
+    for ($i = 0; $i < $counter; $i++) {
         $exp = explode("-", $ret1[$i]);
         if (count($exp) == 2) {
-            $rq = "INSERT INTO dependency_serviceChild_relation ";
-            $rq .= "(dependency_dep_id, service_service_id, host_host_id) ";
-            $rq .= "VALUES ";
-            $rq .= "('" . $dep_id . "', '" . $exp[1] . "', '" . $exp[0] . "')";
-            $dbResult = $pearDB->query($rq);
+            $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+            $statement->bindValue(':service_id', (int) $exp[1], \PDO::PARAM_INT);
+            $statement->bindValue(':host_id', (int) $exp[0], \PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 }
 
 /**
  * Update Service Dependency Host Children
+ * @param null|mixed $dep_id
+ * @param mixed $ret
  */
-function updateServiceDependencyHostChildren($dep_id = null, $ret = array())
+function updateServiceDependencyHostChildren($dep_id = null, $ret = [])
 {
     if (!$dep_id) {
         exit();
@@ -427,19 +458,22 @@ function updateServiceDependencyHostChildren($dep_id = null, $ret = array())
     if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_hostChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare("DELETE FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
     if (isset($ret["dep_hHostChi"])) {
         $ret1 = $ret["dep_hHostChi"];
     } else {
         $ret1 = CentreonUtils::mergeWithInitialValues($form, "dep_hHostChi");
     }
-    for ($i = 0; $i < count($ret1); $i++) {
-        $rq = "INSERT INTO dependency_hostChild_relation ";
-        $rq .= "(dependency_dep_id, host_host_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret1[$i] . "')";
-        $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_hostChild_relation (dependency_dep_id, host_host_id)
+        VALUES (:dep_id, :host_id)"
+    );
+    $counter = count($ret1);
+    for ($i = 0; $i < $counter; $i++) {
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':host_id', (int) $ret1[$i], \PDO::PARAM_INT);
+        $statement->execute();
     }
 }

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -66,8 +66,8 @@ function testServiceGroupDependencyCycle($childs = null)
 {
     global $pearDB;
     global $form;
-    $parents = [];
-    $childs = [];
+    $parents = array();
+    $childs = array();
     if (isset($form)) {
         $parents = $form->getSubmitValue('dep_sgParents');
         $childs = $form->getSubmitValue('dep_sgChilds');
@@ -81,7 +81,7 @@ function testServiceGroupDependencyCycle($childs = null)
     return true;
 }
 
-function deleteServiceGroupDependencyInDB($dependencies = [])
+function deleteServiceGroupDependencyInDB($dependencies = array())
 {
     global $pearDB, $oreon;
     $selectStatement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
@@ -100,7 +100,7 @@ function deleteServiceGroupDependencyInDB($dependencies = [])
     }
 }
 
-function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
+function multipleServiceGroupDependencyInDB($dependencies = array(), $nbrDup = array())
 {
     global $pearDB, $oreon;
     $selectStmt = $pearDB->prepare(
@@ -200,7 +200,7 @@ function updateServiceGroupDependencyInDB($dep_id = null)
     updateServiceGroupDependencyServiceGroupChilds($dep_id);
 }
 
-function insertServiceGroupDependencyInDB($ret = [])
+function insertServiceGroupDependencyInDB($ret = array())
 {
     $dep_id = insertServiceGroupDependency($ret);
     updateServiceGroupDependencyServiceGroupParents($dep_id, $ret);
@@ -214,7 +214,7 @@ function insertServiceGroupDependencyInDB($ret = [])
  * @param array<string, mixed> $ret
  * @return int
  */
-function insertServiceGroupDependency($ret = []): int
+function insertServiceGroupDependency($ret = array()): int
 {
     global $form, $pearDB, $centreon;
     if (!count($ret)) {
@@ -335,7 +335,7 @@ function sanitizeResourceParameters(array $resources): array
     return $sanitizedParameters;
 }
 
-function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = [])
+function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = array())
 {
     if (!$dep_id) {
         exit();
@@ -357,15 +357,14 @@ function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = 
         "INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id)
         VALUES (:dep_id, :sg_id)"
     );
-    $counter = count($ret);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret); $i++) {
         $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
         $statement->bindValue(':sg_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();
     }
 }
 
-function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = [])
+function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = array())
 {
     if (!$dep_id) {
         exit();
@@ -387,8 +386,7 @@ function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = [
         "INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id)
         VALUES (:dep_id, :sg_id)"
     );
-    $counter = count($ret);
-    for ($i = 0; $i < $counter; $i++) {
+    for ($i = 0; $i < count($ret); $i++) {
         $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
         $statement->bindValue(':sg_id', (int) $ret[$i], \PDO::PARAM_INT);
         $statement->execute();

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -51,27 +51,23 @@ function testServiceGroupDependencyExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dep_id');
     }
-    $query = "SELECT dep_name, dep_id FROM dependency WHERE dep_name = '" .
-        htmlentities($name, ENT_QUOTES, "UTF-8") . "'";
-    $dbResult = $pearDB->query($query);
-    $dep = $dbResult->fetch();
-    #Modif case
-    if ($dbResult->rowCount() >= 1 && $dep["dep_id"] == $id) {
-        return true;
-    } #Duplicate entry
-    elseif ($dbResult->rowCount() >= 1 && $dep["dep_id"] != $id) {
-        return false;
-    } else {
+    $statement = $pearDB->prepare("SELECT dep_name, dep_id FROM dependency WHERE dep_name = :name");
+    $statement->bindValue(':name', $name, \PDO::PARAM_STR);
+    $statement->execute();
+    $dep = $statement->fetch();
+    if ($dep === false) {
         return true;
     }
+
+    return $dep['dep_id'] == $id;
 }
 
 function testServiceGroupDependencyCycle($childs = null)
 {
     global $pearDB;
     global $form;
-    $parents = array();
-    $childs = array();
+    $parents = [];
+    $childs = [];
     if (isset($form)) {
         $parents = $form->getSubmitValue('dep_sgParents');
         $childs = $form->getSubmitValue('dep_sgChilds');
@@ -85,83 +81,109 @@ function testServiceGroupDependencyCycle($childs = null)
     return true;
 }
 
-function deleteServiceGroupDependencyInDB($dependencies = array())
+function deleteServiceGroupDependencyInDB($dependencies = [])
 {
     global $pearDB, $oreon;
-    foreach ($dependencies as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT dep_name FROM `dependency` WHERE `dep_id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+    $selectStatement = $pearDB->prepare("SELECT dep_name FROM `dependency` WHERE `dep_id` = :dep_id LIMIT 1");
+    $deleteStatement = $pearDB->prepare("DELETE FROM dependency WHERE dep_id = :dep_id");
+    foreach (array_keys($dependencies) as $key) {
+        $selectStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $selectStatement->execute();
+        $row = $selectStatement->fetch();
+        if ($row === false) {
+            continue;
+        }
 
-        $pearDB->query("DELETE FROM dependency WHERE dep_id = '" . $key . "'");
+        $deleteStatement->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $deleteStatement->execute();
         $oreon->CentreonLogAction->insertLog("servicegroup dependency", $key, $row['dep_name'], "d");
     }
 }
 
-function multipleServiceGroupDependencyInDB($dependencies = array(), $nbrDup = array())
+function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
-    foreach ($dependencies as $key => $value) {
-        global $pearDB, $oreon;
-        $dbResult = $pearDB->query("SELECT * FROM dependency WHERE dep_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row["dep_id"] = null;
+    global $pearDB, $oreon;
+    $selectStmt = $pearDB->prepare(
+        "SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
+                notification_failure_criteria, dep_comment
+        FROM dependency WHERE dep_id = :dep_id LIMIT 1"
+    );
+    $insertStmt = $pearDB->prepare(
+        "INSERT INTO dependency
+        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
+         notification_failure_criteria, dep_comment)
+        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
+         :notification_failure_criteria, :dep_comment)"
+    );
+    $selectParentStmt = $pearDB->prepare(
+        "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation "
+        . "WHERE dependency_dep_id = :dep_id"
+    );
+    $insertParentStmt = $pearDB->prepare(
+        "INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id) "
+        . "VALUES (:depId, :servicegroupId)"
+    );
+    $selectChildStmt = $pearDB->prepare(
+        "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation "
+        . "WHERE dependency_dep_id = :dep_id"
+    );
+    $insertChildStmt = $pearDB->prepare(
+        "INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id) "
+        . "VALUES (:depId, :servicegroupId)"
+    );
+
+    foreach (array_keys($dependencies) as $key) {
+        $selectStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch(\PDO::FETCH_ASSOC);
+        if ($row === false) {
+            continue;
+        }
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
+            $dep_name = $row['dep_name'] . '_' . $i;
+            $fields = [];
             foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                $key2 == "dep_name" ? ($dep_name = $value2 = $value2 . "_" . $i) : null;
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");
-                if ($key2 != "dep_id") {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($dep_name)) {
-                    $fields["dep_name"] = $dep_name;
-                }
+                $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
-            if (isset($dep_name) && testServiceGroupDependencyExistence($dep_name)) {
-                $val ? $rq = "INSERT INTO dependency VALUES (" . $val . ")" : $rq = null;
-                $pearDB->query($rq);
-                $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-                $maxId = $dbResult->fetch();
-                if (isset($maxId["MAX(dep_id)"])) {
-                    $query = "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+            if (testServiceGroupDependencyExistence($dep_name)) {
+                $insertStmt->bindValue(':dep_name', $dep_name, \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_description', $row['dep_description'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], \PDO::PARAM_STR);
+                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], \PDO::PARAM_STR);
+                $insertStmt->execute();
+                $lastId = (int) $pearDB->lastInsertId();
+                if ($lastId > 0) {
+                    $selectParentStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectParentStmt->execute();
                     $fields["dep_sgParents"] = "";
-                    $query = "INSERT INTO dependency_servicegroupParent_relation " .
-                             "VALUES (:dep_id, :servicegroup_sg_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($sg = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':servicegroup_sg_id', (int) $sg["servicegroup_sg_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_sgParents"] .= $sg["servicegroup_sg_id"] . ",";
+                    while ($sg = $selectParentStmt->fetch()) {
+                        $insertParentStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertParentStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], \PDO::PARAM_INT);
+                        $insertParentStmt->execute();
+                        $fields["dep_sgParents"] .= $sg['servicegroup_sg_id'] . ",";
                     }
                     $fields["dep_sgParents"] = trim($fields["dep_sgParents"], ",");
-                    $dbResult->closeCursor();
-                    $query = "SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupChild_relation " .
-                        "WHERE dependency_dep_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectParentStmt->closeCursor();
+                    $selectChildStmt->bindValue(':dep_id', (int) $key, \PDO::PARAM_INT);
+                    $selectChildStmt->execute();
                     $fields["dep_sgChilds"] = "";
-                    $query = "INSERT INTO dependency_servicegroupChild_relation " .
-                             "VALUES (:dep_id, :servicegroup_sg_id)";
-                    $statement = $pearDB->prepare($query);
-                    while ($sg = $dbResult->fetch()) {
-                        $statement->bindValue(':dep_id', (int) $maxId["MAX(dep_id)"], \PDO::PARAM_INT);
-                        $statement->bindValue(':servicegroup_sg_id', (int) $sg["servicegroup_sg_id"], \PDO::PARAM_INT);
-                        $statement->execute();
-                        $fields["dep_sgChilds"] .= $sg["servicegroup_sg_id"] . ",";
+                    while ($sg = $selectChildStmt->fetch()) {
+                        $insertChildStmt->bindValue(':depId', (int) $lastId, \PDO::PARAM_INT);
+                        $insertChildStmt->bindValue(':servicegroupId', (int) $sg['servicegroup_sg_id'], \PDO::PARAM_INT);
+                        $insertChildStmt->execute();
+                        $fields["dep_sgChilds"] .= $sg['servicegroup_sg_id'] . ",";
                     }
+                    $selectChildStmt->closeCursor();
                     $fields["dep_sgChilds"] = trim($fields["dep_sgChilds"], ",");
                     $oreon->CentreonLogAction->insertLog(
                         "servicegroup dependency",
-                        $maxId["MAX(dep_id)"],
+                        $lastId,
                         $dep_name,
                         "a",
                         $fields
                     );
-                    $dbResult->closeCursor();
                 }
             }
         }
@@ -178,7 +200,7 @@ function updateServiceGroupDependencyInDB($dep_id = null)
     updateServiceGroupDependencyServiceGroupChilds($dep_id);
 }
 
-function insertServiceGroupDependencyInDB($ret = array())
+function insertServiceGroupDependencyInDB($ret = [])
 {
     $dep_id = insertServiceGroupDependency($ret);
     updateServiceGroupDependencyServiceGroupParents($dep_id, $ret);
@@ -192,7 +214,7 @@ function insertServiceGroupDependencyInDB($ret = array())
  * @param array<string, mixed> $ret
  * @return int
  */
-function insertServiceGroupDependency($ret = array()): int
+function insertServiceGroupDependency($ret = []): int
 {
     global $form, $pearDB, $centreon;
     if (!count($ret)) {
@@ -215,19 +237,18 @@ function insertServiceGroupDependency($ret = array()): int
     $statement->bindValue(':depComment', $resourceValues['dep_comment'], \PDO::PARAM_STR);
     $statement->execute();
 
-    $dbResult = $pearDB->query("SELECT MAX(dep_id) FROM dependency");
-    $depId = $dbResult->fetch();
+    $depId = (int) $pearDB->lastInsertId();
 
     /* Prepare value for changelog */
     $fields = CentreonLogAction::prepareChanges($resourceValues);
     $centreon->CentreonLogAction->insertLog(
         "servicegroup dependency",
-        $depId["MAX(dep_id)"],
+        $depId,
         $resourceValues["dep_name"],
         "a",
         $fields
     );
-    return ((int) $depId["MAX(dep_id)"]);
+    return $depId;
 }
 
 /**
@@ -314,7 +335,7 @@ function sanitizeResourceParameters(array $resources): array
     return $sanitizedParameters;
 }
 
-function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = array())
+function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = [])
 {
     if (!$dep_id) {
         exit();
@@ -324,24 +345,27 @@ function updateServiceGroupDependencyServiceGroupParents($dep_id = null, $ret = 
     if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_servicegroupParent_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare("DELETE FROM dependency_servicegroupParent_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
     if (isset($ret["dep_sgParents"])) {
         $ret = $ret["dep_sgParents"];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgParents');
     }
-    for ($i = 0; $i < count($ret); $i++) {
-        $rq = "INSERT INTO dependency_servicegroupParent_relation ";
-        $rq .= "(dependency_dep_id, servicegroup_sg_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_servicegroupParent_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)"
+    );
+    $counter = count($ret);
+    for ($i = 0; $i < $counter; $i++) {
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], \PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
-function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = array())
+function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = [])
 {
     if (!$dep_id) {
         exit();
@@ -351,19 +375,22 @@ function updateServiceGroupDependencyServiceGroupChilds($dep_id = null, $ret = a
     if (!count($ret)) {
         $ret = $form->getSubmitValues();
     }
-    $rq = "DELETE FROM dependency_servicegroupChild_relation ";
-    $rq .= "WHERE dependency_dep_id = '" . $dep_id . "'";
-    $pearDB->query($rq);
+    $statement = $pearDB->prepare("DELETE FROM dependency_servicegroupChild_relation WHERE dependency_dep_id = :dep_id");
+    $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+    $statement->execute();
     if (isset($ret["dep_sgChilds"])) {
         $ret = $ret["dep_sgChilds"];
     } else {
         $ret = CentreonUtils::mergeWithInitialValues($form, 'dep_sgChilds');
     }
-    for ($i = 0; $i < count($ret); $i++) {
-        $rq = "INSERT INTO dependency_servicegroupChild_relation ";
-        $rq .= "(dependency_dep_id, servicegroup_sg_id) ";
-        $rq .= "VALUES ";
-        $rq .= "('" . $dep_id . "', '" . $ret[$i] . "')";
-        $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        "INSERT INTO dependency_servicegroupChild_relation (dependency_dep_id, servicegroup_sg_id)
+        VALUES (:dep_id, :sg_id)"
+    );
+    $counter = count($ret);
+    for ($i = 0; $i < $counter; $i++) {
+        $statement->bindValue(':dep_id', (int) $dep_id, \PDO::PARAM_INT);
+        $statement->bindValue(':sg_id', (int) $ret[$i], \PDO::PARAM_INT);
+        $statement->execute();
     }
 }


### PR DESCRIPTION
## Description

Backport of #9665 to dev-24.04.x.

- Fix SQL injection (CWE-89) in service, metaservice, and servicegroup dependency `DB-Func.php` files
- Replace all raw SQL string concatenation with prepared statements using `bindValue()`

[MON-195279](https://centreon.atlassian.net/browse/MON-195279)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

[MON-195279]: https://centreon.atlassian.net/browse/MON-195279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ