### PR TITLE
fix(awie): use prepared statement in Export

### DIFF
--- a/centreon-awie/www/modules/centreon-awie/class/Export.class.php
+++ b/centreon-awie/www/modules/centreon-awie/class/Export.class.php
@@ -156,8 +156,10 @@ class Export
             'm' => 3,
             'd' => 4,
         ];
-        $query = 'SELECT `command_name` FROM `command`WHERE `command_type` =' . $cmdTypeRelation[$type];
-        $res = $this->db->query($query);
+        $query = 'SELECT `command_name` FROM `command` WHERE `command_type` = :commandType';
+        $res = $this->db->prepare($query);
+        $res->bindValue(':commandType', $cmdTypeRelation[$type], \PDO::PARAM_INT);
+        $res->execute();
 
         while ($row = $res->fetch()) {
             $result = $this->generateObject('CMD', ';' . $row['command_name']);

--- a/centreon-awie/www/modules/centreon-awie/class/Export.class.php
+++ b/centreon-awie/www/modules/centreon-awie/class/Export.class.php
@@ -156,6 +156,9 @@ class Export
             'm' => 3,
             'd' => 4,
         ];
+        if (! isset($cmdTypeRelation[$type])) {
+            return $cmdScript;
+        }
         $query = 'SELECT `command_name` FROM `command` WHERE `command_type` = :commandType';
         $res = $this->db->prepare($query);
         $res->bindValue(':commandType', $cmdTypeRelation[$type], PDO::PARAM_INT);

--- a/centreon-awie/www/modules/centreon-awie/class/Export.class.php
+++ b/centreon-awie/www/modules/centreon-awie/class/Export.class.php
@@ -158,7 +158,7 @@ class Export
         ];
         $query = 'SELECT `command_name` FROM `command` WHERE `command_type` = :commandType';
         $res = $this->db->prepare($query);
-        $res->bindValue(':commandType', $cmdTypeRelation[$type], \PDO::PARAM_INT);
+        $res->bindValue(':commandType', $cmdTypeRelation[$type], PDO::PARAM_INT);
         $res->execute();
 
         while ($row = $res->fetch()) {


### PR DESCRIPTION
## Description

- Fix SQL injection (CWE-89) in `centreon-awie/www/modules/centreon-awie/class/Export.class.php`
- Replace `escape()` + string concatenation with prepared statement using `bindValue()`

[MON-195880](https://centreon.atlassian.net/browse/MON-195880)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

[MON-195880]: https://centreon.atlassian.net/browse/MON-195880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ