### PR TITLE
fix(resources): remove unecessary join on resources_tags

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -184,8 +184,6 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
                 AND parent_resource.type = {$resourceTypeHost}
             LEFT JOIN `:dbstg`.`severities`
                 ON `severities`.severity_id = `resources`.severity_id
-            LEFT JOIN `:dbstg`.`resources_tags` AS rtags
-                ON `rtags`.resource_id = `resources`.resource_id
             INNER JOIN `:dbstg`.`instances`
                 ON `instances`.instance_id = `resources`.poller_id
             WHERE resources.name NOT LIKE '\_Module\_%'
@@ -540,7 +538,7 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
             : ' INNER JOIN cte ON cte.resource_id = resources.resource_id ';
 
         $query .= <<<SQL
-            SELECT :sql_query_find DISTINCT
+            SELECT :sql_query_find
                 1 AS REALTIME,
                 resources.resource_id,
                 resources.name,
@@ -593,8 +591,6 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
                 AND parent_resource.type = {$resourceType}
             LEFT JOIN `:dbstg`.`severities`
                 ON `severities`.severity_id = `resources`.severity_id
-            LEFT JOIN `:dbstg`.`resources_tags` AS rtags
-                ON `rtags`.resource_id = `resources`.resource_id
             SQL;
 
         /**

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -218,7 +218,7 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
          * Handle sort parameters.
          */
         $query .= $this->sqlRequestTranslator->translateSortParameterToSql()
-            ?: ' ORDER BY resources.status_ordered DESC, resources.name ASC';
+            ?: ' ORDER BY resources.status_ordered DESC, resources.last_status_change DESC';
 
         /**
          * Handle pagination.
@@ -670,7 +670,7 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
              * Handle sort parameters.
              */
             $query .= $this->sqlRequestTranslator->translateSortParameterToSql()
-                ?: ' ORDER BY resources.status_ordered DESC, resources.name ASC';
+                ?: ' ORDER BY resources.status_ordered DESC, resources.last_status_change DESC';
         }
 
         /**

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -823,7 +823,7 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
             $nextHeaders();
             $headers .= <<<SQL
                 service_groups AS (
-                    SELECT rtags.resource_id
+                    SELECT DISTINCT rtags.resource_id
                     FROM `:dbstg`.resources_tags AS rtags
                     INNER JOIN `:dbstg`.tags
                         ON tags.tag_id = rtags.tag_id
@@ -845,7 +845,7 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
             $nextHeaders();
             $headers .= <<<SQL
                 service_categories AS (
-                    SELECT rtags.resource_id
+                    SELECT DISTINCT rtags.resource_id
                     FROM `:dbstg`.resources_tags AS rtags
                     INNER JOIN `:dbstg`.tags
                         ON tags.tag_id = rtags.tag_id


### PR DESCRIPTION
🔗 https://centreon.atlassian.net/browse/MON-194338
🏷️ This PR intends to remove unecessary join made on resources_tags which can be heavy in terms of performances.
It also change the default order by made by the backend when no sort query parameter provided to match the default functional behaviour expected for resource status