### PR TITLE
fix(exporter): remove ALTER TABLE causing implicit transaction commit

### DIFF
--- a/centreon/phpstan.legacy.src.baseline.neon
+++ b/centreon/phpstan.legacy.src.baseline.neon
@@ -311,11 +311,6 @@ parameters:
 			path: src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
 
 		-
-			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) di must contain 3 or more characters\.$#'
-			count: 5
-			path: src/CentreonRemote/Application/Clapi/CentreonWorker.php
-
-		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) ip must contain 3 or more characters\.$#'
 			count: 4
 			path: src/CentreonRemote/Application/Webservice/CentreonRemoteServer.php

--- a/centreon/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/centreon/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -35,11 +35,11 @@ use Pimple\Container;
 class CentreonWorker implements CentreonClapiServiceInterface
 {
     /** @var Container */
-    private $di;
+    private $container;
 
-    public function __construct(Container $di)
+    public function __construct(Container $container)
     {
-        $this->di = $di;
+        $this->container = $container;
     }
 
     /**
@@ -117,7 +117,7 @@ class CentreonWorker implements CentreonClapiServiceInterface
 
     public function getDi(): Container
     {
-        return $this->di;
+        return $this->container;
     }
 
     /**

--- a/centreon/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
+++ b/centreon/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
@@ -83,15 +83,27 @@ class ConfigurationExporter extends ExporterServiceAbstract
             }
         }
 
-        // start transaction
+        $import = $manifest->get('import');
+
+        // Phase 1: clear tables and reset auto_increment outside transaction.
+        // ALTER TABLE (DDL) causes an implicit commit in MySQL/MariaDB, so it must
+        // run before beginTransaction() to avoid breaking the import transaction.
+        $truncated = [];
+        foreach ($import['data'] as $data) {
+            if (! isset($truncated[$data['table']]) && isset($tables[$data['table']])) {
+                $db->query('DELETE FROM `' . $data['table'] . '`');
+                $db->query('ALTER TABLE `' . $data['table'] . '` AUTO_INCREMENT = 1');
+                $truncated[$data['table']] = 1;
+            }
+        }
+
+        // Phase 2: import data inside a transaction.
         $db->beginTransaction();
 
         try {
-            $truncated = [];
             // allow insert records without foreign key checks
             $db->query('SET FOREIGN_KEY_CHECKS=0;');
 
-            $import = $manifest->get('import');
             foreach ($import['data'] as $data) {
                 $exportPathFile = $this->getFile($data['filename']);
                 $size = filesize($exportPathFile);
@@ -100,13 +112,6 @@ class ConfigurationExporter extends ExporterServiceAbstract
                 if ($size > 0 && ! isset($tables[$data['table']])) {
                     echo date('Y-m-d H:i:s') . " - ERROR - cannot import table '" . $data['table'] . "': not exist.\n";
                     continue;
-                }
-
-                if (! isset($truncated[$data['table']]) && isset($tables[$data['table']])) {
-                    // empty table
-                    $db->query('DELETE FROM `' . $data['table'] . '`');
-                    $db->query('ALTER TABLE `' . $data['table'] . '` AUTO_INCREMENT = 1');
-                    $truncated[$data['table']] = 1;
                 }
 
                 // insert data


### PR DESCRIPTION
## Description

Backport of #9839

**Fixes** MON-196403

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

- Install a central server and a remote server
- Add resources linked to the remote server and export the configuration
- Check that tasks in `SELECT * FROM centreon.task` show `completed` status instead of `failed`

## Checklist

- [ ] I have followed the coding style guidelines provided by Centreon
- [ ] I have commented my code, especially new classes, functions or any legacy code modified.
- [ ] I have commented my code, especially hard-to-understand areas of the PR.
- [ ] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Moved DELETE/ALTER TABLE operations before transaction to prevent implicit commits

**🔧 Refactors**
* Renamed internal dependency-injection property and adjusted constructor/getter accordingly


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91794258?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->