### PR TITLE
fix(cfgexport): fix macro parent not retrieved if overrided by child (for host and services)

### DIFF
--- a/centreon/www/class/config-generate/host.class.php
+++ b/centreon/www/class/config-generate/host.class.php
@@ -360,7 +360,14 @@ class Host extends AbstractHost
             $isPollerEncryptionReady
         );
 
-        return  Macro::resolveInheritance($existingHostMacros, $inheritanceLine, $hostId);
+        [$directMacros] = Macro::resolveInheritance($existingHostMacros, $inheritanceLine, $hostId);
+
+        $allTemplateMacros = array_filter(
+            $existingHostMacros,
+            fn (Macro $macro): bool => $macro->getOwnerId() !== $hostId
+        );
+
+        return [$directMacros, array_values($allTemplateMacros)];
     }
 
     private function findServiceRelatedMacros(int $hostId, bool $isPollerEncryptionReady): array
@@ -382,9 +389,14 @@ class Host extends AbstractHost
                 $serviceTemplateInheritances
             );
             $existingMacros = $readServiceMacroRepository->findByServiceIds($serviceId, ...$inheritanceLine);
-            [$directMacros, $indirectMacros] = Macro::resolveInheritance($existingMacros, $inheritanceLine, $serviceId);
+            [$directMacros] = Macro::resolveInheritance($existingMacros, $inheritanceLine, $serviceId);
             $serviceMacros = array_merge($serviceMacros, array_values($directMacros));
-            $serviceTemplateMacros = array_merge($serviceTemplateMacros, array_values($indirectMacros));
+
+            $allTemplateMacros = array_filter(
+                $existingMacros,
+                fn (Macro $macro): bool => $macro->getOwnerId() !== $serviceId
+            );
+            $serviceTemplateMacros = array_merge($serviceTemplateMacros, array_values($allTemplateMacros));
         }
 
         array_walk(


### PR DESCRIPTION
## Description

In conf export files, if a macro is overridded by a child resource the parent resource should still have the original macro and value

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master
