### PR TITLE
fix(broker): fix vault-related errors on broker output creation and edition

### DIFF
--- a/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
@@ -176,6 +176,9 @@ final class AddBrokerInputOutput
         $updatedParameters = $inputOutput->getParameters();
 
         foreach ($updatedParameters as $paramName => $paramValue) {
+            if (! array_key_exists($paramName, $inputOutputFields)) {
+                continue;
+            }
             if (is_array($inputOutputFields[$paramName])) {
                 if (! is_array($paramValue)) {
                     // for phpstan, should not happen.

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -1913,7 +1913,8 @@ class CentreonConfigCentreonBroker
             foreach ($output as &$value) {
                 if (is_string($value) && $this->isAVaultPath($value)) {
                     $vaultValue = $readVaultRepository->findFromPath($value);
-                    $parameterKey = end(explode('::', $value));
+                    $vaultParts = explode('::', $value);
+                    $parameterKey = end($vaultParts);
                     $value = $vaultValue[$parameterKey] ?? $value;
                 }
             }


### PR DESCRIPTION
## Description

Two bugs affecting broker output management when Vault is enabled:

1. Creating a `unified_sql` broker output failed with an `Undefined array key "filters_category"` error because `filters_category` is not defined in `cb_field` but is present in the request payload. Added an `array_key_exists` guard in `AddBrokerInputOutput::saveInVault()` to skip parameters that have no field definition.

2. Editing a broker configuration with already vaulted outputs failed with a `Only variables should be passed by reference` notice. Fixed by assigning the `explode()` result to an intermediate variable before passing it to `end()` in `CentreonConfigCentreonBroker::retrievePasswordsFromVault()`.

**Fixes** MON-196366

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Enable the `vault_broker` feature flag
2. Configure a working Vault connection
3. Go to **Configuration > Pollers > Broker configuration**, edit a broker config
4. Add a new output of type `unified_sql`, fill in all fields including `db_password`, save → should succeed and store `db_password` in Vault
5. Re-edit the same broker configuration → should open without error and correctly retrieve the vaulted password

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Skipped undefined parameters when saving broker output fields to Vault
* Assigned explode() result to variable to avoid pass-by-reference notice


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91494820?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->