### PR TITLE
feat(apiv2): add GetServiceGroup & UpdateServiceGroup endpoints (#9783)

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/GetServiceGroup.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/GetServiceGroup.yaml
@@ -1,0 +1,22 @@
+get:
+  tags:
+    - Service group
+  summary: "Get a service group"
+  description: |
+    Get an existing service group.
+
+  parameters:
+    - $ref: 'QueryParameter/ServiceGroupId.yaml'
+  responses:
+    '200':
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            $ref: 'Schema/ServiceGroupResponse.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/QueryParameter/ServiceGroupId.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/QueryParameter/ServiceGroupId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: servicegroup_id
+required: true
+description: "Service group ID"
+schema:
+  type: integer
+  minimum: 1
+  example: 1

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupRequest.yaml
@@ -1,0 +1,24 @@
+type: object
+required: ["name", "alias"]
+properties:
+  name:
+    type: string
+    description: "Service group name"
+    example: "service-group"
+  alias:
+    type: string
+    description: "Service group alias"
+    example: "service-group"
+  geo_coords:
+    type: string
+    nullable: true
+    description: "Geographical coordinates used by Centreon Map module to position element on map"
+    example: "48.51,2.20"
+  comment:
+    type: string
+    nullable: true
+    description: "Service group description"
+    example: "Example description"
+  is_activated:
+    type: boolean
+    description: "Indicates whether this service group is enabled or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupResponse.yaml
@@ -1,0 +1,27 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: "Service group ID"
+    example: 1
+  name:
+    type: string
+    description: "Service group name"
+    example: "service-group"
+  alias:
+    type: string
+    description: "Service group alias"
+    example: "service-group"
+  geo_coords:
+    type: string
+    nullable: true
+    description: "Geographical coordinates use by Centreon Map module to position element on map"
+    example: "48.51,2.20"
+  comment:
+    type: string
+    nullable: true
+    description: "Service group description"
+    example: "example comment"
+  is_activated:
+    type: boolean
+    description: "Indicates whether this service group is enabled or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/UpdateServiceGroup.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/UpdateServiceGroup.yaml
@@ -1,0 +1,27 @@
+put:
+  tags:
+    - Service group
+  summary: "Update a service group"
+  description: |
+    Update a service group configuration
+  parameters:
+    - $ref: 'QueryParameter/ServiceGroupId.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'Schema/ServiceGroupRequest.yaml'
+  responses:
+    '204':
+      description: "OK"
+    '400':
+      $ref: '../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '409':
+      $ref: '../../Common/Response/Conflict.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+++ b/centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
@@ -70,6 +70,14 @@ class ServiceGroupException extends \Exception
     /**
      * @return self
      */
+    public static function errorWhileUpdating(): self
+    {
+        return new self(_('Error while updating a service group'));
+    }
+
+    /**
+     * @return self
+     */
     public static function errorWhileRetrievingJustCreated(): self
     {
         return new self(_('Error while retrieving newly created service group'));
@@ -83,5 +91,21 @@ class ServiceGroupException extends \Exception
     public static function nameAlreadyExists(string $serviceGroupName): self
     {
         return new self(sprintf(_("The service group name '%s' already exists"), $serviceGroupName), self::CODE_CONFLICT);
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileRetrieving(): self
+    {
+        return new self(_('Error while retrieving service group'));
+    }
+
+    /**
+     * @return self
+     */
+    public static function editNotAllowed(): self
+    {
+        return new self(_('You are not allowed to update service groups'));
     }
 }

--- a/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
+++ b/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\ServiceGroup\Application\Repository;
 
 use Core\ServiceGroup\Domain\Model\NewServiceGroup;
+use Core\ServiceGroup\Domain\Model\ServiceGroup;
 use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
 
 interface WriteServiceGroupRepositoryInterface
@@ -61,4 +62,13 @@ interface WriteServiceGroupRepositoryInterface
      * @throws \Throwable
      */
     public function unlink(array $serviceGroupRelations): void;
+
+    /**
+     * @param ServiceGroup $serviceGroup
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceGroup $serviceGroup): void;
 }

--- a/centreon/src/Core/ServiceGroup/Application/UseCase/GetServiceGroup/GetServiceGroup.php
+++ b/centreon/src/Core/ServiceGroup/Application/UseCase/GetServiceGroup/GetServiceGroup.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Application\UseCase\GetServiceGroup;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Infrastructure\RequestParameters\RequestParametersTranslatorException;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Contact\Domain\AdminResolver;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Core\ServiceGroup\Application\Exception\ServiceGroupException;
+use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Domain\Model\ServiceGroup;
+
+final class GetServiceGroup
+{
+    use LoggerTrait;
+
+    /** @var AccessGroup[] */
+    private array $accessGroups;
+
+    public function __construct(
+        private readonly ReadServiceGroupRepositoryInterface $readServiceGroupRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    /**
+     * @param PresenterInterface $presenter
+     * @param int $serviceGroupId
+     */
+    public function __invoke(PresenterInterface $presenter, int $serviceGroupId): void
+    {
+        try {
+            if (
+                ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_SERVICE_GROUPS_READ)
+                && ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_SERVICE_GROUPS_READ_WRITE)
+            ) {
+                $this->error(
+                    "User doesn't have sufficient rights to see services groups",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceGroupException::accessNotAllowed())
+                );
+
+                return;
+            }
+
+            $serviceGroup = null;
+            if ($this->adminResolver->isAdmin($this->user)) {
+                $serviceGroup = $this->readServiceGroupRepository->findOne($serviceGroupId);
+
+            } else {
+
+                $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+                $serviceGroup = $this->readServiceGroupRepository->findOneByAccessGroups(
+                    $serviceGroupId,
+                    $this->accessGroups
+                );
+            }
+
+            if (! $serviceGroup) {
+                $this->error(
+                    'ServiceGroup not found',
+                    ['service_group_id' => $serviceGroupId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('ServiceGroup'));
+
+                return;
+            }
+
+            $presenter->present($this->createResponse($serviceGroup));
+        } catch (RequestParametersTranslatorException $ex) {
+            $presenter->setResponseStatus(new ErrorResponse($ex->getMessage()));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceGroupException::errorWhileRetrieving())
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        }
+    }
+
+    /**
+     * @param ServiceGroup $serviceGroup
+     *
+     * @throws \Throwable
+     *
+     * @return GetServiceGroupResponse
+     */
+    private function createResponse(ServiceGroup $serviceGroup): GetServiceGroupResponse
+    {
+        $response = new GetServiceGroupResponse();
+        $response->id = $serviceGroup->getId();
+        $response->name = $serviceGroup->getName();
+        $response->alias = $serviceGroup->getAlias();
+        $response->geoCoords = $serviceGroup->getGeoCoords() ? (string) $serviceGroup->getGeoCoords() : null;
+        $response->comment = $serviceGroup->getComment();
+        $response->isActivated = $serviceGroup->isActivated();
+
+        return $response;
+    }
+}

--- a/centreon/src/Core/ServiceGroup/Application/UseCase/GetServiceGroup/GetServiceGroupResponse.php
+++ b/centreon/src/Core/ServiceGroup/Application/UseCase/GetServiceGroup/GetServiceGroupResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Application\UseCase\GetServiceGroup;
+
+final class GetServiceGroupResponse
+{
+    public int $id = 0;
+
+    public string $name = '';
+
+    public string $alias = '';
+
+    public ?string $geoCoords = null;
+
+    public string $comment = '';
+
+    public bool $isActivated = true;
+}

--- a/centreon/src/Core/ServiceGroup/Application/UseCase/UpdateServiceGroup/UpdateServiceGroup.php
+++ b/centreon/src/Core/ServiceGroup/Application/UseCase/UpdateServiceGroup/UpdateServiceGroup.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Application\UseCase\UpdateServiceGroup;
+
+use Assert\AssertionFailedException;
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Common\Application\Type\NoValue;
+use Core\Common\Domain\TrimmedString;
+use Core\Contact\Domain\AdminResolver;
+use Core\Domain\Common\GeoCoords;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceGroup\Application\Exception\ServiceGroupException;
+use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Domain\Model\ServiceGroup;
+
+final class UpdateServiceGroup
+{
+    use LoggerTrait;
+
+    public function __construct(
+        private readonly WriteServiceGroupRepositoryInterface $writeServiceGroupRepository,
+        private readonly ReadServiceGroupRepositoryInterface $readServiceGroupRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    /**
+     * @param UpdateServiceGroupRequest $dto
+     * @param DefaultPresenter $presenter
+     * @param int $serviceGroupId
+     */
+    public function __invoke(
+        UpdateServiceGroupRequest $dto,
+        PresenterInterface $presenter,
+        int $serviceGroupId,
+    ): void {
+        try {
+            if (! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_SERVICE_GROUPS_READ_WRITE)) {
+                $this->error(
+                    "User doesn't have sufficient rights to edit service groups",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceGroupException::editNotAllowed()->getMessage())
+                );
+
+                return;
+            }
+
+            $serviceGroup = null;
+
+            if ($this->adminResolver->isAdmin($this->user)) {
+                $serviceGroup = $this->readServiceGroupRepository->findOne($serviceGroupId);
+            } else {
+                $serviceGroup = $this->readServiceGroupRepository->findOneByAccessGroups(
+                    $serviceGroupId,
+                    $this->readAccessGroupRepositoryInterface->findByContact($this->user)
+                );
+            }
+
+            if (! $serviceGroup) {
+                $this->error(
+                    'Service group not found',
+                    ['service_group_id' => $serviceGroupId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('Service group'));
+
+                return;
+            }
+
+            $this->validateNameOrFail($dto->name, $serviceGroup);
+
+            $serviceGroup = new ServiceGroup(
+                $serviceGroup->getId(),
+                $dto->name,
+                $dto->alias,
+                $dto->geoCoords instanceof NoValue
+                    ? $serviceGroup->getGeoCoords()
+                    : match ($dto->geoCoords) {
+                        null, '' => null,
+                        default => GeoCoords::fromString($dto->geoCoords),
+                    },
+                $dto->comment instanceof NoValue
+                    ? $serviceGroup->getComment()
+                    : ($dto->comment ?? ''),
+                $dto->isActivated instanceof NoValue
+                    ? $serviceGroup->isActivated()
+                    : $dto->isActivated,
+            );
+
+            $this->writeServiceGroupRepository->update($serviceGroup);
+
+            $presenter->setResponseStatus(new NoContentResponse());
+        } catch (ServiceGroupException $ex) {
+            $presenter->setResponseStatus(
+                match ($ex->getCode()) {
+                    ServiceGroupException::CODE_CONFLICT => new ConflictResponse($ex),
+                    default => new ErrorResponse($ex),
+                }
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (AssertionFailedException $ex) {
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceGroupException::errorWhileUpdating())
+            );
+            $this->error((string) $ex);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param ServiceGroup $serviceGroup
+     *
+     * @throws ServiceGroupException
+     */
+    private function validateNameOrFail(string $name, ServiceGroup $serviceGroup): void
+    {
+        $normalizedName = (new TrimmedString($name))->value;
+
+        if (
+            $normalizedName !== $serviceGroup->getName()
+            && $this->readServiceGroupRepository->nameAlreadyExists($normalizedName)
+        ) {
+            $this->error(
+                'Service group name already exists',
+                ['service_group_name' => $normalizedName]
+            );
+
+            throw ServiceGroupException::nameAlreadyExists($normalizedName);
+        }
+    }
+}

--- a/centreon/src/Core/ServiceGroup/Application/UseCase/UpdateServiceGroup/UpdateServiceGroupRequest.php
+++ b/centreon/src/Core/ServiceGroup/Application/UseCase/UpdateServiceGroup/UpdateServiceGroupRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Application\UseCase\UpdateServiceGroup;
+
+use Core\Common\Application\Type\NoValue;
+
+final class UpdateServiceGroupRequest
+{
+    public string $name = '';
+
+    public string $alias = '';
+
+    public NoValue|string|null $geoCoords;
+
+    public NoValue|string|null $comment;
+
+    public NoValue|bool $isActivated;
+
+    public function __construct()
+    {
+        $this->geoCoords = new NoValue();
+        $this->comment = new NoValue();
+        $this->isActivated = new NoValue();
+    }
+}

--- a/centreon/src/Core/ServiceGroup/Infrastructure/API/GetServiceGroup/GetServiceGroupController.php
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/API/GetServiceGroup/GetServiceGroupController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Infrastructure\API\GetServiceGroup;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\ServiceGroup\Application\UseCase\GetServiceGroup\GetServiceGroup;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class GetServiceGroupController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param GetServiceGroup $useCase
+     * @param GetServiceGroupPresenter $presenter
+     * @param int $serviceGroupId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        GetServiceGroup $useCase,
+        GetServiceGroupPresenter $presenter,
+        int $serviceGroupId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($presenter, $serviceGroupId);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/ServiceGroup/Infrastructure/API/GetServiceGroup/GetServiceGroupPresenter.php
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/API/GetServiceGroup/GetServiceGroupPresenter.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Infrastructure\API\GetServiceGroup;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\ServiceGroup\Application\UseCase\GetServiceGroup\GetServiceGroupResponse;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class GetServiceGroupPresenter extends AbstractPresenter
+{
+    use LoggerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function present(mixed $data): void
+    {
+        if ($data instanceof GetServiceGroupResponse) {
+            $normalizer = new ObjectNormalizer(null, new CamelCaseToSnakeCaseNameConverter());
+            $serializer = new Serializer([$normalizer]);
+            $data = $serializer->normalize($data);
+
+            // NOT setting location as required route does not currently exist
+        }
+        parent::present($data);
+    }
+}

--- a/centreon/src/Core/ServiceGroup/Infrastructure/API/GetServiceGroup/GetServiceGroupRoute.yaml
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/API/GetServiceGroup/GetServiceGroupRoute.yaml
@@ -1,0 +1,7 @@
+GetServiceGroup:
+  methods: GET
+  path: /configuration/services/groups/{serviceGroupId}
+  requirements:
+    serviceGroupId: '\d+'
+  controller: 'Core\ServiceGroup\Infrastructure\API\GetServiceGroup\GetServiceGroupController'
+  condition: "request.attributes.get('version') >= '25.10'"

--- a/centreon/src/Core/ServiceGroup/Infrastructure/API/UpdateServiceGroup/UpdateServiceGroupController.php
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/API/UpdateServiceGroup/UpdateServiceGroupController.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceGroup\Infrastructure\API\UpdateServiceGroup;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ServiceGroup\Application\UseCase\UpdateServiceGroup\UpdateServiceGroup;
+use Core\ServiceGroup\Application\UseCase\UpdateServiceGroup\UpdateServiceGroupRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class UpdateServiceGroupController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param Request $request
+     * @param UpdateServiceGroup $useCase
+     * @param DefaultPresenter $presenter
+     * @param int $serviceGroupId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        Request $request,
+        UpdateServiceGroup $useCase,
+        DefaultPresenter $presenter,
+        int $serviceGroupId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        try {
+            /** @var array{
+             *     name: string,
+             *     alias: string,
+             *     geo_coords?: ?string,
+             *     comment?: ?string,
+             *     is_activated?: bool
+             * } $data
+             */
+            $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/UpdateServiceGroupSchema.json');
+        } catch (\InvalidArgumentException $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+
+            return $presenter->show();
+        }
+
+        $serviceGroupRequest = $this->createRequestDto($data);
+        $useCase($serviceGroupRequest, $presenter, $serviceGroupId);
+
+        return $presenter->show();
+    }
+
+    /**
+     * @param array{
+     *     name: string,
+     *     alias: string,
+     *     geo_coords?: ?string,
+     *     comment?: ?string,
+     *     is_activated?: bool
+     * } $data
+     *
+     * @return UpdateServiceGroupRequest
+     */
+    private function createRequestDto(array $data): UpdateServiceGroupRequest
+    {
+        $serviceGroupRequest = new UpdateServiceGroupRequest();
+        $serviceGroupRequest->name = $data['name'];
+        $serviceGroupRequest->alias = $data['alias'];
+
+        if (array_key_exists('comment', $data)) {
+            $serviceGroupRequest->comment = $data['comment'];
+        }
+        if (array_key_exists('geo_coords', $data)) {
+            $serviceGroupRequest->geoCoords = $data['geo_coords'];
+        }
+        if (array_key_exists('is_activated', $data)) {
+            $serviceGroupRequest->isActivated = $data['is_activated'];
+        }
+
+        return $serviceGroupRequest;
+    }
+}

--- a/centreon/src/Core/ServiceGroup/Infrastructure/API/UpdateServiceGroup/UpdateServiceGroupRoute.yaml
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/API/UpdateServiceGroup/UpdateServiceGroupRoute.yaml
@@ -1,0 +1,7 @@
+UpdateServiceGroup:
+  methods: PUT
+  path: /configuration/services/groups/{serviceGroupId}
+  requirements:
+    serviceGroupId: '\d+'
+  controller: 'Core\ServiceGroup\Infrastructure\API\UpdateServiceGroup\UpdateServiceGroupController'
+  condition: "request.attributes.get('version') >= '25.10'"

--- a/centreon/src/Core/ServiceGroup/Infrastructure/API/UpdateServiceGroup/UpdateServiceGroupSchema.json
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/API/UpdateServiceGroup/UpdateServiceGroupSchema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Update a service group",
+  "type": "object",
+  "required": [
+    "name",
+    "alias"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "alias": {
+      "type": "string"
+    },
+    "geo_coords": {
+      "type": ["string", "null"]
+    },
+    "comment": {
+      "type": ["string", "null"]
+    },
+    "is_activated": {
+      "type": "boolean"
+    }
+  }
+}

--- a/centreon/src/Core/ServiceGroup/Infrastructure/Repository/DbWriteServiceGroupRepository.php
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/Repository/DbWriteServiceGroupRepository.php
@@ -200,6 +200,35 @@ class DbWriteServiceGroupRepository extends AbstractRepositoryRDB implements Wri
     }
 
     /**
+     * @param ServiceGroup $serviceGroup
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceGroup $serviceGroup): void
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                UPDATE `:db`.servicegroup
+                SET
+                    `sg_name` = :name,
+                    `sg_alias` = :alias,
+                    `sg_comment` = :comment,
+                    `geo_coords` = :geo_coords,
+                    `sg_activate` = :activate
+                WHERE sg_id = :id
+                SQL
+        );
+        $statement = $this->db->prepare($request);
+
+        $this->bindValueOfServiceGroup($statement, $serviceGroup);
+        $statement->bindValue(':id', $serviceGroup->getId(), \PDO::PARAM_INT);
+
+        $statement->execute();
+    }
+
+    /**
      * @param \PDOStatement $statement
      * @param ServiceGroup|NewServiceGroup $newServiceGroup
      */

--- a/centreon/tests/php/Core/ServiceGroup/Application/GetServiceGroup/GetServiceGroupTest.php
+++ b/centreon/tests/php/Core/ServiceGroup/Application/GetServiceGroup/GetServiceGroupTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceGroup\Application\UseCase\GetServiceGroup;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Domain\Common\GeoCoords;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceGroup\Application\Exception\ServiceGroupException;
+use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Application\UseCase\GetServiceGroup\GetServiceGroup;
+use Core\ServiceGroup\Application\UseCase\GetServiceGroup\GetServiceGroupResponse;
+use Core\ServiceGroup\Domain\Model\ServiceGroup;
+
+beforeEach(function (): void {
+    $this->readServiceGroupRepository = $this->createMock(ReadServiceGroupRepositoryInterface::class);
+    $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+    $this->user = $this->createMock(ContactInterface::class);
+    $this->presenter = new DefaultPresenter($this->presenterFormatter);
+    $this->adminResolver = $this->createMock(AdminResolver::class);
+    $this->useCase = new GetServiceGroup(
+        $this->readServiceGroupRepository,
+        $this->readAccessGroupRepository,
+        $this->user,
+        $this->adminResolver,
+    );
+    $this->serviceGroup = new ServiceGroup(
+        1,
+        'sg-name',
+        'sg-alias',
+        GeoCoords::fromString('-2,100'),
+        'sg-comment',
+        true,
+    );
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOne')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and(value: $this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceGroupException::errorWhileRetrieving()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceGroupException::accessNotAllowed()->getMessage());
+});
+
+it('should present a GetServiceGroupResponse with non-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOneByAccessGroups')
+        ->willReturn($this->serviceGroup);
+
+    ($this->useCase)($this->presenter, $this->serviceGroup->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceGroupResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceGroup->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceGroup->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceGroup->isActivated())
+        ->and($dto->geoCoords)
+        ->toBe((string) $this->serviceGroup->getGeoCoords())
+        ->and($dto->comment)
+        ->toBe($this->serviceGroup->getComment());
+});
+
+it('should present a GetServiceGroupResponse with admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOne')
+        ->willReturn($this->serviceGroup);
+
+    ($this->useCase)($this->presenter, $this->serviceGroup->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceGroupResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceGroup->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceGroup->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceGroup->isActivated())
+        ->and($dto->geoCoords)
+        ->toBe((string) $this->serviceGroup->getGeoCoords())
+        ->and($dto->comment)
+        ->toBe($this->serviceGroup->getComment());
+});

--- a/centreon/tests/php/Core/ServiceGroup/Application/UpdateServiceGroup/UpdateServiceGroupTest.php
+++ b/centreon/tests/php/Core/ServiceGroup/Application/UpdateServiceGroup/UpdateServiceGroupTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceGroup\Application\UseCase\UpdateServiceGroup;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Domain\Common\GeoCoords;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceGroup\Application\Exception\ServiceGroupException;
+use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Application\UseCase\UpdateServiceGroup\UpdateServiceGroup;
+use Core\ServiceGroup\Application\UseCase\UpdateServiceGroup\UpdateServiceGroupRequest;
+use Core\ServiceGroup\Domain\Model\ServiceGroup;
+
+beforeEach(function (): void {
+    $this->presenter = new DefaultPresenter(
+        $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class)
+    );
+    $this->useCase = new UpdateServiceGroup(
+        $this->writeServiceGroupRepository = $this->createMock(WriteServiceGroupRepositoryInterface::class),
+        $this->readServiceGroupRepository = $this->createMock(ReadServiceGroupRepositoryInterface::class),
+        $this->readAccessGroupRepositoryInterface = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        $this->user = $this->createMock(ContactInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class)
+    );
+
+    $this->serviceGroup = new ServiceGroup(
+        1,
+        'sg-name',
+        'sg-alias',
+        GeoCoords::fromString('-2,100'),
+        'sg-comment',
+        true
+    );
+
+    $this->request = new UpdateServiceGroupRequest();
+    $this->request->name = $this->serviceGroup->getName() . '-edited';
+    $this->request->alias = $this->serviceGroup->getAlias() . '-edited';
+    $this->request->comment = $this->serviceGroup->getComment() . '-edited';
+    $this->request->geoCoords = '-3,100';
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOne')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceGroupException::errorWhileUpdating()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceGroupException::editNotAllowed()->getMessage());
+});
+
+it('should present a ConflictResponse when name is already used', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOne')
+        ->willReturn($this->serviceGroup);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('nameAlreadyExists')
+        ->willReturn(true);
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ConflictResponse::class)
+        ->and($this->presenter->getResponseStatus()?->getMessage())
+        ->toBe(ServiceGroupException::nameAlreadyExists($this->request->name)->getMessage());
+});
+
+it('should return void on success when admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOne')
+        ->willReturn($this->serviceGroup);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('nameAlreadyExists')
+        ->willReturn(false);
+
+    $this->writeServiceGroupRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should return void on success when no-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findOneByAccessGroups')
+        ->willReturn($this->serviceGroup);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('nameAlreadyExists')
+        ->willReturn(false);
+
+    $this->writeServiceGroupRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceGroup->getId());
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});


### PR DESCRIPTION
## Description

Backport of #9783

[MON-196275](https://centreon.atlassian.net/browse/MON-196275)

[MON-196275]: https://centreon.atlassian.net/browse/MON-196275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Introduced GET service group endpoint and response presenter.
* Introduced PUT update service group endpoint with request schema.

**⚡ Enhancements**
* Added update method to write repository and updated interface.
* Extended service group exceptions with update and retrieval errors.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91127020?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->