### PR TITLE
fix(web): prevent duplicate engine config when creating broker config

### DIFF
--- a/centreon/www/class/centreon-config/centreonMainCfg.class.php
+++ b/centreon/www/class/centreon-config/centreonMainCfg.class.php
@@ -247,7 +247,8 @@ class CentreonMainCfg
             `admin_pager`, `nagios_comment`, `nagios_activate`, `event_broker_options`,
             `enable_predictive_host_dependency_checks`, `enable_predictive_service_dependency_checks`,
             `host_down_disable_service_checks`, `passive_host_checks_are_soft`, `enable_environment_macros`,
-            `debug_file`, `debug_level`, `debug_level_opt`, `debug_verbosity`, `max_debug_file_size`, `cfg_file`
+            `debug_file`, `debug_level`, `debug_level_opt`, `debug_verbosity`, `max_debug_file_size`, `cfg_file`,
+            `broker_module_cfg_file`
             )
             VALUES (
             :nagios_name, :nagios_server_id, :log_file, :cfg_dir,
@@ -270,7 +271,8 @@ class CentreonMainCfg
             :admin_pager, :nagios_comment, :nagios_activate, :event_broker_options,
             :enable_predictive_host_dependency_checks, :enable_predictive_service_dependency_checks,
             :host_down_disable_service_checks, :passive_host_checks_are_soft, :enable_environment_macros, :debug_file,
-            :debug_level, :debug_level_opt, :debug_verbosity, :max_debug_file_size, :cfg_file
+            :debug_level, :debug_level_opt, :debug_verbosity, :max_debug_file_size, :cfg_file,
+            :broker_module_cfg_file
             )';
 
         $params = [
@@ -346,6 +348,8 @@ class CentreonMainCfg
             ':debug_verbosity' => $baseValues['debug_verbosity'],
             ':max_debug_file_size' => $baseValues['max_debug_file_size'],
             ':cfg_file' => $baseValues['cfg_file'],
+            ':broker_module_cfg_file' => $baseValues['broker_module_cfg_file']
+                ?? "/etc/centreon-broker/{$sName}-module.json",
         ];
 
         try {
@@ -365,8 +369,19 @@ class CentreonMainCfg
 
         $res1 = $this->DB->query('SELECT MAX(nagios_id) as last_id FROM `cfg_nagios`');
         $nagios = $res1->fetch();
+        $lastId = $nagios['last_id'];
 
-        return $nagios['last_id'];
+        if ($baseValues['nagios_activate'] === '1' || $baseValues['nagios_activate'] === 1) {
+            $deactivate = $this->DB->prepare(
+                "UPDATE cfg_nagios SET nagios_activate = '0'
+                 WHERE nagios_id != :nagios_id AND nagios_server_id = :server_id"
+            );
+            $deactivate->bindValue(':nagios_id', (int) $lastId, PDO::PARAM_INT);
+            $deactivate->bindValue(':server_id', (int) $iId, PDO::PARAM_INT);
+            $deactivate->execute();
+        }
+
+        return $lastId;
     }
 
     /**

--- a/centreon/www/class/centreon-config/centreonMainCfg.class.php
+++ b/centreon/www/class/centreon-config/centreonMainCfg.class.php
@@ -223,6 +223,16 @@ class CentreonMainCfg
             return false;
         }
 
+        $hasEngineCfg = $this->DB->prepare(
+            "SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id"
+        );
+        $hasEngineCfg->bindValue(':server_id', (int) $iId, PDO::PARAM_INT);
+        $hasEngineCfg->execute();
+        $row = $hasEngineCfg->fetch(PDO::FETCH_ASSOC);
+        if ((int) $row['nb'] > 0) {
+            return false;
+        }
+
         $res = $this->DB->query('SELECT * FROM cfg_nagios WHERE  nagios_server_id = ' . $source);
         $baseValues = $res->rowCount() == 0 ? $this->aInstanceDefaultValues : $res->fetch();
 

--- a/centreon/www/class/centreon-config/centreonMainCfg.class.php
+++ b/centreon/www/class/centreon-config/centreonMainCfg.class.php
@@ -358,8 +358,7 @@ class CentreonMainCfg
             ':debug_verbosity' => $baseValues['debug_verbosity'],
             ':max_debug_file_size' => $baseValues['max_debug_file_size'],
             ':cfg_file' => $baseValues['cfg_file'],
-            ':broker_module_cfg_file' => $baseValues['broker_module_cfg_file']
-                ?? "/etc/centreon-broker/{$sName}-module.json",
+            ':broker_module_cfg_file' => "/etc/centreon-broker/{$sName}-module.json",
         ];
 
         try {

--- a/centreon/www/class/centreon-config/centreonMainCfg.class.php
+++ b/centreon/www/class/centreon-config/centreonMainCfg.class.php
@@ -224,7 +224,7 @@ class CentreonMainCfg
         }
 
         $hasEngineCfg = $this->DB->prepare(
-            "SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id"
+            'SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id'
         );
         $hasEngineCfg->bindValue(':server_id', (int) $iId, PDO::PARAM_INT);
         $hasEngineCfg->execute();

--- a/centreon/www/class/centreon-config/centreonMainCfg.class.php
+++ b/centreon/www/class/centreon-config/centreonMainCfg.class.php
@@ -367,9 +367,7 @@ class CentreonMainCfg
             return false;
         }
 
-        $res1 = $this->DB->query('SELECT MAX(nagios_id) as last_id FROM `cfg_nagios`');
-        $nagios = $res1->fetch();
-        $lastId = $nagios['last_id'];
+        $lastId = (int) $this->DB->lastInsertId();
 
         if ($baseValues['nagios_activate'] === '1' || $baseValues['nagios_activate'] === 1) {
             $deactivate = $this->DB->prepare(

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -695,9 +695,17 @@ class CentreonConfigCentreonBroker
         }
 
         $iIdServer = $values['ns_nagios_server'];
-        $iId = $objMain->insertServerInCfgNagios(-1, $iIdServer, $values['name']);
-        if (! empty($iId)) {
-            $objMain->insertDefaultCfgNagiosLogger($iId);
+        $hasEngineCfg = $this->db->prepare(
+            "SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id"
+        );
+        $hasEngineCfg->bindValue(':server_id', (int) $iIdServer, PDO::PARAM_INT);
+        $hasEngineCfg->execute();
+        $row = $hasEngineCfg->fetch(PDO::FETCH_ASSOC);
+        if ((int) $row['nb'] === 0) {
+            $iId = $objMain->insertServerInCfgNagios(-1, $iIdServer, $values['name']);
+            if (! empty($iId)) {
+                $objMain->insertDefaultCfgNagiosLogger($iId);
+            }
         }
 
         // Get the ID

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -711,7 +711,8 @@ class CentreonConfigCentreonBroker
             }
             $this->db->commit();
         } catch (PDOException $e) {
-            $this->db->rollBack();
+            try { $this->db->rollBack(); } catch (PDOException $ignored) {}
+            error_log('Failed to create engine config for server ' . $iIdServer . ': ' . $e->getMessage());
         }
 
         // Get the ID

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -695,17 +695,23 @@ class CentreonConfigCentreonBroker
         }
 
         $iIdServer = $values['ns_nagios_server'];
-        $hasEngineCfg = $this->db->prepare(
-            "SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id"
-        );
-        $hasEngineCfg->bindValue(':server_id', (int) $iIdServer, PDO::PARAM_INT);
-        $hasEngineCfg->execute();
-        $row = $hasEngineCfg->fetch(PDO::FETCH_ASSOC);
-        if ((int) $row['nb'] === 0) {
-            $iId = $objMain->insertServerInCfgNagios(-1, $iIdServer, $values['name']);
-            if (! empty($iId)) {
-                $objMain->insertDefaultCfgNagiosLogger($iId);
+        try {
+            $this->db->beginTransaction();
+            $hasEngineCfg = $this->db->prepare(
+                "SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id FOR UPDATE"
+            );
+            $hasEngineCfg->bindValue(':server_id', (int) $iIdServer, PDO::PARAM_INT);
+            $hasEngineCfg->execute();
+            $row = $hasEngineCfg->fetch(PDO::FETCH_ASSOC);
+            if ((int) $row['nb'] === 0) {
+                $iId = $objMain->insertServerInCfgNagios(-1, $iIdServer, $values['name']);
+                if (! empty($iId)) {
+                    $objMain->insertDefaultCfgNagiosLogger($iId);
+                }
             }
+            $this->db->commit();
+        } catch (PDOException $e) {
+            $this->db->rollBack();
         }
 
         // Get the ID

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -695,24 +695,9 @@ class CentreonConfigCentreonBroker
         }
 
         $iIdServer = $values['ns_nagios_server'];
-        try {
-            $this->db->beginTransaction();
-            $hasEngineCfg = $this->db->prepare(
-                "SELECT COUNT(*) as nb FROM cfg_nagios WHERE nagios_server_id = :server_id FOR UPDATE"
-            );
-            $hasEngineCfg->bindValue(':server_id', (int) $iIdServer, PDO::PARAM_INT);
-            $hasEngineCfg->execute();
-            $row = $hasEngineCfg->fetch(PDO::FETCH_ASSOC);
-            if ((int) $row['nb'] === 0) {
-                $iId = $objMain->insertServerInCfgNagios(-1, $iIdServer, $values['name']);
-                if (! empty($iId)) {
-                    $objMain->insertDefaultCfgNagiosLogger($iId);
-                }
-            }
-            $this->db->commit();
-        } catch (PDOException $e) {
-            try { $this->db->rollBack(); } catch (PDOException $ignored) {}
-            error_log('Failed to create engine config for server ' . $iIdServer . ': ' . $e->getMessage());
+        $iId = $objMain->insertServerInCfgNagios(-1, $iIdServer, $values['name']);
+        if (! empty($iId)) {
+            $objMain->insertDefaultCfgNagiosLogger($iId);
         }
 
         // Get the ID

--- a/centreon/www/class/config-generate-remote/Engine.php
+++ b/centreon/www/class/config-generate-remote/Engine.php
@@ -213,14 +213,14 @@ class Engine extends AbstractObject
         if (is_null($this->stmtEngine)) {
             $this->stmtEngine = $this->backendInstance->db->prepare(
                 "SELECT {$this->attributesSelect} FROM cfg_nagios "
-                . "WHERE nagios_server_id = :poller_id AND nagios_activate = '1'"
+                . "WHERE nagios_server_id = :poller_id AND nagios_activate = '1' "
+                . "ORDER BY nagios_id ASC LIMIT 1"
             );
         }
         $this->stmtEngine->bindParam(':poller_id', $pollerId, PDO::PARAM_INT);
         $this->stmtEngine->execute();
 
-        $result = $this->stmtEngine->fetchAll(PDO::FETCH_ASSOC);
-        $this->engine = array_pop($result);
+        $this->engine = $this->stmtEngine->fetch(PDO::FETCH_ASSOC) ?: null;
         if (is_null($this->engine)) {
             throw new Exception(
                 "Cannot get engine configuration for poller id (maybe not activate) '" . $pollerId . "'"

--- a/centreon/www/class/config-generate-remote/Engine.php
+++ b/centreon/www/class/config-generate-remote/Engine.php
@@ -214,7 +214,7 @@ class Engine extends AbstractObject
             $this->stmtEngine = $this->backendInstance->db->prepare(
                 "SELECT {$this->attributesSelect} FROM cfg_nagios "
                 . "WHERE nagios_server_id = :poller_id AND nagios_activate = '1' "
-                . "ORDER BY nagios_id ASC LIMIT 1"
+                . 'ORDER BY nagios_id ASC LIMIT 1'
             );
         }
         $this->stmtEngine->bindParam(':poller_id', $pollerId, PDO::PARAM_INT);

--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -443,15 +443,14 @@ class Engine extends AbstractObject
         if (is_null($this->stmt_engine)) {
             $this->stmt_engine = $this->backend_instance->db->prepare(
                 "SELECT {$this->attributes_select} FROM cfg_nagios "
-                . "WHERE nagios_server_id = :poller_id AND nagios_activate = '1'"
+                . "WHERE nagios_server_id = :poller_id AND nagios_activate = '1' "
+                . "ORDER BY nagios_id ASC LIMIT 1"
             );
         }
         $this->stmt_engine->bindParam(':poller_id', $poller_id, PDO::PARAM_INT);
         $this->stmt_engine->execute();
 
-        $result = $this->stmt_engine->fetchAll(PDO::FETCH_ASSOC);
-
-        $this->engine = array_pop($result);
+        $this->engine = $this->stmt_engine->fetch(PDO::FETCH_ASSOC) ?: null;
         $this->setEngineNotificationState();
 
         if (is_null($this->engine)) {

--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -444,7 +444,7 @@ class Engine extends AbstractObject
             $this->stmt_engine = $this->backend_instance->db->prepare(
                 "SELECT {$this->attributes_select} FROM cfg_nagios "
                 . "WHERE nagios_server_id = :poller_id AND nagios_activate = '1' "
-                . "ORDER BY nagios_id ASC LIMIT 1"
+                . 'ORDER BY nagios_id ASC LIMIT 1'
             );
         }
         $this->stmt_engine->bindParam(':poller_id', $poller_id, PDO::PARAM_INT);

--- a/centreon/www/include/configuration/configNagios/DB-Func.php
+++ b/centreon/www/include/configuration/configNagios/DB-Func.php
@@ -375,6 +375,7 @@ function getNagiosCfgColumnsDetails(): array
         'illegal_macro_output_chars' => ['default' => null],
         'illegal_object_name_chars' => ['default' => null],
         'instance_heartbeat_interval' => ['default' => '30'],
+        'broker_module_cfg_file' => ['default' => null],
         // Radio inputs
         'accept_passive_host_checks' => ['isRadio' => true, 'default' => '1'],
         'accept_passive_service_checks' => ['isRadio' => true, 'default' => '1'],

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -391,7 +391,9 @@ function duplicateServer(array $server, array $nbrDup): void
                     if ($statement->rowCount() > 0) {
                         $row = $statement->fetch(PDO::FETCH_ASSOC);
                         $iId = $obj->insertServerInCfgNagios($serverId, $row['id'], $serverName);
-                        $obj->insertCfgNagiosLogger($iId, $serverId);
+                        if (! empty($iId)) {
+                            $obj->insertCfgNagiosLogger($iId, $serverId);
+                        }
 
                         if (isset($rowBks)) {
                             $rqBk = 'INSERT INTO cfg_nagios_broker_module (`cfg_nagios_id`, `broker_module`)'

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -393,17 +393,17 @@ function duplicateServer(array $server, array $nbrDup): void
                         $iId = $obj->insertServerInCfgNagios($serverId, $row['id'], $serverName);
                         if (! empty($iId)) {
                             $obj->insertCfgNagiosLogger($iId, $serverId);
-                        }
 
-                        if (isset($rowBks)) {
-                            $rqBk = 'INSERT INTO cfg_nagios_broker_module (`cfg_nagios_id`, `broker_module`)'
-                                    . ' VALUES (:cfg_nagios_id, :broker_module)';
-                            $statement = $pearDB->prepare($rqBk);
-                            foreach ($rowBks as $keyBk => $valBk) {
-                                if ($valBk['broker_module']) {
-                                    $statement->bindValue(':cfg_nagios_id', (int) $iId, PDO::PARAM_INT);
-                                    $statement->bindValue(':broker_module', $valBk['broker_module'], PDO::PARAM_STR);
-                                    $statement->execute();
+                            if (isset($rowBks)) {
+                                $rqBk = 'INSERT INTO cfg_nagios_broker_module (`cfg_nagios_id`, `broker_module`)'
+                                        . ' VALUES (:cfg_nagios_id, :broker_module)';
+                                $statement = $pearDB->prepare($rqBk);
+                                foreach ($rowBks as $keyBk => $valBk) {
+                                    if ($valBk['broker_module']) {
+                                        $statement->bindValue(':cfg_nagios_id', (int) $iId, PDO::PARAM_INT);
+                                        $statement->bindValue(':broker_module', $valBk['broker_module'], PDO::PARAM_STR);
+                                        $statement->execute();
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Description

Creating a Broker configuration (`Configuration > Pollers > Broker Configuration > Add/Duplicate`)
unconditionally called `insertServerInCfgNagios()`, which created a duplicate `cfg_nagios` row for
servers that already had one. The duplicate row had `broker_module_cfg_file=NULL` and
`nagios_activate=1` without deactivating the existing row.

During config generation, the query used `array_pop()` with no `ORDER BY`, so it picked the
duplicate row (highest `nagios_id`) which had a NULL `broker_module_cfg_file`. This produced a
`centengine.cfg` missing the `broker_module_cfg_file` directive, causing centreon-engine to fail
with: `No module configuration file provided in the Engine configuration file.`

**Fixes:**
- Skip engine config creation in `insertConfig()` when one already exists for the server
- Add `broker_module_cfg_file` to `insertServerInCfgNagios()` INSERT statement
- Deactivate sibling `cfg_nagios` rows when inserting with `nagios_activate=1`
- Add `broker_module_cfg_file` to `getNagiosCfgColumnsDetails()` for the UI form
- Make config generation deterministic with `ORDER BY nagios_id ASC LIMIT 1`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master