### PR TITLE
improve ivanti connector

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -96,23 +96,23 @@ class IvantiProvider extends AbstractProvider
         }
 
         $curl = curl_init();
-        $apiAddress = $info['address'] . '/HEAT/api/odata/businessobject/incidents?$top=1';
+        $apiAddress = $info['protocol'] . '://' . $info['address'] . '/HEAT/api/odata/businessobject/incidents?$top=1';
 
         $headers = [
             'Authorization: rest_api_key=' . $info['apiKey'],
             'Content-Type: application/json',
         ];
 
-        $peerVerify = ($this->rule_data['peer_verify'] ?? 'yes') === 'yes';
+        $peerVerify = ($info['peer_verify'] ?? 'yes') === 'yes';
         $verifyHost = $peerVerify ? 2 : 0;
-        $caCertPath = $this->rule_data['ca_cert_path'] ?? '';
+        $caCertPath = $info['ca_cert_path'] ?? '';
 
         curl_setopt($curl, CURLOPT_URL, $apiAddress);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $peerVerify);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $verifyHost);
-        curl_setopt($curl, CURLOPT_TIMEOUT, (int) $this->getFormValue('timeout', false));
+        curl_setopt($curl, CURLOPT_TIMEOUT, (int) $info['timeout']);
 
         $optionsToLog = [
             'apiAddress' => $apiAddress,

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -24,10 +24,6 @@ use Centreon\Domain\Log\LoggerTrait;
 class IvantiProvider extends AbstractProvider
 {
     use LoggerTrait;
-    public const IVANTI_INCIDENT_TYPE = 10;
-    public const IVANTI_SERVICE_REQUEST_TYPE = 11;
-    public const IVANTI_PROBLEM_TYPE = 12;
-    public const IVANTI_CHANGE_TYPE = 13;
     public const IVANTI_EMPLOYEE_TYPE = 14;
     public const IVANTI_TEAM_TYPE = 15;
     public const IVANTI_CATEGORY_TYPE = 16;

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -138,7 +138,6 @@ class IvantiProvider extends AbstractProvider
 
         if ($httpCode >= 400) {
             $this->error('Ivanti answer', ['answer' => $curlResult]);
-            throw new Exception("Erreur lors de la connexion à l'API Ivanti : HTTP {$httpCode} - {$curlResult}", 11);
             throw new Exception("Ivanti api connection error: HTTP {$httpCode} - {$curlResult}", 11);
         }
 

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -39,6 +39,10 @@ class IvantiProvider extends AbstractProvider
     public const ARG_EMPLOYEE = 7;
     public const ARG_TEAM = 8;
     public const ARG_STATUS = 9;
+    public const ARG_SOURCE = 10;
+    public const ARG_PROFILE_LINK = 11;
+    public const ARG_ALTERNATE_CONTACT_LINK = 12;
+    public const ARG_SERVICE = 13;
 
     protected $close_advanced = 1;
 
@@ -56,6 +60,10 @@ class IvantiProvider extends AbstractProvider
         self::ARG_EMPLOYEE => 'employee',
         self::ARG_TEAM => 'team',
         self::ARG_STATUS => 'status',
+        self::ARG_SOURCE => 'source',
+        self::ARG_PROFILE_LINK => 'profile_link',
+        self::ARG_ALTERNATE_CONTACT_LINK => 'alternate_contact_link',
+        self::ARG_SERVICE => 'service',
     ];
 
     /*
@@ -198,15 +206,31 @@ class IvantiProvider extends AbstractProvider
             ],
             [
                 'Arg' => self::ARG_IMPACT,
-                'Value' => '{$select.impact.placeholder}',
+                'Value' => '{$select.impact.value}',
             ],
             [
                 'Arg' => self::ARG_URGENCY,
-                'Value' => '{$select.urgency.placeholder}',
+                'Value' => '{$select.urgency.value}',
             ],
             [
                 'Arg' => self::ARG_STATUS,
                 'Value' => '{$select.status.value}',
+            ],
+            [
+                'Arg' => self::ARG_SOURCE,
+                'Value' => '{$select.source.value}',
+            ],
+            [
+                'Arg' => self::ARG_PROFILE_LINK,
+                'Value' => '{$select.profile_link.value}',
+            ],
+            [
+                'Arg' => self::ARG_ALTERNATE_CONTACT_LINK,
+                'Value' => '{$select.alternate_contact_link.value}',
+            ],
+            [
+                'Arg' => self::ARG_SERVICE,
+                'Value' => '{$select.service.value}',
             ],
         ];
     }
@@ -255,44 +279,85 @@ class IvantiProvider extends AbstractProvider
                 'Filter' => '',
                 'Mandatory' => '',
             ],
+            [
+                'Id' => 'source',
+                'Label' => _('Source'),
+                'Type' => self::CUSTOM_TYPE,
+                'Filter' => '',
+                'Mandatory' => '',
+            ],
+            [
+                'Id' => 'profile_link',
+                'Label' => _('Profile link'),
+                'Type' => self::CUSTOM_TYPE,
+                'Filter' => '',
+                'Mandatory' => 1,
+            ],
+            [
+                'Id' => 'alternate_contact_link',
+                'Label' => _('Alternate contact link'),
+                'Type' => self::CUSTOM_TYPE,
+                'Filter' => '',
+                'Mandatory' => '',
+            ],
+            [
+                'Id' => 'status',
+                'Label' => _('Status'),
+                'Type' => self::CUSTOM_TYPE,
+                'Filter' => '',
+                'Mandatory' => 1,
+            ],
+            [
+                'Id' => 'service',
+                'Label' => _('Service'),
+                'Type' => self::CUSTOM_TYPE,
+                'Filter' => '',
+                'Mandatory' => 1,
+            ],
         ];
 
         $this->default_data['clones']['customList'] = [
             [
                 'Id' => 'impact',
-                'Value' => '1',
+                'Value' => 'Low',
                 'Label' => 'Low',
                 'Default' => '',
             ],
             [
                 'Id' => 'impact',
-                'Value' => '2',
+                'Value' => 'Medium',
                 'Label' => 'Medium',
                 'Default' => '',
             ],
             [
                 'Id' => 'impact',
-                'Value' => '3',
+                'Value' => 'High',
                 'Label' => 'High',
                 'Default' => '',
             ],
             [
                 'Id' => 'urgency',
-                'Value' => '1',
+                'Value' => 'Low',
                 'Label' => 'Low',
                 'Default' => '',
             ],
             [
                 'Id' => 'urgency',
-                'Value' => '2',
+                'Value' => 'Medium',
                 'Label' => 'Medium',
                 'Default' => '',
             ],
             [
                 'Id' => 'urgency',
-                'Value' => '3',
+                'Value' => 'High',
                 'Label' => 'High',
                 'Default' => '',
+            ],
+            [
+                'Id' => 'status',
+                'Value' => 'Logged',
+                'Label' => 'Logged',
+                'Default' => 1,
             ],
         ];
     }
@@ -367,6 +432,11 @@ class IvantiProvider extends AbstractProvider
             . '<option value="' . self::ARG_IMPACT . '">' . _('Impact') . '</option>'
             . '<option value="' . self::ARG_URGENCY . '">' . _('Urgency') . '</option>'
             . '<option value="' . self::ARG_STATUS . '">' . _('Status') . '</option>'
+            . '<option value="' . self::ARG_SOURCE . '">' . _('Source') . '</option>'
+            . '<option value="' . self::ARG_PROFILE_LINK . '">' . _('Profile link') . '</option>'
+            . '<option value="' . self::ARG_ALTERNATE_CONTACT_LINK . '">' . _('Alternate contact link') . '</option>'
+            . '<option value="' . self::ARG_SOURCE . '">' . _('Source') . '</option>'
+            . '<option value="' . self::ARG_SERVICE . '">' . _('Service') . '</option>'
             . '</select>';
 
         // we asociate the label with the html code but for the arguments that we've been working on lately
@@ -668,11 +738,33 @@ class IvantiProvider extends AbstractProvider
             $headers = array_merge($headers, $info['headers']);
         }
 
+        $peerVerify = ($this->rule_data['peer_verify'] ?? 'yes') === 'yes';
+        $verifyHost = $peerVerify ? 2 : 0;
+        $caCertPath = $this->rule_data['ca_cert_path'] ?? '';
+
         curl_setopt($curl, CURLOPT_URL, $apiAddress);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_TIMEOUT, (int) $this->getFormValue('timeout', false));
+
+        $optionsToLog = [
+            'apiAddress' => $apiAddress,
+            'method' => $info['method'],
+            'peerVerify' => $peerVerify,
+            'verifyHost' => $verifyHost,
+            'caCertPath' => '',
+        ];
+
+        // Use custom CA only when verification is enabled
+        if ($peerVerify && is_string($caCertPath) && $caCertPath !== '') {
+            curl_setopt($curl, CURLOPT_CAINFO, $caCertPath);
+            $optionsToLog['caCertPath'] = $caCertPath;
+        }
+
+        $this->debug('Ivanti request options', [
+            'options' => $optionsToLog,
+        ]);
 
         if ($info['method']) {
             curl_setopt($curl, CURLOPT_POST, true);
@@ -692,6 +784,7 @@ class IvantiProvider extends AbstractProvider
 
         if ($httpCode >= 400) {
             $errorMessage = " Erreur API Ivanti (HTTP {$httpCode}) : {$curlResult}";
+            $this->error('Ivanti answer', ['answer' => $curlResult]);
 
             throw new Exception($errorMessage, 11);
         }
@@ -779,28 +872,47 @@ class IvantiProvider extends AbstractProvider
     * @return {string} $ticketId ticket id
     *
     * throw \Exception if we can't open a ticket
-    * throw \Exception if we can't assign a user to the ticket
-    * throw \Exception if we can't assign a group to the ticket
-    * throw \Exception if we can't assign a supplier to the ticket
-    * throw \Exception if we can't assign a requester to the ticket
     */
     protected function createTicket($ticketArguments)
     {
         $endpoint = '/incidents';
-
         $data = [
-            'Service' => $ticketArguments['service'],
-            'Category' => $ticketArguments['category'] ?? 'Functionality Loss',
-            'Impact' => $ticketArguments['impact'] ?? 'Low',
-            'Urgency' => $ticketArguments['urgency'] ?? 'High',
-            'Source' => 'Supervision',
-            'Status' => 'Logged',
-            'OwnerTeam' => $ticketArguments['team'],
-            'Subject' => $ticketArguments['title'],
-            'Symptom' => $ticketArguments['symptom'],
-            'ProfileLink' => $ticketArguments['profile_link'] ?? '5ECF36C0AB57473C83DBB03470A28254',
-            'AlternateContactLink' => $ticketArguments['alternate_contact_link'] ?? '5ECF36C0AB57473C83DBB03470A28254',
+            'Symptom' => $ticketArguments[$this->internal_arg_name[self::ARG_SYMPTOM]],
+            'Subject' => $ticketArguments[$this->internal_arg_name[self::ARG_TITLE]],
+            'Status' =>$ticketArguments[$this->internal_arg_name[self::ARG_STATUS]],
         ];
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_SOURCE]]) && $ticketArguments[$this->internal_arg_name[self::ARG_SOURCE]] !== -1) {
+            $data['Source'] = $ticketArguments[$this->internal_arg_name[self::ARG_SOURCE]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_SERVICE]]) && $ticketArguments[$this->internal_arg_name[self::ARG_SERVICE]] !== -1) {
+            $data['Service'] = $ticketArguments[$this->internal_arg_name[self::ARG_SERVICE]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_CATEGORY]]) && $ticketArguments[$this->internal_arg_name[self::ARG_CATEGORY]] !== -1) {
+            $data['Category'] = $ticketArguments[$this->internal_arg_name[self::ARG_CATEGORY]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_IMPACT]]) && $ticketArguments[$this->internal_arg_name[self::ARG_IMPACT]] !== -1) {
+            $data['Impact'] = $ticketArguments[$this->internal_arg_name[self::ARG_IMPACT]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_URGENCY]]) && $ticketArguments[$this->internal_arg_name[self::ARG_URGENCY]] !== -1) {
+            $data['Urgency'] = $ticketArguments[$this->internal_arg_name[self::ARG_URGENCY]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_TEAM]]) && $ticketArguments[$this->internal_arg_name[self::ARG_TEAM]] !== -1) {
+            $data['OwnerTeam'] = $ticketArguments[$this->internal_arg_name[self::ARG_TEAM]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_PROFILE_LINK]]) && $ticketArguments[$this->internal_arg_name[self::ARG_PROFILE_LINK]] !== -1) {
+            $data['ProfileLink'] = $ticketArguments[$this->internal_arg_name[self::ARG_PROFILE_LINK]];
+        }
+
+        if (isset($ticketArguments[$this->internal_arg_name[self::ARG_ALTERNATE_CONTACT_LINK]]) && $ticketArguments[$this->internal_arg_name[self::ARG_ALTERNATE_CONTACT_LINK]] !== -1) {
+            $data['AlternateContactLink'] = $ticketArguments[$this->internal_arg_name[self::ARG_ALTERNATE_CONTACT_LINK]];
+        }
 
         $info = [
             'query_endpoint' => $endpoint,

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -19,8 +19,11 @@
  *
  */
 
+use Centreon\Domain\Log\LoggerTrait;
+
 class IvantiProvider extends AbstractProvider
 {
+    use LoggerTrait;
     public const IVANTI_INCIDENT_TYPE = 10;
     public const IVANTI_SERVICE_REQUEST_TYPE = 11;
     public const IVANTI_PROBLEM_TYPE = 12;
@@ -96,16 +99,41 @@ class IvantiProvider extends AbstractProvider
             'Content-Type: application/json',
         ];
 
+        $peerVerify = ($this->rule_data['peer_verify'] ?? 'yes') === 'yes';
+        $verifyHost = $peerVerify ? 2 : 0;
+        $caCertPath = $this->rule_data['ca_cert_path'] ?? '';
+
         curl_setopt($curl, CURLOPT_URL, $apiAddress);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $peerVerify);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, $verifyHost);
+        curl_setopt($curl, CURLOPT_TIMEOUT, (int) $this->getFormValue('timeout', false));
+
+        $optionsToLog = [
+            'apiAddress' => $apiAddress,
+            'method' => $info['method'],
+            'peerVerify' => $peerVerify,
+            'verifyHost' => $verifyHost,
+            'caCertPath' => '',
+        ];
+
+        // Use custom CA only when verification is enabled
+        if ($peerVerify && is_string($caCertPath) && $caCertPath !== '') {
+            curl_setopt($curl, CURLOPT_CAINFO, $caCertPath);
+            $optionsToLog['caCertPath'] = $caCertPath;
+        }
+
+        $this->debug('Ivanti request options', [
+            'options' => $optionsToLog,
+        ]);
 
         $curlResult = curl_exec($curl);
         $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
 
         if ($httpCode >= 400) {
+            $this->error('Ivanti answer', ['answer' => $curlResult]);
             throw new Exception("Erreur lors de la connexion à l'API Ivanti : HTTP {$httpCode} - {$curlResult}", 11);
         }
 

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -88,11 +88,11 @@ class IvantiProvider extends AbstractProvider
     public static function test($info)
     {
         if (! isset($info['address']) || ! isset($info['apiKey'])) {
-            throw new Exception('Paramètres manquants : address ou apiKey.');
+            throw new Exception('missing paramters : address or apiKey.');
         }
 
         if (! extension_loaded('curl')) {
-            throw new Exception("L'extension PHP curl est requise.");
+            throw new Exception("PHP curl extension is missing");
         }
 
         $curl = curl_init();
@@ -139,6 +139,7 @@ class IvantiProvider extends AbstractProvider
         if ($httpCode >= 400) {
             $this->error('Ivanti answer', ['answer' => $curlResult]);
             throw new Exception("Erreur lors de la connexion à l'API Ivanti : HTTP {$httpCode} - {$curlResult}", 11);
+            throw new Exception("Ivanti api connection error: HTTP {$httpCode} - {$curlResult}", 11);
         }
 
         return true;
@@ -714,7 +715,7 @@ class IvantiProvider extends AbstractProvider
     protected function curlQuery($info)
     {
         if (! extension_loaded('curl')) {
-            throw new Exception("L'extension PHP curl est requise.", 10);
+            throw new Exception("PHP curl extension is missing.", 10);
         }
 
         $curl = curl_init();
@@ -779,7 +780,7 @@ class IvantiProvider extends AbstractProvider
         curl_close($curl);
 
         if ($httpCode >= 400) {
-            $errorMessage = " Erreur API Ivanti (HTTP {$httpCode}) : {$curlResult}";
+            $errorMessage = "Ivanti API error (HTTP {$httpCode}) : {$curlResult}";
             $this->error('Ivanti answer', ['answer' => $curlResult]);
 
             throw new Exception($errorMessage, 11);
@@ -926,9 +927,9 @@ class IvantiProvider extends AbstractProvider
                 return $response['RecId'];
             }
 
-            throw new Exception("Reponse inattendue de l'API Ivanti : " . json_encode($response));
+            throw new Exception("Unknown Ivanti error: " . json_encode($response));
         } catch (Exception $e) {
-            throw new Exception('Erreur lors de la creation du ticket : ' . $e->getMessage(), $e->getCode(), $e);
+            throw new Exception('Error during ticket creation: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -965,7 +966,7 @@ class IvantiProvider extends AbstractProvider
 
             return true;
         } catch (Exception $e) {
-            throw new Exception('Erreur lors de la clôture du ticket : ' . $e->getMessage(), $e->getCode());
+            throw new Exception('Close ticket error: ' . $e->getMessage(), $e->getCode());
         }
     }
 }

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/IvantiProvider.class.php
@@ -39,6 +39,7 @@ class IvantiProvider extends AbstractProvider
     public const ARG_PROFILE_LINK = 11;
     public const ARG_ALTERNATE_CONTACT_LINK = 12;
     public const ARG_SERVICE = 13;
+    public const ARG_IVANTI_CUSTOM_FIELD = 14;
 
     protected $close_advanced = 1;
 
@@ -60,6 +61,7 @@ class IvantiProvider extends AbstractProvider
         self::ARG_PROFILE_LINK => 'profile_link',
         self::ARG_ALTERNATE_CONTACT_LINK => 'alternate_contact_link',
         self::ARG_SERVICE => 'service',
+        self::ARG_IVANTI_CUSTOM_FIELD => 'ivanti_custom_field',
     ];
 
     /*
@@ -228,6 +230,10 @@ class IvantiProvider extends AbstractProvider
                 'Arg' => self::ARG_SERVICE,
                 'Value' => '{$select.service.value}',
             ],
+            [
+                'Arg' => self::ARG_IVANTI_CUSTOM_FIELD,
+                'Value' => '{$select._cf_xxxxxxxxxx.value}',
+            ],
         ];
     }
 
@@ -308,7 +314,14 @@ class IvantiProvider extends AbstractProvider
                 'Label' => _('Service'),
                 'Type' => self::CUSTOM_TYPE,
                 'Filter' => '',
-                'Mandatory' => 1,
+                'Mandatory' => '',
+            ],
+            [
+                'Id' => '_cf_xxxxxxxxxx',
+                'Label' => _('Ivanti Custom Field'),
+                'Type' => self::CUSTOM_TYPE,
+                'Filter' => '',
+                'Mandatory' => '',
             ],
         ];
 
@@ -433,6 +446,7 @@ class IvantiProvider extends AbstractProvider
             . '<option value="' . self::ARG_ALTERNATE_CONTACT_LINK . '">' . _('Alternate contact link') . '</option>'
             . '<option value="' . self::ARG_SOURCE . '">' . _('Source') . '</option>'
             . '<option value="' . self::ARG_SERVICE . '">' . _('Service') . '</option>'
+            . '<option value="' . self::ARG_IVANTI_CUSTOM_FIELD . '">' . _('Ivanti Custom Field') . '</option>'
             . '</select>';
 
         // we asociate the label with the html code but for the arguments that we've been working on lately
@@ -680,7 +694,12 @@ class IvantiProvider extends AbstractProvider
                     $resultString = null;
                 }
 
-                $ticketArguments[$this->internal_arg_name[$value['Arg']]] = $resultString;
+                 // specific condition to handle custom field "dynamically"
+                if ($this->internal_arg_name[$value['Arg']] == $this->internal_arg_name[self::ARG_IVANTI_CUSTOM_FIELD]) {
+                    $ticketArguments[$value['Value']] = $resultString;
+                } else {
+                    $ticketArguments[$this->internal_arg_name[$value['Arg']]] = $resultString;
+                }
             }
         }
 
@@ -908,6 +927,13 @@ class IvantiProvider extends AbstractProvider
 
         if (isset($ticketArguments[$this->internal_arg_name[self::ARG_ALTERNATE_CONTACT_LINK]]) && $ticketArguments[$this->internal_arg_name[self::ARG_ALTERNATE_CONTACT_LINK]] !== -1) {
             $data['AlternateContactLink'] = $ticketArguments[$this->internal_arg_name[self::ARG_ALTERNATE_CONTACT_LINK]];
+        }
+
+        foreach ($ticketArguments as $id => $value) {
+            // $id is structure is "{$select._cf_customFieldName.value}" we keep "customFieldName"
+            if (preg_match('/.*\._cf_(.*)\.[id|value|placeholder].*/', $id, $match)) {
+                $data[$match[1]] = $value;
+            }
         }
 
         $info = [

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/templates/conf_container1extra.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Ivanti/templates/conf_container1extra.ihtml
@@ -72,6 +72,10 @@
 </script>
 {literal}
 <script>
+  jQuery('input[name="peer_verify"]').on("click", function() {
+    this.value = (this.value === 'no') ? 'yes' : 'no';
+  });
+
   // start the button on click event
   jQuery('#test-ivanti').on('click', function (e) {
     e.preventDefault();
@@ -117,6 +121,8 @@
         protocol: jQuery('input[name="protocol"]').val(),
         apiKey: jQuery('input[name="apiKey"]').val(),
         timeout: jQuery('input[name="timeout"]').val(),
+        peer_verify: jQuery('input[name="peer_verify"]').val(),
+        ca_cert_path: jQuery('input[name="ca_cert_path"]').val(),
         proxy_address: jQuery('input[name="proxy_address"]').val(),
         proxy_port: jQuery('input[name="proxy_port"]').val(),
         proxy_username: jQuery('input[name="proxy_username"]').val(),


### PR DESCRIPTION
## Description

features:

- handle newly added ssl verification options
- handle custom fields for Ivanti
- handle newly added log mechanism

fixes:

- remove useless variables
- switch error messages from french to english
- missing mapping between options and data sent in the payload
- remove default values from the payload (default values must be set as is in the rule configuration, not in the code)
- remove the use of placeholder values for urgency and impact. Use the .value and copy the placeholder value in the value field. to avoid confusion with ID that people will not now where they come from


**custom field explanation:**

In the mapping ticket arguments part of the rule:

-  add as many as you want "Ivanti Custom Field" arguments
- as a value you must put {$select._cf_xxxxxxx.value} where xxxxxx is the name of the field in the payload

In the Lists part of the rule:

- add an entry with:
  -  Id = _cf_xxxxxxx  where xxxxxx is the name of the field in the payload
  - Type must be Custom

In the Custom list definition part add values for your custom field

When you open a ticket, you'll get this kind of popup
<img width="724" height="666" alt="image" src="https://github.com/user-attachments/assets/f3d4235a-b6f9-4912-a947-8e7d73a06e1f" />

which result in the following payload being sent:

```json
{
  "Symptom": "\nadmin open ticket at 27/02/26 11:29:15\n\n\n\n            Category: ivanti_category - ivanti_category_value\n                Employee: ivanti_employee - ivanti_employee_value\n                Team: ivanti_team - ivanti_team_value\n                Urgency: Low - Low\n                Impact: Low - Low\n                Source: source - source_value\n                Profile link: profile_link - profile_link_value\n                Alternate contact link: alternate_contact_link - alternate_contact_link_value\n                Status: Logged - Logged\n                Service: service - service_value\n                Ivanti Custom Field: MySuperCustomField - MySuperCustomField_value\n                Another Custom Field: AnotherSuperCustomField - AnotherSuperCustomField_value\n    \n\nHost: host_on_rs\nService: passif-notif\nState: UNKNOWN\nDuration: 2M 1w\nOutput: (Execute command failed)\n\n",
  "Subject": "Issue  host_on_rs/passif-notif/UNKNOWN",
  "Status": "Logged",
  "Source": "source_value",
  "Service": "service_value",
  "Category": "ivanti_category_value",
  "Impact": "Low",
  "Urgency": "Low",
  "OwnerTeam": "ivanti_team_value",
  "ProfileLink": "profile_link_value",
  "AlternateContactLink": "alternate_contact_link_value",
  "MySuperCustomField": "MySuperCustomField_value",
  "AnotherSuperCustomField": "AnotherSuperCustomField_value"
}
```



## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
