### PR TITLE
fix(api): sql error on ackowledgement list

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
@@ -168,7 +168,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
 
         $this->sqlRequestTranslator->addSearchValue('host_id', [\PDO::PARAM_INT => $hostId]);
 
-        return $this->processListingRequest($request);
+        return $this->processListingRequest($request, false);
     }
 
     /**
@@ -205,7 +205,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
         $this->sqlRequestTranslator->addSearchValue('host_id', [\PDO::PARAM_INT => $hostId]);
         $this->sqlRequestTranslator->addSearchValue('service_id', [\PDO::PARAM_INT => $serviceId]);
 
-        return $this->processListingRequest($request);
+        return $this->processListingRequest($request, false);
     }
 
     /**
@@ -402,7 +402,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
             . $accessGroupFilter
             . 'WHERE ack.service_id ' . (($type === Acknowledgement::TYPE_HOST_ACKNOWLEDGEMENT) ? ' = 0' : ' != 0');
 
-        return $this->processListingRequest($request);
+        return $this->processListingRequest($request, false);
     }
 
     /**
@@ -522,12 +522,12 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
      * @throws \Exception
      * @return Acknowledgement[]
      */
-    private function processListingRequest(string $request): array
+    private function processListingRequest(string $request, bool $prependWhere = true): array
     {
         $request = $this->translateDbName($request);
 
         // Search
-        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
+        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql($prependWhere);
         $request .= ! is_null($searchRequest) ? $searchRequest : '';
 
         // Sort

--- a/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -106,7 +106,6 @@ class SqlRequestParametersTranslator
             $whereQuery .= $this->createDatabaseQuery($search);
         }
 
-        // return ! empty($whereQuery) ? ' WHERE ' . $whereQuery : null;
         if (empty($whereQuery)) {
             return null;
         }

--- a/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -98,7 +98,7 @@ class SqlRequestParametersTranslator
      * @throws RequestParametersTranslatorException
      * @return string|null SQL request according to the search parameters
      */
-    public function translateSearchParameterToSql(): ?string
+    public function translateSearchParameterToSql(bool $prependWhere = true): ?string
     {
         $whereQuery = '';
         $search = $this->requestParameters->getSearch();
@@ -106,7 +106,12 @@ class SqlRequestParametersTranslator
             $whereQuery .= $this->createDatabaseQuery($search);
         }
 
-        return ! empty($whereQuery) ? ' WHERE ' . $whereQuery : null;
+        // return ! empty($whereQuery) ? ' WHERE ' . $whereQuery : null;
+        if (empty($whereQuery)) {
+            return null;
+        }
+
+        return $prependWhere ? ' WHERE ' . $whereQuery : ' AND ' . $whereQuery;
     }
 
     public function appendQueryBuilderWithSearchParameter(QueryBuilderInterface $queryBuilder): void


### PR DESCRIPTION
## Description

This PR intends to fix a sql error cause by duplicated WHERE in ackowledement listing.

[MON-194815](https://centreon.atlassian.net/browse/MON-194815)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

test api listing of ackowledement with query parameters like hjost_id or poller_id

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-194815]: https://centreon.atlassian.net/browse/MON-194815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ