### PR TITLE
fix(open-tickets): use prepared statements throughout

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/rule.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/rule.php
@@ -51,9 +51,9 @@ class Centreon_OpenTickets_Rule
             return $result;
         }
 
-        $dbResult = $this->_db->query(
-            "SELECT alias, provider_id FROM mod_open_tickets_rule WHERE rule_id = '" . $rule_id . "' LIMIT 1"
-        );
+        $dbResult = $this->_db->prepare('SELECT alias, provider_id FROM mod_open_tickets_rule WHERE rule_id = :ruleId LIMIT 1');
+        $dbResult->bindValue(':ruleId', (int) $rule_id, PDO::PARAM_INT);
+        $dbResult->execute();
         if (($row = $dbResult->fetch())) {
             $result['alias'] = $row['alias'];
             $result['provider_id'] = $row['provider_id'];
@@ -760,13 +760,13 @@ class Centreon_OpenTickets_Rule
     public function getHostgroup($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " hg_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare("SELECT hg_id, hg_name FROM hostgroup WHERE hg_name LIKE :filter AND hg_activate = '1' ORDER BY hg_name ASC");
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT hg_id, hg_name FROM hostgroup WHERE hg_activate = '1' ORDER BY hg_name ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT hg_id, hg_name FROM hostgroup WHERE ' . $where . " hg_activate = '1' ORDER BY hg_name ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['hg_id']] = $row['hg_name'];
         }
@@ -777,13 +777,13 @@ class Centreon_OpenTickets_Rule
     public function getContactgroup($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " cg_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare("SELECT cg_id, cg_name FROM contactgroup WHERE cg_name LIKE :filter AND cg_activate = '1' ORDER BY cg_name ASC");
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT cg_id, cg_name FROM contactgroup WHERE cg_activate = '1' ORDER BY cg_name ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT cg_id, cg_name FROM contactgroup WHERE ' . $where . " cg_activate = '1' ORDER BY cg_name ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['cg_id']] = $row['cg_name'];
         }
@@ -794,13 +794,13 @@ class Centreon_OpenTickets_Rule
     public function getServicegroup($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " sg_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare("SELECT sg_id, sg_name FROM servicegroup WHERE sg_name LIKE :filter AND sg_activate = '1' ORDER BY sg_name ASC");
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT sg_id, sg_name FROM servicegroup WHERE sg_activate = '1' ORDER BY sg_name ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT sg_id, sg_name FROM servicegroup WHERE ' . $where . " sg_activate = '1' ORDER BY sg_name ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['sg_id']] = $row['sg_name'];
         }
@@ -811,16 +811,13 @@ class Centreon_OpenTickets_Rule
     public function getHostcategory($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " hc_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare("SELECT hc_id, hc_name FROM hostcategories WHERE hc_name LIKE :filter AND hc_activate = '1' ORDER BY hc_name ASC");
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT hc_id, hc_name FROM hostcategories WHERE hc_activate = '1' ORDER BY hc_name ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT hc_id, hc_name
-            FROM hostcategories
-            WHERE ' . $where . " hc_activate = '1'
-            ORDER BY hc_name ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['hc_id']] = $row['hc_name'];
         }
@@ -831,17 +828,13 @@ class Centreon_OpenTickets_Rule
     public function getHostseverity($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " hc_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare("SELECT hc_id, hc_name FROM hostcategories WHERE hc_name LIKE :filter AND level IS NOT NULL AND hc_activate = '1' ORDER BY level ASC");
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT hc_id, hc_name FROM hostcategories WHERE level IS NOT NULL AND hc_activate = '1' ORDER BY level ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT hc_id, hc_name
-            FROM hostcategories
-            WHERE ' . $where . " level IS NOT NULL
-            AND hc_activate = '1'
-            ORDER BY level ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['hc_id']] = $row['hc_name'];
         }
@@ -852,16 +845,13 @@ class Centreon_OpenTickets_Rule
     public function getServicecategory($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " sc_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare("SELECT sc_id, sc_name FROM service_categories WHERE sc_name LIKE :filter AND sc_activate = '1' ORDER BY sc_name ASC");
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT sc_id, sc_name FROM service_categories WHERE sc_activate = '1' ORDER BY sc_name ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT sc_id, sc_name
-            FROM service_categories
-            WHERE ' . $where . " sc_activate = '1'
-            ORDER BY sc_name ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['sc_id']] = $row['sc_name'];
         }
@@ -872,17 +862,19 @@ class Centreon_OpenTickets_Rule
     public function getServiceseverity($filter)
     {
         $result = [];
-        $where = '';
         if (! is_null($filter) && $filter != '') {
-            $where = " sc_name LIKE '" . $this->_db->escape($filter) . "' AND ";
+            $dbResult = $this->_db->prepare(
+                "SELECT sc_id, sc_name
+                FROM service_categories
+                WHERE sc_name LIKE :filter AND level IS NOT NULL
+                AND sc_activate = '1'
+                ORDER BY level ASC"
+            );
+            $dbResult->bindValue(':filter', $filter);
+            $dbResult->execute();
+        } else {
+            $dbResult = $this->_db->query("SELECT sc_id, sc_name FROM service_categories WHERE level IS NOT NULL AND sc_activate = '1' ORDER BY level ASC");
         }
-        $dbResult = $this->_db->query(
-            'SELECT sc_id, sc_name
-            FROM service_categories
-            WHERE ' . $where . " level IS NOT NULL
-            AND sc_activate = '1'
-            ORDER BY level ASC"
-        );
         while (($row = $dbResult->fetch())) {
             $result[$row['sc_id']] = $row['sc_name'];
         }

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/ticketLog.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/ticketLog.php
@@ -69,41 +69,56 @@ class Centreon_OpenTickets_Log
             $params['period']
         );
 
+        $bindParams = [];
         $query = 'SELECT SQL_CALC_FOUND_ROWS mot.ticket_value AS ticket_id, mot.timestamp, mot.user, '
             . 'motl.hostname AS host_name, motl.service_description, motd.subject '
             . 'FROM mod_open_tickets_link motl, mod_open_tickets_data motd, mod_open_tickets mot WHERE ';
         if (! is_null($range_time['start'])) {
-            $query .= 'mot.timestamp >= ' . $range_time['start'] . ' AND ';
+            $query .= 'mot.timestamp >= :rangeStart AND ';
+            $bindParams[':rangeStart'] = [PDO::PARAM_INT, (int) $range_time['start']];
         }
         if (! is_null($range_time['end'])) {
-            $query .= 'mot.timestamp <= ' . $range_time['end'] . ' AND ';
+            $query .= 'mot.timestamp <= :rangeEnd AND ';
+            $bindParams[':rangeEnd'] = [PDO::PARAM_INT, (int) $range_time['end']];
         }
         if (! is_null($params['ticket_id']) && $params['ticket_id'] != '') {
-            $query .= "mot.ticket_value LIKE '%" . $this->_db->escape($params['ticket_id']) . "%' AND ";
+            $query .= 'mot.ticket_value LIKE :ticketId AND ';
+            $bindParams[':ticketId'] = [PDO::PARAM_STR, '%' . $params['ticket_id'] . '%'];
         }
         if (! is_null($params['subject']) && $params['subject'] != '') {
-            $query .= "motd.subject LIKE '%" . $this->_db->escape($params['subject']) . "%' AND ";
+            $query .= 'motd.subject LIKE :subject AND ';
+            $bindParams[':subject'] = [PDO::PARAM_STR, '%' . $params['subject'] . '%'];
         }
 
-        $build_services_filter = '';
-        $build_services_filter_append = '';
+        $serviceConditions = [];
+        $serviceParamIndex = 0;
         if (isset($params['service_filter']) && is_array($params['service_filter'])) {
             foreach ($params['service_filter'] as $val) {
                 $tmp = explode('-', $val);
-                $build_services_filter .= $build_services_filter_append . '(motl.host_id = ' . $tmp[0]
-                    . ' AND motl.service_id = ' . $tmp[1] . ') ';
-                $build_services_filter_append = 'OR ';
+                $hostParam = ':svcFilterHost' . $serviceParamIndex;
+                $svcParam = ':svcFilterSvc' . $serviceParamIndex;
+                $serviceConditions[] = '(motl.host_id = ' . $hostParam . ' AND motl.service_id = ' . $svcParam . ')';
+                $bindParams[$hostParam] = [PDO::PARAM_INT, (int) $tmp[0]];
+                $bindParams[$svcParam] = [PDO::PARAM_INT, (int) $tmp[1]];
+                $serviceParamIndex++;
             }
         }
-        if (isset($params['host_filter']) && count($params['host_filter']) > 0) {
-            if ($build_services_filter != '') {
-                $query .= '(motl.host_id IN (' . join(',', $params['host_filter']) . ') '
-                   . 'OR (' . $build_services_filter . ')) AND ';
-            } else {
-                $query .= 'motl.host_id IN (' . join(',', $params['host_filter']) . ') AND ';
+
+        $hostPlaceholders = [];
+        if (isset($params['host_filter']) && is_array($params['host_filter']) && $params['host_filter'] !== []) {
+            foreach ($params['host_filter'] as $idx => $hostId) {
+                $param = ':hostFilter' . $idx;
+                $hostPlaceholders[] = $param;
+                $bindParams[$param] = [PDO::PARAM_INT, (int) $hostId];
             }
-        } elseif ($build_services_filter != '') {
-            $query .= '(' . $build_services_filter . ') AND ';
+            if ($serviceConditions !== []) {
+                $query .= '(motl.host_id IN (' . implode(',', $hostPlaceholders) . ') '
+                    . 'OR (' . implode(' OR ', $serviceConditions) . ')) AND ';
+            } else {
+                $query .= 'motl.host_id IN (' . implode(',', $hostPlaceholders) . ') AND ';
+            }
+        } elseif ($serviceConditions !== []) {
+            $query .= '(' . implode(' OR ', $serviceConditions) . ') AND ';
         }
 
         if (! $centreon_bg->is_admin) {
@@ -124,10 +139,15 @@ class Centreon_OpenTickets_Log
         }
 
         if ($all == false) {
-            $query .= 'LIMIT ' . (($current_page - 1) * $pagination) . ', ' . $pagination;
+            $query .= 'LIMIT :paginationOffset, :paginationLimit';
+            $bindParams[':paginationOffset'] = [PDO::PARAM_INT, ($current_page - 1) * $pagination];
+            $bindParams[':paginationLimit'] = [PDO::PARAM_INT, (int) $pagination];
         }
 
         $stmt = $this->_dbStorage->prepare($query);
+        foreach ($bindParams as $param => $paramData) {
+            $stmt->bindValue($param, $paramData[1], $paramData[0]);
+        }
         $stmt->execute();
         $result['tickets'] = $stmt->fetchAll();
         $rows = $stmt->rowCount();

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -1592,67 +1592,57 @@ Output: {$service.output|substr:0:1024}
             $db_storage->beginTransaction();
 
             if ($extra_args['no_create_ticket_id'] == false) {
-                $db_storage->query(
-                    'INSERT INTO mod_open_tickets
-                        (`timestamp`, `user`' . (is_null($extra_args['ticket_value']) ? '' : ', `ticket_value`') . ")
-                    VALUES ('" . $result['ticket_time'] . "', '"
-                    . $db_storage->escape($extra_args['contact']['name']) . "'"
-                    . (is_null($extra_args['ticket_value']) ? '' : ", '"
-                    . $db_storage->escape($extra_args['ticket_value']) . "'") . ')'
-                );
+                if (is_null($extra_args['ticket_value'])) {
+                    $insertTicket = $db_storage->prepare('INSERT INTO mod_open_tickets (`timestamp`, `user`) VALUES (:timestamp, :user)');
+                    $insertTicket->bindValue(':timestamp', $result['ticket_time'], PDO::PARAM_INT);
+                    $insertTicket->bindValue(':user', $extra_args['contact']['name']);
+                } else {
+                    $insertTicket = $db_storage->prepare('INSERT INTO mod_open_tickets (`timestamp`, `user`, `ticket_value`) VALUES (:timestamp, :user, :ticketValue)');
+                    $insertTicket->bindValue(':timestamp', $result['ticket_time'], PDO::PARAM_INT);
+                    $insertTicket->bindValue(':user', $extra_args['contact']['name']);
+                    $insertTicket->bindValue(':ticketValue', $extra_args['ticket_value']);
+                }
+                $insertTicket->execute();
                 $result['ticket_id'] = $db_storage->lastinsertId('mod_open_tickets');
             }
 
             if (is_null($extra_args['ticket_value'])) {
-                $db_storage->query(
-                    "UPDATE mod_open_tickets SET `ticket_value` = '" . $db_storage->escape($result['ticket_id']) . "'
-                    WHERE `ticket_id` = '" . $db_storage->escape($result['ticket_id']) . "'"
-                );
+                $updateTicket = $db_storage->prepare('UPDATE mod_open_tickets SET `ticket_value` = :ticketValue WHERE `ticket_id` = :ticketId');
+                $updateTicket->bindValue(':ticketValue', $result['ticket_id']);
+                $updateTicket->bindValue(':ticketId', $result['ticket_id'], PDO::PARAM_INT);
+                $updateTicket->execute();
             }
 
+            $insertHostLink = $db_storage->prepare('INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`) VALUES (:ticketId, :hostId, :hostState, :hostname)');
             foreach ($extra_args['host_problems'] as $row) {
-                $db_storage->query(
-                    "INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`) VALUES (
-                        '" . $db_storage->escape($result['ticket_id']) . "',
-                        '" . $db_storage->escape($row['host_id']) . "',
-                        '" . $db_storage->escape($row['host_state']) . "',
-                        '" . $db_storage->escape($row['name']) . "'
-                    )"
-                );
+                $insertHostLink->bindValue(':ticketId', $result['ticket_id'], PDO::PARAM_INT);
+                $insertHostLink->bindValue(':hostId', (int) $row['host_id'], PDO::PARAM_INT);
+                $insertHostLink->bindValue(':hostState', (int) $row['host_state'], PDO::PARAM_INT);
+                $insertHostLink->bindValue(':hostname', $row['name']);
+                $insertHostLink->execute();
             }
+            $insertSvcLink = $db_storage->prepare(
+                'INSERT INTO mod_open_tickets_link (`ticket_id`, `host_id`, `host_state`, `hostname`, `service_id`, `service_state`, `service_description`)
+                 VALUES (:ticketId, :hostId, :hostState, :hostname, :serviceId, :serviceState, :serviceDescription)'
+            );
             foreach ($extra_args['service_problems'] as $row) {
-                $db_storage->query(
-                    "INSERT INTO mod_open_tickets_link (
-                        `ticket_id`,
-                        `host_id`,
-                        `host_state`,
-                        `hostname`,
-                        `service_id`,
-                        `service_state`,
-                        `service_description`
-                    ) VALUES (
-                        '" . $db_storage->escape($result['ticket_id']) . "',
-                        '" . $db_storage->escape($row['host_id']) . "',
-                        '" . $db_storage->escape($row['host_state']) . "',
-                        '" . $db_storage->escape($row['host_name']) . "',
-                        '" . $db_storage->escape($row['service_id']) . "',
-                        '" . $db_storage->escape($row['service_state']) . "',
-                        '" . $db_storage->escape($row['description']) . "'
-                    )"
-                );
+                $insertSvcLink->bindValue(':ticketId', $result['ticket_id'], PDO::PARAM_INT);
+                $insertSvcLink->bindValue(':hostId', (int) $row['host_id'], PDO::PARAM_INT);
+                $insertSvcLink->bindValue(':hostState', (int) $row['host_state'], PDO::PARAM_INT);
+                $insertSvcLink->bindValue(':hostname', $row['host_name']);
+                $insertSvcLink->bindValue(':serviceId', (int) $row['service_id'], PDO::PARAM_INT);
+                $insertSvcLink->bindValue(':serviceState', (int) $row['service_state'], PDO::PARAM_INT);
+                $insertSvcLink->bindValue(':serviceDescription', $row['description']);
+                $insertSvcLink->execute();
             }
 
             if (! is_null($extra_args['data_type']) && ! is_null($extra_args['data'])) {
-                $db_storage->query(
-                    "INSERT INTO mod_open_tickets_data (
-                        `ticket_id`, `subject`, `data_type`, `data`
-                    ) VALUES (
-                        '" . $db_storage->escape($result['ticket_id']) . "',
-                        '" . $db_storage->escape($extra_args['subject']) . "',
-                        '" . $db_storage->escape($extra_args['data_type']) . "',
-                        '" . $db_storage->escape($extra_args['data']) . "'
-                    )"
-                );
+                $insertData = $db_storage->prepare('INSERT INTO mod_open_tickets_data (`ticket_id`, `subject`, `data_type`, `data`) VALUES (:ticketId, :subject, :dataType, :data)');
+                $insertData->bindValue(':ticketId', $result['ticket_id'], PDO::PARAM_INT);
+                $insertData->bindValue(':subject', $extra_args['subject']);
+                $insertData->bindValue(':dataType', (string) $extra_args['data_type']);
+                $insertData->bindValue(':data', $extra_args['data']);
+                $insertData->execute();
             }
 
             $result['ticket_id'] = is_null($extra_args['ticket_value'])

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Mail/MailProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Mail/MailProvider.class.php
@@ -131,14 +131,12 @@ class MailProvider extends AbstractProvider
     {
         $result = ['ticket_id' => null, 'ticket_error_message' => null, 'ticket_is_ok' => 0, 'ticket_time' => time()];
 
-        /**
-         * @phpstan-ignore-next-line
-         * FIXME $contact['name'] => Offset 'name' does not exist on string => $contact is a string or an array ??
-         */
-        $values = "('" . $result['ticket_time'] . "', '" . $db_storage->escape($contact['name']) . "')";
-
         try {
-            $db_storage->query("INSERT INTO mod_open_tickets (`timestamp`, `user`) VALUES {$values}");
+            $insertStatement = $db_storage->prepare('INSERT INTO mod_open_tickets (`timestamp`, `user`) VALUES (:timestamp, :user)');
+            $insertStatement->bindValue(':timestamp', $result['ticket_time'], PDO::PARAM_INT);
+            // FIXME $contact['name'] => Offset 'name' does not exist on string => $contact is a string or an array ??
+            $insertStatement->bindValue(':user', $contact['name']); // @phpstan-ignore offsetAccess.notFound
+            $insertStatement->execute();
             $result['ticket_id'] = $db_storage->lastinsertId('mod_open_tickets');
         } catch (Exception $e) {
             $result['ticket_error_message'] = $e->getMessage();


### PR DESCRIPTION
## Description

Backport of #9822.

- Fix SQL injection (CWE-89) across the Open Tickets module:
  - `centreon-open-tickets/www/modules/centreon-open-tickets/class/rule.php`
  - `centreon-open-tickets/www/modules/centreon-open-tickets/class/ticketLog.php`
  - `centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php`
  - `centreon-open-tickets/www/modules/centreon-open-tickets/providers/Mail/MailProvider.class.php`
- Replace all `escape()` + string concatenation with prepared statements using `bindValue()`
- Convert dynamic IN clauses to use numbered placeholders

Fixes: [MON-196244](https://centreon.atlassian.net/browse/MON-196244)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

[MON-196244]: https://centreon.atlassian.net/browse/MON-196244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 22 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed SQL injection vulnerabilities in Open Tickets module classes.

**🔧 Refactors**
* Replaced concatenated SQL queries with prepared statements and bound parameters.
* Converted dynamic IN and filter clauses to numbered placeholders.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90256579?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->