### PR TITLE
fix(awie): use prepared statement in Export

### DIFF
--- a/centreon-awie/www/modules/centreon-awie/class/Export.class.php
+++ b/centreon-awie/www/modules/centreon-awie/class/Export.class.php
@@ -156,8 +156,13 @@ class Export
             'm' => 3,
             'd' => 4,
         ];
-        $query = 'SELECT `command_name` FROM `command`WHERE `command_type` =' . $cmdTypeRelation[$type];
-        $res = $this->db->query($query);
+        if (! isset($cmdTypeRelation[$type])) {
+            return $cmdScript;
+        }
+        $query = 'SELECT `command_name` FROM `command` WHERE `command_type` = :commandType';
+        $res = $this->db->prepare($query);
+        $res->bindValue(':commandType', $cmdTypeRelation[$type], PDO::PARAM_INT);
+        $res->execute();
 
         while ($row = $res->fetch()) {
             $result = $this->generateObject('CMD', ';' . $row['command_name']);


### PR DESCRIPTION
## Description

Backport of #9820.

- Fix SQL injection (CWE-89) in `centreon-awie/www/modules/centreon-awie/class/Export.class.php`
- Replace `escape()` + string concatenation with prepared statement using `bindValue()`

Fixes: [MON-196243](https://centreon.atlassian.net/browse/MON-196243)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

[MON-196243]: https://centreon.atlassian.net/browse/MON-196243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Replaced string-concatenated SQL with prepared statements and bindValue
* Added validation for command type and early return on invalid input


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90256703?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->