### PR TITLE
fix(dsm): use prepared statements in DB-Func and listSlot

### DIFF
--- a/centreon-dsm/phpstan.legacy.baseline.neon
+++ b/centreon-dsm/phpstan.legacy.baseline.neon
@@ -42,7 +42,7 @@ parameters:
 
 		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) rq must contain 3 or more characters\.$#'
-			count: 3
+			count: 4
 			path: www/modules/centreon-dsm/core/configuration/services/listSlot.php
 
 		-

--- a/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/DB-Func.php
+++ b/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/DB-Func.php
@@ -438,7 +438,8 @@ function multiplePoolInDB($pool = [], $nbrDup = [])
                     'pool_service_template_id' => PDO::PARAM_INT,
                 ];
 
-                for ($i = 1; $i <= $nbrDup[$key]; $i++) {
+                $dupCount = (int) ($nbrDup[$key] ?? 0);
+                for ($i = 1; $i <= $dupCount; $i++) {
                     $parameters = [];
                     $row['pool_name'] = isset($row['pool_name']) ? $row['pool_name'] . '_' . $i : null;
                     $row['pool_host_id'] = null;
@@ -475,10 +476,6 @@ function multiplePoolInDB($pool = [], $nbrDup = [])
                                 SQL
                         );
                         $pearDB->executePreparedQuery($statement, $parameters, true);
-                        $pearDB->closeQuery($statement);
-
-                        $statement = $pearDB->executeQuery('SELECT MAX(pool_id) FROM `mod_dsm_pool`');
-                        $cmd_id = $pearDB->fetch($statement);
                         $pearDB->closeQuery($statement);
                     }
                 }
@@ -573,37 +570,27 @@ function generateServices($prefix, $number, $host_id, $template, $cmd, $args, $o
                 ], true);
                 $pearDB->closeQuery($statementInsert);
 
-                $statementMax = $pearDB->prepareQuery(
-                    <<<'SQL'
-                            SELECT MAX(service_id)
-                            FROM service
-                            WHERE service_description = :service_description
-                                AND service_activate = '1'
-                                AND service_register = '1'
-                        SQL
-                );
-                $pearDB->executePreparedQuery($statementMax, [':service_description' => [$prefix . $suffix, PDO::PARAM_STR]], true);
-                $service = $pearDB->fetch($statementMax);
-                $service_id = $service['MAX(service_id)'];
-                $pearDB->closeQuery($statementMax);
+                $service_id = (int) $pearDB->lastInsertId();
 
-                if ($service_id != 0) {
-                    $statementInsertHostRelation = $pearDB->prepareQuery(
-                        'INSERT INTO host_service_relation (service_service_id, host_host_id)
-                        VALUES (:service_id, :host_id)'
-                    );
-                    $pearDB->executePreparedQuery($statementInsertHostRelation, [
-                        ':service_id' => [$service_id, PDO::PARAM_INT],
-                        ':host_id' => [$host_id, PDO::PARAM_INT],
-                    ], true);
-                    $pearDB->closeQuery($statementInsertHostRelation);
-
-                    $statementInsertExtended = $pearDB->prepareQuery(
-                        'INSERT INTO extended_service_information (service_service_id) VALUES (:service_id)'
-                    );
-                    $pearDB->executePreparedQuery($statementInsertExtended, [':service_id' => [$service_id, PDO::PARAM_INT]], true);
-                    $pearDB->closeQuery($statementInsertExtended);
+                if ($service_id === 0) {
+                    throw new RuntimeException('Failed to retrieve last insert ID for service');
                 }
+
+                $statementInsertHostRelation = $pearDB->prepareQuery(
+                    'INSERT INTO host_service_relation (service_service_id, host_host_id)
+                    VALUES (:service_id, :host_id)'
+                );
+                $pearDB->executePreparedQuery($statementInsertHostRelation, [
+                    ':service_id' => [$service_id, PDO::PARAM_INT],
+                    ':host_id' => [$host_id, PDO::PARAM_INT],
+                ], true);
+                $pearDB->closeQuery($statementInsertHostRelation);
+
+                $statementInsertExtended = $pearDB->prepareQuery(
+                    'INSERT INTO extended_service_information (service_service_id) VALUES (:service_id)'
+                );
+                $pearDB->executePreparedQuery($statementInsertExtended, [':service_id' => [$service_id, PDO::PARAM_INT]], true);
+                $pearDB->closeQuery($statementInsertExtended);
             }
         } elseif ($currentNumber <= $number) {
             for ($i = 1; $data = $pearDB->fetch($statement); $i++) {
@@ -681,36 +668,27 @@ function generateServices($prefix, $number, $host_id, $template, $cmd, $args, $o
                 ], true);
                 $pearDB->closeQuery($statementInsert);
 
-                $statementMax = $pearDB->prepareQuery(
-                    <<<'SQL'
-                            SELECT MAX(service_id) FROM service
-                            WHERE service_description = :service_description
-                                AND service_activate = '1'
-                                AND service_register = '1'
-                        SQL
-                );
-                $pearDB->executePreparedQuery($statementMax, [':service_description' => [$prefix . $suffix, PDO::PARAM_STR]], true);
-                $service = $pearDB->fetch($statementMax);
-                $service_id = $service['MAX(service_id)'];
-                $pearDB->closeQuery($statementMax);
+                $service_id = (int) $pearDB->lastInsertId();
 
-                if ($service_id != 0) {
-                    $statementInsertHostRelation = $pearDB->prepareQuery(
-                        'INSERT INTO host_service_relation (service_service_id, host_host_id)
-                        VALUES (:service_id, :host_id)'
-                    );
-                    $pearDB->executePreparedQuery($statementInsertHostRelation, [
-                        ':service_id' => [$service_id, PDO::PARAM_INT],
-                        ':host_id' => [$host_id, PDO::PARAM_INT],
-                    ], true);
-                    $pearDB->closeQuery($statementInsertHostRelation);
-
-                    $statementInsertExtended = $pearDB->prepareQuery(
-                        'INSERT INTO extended_service_information (service_service_id) VALUES (:service_id)'
-                    );
-                    $pearDB->executePreparedQuery($statementInsertExtended, [':service_id' => [$service_id, PDO::PARAM_INT]], true);
-                    $pearDB->closeQuery($statementInsertExtended);
+                if ($service_id === 0) {
+                    throw new RuntimeException('Failed to retrieve last insert ID for service');
                 }
+
+                $statementInsertHostRelation = $pearDB->prepareQuery(
+                    'INSERT INTO host_service_relation (service_service_id, host_host_id)
+                    VALUES (:service_id, :host_id)'
+                );
+                $pearDB->executePreparedQuery($statementInsertHostRelation, [
+                    ':service_id' => [$service_id, PDO::PARAM_INT],
+                    ':host_id' => [$host_id, PDO::PARAM_INT],
+                ], true);
+                $pearDB->closeQuery($statementInsertHostRelation);
+
+                $statementInsertExtended = $pearDB->prepareQuery(
+                    'INSERT INTO extended_service_information (service_service_id) VALUES (:service_id)'
+                );
+                $pearDB->executePreparedQuery($statementInsertExtended, [':service_id' => [$service_id, PDO::PARAM_INT]], true);
+                $pearDB->closeQuery($statementInsertExtended);
                 $i++;
             }
         } elseif ($currentNumber > $number) {
@@ -822,17 +800,19 @@ function insertPool($ret = [])
         $pearDB->executePreparedQuery($statement, $parameters, true);
         $pearDB->closeQuery($statement);
 
-        $statementMax = $pearDB->executeQuery('SELECT MAX(pool_id) FROM mod_dsm_pool');
-        $pool_id = $pearDB->fetch($statementMax);
-        $pearDB->closeQuery($statementMax);
+        $pool_id = (int) $pearDB->lastInsertId();
 
-        if ($ret['pool_activate']['pool_activate'] == 1) {
-            enablePoolInDB($pool_id['MAX(pool_id)']);
-        } else {
-            disablePoolInDB($pool_id['MAX(pool_id)']);
+        if ($pool_id === 0) {
+            throw new RuntimeException('Failed to retrieve last insert ID for pool');
         }
 
-        return $pool_id['MAX(pool_id)'];
+        if ($ret['pool_activate']['pool_activate'] == 1) {
+            enablePoolInDB($pool_id);
+        } else {
+            disablePoolInDB($pool_id);
+        }
+
+        return $pool_id;
     } catch (CentreonDbException $e) {
         CentreonLog::create()->error(
             logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
@@ -967,6 +947,8 @@ function updatePoolContactGroup($pool_id = null, $ret = [])
             return;
         }
 
+        $pearDB->beginTransaction();
+
         $statement = $pearDB->prepareQuery('DELETE FROM mod_dsm_cg_relation WHERE pool_id = :pool_id');
         $pearDB->executePreparedQuery($statement, [':pool_id' => [$pool_id, PDO::PARAM_INT]], true);
         $pearDB->closeQuery($statement);
@@ -983,7 +965,13 @@ function updatePoolContactGroup($pool_id = null, $ret = [])
             ], true);
             $pearDB->closeQuery($statement);
         }
+
+        $pearDB->commit();
     } catch (CentreonDbException $e) {
+        if ($pearDB->inTransaction()) {
+            $pearDB->rollBack();
+        }
+
         CentreonLog::create()->error(
             logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
             message: 'Error updating contact groups for pool with ID: ' . ($pool_id ?? 'N/A'),
@@ -1013,6 +1001,8 @@ function updatePoolContact($pool_id = null, $ret = [])
             return;
         }
 
+        $pearDB->beginTransaction();
+
         $statement = $pearDB->prepareQuery('DELETE FROM mod_dsm_cct_relation WHERE pool_id = :pool_id');
         $pearDB->executePreparedQuery($statement, [':pool_id' => [$pool_id, PDO::PARAM_INT]], true);
         $pearDB->closeQuery($statement);
@@ -1029,7 +1019,13 @@ function updatePoolContact($pool_id = null, $ret = [])
             ], true);
             $pearDB->closeQuery($statement);
         }
+
+        $pearDB->commit();
     } catch (CentreonDbException $e) {
+        if ($pearDB->inTransaction()) {
+            $pearDB->rollBack();
+        }
+
         CentreonLog::create()->error(
             logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
             message: 'Error updating contacts for pool with ID: ' . ($pool_id ?? 'N/A'),

--- a/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.php
+++ b/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.php
@@ -49,11 +49,12 @@ while ($data = $dbResult->fetch()) {
 $dbResult->closeCursor();
 
 if (isset($search)) {
-    $dbResult = $pearDB->query(
-        "SELECT COUNT(*) FROM mod_dsm_pool WHERE (pool_name LIKE '%"
-        . htmlentities($search, ENT_QUOTES) . "%' OR pool_description LIKE '%"
-        . htmlentities($search, ENT_QUOTES) . "%')"
+    $dbResult = $pearDB->prepare(
+        'SELECT COUNT(*) FROM mod_dsm_pool WHERE (pool_name LIKE :searchName OR pool_description LIKE :searchDesc)'
     );
+    $dbResult->bindValue(':searchName', '%' . $search . '%');
+    $dbResult->bindValue(':searchDesc', '%' . $search . '%');
+    $dbResult->execute();
 } else {
     $dbResult = $pearDB->query('SELECT COUNT(*) FROM mod_dsm_pool');
 }
@@ -80,7 +81,7 @@ $tpl->assign('search', $search);
 $tpl->assign('p', $p);
 
 if ($search) {
-    $rq = "SELECT
+    $rq = 'SELECT
             pool_id,
             pool_prefix,
             pool_name,
@@ -89,9 +90,15 @@ if ($search) {
             pool_activate
         FROM mod_dsm_pool
         WHERE (
-            pool_name LIKE '%" . htmlentities($search, ENT_QUOTES) . "%'
-        OR pool_description LIKE '%" . htmlentities($search, ENT_QUOTES) . "%')
-        ORDER BY pool_name LIMIT " . $num * $limit . ', ' . $limit;
+            pool_name LIKE :searchName
+        OR pool_description LIKE :searchDesc)
+        ORDER BY pool_name LIMIT :offset, :limit';
+    $dbResult = $pearDB->prepare($rq);
+    $dbResult->bindValue(':searchName', '%' . $search . '%');
+    $dbResult->bindValue(':searchDesc', '%' . $search . '%');
+    $dbResult->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+    $dbResult->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $dbResult->execute();
 } else {
     $rq = 'SELECT
             pool_id,
@@ -102,9 +109,12 @@ if ($search) {
             pool_activate
         FROM mod_dsm_pool
         ORDER BY pool_name
-        LIMIT ' . $num * $limit . ', ' . $limit;
+        LIMIT :offset, :limit';
+    $dbResult = $pearDB->prepare($rq);
+    $dbResult->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+    $dbResult->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $dbResult->execute();
 }
-$dbResult = $pearDB->query($rq);
 
 $search = tidySearchKey($search, $advanced_search);
 


### PR DESCRIPTION
## Description

Backport of #9821.

- Fix SQL injection (CWE-89) in DSM module files:
  - `centreon-dsm/www/modules/centreon-dsm/core/configuration/services/DB-Func.php`
  - `centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.php`
- Replace `escape()` + string concatenation with prepared statements using `bindValue()`
- Convert search/pagination queries in `listSlot.php` to parameterized queries

Fixes: [MON-196243](https://centreon.atlassian.net/browse/MON-196243)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

[MON-196243]: https://centreon.atlassian.net/browse/MON-196243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added structured error logging in DSM database exception handlers

**🔧 Refactors**
* Replaced escape-plus-concatenation with prepared statements in DB-Func.php
* Converted listSlot.php search and pagination queries to parameterized statements


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90256767?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->