### PR TITLE
fix(traps): Only get macros for host on the pollers being generated

### DIFF
--- a/centreon/bin/generateSqlLite
+++ b/centreon/bin/generateSqlLite
@@ -40,7 +40,7 @@ try {
     $stmt->bindParam(':server_id', $serverID, PDO::PARAM_INT);
     $stmt->execute();
     $result_pollers = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // Get engine command file
     $stmt = $db_centreon->prepare("SELECT command_file
         FROM cfg_nagios
@@ -48,7 +48,7 @@ try {
     $stmt->bindParam(':server_id', $serverID, PDO::PARAM_INT);
     $stmt->execute();
     $result_cfg_engine = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // get host relations with poller
     $stmt = $db_centreon->prepare("SELECT nagios_server_id, host_host_id
         FROM ns_host_relation
@@ -56,12 +56,12 @@ try {
     $stmt->bindParam(':server_id', $serverID, PDO::PARAM_INT);
     $stmt->execute();
     $result_pollers_relations = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // get hosts
     $stmt = $db_centreon->prepare("SELECT host.host_id, host.host_name, host.host_address, host.host_snmp_community, host.host_snmp_version
-        FROM host, ns_host_relation 
-        WHERE ns_host_relation.nagios_server_id = :server_id 
-        AND ns_host_relation.host_host_id = host.host_id 
+        FROM host, ns_host_relation
+        WHERE ns_host_relation.nagios_server_id = :server_id
+        AND ns_host_relation.host_host_id = host.host_id
         AND host.host_activate = '1'");
     $stmt->bindParam(':server_id', $serverID, PDO::PARAM_INT);
     $stmt->execute();
@@ -69,28 +69,43 @@ try {
 
     // get hosts templates
     $stmt = $db_centreon->prepare("SELECT host.host_id, host.host_snmp_community, host.host_snmp_version
-        FROM host 
+        FROM host
         WHERE host_register = '0' AND host_activate = '1'");
     $stmt->execute();
     $result_host_templates = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // get host relations
     $stmt = $db_centreon->prepare("SELECT host_tpl_id, host_host_id, `order` FROM host_template_relation");
     $stmt->execute();
     $result_host_templates_relation = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // get host macros
-    $stmt = $db_centreon->prepare("SELECT host_host_id, host_macro_name, host_macro_value FROM on_demand_macro_host");
-    $stmt->execute();
-    $result_host_macros = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+    $hostIds = array_column($result_hosts, 'host_id');
+    if (!empty($hostIds)) {
+        $placeholders = [];
+        foreach ($hostIds as $index => $id) {
+            $placeholder = ':id' . $index;
+            $placeholders[] = $placeholder;
+        }
+        $inQuery = implode(',', $placeholders);
+        $sql = "SELECT host_host_id, host_macro_name, host_macro_value FROM on_demand_macro_host WHERE host_host_id IN ($inQuery)";
+        $stmt = $db_centreon->prepare($sql);
+        foreach ($hostIds as $index => $id) {
+            $stmt->bindValue(':id' . $index, $id, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        $result_host_macros = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    } else {
+        $result_host_macros = [];
+    }
+
     // get services
     $stmt = $db_centreon->prepare("SELECT host.host_id, service.service_id, service.service_description, service.service_template_model_stm_id, extended_service_information.esi_notes
         FROM host, host_service_relation, ns_host_relation, service LEFT JOIN extended_service_information ON service.service_id = extended_service_information.service_service_id
-        WHERE ns_host_relation.nagios_server_id = :server_id 
-        AND ns_host_relation.host_host_id = host.host_id 
-        AND host.host_id = host_service_relation.host_host_id 
-        AND host_service_relation.service_service_id = service.service_id 
+        WHERE ns_host_relation.nagios_server_id = :server_id
+        AND ns_host_relation.host_host_id = host.host_id
+        AND host.host_id = host_service_relation.host_host_id
+        AND host_service_relation.service_service_id = service.service_id
         AND service.service_activate = '1'");
     $stmt->bindParam(':server_id', $serverID, PDO::PARAM_INT);
     $stmt->execute();
@@ -99,65 +114,65 @@ try {
     // get services by hostgroup
     $stmt = $db_centreon->prepare("SELECT host.host_id, service.service_id, service.service_description, service.service_template_model_stm_id, hostgroup_relation.hostgroup_hg_id, extended_service_information.esi_notes
         FROM host, host_service_relation, hostgroup_relation, ns_host_relation, service LEFT JOIN extended_service_information ON service.service_id = extended_service_information.service_service_id
-        WHERE ns_host_relation.nagios_server_id = :server_id 
-        AND ns_host_relation.host_host_id = host.host_id 
-        AND host.host_id = hostgroup_relation.host_host_id 
-        AND hostgroup_relation.hostgroup_hg_id = host_service_relation.hostgroup_hg_id 
-        AND host_service_relation.service_service_id = service.service_id 
+        WHERE ns_host_relation.nagios_server_id = :server_id
+        AND ns_host_relation.host_host_id = host.host_id
+        AND host.host_id = hostgroup_relation.host_host_id
+        AND hostgroup_relation.hostgroup_hg_id = host_service_relation.hostgroup_hg_id
+        AND host_service_relation.service_service_id = service.service_id
         AND service.service_activate = '1'");
     $stmt->bindParam(':server_id', $serverID, PDO::PARAM_INT);
     $stmt->execute();
     $resultServicesFromHg = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     // get service templates
-    $stmt = $db_centreon->prepare("SELECT service.service_id, service.service_description, service.service_template_model_stm_id 
-        FROM service 
-        WHERE service.service_register = '0' 
+    $stmt = $db_centreon->prepare("SELECT service.service_id, service.service_description, service.service_template_model_stm_id
+        FROM service
+        WHERE service.service_register = '0'
         AND service.service_activate = '1'");
     $stmt->execute();
     $result_services_template = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     // get trap info
-    $stmt = $db_centreon->prepare("SELECT traps_id, traps_mode, traps_oid, traps_status, severity_id, traps_submit_result_enable, 
-        traps_execution_command, traps_reschedule_svc_enable, traps_execution_command_enable, traps_args, 
+    $stmt = $db_centreon->prepare("SELECT traps_id, traps_mode, traps_oid, traps_status, severity_id, traps_submit_result_enable,
+        traps_execution_command, traps_reschedule_svc_enable, traps_execution_command_enable, traps_args,
         traps_routing_mode, traps_routing_value, traps_log, traps_name, traps_exec_method, traps_downtime, traps_routing_filter_services, traps_advanced_treatment, traps_advanced_treatment_default,
         traps_timeout, traps_customcode, traps_exec_interval, traps_exec_interval_type, manufacturer_id, traps_output_transform
         FROM traps");
     $stmt->execute();
     $result_traps = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    $stmt = $db_centreon->prepare("SELECT tmo_id, trap_id, tmo_order, tmo_regexp, tmo_string, tmo_status, severity_id 
+    $stmt = $db_centreon->prepare("SELECT tmo_id, trap_id, tmo_order, tmo_regexp, tmo_string, tmo_status, severity_id
         FROM traps_matching_properties");
     $stmt->execute();
     $result_traps_matching = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    $stmt = $db_centreon->prepare("SELECT traps_id, service_id 
+    $stmt = $db_centreon->prepare("SELECT traps_id, service_id
         FROM traps_service_relation");
     $stmt->execute();
     $result_traps_relation = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     $stmt = $db_centreon->prepare("SELECT trap_id, tpe_string, tpe_order
         FROM traps_preexec");
     $stmt->execute();
     $result_traps_preexec = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     $stmt = $db_centreon->prepare("SELECT traps_group_id, traps_id
         FROM traps_group_relation");
     $stmt->execute();
     $result_traps_group = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // Get trap Vendor
     $stmt = $db_centreon->prepare("SELECT id, name
         FROM traps_vendor");
     $stmt->execute();
     $result_traps_vendor = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
     // Get Severities
     $stmt = $db_centreon->prepare("SELECT sc_id, sc_name, `level`
         FROM service_categories WHERE `level` IS NOT NULL");
     $stmt->execute();
     $result_severities = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    
+
 } catch (PDOException $e ) {
     echo "Error on poller (id:$serverID): " . $e->getMessage() . "\n";
     exit(NOK);
@@ -168,25 +183,25 @@ try {
     $dbh_sqlite->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
     $dbh_sqlite->beginTransaction();
-    
+
     $dbh_sqlite->exec("
             CREATE TABLE IF NOT EXISTS `nagios_server` (
                 `id` int(11) UNIQUE NOT NULL,
                 `ns_ip_address` varchar(200) DEFAULT NULL
             );
-            
+
             CREATE TABLE IF NOT EXISTS `cfg_nagios` (
                 `command_file` varchar(255) DEFAULT NULL,
                 `nagios_activate` int(11) DEFAULT '1'
             );
-            
+
             CREATE TABLE IF NOT EXISTS `ns_host_relation` (
                 `host_host_id` int(11) DEFAULT NULL,
                 `nagios_server_id` int(11) DEFAULT NULL
             );
-            
+
             CREATE INDEX IF NOT EXISTS idx_nhr_host_host_id ON ns_host_relation (host_host_id);
-            
+
             CREATE TABLE IF NOT EXISTS `host` (
                 `host_id` int(11) UNIQUE NOT NULL,
                 `host_name` varchar(200) DEFAULT NULL,
@@ -195,7 +210,7 @@ try {
                 `host_snmp_version` varchar(255) DEFAULT NULL,
                 `host_activate` int(11) DEFAULT '1'
             );
-            
+
             CREATE INDEX IF NOT EXISTS idx_host_host_id ON host (host_id);
 
             CREATE TABLE IF NOT EXISTS `service` (
@@ -204,14 +219,14 @@ try {
                 `service_template_model_stm_id` int(11) DEFAULT NULL,
                 `service_activate` int(11) DEFAULT '1'
                 );
-                
+
             CREATE INDEX IF NOT EXISTS idx_service_service_id ON service (service_id);
-            
+
             CREATE TABLE IF NOT EXISTS `extended_service_information` (
                 `service_service_id` int(11) UNIQUE NOT NULL,
                 `esi_notes` text DEFAULT NULL
                 );
-            
+
             CREATE INDEX IF NOT EXISTS idx_esi_service_service_id ON extended_service_information (service_service_id);
 
             CREATE TABLE IF NOT EXISTS `hostgroup_relation` (
@@ -226,17 +241,17 @@ try {
                 `host_tpl_id` int(11) DEFAULT NULL,
                 `order` int(11) DEFAULT NULL
                 );
-            
+
             CREATE INDEX IF NOT EXISTS idx_htr_host_host_id ON host_template_relation (host_host_id);
-            
+
             CREATE TABLE IF NOT EXISTS `on_demand_macro_host` (
                 `host_macro_name` varchar(255) NOT NULL,
                 `host_macro_value` varchar(255) NOT NULL,
                 `host_host_id` int(11) DEFAULT NULL
                 );
-              
+
             CREATE INDEX IF NOT EXISTS idx_odmh_host_host_id ON on_demand_macro_host (host_host_id);
-            
+
             CREATE TABLE IF NOT EXISTS `host_service_relation` (
                 `service_service_id` int(11) DEFAULT NULL,
                 `host_host_id` int(11) DEFAULT NULL,
@@ -250,8 +265,8 @@ try {
                     `service_id` int(11) DEFAULT NULL
                     );
 
-            CREATE INDEX IF NOT EXISTS idx_tsr_mult_ids ON traps_service_relation (service_id, traps_id);            
-            
+            CREATE INDEX IF NOT EXISTS idx_tsr_mult_ids ON traps_service_relation (service_id, traps_id);
+
             CREATE TABLE IF NOT EXISTS `traps` (
                     `traps_id` int(11) UNIQUE NOT NULL,
                     `traps_name` varchar(255) DEFAULT NULL,
@@ -299,14 +314,14 @@ try {
                     `tpe_order` int(11) DEFAULT NULL,
                     `tpe_string` varchar(512) DEFAULT NULL
                     );
-                    
+
             CREATE INDEX IF NOT EXISTS idx_tprexec_trap_id ON traps_preexec (trap_id);
-            
+
             CREATE TABLE IF NOT EXISTS `traps_group_relation` (
                     `traps_group_id` int(11) DEFAULT NULL,
                     `traps_id` int(11) DEFAULT NULL
                     );
-                    
+
             CREATE INDEX IF NOT EXISTS idx_tg_traps_id ON traps_group_relation (traps_id);
             CREATE INDEX IF NOT EXISTS idx_tg_traps_group_id ON traps_group_relation (traps_group_id);
 
@@ -314,37 +329,37 @@ try {
                 `id` int(11) DEFAULT NULL,
                 `name` int(11) DEFAULT NULL
             );
-            
+
             CREATE INDEX IF NOT EXISTS idx_tv_id ON traps_vendor (`id`);
-            
+
             CREATE TABLE IF NOT EXISTS `service_categories` (
                 `sc_id` int(11) DEFAULT NULL,
                 `sc_name` varchar(255) DEFAULT NULL,
                 `level` int(11) DEFAULT NULL
             );
-            
+
             CREATE INDEX IF NOT EXISTS idx_sc_sc_id ON service_categories (`sc_id`);
-            
+
             ");
 
-            
+
             // Poller
             $stmt = $dbh_sqlite->prepare("INSERT INTO nagios_server (`id`, ns_ip_address) VALUES (
                     :id, :ns_ip_address)");
             foreach ($result_pollers as $value) {
                 $stmt->bindParam(':id', $value['id'], PDO::PARAM_INT);
                 $stmt->bindParam(':ns_ip_address', $value['ns_ip_address'], PDO::PARAM_STR);
-                $stmt->execute();	
+                $stmt->execute();
             }
-            
+
             // Engine command file
             $stmt = $dbh_sqlite->prepare("INSERT INTO cfg_nagios (`command_file`) VALUES (
                     :command_file)");
             foreach ($result_cfg_engine as $value) {
                 $stmt->bindParam(':command_file', $value['command_file'], PDO::PARAM_STR);
-                $stmt->execute();	
+                $stmt->execute();
             }
-            
+
             // poller/host relation
             $stmt = $dbh_sqlite->prepare("INSERT INTO ns_host_relation (host_host_id, nagios_server_id) VALUES (
                     :host_host_id, :nagios_server_id)");
@@ -353,7 +368,7 @@ try {
                 $stmt->bindParam(':nagios_server_id', $value['nagios_server_id'], PDO::PARAM_INT);
                 $stmt->execute();
             }
-            
+
             // Insert host
             $stmt = $dbh_sqlite->prepare("INSERT INTO host (host_id, host_name, host_address, host_snmp_community, host_snmp_version) VALUES (
                     :host_id, :host_name, :host_address, :host_snmp_community, :host_snmp_version)");
@@ -363,7 +378,7 @@ try {
                 $stmt->bindParam(':host_address', $value['host_address'], PDO::PARAM_STR);
                 $stmt->bindParam(':host_snmp_community', $value['host_snmp_community'], PDO::PARAM_STR);
                 $stmt->bindParam(':host_snmp_version', $value['host_snmp_version'], PDO::PARAM_STR);
-                $stmt->execute();	
+                $stmt->execute();
             }
             $stmt = $dbh_sqlite->prepare("INSERT INTO host (host_id, host_snmp_community, host_snmp_version) VALUES (
                     :host_id, :host_snmp_community, :host_snmp_version)");
@@ -371,17 +386,17 @@ try {
                 $stmt->bindParam(':host_id', $value['host_id'], PDO::PARAM_INT);
                 $stmt->bindParam(':host_snmp_community', $value['host_snmp_community'], PDO::PARAM_STR);
                 $stmt->bindParam(':host_snmp_version', $value['host_snmp_version'], PDO::PARAM_STR);
-                $stmt->execute();	
+                $stmt->execute();
             }
-            
+
             // Insert host template relations
             $stmt = $dbh_sqlite->prepare("INSERT INTO host_template_relation (host_host_id, host_tpl_id, `order`) VALUES (
                     :host_host_id, :host_tpl_id, :order)");
             foreach ($result_host_templates_relation as $value) {
                 $stmt->bindParam(':host_host_id', $value['host_host_id'], PDO::PARAM_INT);
                 $stmt->bindParam(':host_tpl_id', $value['host_tpl_id'], PDO::PARAM_INT);
-                $stmt->bindParam(':order', $value['order'], PDO::PARAM_INT);                
-                $stmt->execute();	
+                $stmt->bindParam(':order', $value['order'], PDO::PARAM_INT);
+                $stmt->execute();
             }
 
             // Insert Host macro
@@ -439,7 +454,7 @@ try {
                     $stmt->bindParam(':service_service_id', $value['service_id'], PDO::PARAM_INT);
                     $stmt->bindParam(':esi_notes', $value['esi_notes'], PDO::PARAM_STR);
                     $stmt->execute();
-                
+
                     $insertedServices[$value['service_id']] = true;
                 }
 
@@ -467,7 +482,7 @@ try {
 
             // Insert traps
             $stmt = $dbh_sqlite->prepare("INSERT INTO traps (traps_id, traps_name, traps_mode, traps_oid, traps_args, traps_status, severity_id, manufacturer_id,
-                                            traps_reschedule_svc_enable, traps_execution_command, traps_execution_command_enable, traps_submit_result_enable, 
+                                            traps_reschedule_svc_enable, traps_execution_command, traps_execution_command_enable, traps_submit_result_enable,
                                             traps_advanced_treatment, traps_advanced_treatment_default, traps_timeout, traps_customcode,
                                             traps_exec_interval, traps_exec_interval_type, traps_log,
                                             traps_routing_mode, traps_routing_value, traps_exec_method, traps_downtime, traps_output_transform, traps_routing_filter_services) VALUES (
@@ -526,7 +541,7 @@ try {
                 $stmt->bindParam(':service_id', $value['service_id'], PDO::PARAM_INT);
                 $stmt->execute();
             }
-            
+
             $stmt = $dbh_sqlite->prepare("INSERT INTO traps_preexec (trap_id, tpe_string, tpe_order) VALUES (
                     :trap_id, :tpe_string, :tpe_order)");
             foreach ($result_traps_preexec as $value) {
@@ -535,7 +550,7 @@ try {
                 $stmt->bindParam(':tpe_order', $value['tpe_order'], PDO::PARAM_INT);
                 $stmt->execute();
             }
-            
+
             $stmt = $dbh_sqlite->prepare("INSERT INTO traps_group_relation (traps_group_id, traps_id) VALUES (
                     :traps_group_id, :traps_id)");
             foreach ($result_traps_group as $value) {
@@ -543,7 +558,7 @@ try {
                 $stmt->bindParam(':traps_id', $value['traps_id'], PDO::PARAM_INT);
                 $stmt->execute();
             }
-            
+
             // Insert traps vendor
             $stmt = $dbh_sqlite->prepare("INSERT INTO traps_vendor (`id`, `name`) VALUES (
                     :id, :name)");
@@ -552,7 +567,7 @@ try {
                 $stmt->bindParam(':name', $value['name'], PDO::PARAM_STR);
                 $stmt->execute();
             }
-            
+
             // Insert severities
             $stmt = $dbh_sqlite->prepare("INSERT INTO service_categories (`sc_id`, `sc_name`, `level`) VALUES (
                     :sc_id, :sc_name, :level)");


### PR DESCRIPTION
## Description

Backport of #9372 onto `dev-24.10.x`.

Only fetch host macros for hosts assigned to the poller being generated, instead of fetching all macros from `on_demand_macro_host`. This avoids unnecessary data loading and potential performance issues on large installations.

**Fixes** MON-195859

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

Generate the SQLite configuration for a poller that has hosts with macros defined and verify that:
- Trap generation completes successfully
- Only macros for hosts assigned to the target poller are included

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).