### PR TITLE
fix(ResourceStatus): enable sorting on Information column (#9330)

### DIFF
--- a/centreon/www/front_src/src/Resources/Listing/columns/index.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/index.tsx
@@ -183,7 +183,7 @@ export const getColumns = ({
       id: 'information',
       label: t(labelInformation),
       rowMemoProps: ['information'],
-      sortable: false,
+      sortable: true,
       type: ColumnType.string,
       width: 'minmax(100px, 1fr)'
     },


### PR DESCRIPTION
## Description

## Summary

- The "Information" column in the Resources Status listing was not sortable due to `sortable: false` being explicitly set in the column definition since commit d2f5c72524 (Feb 2021), likely introduced by oversight during a filter refactoring
- Changed `sortable: false` to `sortable: true` — no backend change needed as the API already maps `information` to `resources.output` in `DbReadResourceRepository`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## How this pull request can be tested ? ##

## Test plan

- [ ] Navigate to Monitoring → Resources Status
- [ ] Click the "Information" column header → verify the list sorts alphabetically (ascending)
- [ ] Click again → verify it toggles to descending
- [ ] Verify other columns still sort correctly
- [ ] Verify the sort persists after page refresh (if applicable)

Closes #9330
