### PR TITLE
feat(ui): add silent option to useRequest hook

### DIFF
--- a/centreon/packages/ui/src/api/useRequest/index.ts
+++ b/centreon/packages/ui/src/api/useRequest/index.ts
@@ -13,6 +13,7 @@ export interface RequestParams<TResult> {
   getErrorMessage?: (error) => string;
   httpCodesBypassErrorSnackbar?: Array<number>;
   request: (token) => (params?) => Promise<TResult>;
+  silent?: boolean;
 }
 
 export interface RequestResult<TResult> {
@@ -25,7 +26,8 @@ const useRequest = <TResult>({
   decoder,
   getErrorMessage,
   defaultFailureMessage = 'Oops, something went wrong',
-  httpCodesBypassErrorSnackbar = []
+  httpCodesBypassErrorSnackbar = [],
+  silent = false
 }: RequestParams<TResult>): RequestResult<TResult> => {
   const { token, cancel } = useCancelTokenSource();
   const { showErrorMessage } = useSnackbar();
@@ -74,7 +76,7 @@ const useRequest = <TResult>({
           httpCodesBypassErrorSnackbar
         );
 
-        if (hasACorrespondingHttpCode) {
+        if (silent || hasACorrespondingHttpCode) {
           throw error;
         }
 


### PR DESCRIPTION
## Description

Add a `silent` boolean option to the `useRequest` hook that suppresses all error snackbars when set to `true`.

The existing `httpCodesBypassErrorSnackbar` only works for HTTP responses that carry a status code. It cannot silence errors that lack a response object — for example, network failures, DNS resolution errors, CORS blocks, or request timeouts — because `path(['response', 'status'], error)` returns `undefined`, which never matches the bypass list.

With `silent: true`, every error is re-thrown without triggering the snackbar, regardless of whether a response exists.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

Use `useRequest` with `silent: true` and trigger a network error (e.g., request to an unreachable host). Verify that no error snackbar appears and the error is still thrown to the caller.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added silent option to useRequest to suppress error snackbars


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90198174?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->