### PR TITLE
fix(contact): fix SQL syntax error when unblocking contacts

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -355,11 +355,12 @@ function unblockContactInDB(int|array|null $contact = null): void
 
     try {
         // Build IN() clause safely
-        [$inClause, $queryParameters] = createMultipleBindParameters(
+        ['placeholderList' => $inClause, 'parameters' => $parameters] = createMultipleBindParameters(
             $contactIds,
             'contact_id_',
             QueryParameterTypeEnum::INTEGER,
         );
+        $queryParameters = QueryParameters::create($parameters);
 
         // Retrieve contacts for logging
         $selectQuery = <<<SQL


### PR DESCRIPTION
## Description

Wrong array destructuring of createMultipleBindParameters() return value caused an empty IN() clause. Also wrap parameters in QueryParameters collection as required by fetchAllAssociative/update.

**Fixes** # MON-196359

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed array destructuring bug causing empty IN() clause when unblocking contacts
* Wrapped SQL parameters in QueryParameters collection for DB calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91492741?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->