### PR TITLE
fix(ldap): fix reach api rt value

### DIFF
--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -256,11 +256,7 @@ class CentreonAuthLDAP
                     $stmt->bindValue(':userDisplay', $userDisplay, PDO::PARAM_STR);
                     $stmt->bindValue(':userEmail', $userEmail, PDO::PARAM_STR);
                     $stmt->bindValue(':userPager', $userPager, PDO::PARAM_STR);
-                    $stmt->bindValue(
-                        ':reachApiRt',
-                        $this->contactInfos['contact_oreon'] === '1' ? 1 : 0,
-                        PDO::PARAM_INT
-                    );
+                    $stmt->bindValue(':reachApiRt', $this->contactInfos['reach_api_rt'], PDO::PARAM_INT);
                     $stmt->bindValue(':arId', $this->arId, PDO::PARAM_INT);
                     $stmt->bindValue(':contactId', $this->contactInfos['contact_id'], PDO::PARAM_INT);
                     $stmt->execute();


### PR DESCRIPTION
## Description

This PR intends to fix value of reach api real time of an ldap contact that was incorerctly reset to no

[MON-193117](https://centreon.atlassian.net/browse/MON-193117)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-193117]: https://centreon.atlassian.net/browse/MON-193117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ