### PR TITLE
docs(api): clarify $and/$or aggregator semantics and add examples

### DIFF
--- a/centreon/doc/API/latest/Common/QueryParameter/Search.yaml
+++ b/centreon/doc/API/latest/Common/QueryParameter/Search.yaml
@@ -17,6 +17,13 @@ description: >
     * `$or`
     * `$and`
 
+  `$and` requires **all** conditions to be true simultaneously for the same resource (intersection).
+  `$or` requires **at least one** condition to be true (union).
+
+  > **Important:** Using `$and` on the same field with incompatible values will always return
+  > an empty result. For example, a host whose name is "host1" cannot simultaneously have
+  > the name "host2". To search for resources matching either value, use `$or` instead.
+
   Available search operators are:
     * `$eq` → equal
     * `$neq` → not equal
@@ -31,14 +38,18 @@ description: >
     * `$rg` → regex
 
   Examples without nested aggregators:
+
+  Use `$or` to find hosts named "host1" OR "host2":
     ```
     search={
       "$or":[
-        {"host.name":{"$eq":"name_1"}},
-        {"host.name":{"$eq":"name_2"}}
+        {"host.name":{"$eq":"host1"}},
+        {"host.name":{"$eq":"host2"}}
       ]
     }
     ```
+
+  Use `$and` to combine conditions on **different fields**:
     ```
     search={
       "$and":[


### PR DESCRIPTION
## Description

Clarifies the semantics of `$and` and `$or` search aggregators in the API v2 documentation to prevent common misuse.

- Adds explicit definitions: `$and` = intersection (all conditions must be true simultaneously), `$or` = union (at least one condition must be true)
- Adds a warning explaining that using `$and` on the same field with incompatible values always returns an empty result
- Improves examples to better illustrate correct usage of each aggregator

**Fixes** MON-194607

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

Review the updated `doc/API/latest/Common/QueryParameter/Search.yaml` and verify the documentation renders correctly in the API reference.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).