### PR TITLE
[25.10] fix(dashboard): restrict performance metrics to selected host only

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -554,7 +554,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
                     m.max, r.parent_name, r.name, r.id as service_id, r.parent_id
                     FROM `:dbstg`.`metrics` AS m
                     INNER JOIN `:dbstg`.`index_data` AS id ON id.id = m.index_id
-                    INNER JOIN `:dbstg`.`resources` AS r ON r.id = id.service_id
+                    INNER JOIN `:dbstg`.`resources` AS r ON r.id = id.service_id AND r.parent_id = id.host_id
                 SQL_WRAP;
 
         $accessGroupIds = array_map(


### PR DESCRIPTION
Add host correlation to the resources JOIN in DbReadDashboardPerformanceMetricRepository so that metrics are filtered by the selected host instead of returning metrics from all hosts linked to the same service.

Ref MON-196355
Backports #9873

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Restricted performance metrics query to selected host via JOIN correlation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90212328?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->