### PR TITLE
fix(servicegroup): restore ACL groups block visibility when editing a service group in cloud mode

### DIFF
--- a/centreon/www/api/class/centreon_administration_aclgroup.class.php
+++ b/centreon/www/api/class/centreon_administration_aclgroup.class.php
@@ -172,6 +172,92 @@ class CentreonAdministrationAclgroup extends CentreonConfigurationObjects
         ];
     }
 
+    public function getSelectedValues(): array
+    {
+        global $centreon;
+
+        /**
+         * Determine if the connected user is an admin (or not). User is admin if
+         *  - he is configured as being an admin (onPrem) - is_admin = true
+         *  - he belongs to the customer_admin_acl acl_group (cloud).
+         */
+        $serviceGroupId = isset($this->arguments['serviceGroupId'])
+            ? filter_var($this->arguments['serviceGroupId'], FILTER_VALIDATE_INT)
+            : null;
+
+        if (! is_int($serviceGroupId)) {
+            return [];
+        }
+        $isUserAdmin = $this->isUserAdmin();
+        $filterAclGroup = null;
+
+        $aclBindings = [];
+        if (! $isUserAdmin) {
+            $acl = new CentreonACL($centreon->user->user_id, false);
+            $accessGroups = $acl->getAccessGroups();
+            if ($accessGroups === []) {
+                // Not admin user with no access group defined
+                return [];
+            }
+
+            foreach (array_keys($accessGroups) as $index => $groupId) {
+                $key = ':aclGroup' . $index;
+                $aclBindings[$key] = (int) $groupId;
+            }
+            $filterAclGroup = ' AND ag.acl_group_id IN (' . implode(',', array_keys($aclBindings)) . ') ';
+        }
+
+        $useResourceAccessManagement = filter_var(
+            $this->arguments['use_ram'] ?? false,
+            FILTER_VALIDATE_BOOL
+        );
+
+        $query = <<<'SQL'
+            SELECT ag.acl_group_id, ag.acl_group_name
+            FROM acl_groups ag
+            INNER JOIN acl_res_group_relations rgl
+                ON ag.acl_group_id = rgl.acl_group_id
+            INNER JOIN acl_resources ar
+                ON ar.acl_res_id = rgl.acl_res_id
+            INNER JOIN acl_resources_sg_relations rsr
+                ON ar.acl_res_id = rsr.acl_res_id
+            SQL;
+
+        $whereCondition = '';
+
+        // In cloud environment we only want to return ACL defines through Resource Access Management page
+        if ($useResourceAccessManagement === true) {
+            $whereCondition = ' WHERE ag.cloud_specific = 1';
+        }
+
+        $whereCondition .= empty($whereCondition) ? ' WHERE ' : ' AND ';
+        $whereCondition .= ' rsr.sg_id = :serviceGroupId';
+
+        if (! $isUserAdmin) {
+            $whereCondition .= $filterAclGroup;
+        }
+
+        $query .= $whereCondition;
+        $query .= ' GROUP BY ag.acl_group_id ORDER BY ag.acl_group_name';
+
+        $statement = $this->pearDB->prepare($query);
+        $statement->bindValue(':serviceGroupId', $serviceGroupId, PDO::PARAM_INT);
+        foreach ($aclBindings as $placeholder => $value) {
+            $statement->bindValue($placeholder, $value, PDO::PARAM_INT);
+        }
+        $statement->execute();
+
+        $aclGroupList = [];
+        while ($data = $statement->fetch()) {
+            $aclGroupList[] = [
+                'id' => $data['acl_group_id'],
+                'text' => $data['acl_group_name'],
+            ];
+        }
+
+        return $aclGroupList;
+    }
+
     /**
      * @return bool
      */

--- a/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -281,6 +281,11 @@ function updateServiceGroupAcl(int $serviceGroupId, array $submittedValues = [])
 
     $ruleIds = $submittedValues['resource_access_rules'];
 
+    /**
+     * Before linking a service group to ACL resources, we must remove all previous relationships.
+     * @see linkServiceGroupToDataset
+     */
+    deleteServiceGroupToDataset($serviceGroupId);
     foreach ($ruleIds as $ruleId) {
         $datasets = findDatasetsByRuleId($ruleId);
 
@@ -320,11 +325,19 @@ function updateServiceGroupAcl(int $serviceGroupId, array $submittedValues = [])
             try {
                 linkServiceGroupToDataset(datasetId: $serviceGroupDatasetFilters[0]['dataset_id'], serviceGroupId: $serviceGroupId);
                 // Expend the existing hostgroup dataset_filter
-                $expendedResourceIds = $serviceGroupDatasetFilters[0]['dataset_filter_resources'] . ', ' . $serviceGroupId;
+                $existingResourceIds = explode(',', $serviceGroupDatasetFilters[0]['dataset_filter_resources']);
+                /**
+                 * Removes duplicates that the code may have introduced before correction.
+                 * This way, the dataset_filters.resource_ids column no longer has duplicates.
+                 */
+                $existingResourceIds = array_unique($existingResourceIds);
+                if (! in_array($serviceGroupId, $existingResourceIds)) {
+                    $existingResourceIds[] = $serviceGroupId;
+                }
 
                 updateDatasetFiltersResourceIds(
                     datasetFilterId: $serviceGroupDatasetFilters[0]['dataset_filter_id'],
-                    resourceIds: $expendedResourceIds
+                    resourceIds: implode(',', $existingResourceIds)
                 );
                 $pearDB->commit();
             } catch (Throwable $exception) {
@@ -351,6 +364,20 @@ function updateDatasetFiltersResourceIds(int $datasetFilterId, string $resourceI
     $statement = $pearDB->prepare($request);
     $statement->bindValue(':datasetFilterId', $datasetFilterId, PDO::PARAM_INT);
     $statement->bindValue(':resourceIds', $resourceIds, PDO::PARAM_STR);
+    $statement->execute();
+}
+
+/**
+ * @param int $serviceGroupId
+ *
+ * @return void
+ */
+function deleteServiceGroupToDataset(int $serviceGroupId): void
+{
+    global $pearDB;
+    $request = 'DELETE FROM acl_resources_sg_relations WHERE sg_id = :serviceGroupId';
+    $statement = $pearDB->prepare($request);
+    $statement->bindValue(':serviceGroupId', $serviceGroupId, PDO::PARAM_INT);
     $statement->execute();
 }
 

--- a/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -285,7 +285,7 @@ function updateServiceGroupAcl(int $serviceGroupId, array $submittedValues = [])
      * Before linking a service group to ACL resources, we must remove all previous relationships.
      * @see linkServiceGroupToDataset
      */
-    deleteServiceGroupToDataset($serviceGroupId);
+    deleteServiceGroupFromDataset($serviceGroupId);
     foreach ($ruleIds as $ruleId) {
         $datasets = findDatasetsByRuleId($ruleId);
 
@@ -372,7 +372,7 @@ function updateDatasetFiltersResourceIds(int $datasetFilterId, string $resourceI
  *
  * @return void
  */
-function deleteServiceGroupToDataset(int $serviceGroupId): void
+function deleteServiceGroupFromDataset(int $serviceGroupId): void
 {
     global $pearDB;
     $request = 'DELETE FROM acl_resources_sg_relations WHERE sg_id = :serviceGroupId';

--- a/centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
@@ -56,14 +56,14 @@ $attrsTextarea = ['rows' => '5', 'cols' => '40'];
 $eTemplate = '<table><tr><td><div class="ams">{label_2}</div>{unselected}</td><td align="center">{add}<br />'
     . '<br /><br />{remove}</td><td><div class="ams">{label_3}</div>{selected}</td></tr></table>';
 
-$route = './include/common/webServices/rest/internal.php?object=centreon_configuration_service&action=list';
+$route = BASE_ROUTE . '?object=centreon_configuration_service&action=list';
 $attrServices = [
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $route,
     'multiple' => true,
     'linkedObject' => 'centreonService',
 ];
-$route = './include/common/webServices/rest/internal.php?object=centreon_configuration_servicetemplate&action=list&l=1';
+$route = BASE_ROUTE . '?object=centreon_configuration_servicetemplate&action=list&l=1';
 $attrServicetemplates = [
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $route,
@@ -71,7 +71,7 @@ $attrServicetemplates = [
     'linkedObject' => 'centreonServicetemplates',
     'defaultDatasetOptions' => ['withHosttemplate' => true],
 ];
-$route = './include/common/webServices/rest/internal.php?object=centreon_configuration_service&action=list&t=hostgroup';
+$route = BASE_ROUTE . '?object=centreon_configuration_service&action=list&t=hostgroup';
 $attrHostgroups = [
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $route,
@@ -105,24 +105,21 @@ $form->applyFilter('geo_coords', 'truncateGeoCoords');
 
 $form->addElement('header', 'relation', _('Relations'));
 
-$route = './include/common/webServices/rest/internal.php?object=centreon_configuration_service'
-    . '&action=defaultValues&target=servicegroups&field=sg_hServices&id=' . $serviceGroupId;
+$route = BASE_ROUTE . '?object=centreon_configuration_service&action=defaultValues&target=servicegroups&field=sg_hServices&id=' . $serviceGroupId;
 $attrService1 = array_merge(
     $attrServices,
     ['defaultDatasetRoute' => $route]
 );
 $form->addElement('select2', 'sg_hServices', _('Linked Host Services'), [], $attrService1);
 
-$route = './include/common/webServices/rest/internal.php?object=centreon_configuration_service'
-    . '&action=defaultValues&target=servicegroups&field=sg_hgServices&id=' . $serviceGroupId;
+$route = BASE_ROUTE . '?object=centreon_configuration_service&action=defaultValues&target=servicegroups&field=sg_hgServices&id=' . $serviceGroupId;
 $attrHostgroup1 = array_merge(
     $attrHostgroups,
     ['defaultDatasetRoute' => $route]
 );
 $form->addElement('select2', 'sg_hgServices', _('Linked Host Group Services'), [], $attrHostgroup1);
 
-$route = './include/common/webServices/rest/internal.php?object=centreon_configuration_servicetemplate'
-    . '&action=defaultValues&target=servicegroups&field=sg_tServices&id=' . $serviceGroupId;
+$route = BASE_ROUTE . '?object=centreon_configuration_servicetemplate&action=defaultValues&target=servicegroups&field=sg_tServices&id=' . $serviceGroupId;
 $attrServicetemplate1 = array_merge(
     $attrServicetemplates,
     ['defaultDatasetRoute' => $route]
@@ -139,7 +136,7 @@ $form->setDefaults(['sg_activate' => '1']);
 $form->addElement('textarea', 'sg_comment', _('Comments'), $attrsTextarea);
 
 if (
-    $o === SERVICE_GROUP_ADD
+    in_array($o, [SERVICE_GROUP_ADD, SERVICE_GROUP_MODIFY])
     && $isCloudPlatform === true
 ) {
     $form->addElement(
@@ -150,7 +147,7 @@ if (
         [
             'datasourceOrigin' => 'ajax',
             'availableDatasetRoute' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list&use_ram=true',
-            'defaultDataset' => [],
+            'defaultDatasetRoute' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=selectedValues&use_ram=true&serviceGroupId=' . $serviceGroupId,
             'multiple' => true,
         ]
     );


### PR DESCRIPTION
## Description

Following the fix for [MON-189711,](https://github.com/centreon/centreon/pull/9858) a new regression appeared when editing a service group in a cloud environment: the block allowing the service group to be associated with a resource access rule (which is mandatory) was not displayed.

Solutions

 - Pre-fill ACL groups select in edit mode (cloud): The ACL groups selector is now correctly pre-filled with existing values when opening the service group edit form in cloud mode.
 - Prevent duplicate ACL resource relations: When updating, relations between the service group and resource access rules are no longer duplicated.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added getSelectedValues API endpoint returning ACL groups linked to service group

**🐛 Bugfixes**
* Prevented duplicate ACL resource relations when updating service group records
* Restored ACL groups selector visibility by pre-filling values in cloud

**🔧 Refactors**
* Replaced hardcoded REST paths with BASE_ROUTE and used defaultDatasetRoute


<sup>[More info](https://app.aikido.dev/featurebranch/scan/95903745?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->