### PR TITLE
fix(api): sql error on ackowledgement list (#9775)

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
@@ -168,7 +168,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
 
         $this->sqlRequestTranslator->addSearchValue('host_id', [\PDO::PARAM_INT => $hostId]);
 
-        return $this->processListingRequest($request);
+        return $this->processListingRequest($request, false);
     }
 
     /**
@@ -205,7 +205,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
         $this->sqlRequestTranslator->addSearchValue('host_id', [\PDO::PARAM_INT => $hostId]);
         $this->sqlRequestTranslator->addSearchValue('service_id', [\PDO::PARAM_INT => $serviceId]);
 
-        return $this->processListingRequest($request);
+        return $this->processListingRequest($request, false);
     }
 
     /**
@@ -402,7 +402,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
             . $accessGroupFilter
             . 'WHERE ack.service_id ' . (($type === Acknowledgement::TYPE_HOST_ACKNOWLEDGEMENT) ? ' = 0' : ' != 0');
 
-        return $this->processListingRequest($request);
+        return $this->processListingRequest($request, false);
     }
 
     /**
@@ -522,12 +522,12 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
      * @throws \Exception
      * @return Acknowledgement[]
      */
-    private function processListingRequest(string $request): array
+    private function processListingRequest(string $request, bool $prependWhere = true): array
     {
         $request = $this->translateDbName($request);
 
         // Search
-        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
+        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql($prependWhere);
         $request .= ! is_null($searchRequest) ? $searchRequest : '';
 
         // Sort

--- a/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -98,7 +98,7 @@ class SqlRequestParametersTranslator
      * @throws RequestParametersTranslatorException
      * @return string|null SQL request according to the search parameters
      */
-    public function translateSearchParameterToSql(): ?string
+    public function translateSearchParameterToSql(bool $prependWhere = true): ?string
     {
         $whereQuery = '';
         $search = $this->requestParameters->getSearch();
@@ -106,7 +106,11 @@ class SqlRequestParametersTranslator
             $whereQuery .= $this->createDatabaseQuery($search);
         }
 
-        return ! empty($whereQuery) ? ' WHERE ' . $whereQuery : null;
+        if (empty($whereQuery)) {
+            return null;
+        }
+
+        return $prependWhere ? ' WHERE ' . $whereQuery : ' AND ' . $whereQuery;
     }
 
     public function appendQueryBuilderWithSearchParameter(QueryBuilderInterface $queryBuilder): void


### PR DESCRIPTION
## Description

Backport of #9775

[MON-196024](https://centreon.atlassian.net/browse/MON-196024)

[MON-196024]: https://centreon.atlassian.net/browse/MON-196024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Allowed search SQL to prepend 'AND' instead of 'WHERE' when needed
* Updated acknowledgement queries to call listing processor without WHERE prepending


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90156061?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->