### PR TITLE
fix(Resources Status): support quoted strings to allow colons in service name search (#9331)

### DIFF
--- a/centreon/www/front_src/src/Resources/Filter/Criterias/searchQueryLanguage/FilterSearchQuery.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/Criterias/searchQueryLanguage/FilterSearchQuery.cypress.spec.tsx
@@ -8,7 +8,7 @@ const search =
   'type:host,service state:unhandled status:ok,up status_type:soft host_group:Linux-Servers monitoring_server:Central host_category:Linux h.name:centreon parent_name:Centreon name:Service';
 
 const builtSearch =
-  'type:host,service state:unhandled status:ok,up status_type:soft host_group:Linux-Servers monitoring_server:Central host_category:Linux parent_name:Centreon name:Service h.name:centreon';
+  'type:host,service state:unhandled status:ok,up status_type:soft host_group:Linux-Servers monitoring_server:Central host_category:Linux parent_name:Centreon name:Service "h.name:centreon"';
 
 const parsedSearch = [
   {
@@ -140,6 +140,115 @@ describe('build', () => {
     const result = build(parsedSearch);
 
     expect(result).to.be.equal(builtSearch);
+  });
+});
+
+/**
+ * Tests for colon-in-service-name support.
+ * @see https://github.com/centreon/centreon/issues/9331
+ */
+describe('parse - services with colons in name (#9331)', () => {
+  it('parses a quoted service name containing a colon as literal search text', () => {
+    const result = parse({ search: '"DB: Backup"' });
+    const searchCriteria = result.find(({ name }) => name === 'search');
+
+    expect(searchCriteria).to.deep.include({
+      name: 'search',
+      object_type: null,
+      type: 'text',
+      value: 'DB: Backup'
+    });
+  });
+
+  it('parses a quoted service name with colons alongside valid criteria', () => {
+    const result = parse({
+      search: 'type:service "HTTP: API Check" status:ok'
+    });
+
+    const searchCriteria = result.find(({ name }) => name === 'search');
+    expect(searchCriteria).to.deep.include({
+      name: 'search',
+      type: 'text',
+      value: 'HTTP: API Check'
+    });
+
+    const typeCriteria = result.find(({ name }) => name === 'resource_types');
+    expect(typeCriteria).to.not.be.undefined;
+
+    const statusCriteria = result.find(({ name }) => name === 'statuses');
+    expect(statusCriteria).to.not.be.undefined;
+  });
+
+  it('treats an unquoted colon-containing token as raw search when prefix is not a valid criteria', () => {
+    const result = parse({ search: 'DB:Backup' });
+    const searchCriteria = result.find(({ name }) => name === 'search');
+
+    expect(searchCriteria).to.deep.include({
+      name: 'search',
+      type: 'text',
+      value: 'DB:Backup'
+    });
+  });
+
+  it('handles multiple quoted segments', () => {
+    const result = parse({
+      search: '"Disk: Usage" "CPU: Load"'
+    });
+    const searchCriteria = result.find(({ name }) => name === 'search');
+
+    expect(searchCriteria).to.deep.include({
+      name: 'search',
+      type: 'text',
+      value: 'Disk: Usage CPU: Load'
+    });
+  });
+});
+
+describe('build - services with colons in name (#9331)', () => {
+  it('wraps search text containing a colon in quotes', () => {
+    const criteriasWithColonSearch = [
+      ...parsedSearch.filter(({ name }) => name !== 'search'),
+      {
+        name: 'search',
+        object_type: null,
+        type: 'text',
+        value: 'DB: Backup'
+      }
+    ];
+
+    const result = build(criteriasWithColonSearch);
+
+    expect(result).to.include('"DB: Backup"');
+  });
+
+  it('does not wrap search text without colons in quotes', () => {
+    const criteriasWithNormalSearch = [
+      ...parsedSearch.filter(({ name }) => name !== 'search'),
+      {
+        name: 'search',
+        object_type: null,
+        type: 'text',
+        value: 'myservice'
+      }
+    ];
+
+    const result = build(criteriasWithNormalSearch);
+
+    expect(result).not.to.include('"myservice"');
+    expect(result).to.include('myservice');
+  });
+
+  it('round-trips: build then parse preserves search text with colons', () => {
+    const original = 'type:service "DB: Backup"';
+    const parsed = parse({ search: original });
+    const rebuilt = build(parsed);
+    const reParsed = parse({ search: rebuilt });
+
+    const originalSearch = parsed.find(({ name }) => name === 'search');
+    const roundTripSearch = reParsed.find(({ name }) => name === 'search');
+
+    expect(roundTripSearch?.value).to.equal(originalSearch?.value);
+    expect(roundTripSearch?.value).to.equal('DB: Backup');
   });
 });
 

--- a/centreon/www/front_src/src/Resources/Filter/Criterias/searchQueryLanguage/index.ts
+++ b/centreon/www/front_src/src/Resources/Filter/Criterias/searchQueryLanguage/index.ts
@@ -89,13 +89,45 @@ interface ParametersParse {
   search: string;
 }
 
+/**
+ * Tokenize the search string, preserving quoted strings as single tokens.
+ * This allows service names containing colons to be searched by quoting them.
+ * e.g. 'type:host "DB: Backup" status:ok' => ['type:host', '"DB: Backup"', 'status:ok']
+ *
+ * @see https://github.com/centreon/centreon/issues/9331
+ */
+const tokenizeSearch = (searchInput: string): string[] => {
+  const tokens: string[] = [];
+  const regex = /"([^"]*)"|\S+/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(searchInput)) !== null) {
+    tokens.push(match[0]);
+  }
+
+  return tokens;
+};
+
+const isQuotedString = (token: string): boolean =>
+  token.startsWith('"') && token.endsWith('"') && token.length > 1;
+
+const unquote = (token: string): string =>
+  isQuotedString(token) ? token.slice(1, -1) : token;
+
 const parse = ({
   search,
   criteriaName = criteriaValueNameById
 }: ParametersParse): Array<Criteria> => {
+  const tokens = tokenizeSearch(search);
+
   const [criteriaParts, rawSearchParts] = partition(
-    allPass([includes(':'), isCriteriaPart, isFilledCriteria]),
-    search.split(' ')
+    allPass([
+      (token: string): boolean => !isQuotedString(token),
+      includes(':'),
+      isCriteriaPart,
+      isFilledCriteria
+    ]),
+    tokens
   );
 
   const criterias: Array<Criteria> = criteriaParts.map((criteria) => {
@@ -143,7 +175,7 @@ const parse = ({
       name: 'search',
       object_type: null,
       type: 'text',
-      value: rawSearchParts.join(' ').trim()
+      value: rawSearchParts.map(unquote).join(' ').trim()
     }
   ];
 
@@ -202,11 +234,24 @@ const build = (criterias: Array<Criteria>): string => {
     })
     .join(' ');
 
+  /**
+   * When the search text contains a colon, wrap it in quotes so that
+   * re-parsing (round-trip) does not misinterpret the colon as a
+   * criteria delimiter.
+   *
+   * @see https://github.com/centreon/centreon/issues/9331
+   */
+  const searchValue = search?.value as string;
+  const quotedSearchValue =
+    searchValue && includes(':', searchValue)
+      ? `"${searchValue}"`
+      : searchValue;
+
   if (isEmpty(builtCriterias.trim())) {
-    return search?.value as string;
+    return quotedSearchValue;
   }
 
-  return [builtCriterias, search?.value].join(' ');
+  return [builtCriterias, quotedSearchValue].join(' ');
 };
 
 const getCriteriaNameSuggestions = (word: string): Array<string> => {


### PR DESCRIPTION
## PR Brief — fix(Resources Status): support quoted strings to allow colons in service name search (#9331)

---

### Context

On Centreon 25.10, the Resources Status page uses a structured query language in the search bar where `:` acts as the delimiter between a criteria name and its value (e.g. `type:service`, `status:ok`, `host_group:Linux-Servers`).

This prevents users from searching for services whose name contains a `:` (e.g. `DB: Backup`, `HTTP: API Check`, `Disk: Usage`). The parser interprets the text before `:` as a potential criteria name instead of treating the whole string as free-text search.

**Impact**: Monitoring teams using naming conventions with `:` cannot find their services through the main search bar. The only workaround is using the legacy page.

---

### Solution

Added support for **quoted strings** (`"..."`) in the search query language parser.

**New helper functions:**
- `tokenizeSearch()` — Splits the search string into tokens while preserving quoted strings as a single token (e.g. `"DB: Backup"` is not split by spaces)
- `isQuotedString()` — Detects whether a token is surrounded by double quotes
- `unquote()` — Strips surrounding quotes before building the search value

**Modified functions:**
- `parse()` — Quoted tokens now bypass `isCriteriaPart` entirely and are always treated as free-text search
- `build()` — Automatically wraps search text containing `:` with quotes to ensure round-trip consistency (parse → build → parse)

**Files changed:**
- `centreon/www/front_src/src/Resources/Filter/Criterias/searchQueryLanguage/index.ts`
- `centreon/www/front_src/src/Resources/Filter/Criterias/searchQueryLanguage/FilterSearchQuery.cypress.spec.tsx`

**Backward compatibility:** Fully preserved. Existing searches without quotes behave exactly as before.

---

### Test plan

#### Unit tests (Cypress spec)

**parse() — colon support:**
1. A quoted string `"DB: Backup"` is parsed as literal search text with `value = "DB: Backup"`
2. Mixed input `type:service "HTTP: API Check" status:ok` correctly extracts `type` and `status` criteria while keeping `HTTP: API Check` as search text
3. An unquoted colon token with an unknown prefix like `DB:Backup` falls through to raw search text (not misinterpreted as a criteria)
4. Multiple quoted segments `"Disk: Usage" "CPU: Load"` are joined into a single search value `Disk: Usage CPU: Load`

**build() — auto-quoting:**
5. When search value contains a colon (e.g. `DB: Backup`), the output wraps it in quotes
6. When search value does not contain a colon (e.g. `myservice`), no quotes are added
7. Round-trip: `type:service "DB: Backup"` → parse → build → parse yields the same `search.value = "DB: Backup"`

#### Non-regression tests

8. Existing multi-criteria search without colons in text (e.g. `type:host,service status:ok host_group:Linux-Servers`) — parse and build output remain unchanged
9. Searchable field `h.name:centreon` still ends up in `search.value` — build now quotes it as `"h.name:centreon"` which re-parses correctly
10. Autocomplete suggestions are not impacted — typing `sta` still suggests `state:`, `status:`, `status_type:`

#### Manual tests (UI)

11. Go to Resources Status, type `"DB: Backup"` in the search bar, press Enter — the service `DB: Backup` appears in results
12. Type `type:service "HTTP: API Check"` — only services are shown and `HTTP: API Check` is present
13. Type `Ping` without quotes — services containing "Ping" appear normally (regression check)
14. Type `type:host status:ok` — only hosts with OK status are displayed (regression check)
15. Search for `"DB: Backup"`, navigate away, come back to Resources Status — the filter is preserved and displayed correctly with quotes
16. Search for `"DB: Backup"`, copy the search bar content, paste into a new search — same result (round-trip check)

#### Edge cases

17. Orphan quote: typing `"DB: Backup` (without closing quote) — the regex treats `"` as a regular character, no crash, graceful degradation
18. Empty quotes: typing `""` — treated as empty search, no error
19. Quotes around text without colons: `"myservice"` — quotes are stripped, search works normally

---

### Identified risks

**Auto-quoting of `h.name:centreon` in build()** — Low risk. The round-trip works correctly (quotes are stripped on re-parse). The search bar may display quotes around searchable field expressions, but the behavior is correct and consistent.

**Orphan/unclosed quotes** — Low risk. The tokenization regex `/"([^"]*)"|\S+/g` treats an unclosed `"` as a regular character. No crash, graceful degradation to space-based splitting.

**Backend impact** — Low risk. Quotes are stripped by `unquote()` before constructing the search value sent to the API. The backend never receives quote characters.