### PR TITLE
fix(ci): fix release new workflow order

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -83,7 +83,7 @@ jobs:
         shell: bash
 
   release:
-    needs: [dependency-scan]
+    needs: [check-inputs]
     if: ${{ github.repository == 'centreon/centreon' }}
     runs-on: ubuntu-24.04
     outputs:


### PR DESCRIPTION
## Description

* This pull request introduces a minor update to the GitHub Actions workflow by making the release job depend on the successful completion of the check-inputs job. This ensures that input validation is performed before the release process starts.

**Fixes** #MON-195787
