### PR TITLE
Fix #9575 - Problem with SAML Auth fails with Azure AD

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
@@ -73,7 +73,9 @@ class OneLoginSettingsFormatter implements SettingsFormatterInterface
                 'x509cert' => $customConfiguration->getPublicCertificate(),
             ],
             'security' => [
-                'requestedAuthnContext' => $customConfiguration->hasRequestedAuthnContext(),
+                'requestedAuthnContext' => $customConfiguration->hasRequestedAuthnContext()
+                    ? ['urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport']
+                    : false,
                 'requestedAuthnContextComparison' => $customConfiguration->getRequestedAuthnContextComparison()->value,
             ],
         ];


### PR DESCRIPTION
## Description

Fixes SAML authentication failing when using Azure AD as Identity Provider.

The OneLoginSettingsFormatter was passing a boolean true for the requestedAuthnContext setting to the onelogin/php-saml library. When the library receives true, it builds the <samlp:RequestedAuthnContext> XML element using a HEREDOC string where the $authnComparisonAttr variable is not properly interpolated, resulting in malformed XML:

<samlp:RequestedAuthnContext $authnComparisonAttr>

Azure AD (and potentially other strict IdPs) correctly rejects this invalid SAML AuthnRequest.

Fix
Instead of passing true, we now pass an array containing the default PasswordProtectedTransport authentication context class reference. The library handles the array code path using string concatenation, which correctly produces:

<samlp:RequestedAuthnContext Comparison="exact">
    <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
</samlp:RequestedAuthnContext>

This is semantically identical to the true behavior (same default AuthnContextClassRef), but avoids the HEREDOC interpolation bug.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ? ##

Test plan
 Configure SAML authentication with Azure AD as IdP with requestedAuthnContext enabled
 Verify the SAML AuthnRequest XML contains a valid Comparison="exact" attribute (not $authnComparisonAttr)
 Verify SAML login completes successfully
 Verify that disabling requestedAuthnContext still works (no RequestedAuthnContext element in the request)
 Test with the 4 comparison modes: exact, minimum, better, maximum
Refs: #9575