### PR TITLE
fix(host): correctly check groups and categories relations for user under ACLs

### DIFF
--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -434,17 +434,27 @@ final class PartialUpdateHost
         }
 
         $categoryIds = array_unique($dto->categories);
-        $this->validation->assertAreValidCategories($categoryIds);
 
         if ($this->user->isAdmin()) {
+            $accessibleCategoryIds = $this->readHostCategoryRepository->exist($categoryIds);
             $originalCategories = $this->readHostCategoryRepository->findByHost($host->getId());
         } else {
+            // For non-admin users, filter submitted IDs to only those the user can access.
+            // Categories outside the user's ACL scope are silently preserved (not touched by the diff).
+            $accessibleCategoryIds = $this->readHostCategoryRepository->existByAccessGroups($categoryIds, $this->accessGroups);
             $originalCategories = $this->readHostCategoryRepository->findByHostAndAccessGroups(
                 $host->getId(),
                 $this->accessGroups
             );
         }
-
+        $droppedIds = array_diff($categoryIds, $accessibleCategoryIds);
+        if ($droppedIds !== []) {
+            $this->warning(
+                'PartialUpdateHost: submitted category IDs not found, they will be ignored',
+                ['dropped_category_ids' => $droppedIds, 'host_id' => $host->getId()]
+            );
+        }
+        $categoryIds = array_values(array_intersect($categoryIds, $accessibleCategoryIds));
         $originalCategoryIds = array_map(
             static fn (HostCategory $category): int => $category->getId(),
             $originalCategories
@@ -479,17 +489,27 @@ final class PartialUpdateHost
         }
 
         $groupIds = array_unique($dto->groups);
-        $this->validation->assertAreValidGroups($groupIds);
-
         if ($this->user->isAdmin()) {
+            $accessibleGroupIds = $this->readHostGroupRepository->exist($groupIds);
             $originalGroups = $this->readHostGroupRepository->findByHost($host->getId());
         } else {
+            // For non-admin users, filter submitted IDs to only those the user can access.
+            // Groups outside the user's ACL scope are silently preserved (not touched by the diff).
+            $accessibleGroupIds = $this->readHostGroupRepository->existByAccessGroups($groupIds, $this->accessGroups);
             $originalGroups = $this->readHostGroupRepository->findByHostAndAccessGroups(
                 $host->getId(),
                 $this->accessGroups
             );
         }
 
+        $droppedIds = array_diff($groupIds, $accessibleGroupIds);
+        if ($droppedIds !== []) {
+            $this->warning(
+                'PartialUpdateHost: submitted group IDs not found, they will be ignored',
+                ['dropped_group_ids' => $droppedIds, 'host_id' => $host->getId()]
+            );
+        }
+        $groupIds = array_values(array_intersect($groupIds, $accessibleGroupIds));
         $originalGroupIds = array_map(
             static fn (HostGroup $group): int => $group->getId(),
             $originalGroups

--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidation.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidation.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace Core\Host\Application\UseCase\PartialUpdateHost;
 
 use Centreon\Domain\Common\Assertion\Assertion;
-use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Command\Domain\Model\CommandType;
@@ -32,8 +31,6 @@ use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Domain\Model\Host;
-use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
-use Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface;
 use Core\HostSeverity\Application\Repository\ReadHostSeverityRepositoryInterface;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
@@ -56,10 +53,7 @@ class PartialUpdateHostValidation
      * @param ReadHostSeverityRepositoryInterface $readHostSeverityRepository
      * @param ReadTimezoneRepositoryInterface $readTimezoneRepository
      * @param ReadCommandRepositoryInterface $readCommandRepository
-     * @param ReadHostCategoryRepositoryInterface $readHostCategoryRepository
-     * @param ReadHostGroupRepositoryInterface $readHostGroupRepository
      * @param InheritanceManager $inheritanceManager
-     * @param ContactInterface $user
      * @param AccessGroup[] $accessGroups
      */
     public function __construct(
@@ -71,10 +65,7 @@ class PartialUpdateHostValidation
         private readonly ReadHostSeverityRepositoryInterface $readHostSeverityRepository,
         private readonly ReadTimezoneRepositoryInterface $readTimezoneRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
-        private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
-        private readonly ReadHostGroupRepositoryInterface $readHostGroupRepository,
         private readonly InheritanceManager $inheritanceManager,
-        private readonly ContactInterface $user,
         public array $accessGroups = [],
     ) {
     }
@@ -235,48 +226,6 @@ class PartialUpdateHostValidation
             $this->error('Command does not exist', ['command_id' => $commandId, 'command_type' => $commandType]);
 
             throw HostException::idDoesNotExist($propertyName ?? 'commandId', $commandId);
-        }
-    }
-
-    /**
-     * Assert category IDs are valid.
-     *
-     * @param int[] $categoryIds
-     *
-     * @throws HostException
-     * @throws \Throwable
-     */
-    public function assertAreValidCategories(array $categoryIds): void
-    {
-        if ($this->user->isAdmin()) {
-            $validCategoryIds = $this->readHostCategoryRepository->exist($categoryIds);
-        } else {
-            $validCategoryIds = $this->readHostCategoryRepository->existByAccessGroups($categoryIds, $this->accessGroups);
-        }
-
-        if ([] !== ($invalidIds = array_diff($categoryIds, $validCategoryIds))) {
-            throw HostException::idsDoNotExist('categories', $invalidIds);
-        }
-    }
-
-    /**
-     * Assert group IDs are valid.
-     *
-     * @param int[] $groupIds
-     *
-     * @throws HostException
-     * @throws \Throwable
-     */
-    public function assertAreValidGroups(array $groupIds): void
-    {
-        if ($this->user->isAdmin()) {
-            $validGroupIds = $this->readHostGroupRepository->exist($groupIds);
-        } else {
-            $validGroupIds = $this->readHostGroupRepository->existByAccessGroups($groupIds, $this->accessGroups);
-        }
-
-        if ([] !== ($invalidIds = array_diff($groupIds, $validGroupIds))) {
-            throw HostException::idsDoNotExist('groups', $invalidIds);
         }
     }
 

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
@@ -509,93 +509,6 @@ it('should present a ConflictResponse when the host icon ID is not valid', funct
         );
 });
 
-// Tests for categories
-
-it('should present a ConflictResponse when a host category does not exist', function (): void {
-    $this->user
-        ->expects($this->once())
-        ->method('hasTopologyRole')
-        ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(2))
-        ->method('isAdmin')
-        ->willReturn(true);
-    $this->readHostRepository
-        ->expects($this->once())
-        ->method('findById')
-        ->willReturn($this->originalHost);
-
-    // Host
-    $this->optionService
-        ->expects($this->once())
-        ->method('findSelectedOptions')
-        ->willReturn([$this->inheritanceModeOption]);
-    $this->writeHostRepository
-        ->expects($this->once())
-        ->method('update');
-
-    // Categories
-    $this->validation
-        ->expects($this->once())
-        ->method('assertAreValidCategories')
-        ->willThrowException(HostException::idsDoNotExist('categories', $this->request->categories));
-
-    ($this->useCase)($this->request, $this->presenter, $this->hostId);
-
-    expect($this->presenter->response)
-        ->toBeInstanceOf(ConflictResponse::class)
-        ->and($this->presenter->response->getMessage())
-        ->toBe(HostException::idsDoNotExist('categories', $this->request->categories)->getMessage());
-});
-
-// Tests for groups
-
-it('should present a ConflictResponse when a host group does not exist', function (): void {
-    $this->user
-        ->expects($this->once())
-        ->method('hasTopologyRole')
-        ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(3))
-        ->method('isAdmin')
-        ->willReturn(true);
-    $this->readHostRepository
-        ->expects($this->once())
-        ->method('findById')
-        ->willReturn($this->originalHost);
-
-    // Host
-    $this->optionService
-        ->expects($this->once())
-        ->method('findSelectedOptions')
-        ->willReturn([$this->inheritanceModeOption]);
-    $this->writeHostRepository
-        ->expects($this->once())
-        ->method('update');
-
-    // Categories
-    $this->readHostCategoryRepository
-        ->expects($this->once())
-        ->method('findByHost')
-        ->willReturn([]);
-    $this->writeHostCategoryRepository
-        ->expects($this->once())
-        ->method('linkToHost');
-
-    // Groups
-    $this->validation
-        ->expects($this->once())
-        ->method('assertAreValidGroups')
-        ->willThrowException(HostException::idsDoNotExist('groups', $this->request->groups));
-
-    ($this->useCase)($this->request, $this->presenter, $this->hostId);
-
-    expect($this->presenter->response)
-        ->toBeInstanceOf(ConflictResponse::class)
-        ->and($this->presenter->response->getMessage())
-        ->toBe(HostException::idsDoNotExist('groups', $this->request->groups)->getMessage());
-});
-
 // Tests for parents templates
 
 it('should present a ConflictResponse when a parent template ID is not valid', function (): void {
@@ -749,9 +662,6 @@ it('should present a NoContentResponse on success', function (): void {
         ->method('update');
 
     // Categories
-    $this->validation
-        ->expects($this->once())
-        ->method('assertAreValidCategories');
     $this->readHostCategoryRepository
         ->expects($this->once())
         ->method('findByHost')
@@ -764,9 +674,6 @@ it('should present a NoContentResponse on success', function (): void {
         ->method('unlinkFromHost');
 
     // Groups
-    $this->validation
-        ->expects($this->once())
-        ->method('assertAreValidGroups');
     $this->readHostGroupRepository
         ->expects($this->once())
         ->method('findByHost')

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidationTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidationTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Tests\Core\Host\Application\UseCase\PartialUpdateHost;
 
-use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Command\Domain\Model\CommandType;
 use Core\Host\Application\Exception\HostException;
@@ -31,8 +30,6 @@ use Core\Host\Application\InheritanceManager;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\UseCase\PartialUpdateHost\PartialUpdateHostValidation;
 use Core\Host\Domain\Model\Host;
-use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
-use Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface;
 use Core\HostSeverity\Application\Repository\ReadHostSeverityRepositoryInterface;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
@@ -50,10 +47,7 @@ beforeEach(function (): void {
         readHostSeverityRepository: $this->readHostSeverityRepository = $this->createMock(ReadHostSeverityRepositoryInterface::class),
         readTimezoneRepository: $this->readTimezoneRepository = $this->createMock(ReadTimezoneRepositoryInterface::class),
         readCommandRepository: $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
-        readHostCategoryRepository: $this->readHostCategoryRepository = $this->createMock(ReadHostCategoryRepositoryInterface::class),
-        readHostGroupRepository: $this->readHostGroupRepository = $this->createMock(ReadHostGroupRepositoryInterface::class),
         inheritanceManager: $this->inheritanceManager = $this->createMock(InheritanceManager::class),
-        user: $this->user = $this->createMock(ContactInterface::class),
         accessGroups: $this->accessGroup = []
     );
 });
@@ -194,70 +188,6 @@ it('throws an exception when command ID does not exist for a specific type', fun
 })->throws(
     HostException::class,
     HostException::idDoesNotExist('commandId', 1)->getMessage()
-);
-
-it('throws an exception when category ID does not exist with admin user', function (): void {
-    $this->user
-        ->expects($this->once())
-        ->method('isAdmin')
-        ->willReturn(true);
-    $this->readHostCategoryRepository
-        ->expects($this->once())
-        ->method('exist')
-        ->willReturn([]);
-
-    $this->validation->assertAreValidCategories([1, 3]);
-})->throws(
-    HostException::class,
-    HostException::idsDoNotExist('categories', [1, 3])->getMessage()
-);
-
-it('throws an exception when category ID does not exist with non-admin user', function (): void {
-    $this->user
-        ->expects($this->once())
-        ->method('isAdmin')
-        ->willReturn(false);
-    $this->readHostCategoryRepository
-        ->expects($this->once())
-        ->method('existByAccessGroups')
-        ->willReturn([]);
-
-    $this->validation->assertAreValidCategories([1, 3]);
-})->throws(
-    HostException::class,
-    HostException::idsDoNotExist('categories', [1, 3])->getMessage()
-);
-
-it('throws an exception when group ID does not exist with admin user', function (): void {
-    $this->user
-        ->expects($this->once())
-        ->method('isAdmin')
-        ->willReturn(true);
-    $this->readHostGroupRepository
-        ->expects($this->once())
-        ->method('exist')
-        ->willReturn([]);
-
-    $this->validation->assertAreValidGroups([1, 3]);
-})->throws(
-    HostException::class,
-    HostException::idsDoNotExist('groups', [1, 3])->getMessage()
-);
-
-it('throws an exception when group ID does not exist with non-admin user', function (): void {
-    $this->user
-        ->expects($this->once())
-        ->method('isAdmin')
-        ->willReturn(false);
-    $this->readHostGroupRepository
-        ->expects($this->once())
-        ->method('existByAccessGroups')
-        ->willReturn([]);
-
-    $this->validation->assertAreValidGroups([1, 3]);
-})->throws(
-    HostException::class,
-    HostException::idsDoNotExist('groups', [1, 3])->getMessage()
 );
 
 it('throws an exception when parent template ID does not exist', function (): void {


### PR DESCRIPTION
## Description

Backport of #9760

**Fixes** MON-196404

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

- Create a non-admin user with ACL Resources that restrict access to only some host groups (e.g. allow Group1, deny Group2)
- Create a host linked to both Group1 and Group2
- Log in as the non-admin user and edit that host (rename it)
- Verify the save succeeds without any error message

## Checklist

- [ ] I have followed the coding style guidelines provided by Centreon
- [ ] I have commented my code, especially new classes, functions or any legacy code modified.
- [ ] I have commented my code, especially hard-to-understand areas of the PR.
- [ ] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed ACL checks to consider user's access groups when validating relations

**🔧 Refactors**
* Removed unused constructor parameters and exposed accessGroups in validation class


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91794244?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->