### PR TITLE
fix(service_group): decode HTML entities before unserializing form payload

### DIFF
--- a/centreon/www/class/centreonUtils.class.php
+++ b/centreon/www/class/centreonUtils.class.php
@@ -216,7 +216,7 @@ class CentreonUtils
         try {
             $initForm = $form->getElement('initialValues');
             $initForm = HtmlAnalyzer::sanitizeAndRemoveTags($initForm->getValue());
-            $initialValues = unserialize($initForm, ['allowed_classes' => false]);
+            $initialValues = unserialize(html_entity_decode($initForm), ['allowed_classes' => false]);
             if (! empty($initialValues) && isset($initialValues[$key])) {
                 $init = $initialValues[$key];
             }


### PR DESCRIPTION
## Description

When creating a Service Group on the Cloud platform in debug mode, an error is displayed.
However, the Service Group is created correctly.

**Fixes** 

The front-end form submits a PHP-serialized payload in which double quotes are HTML-encoded (" → `&#34;`). This corrupts the serialized string structure, causing unserialize() to fail silently and return false.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Decoded HTML entities before unserializing form payload to fix errors


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90207159?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->