### PR TITLE
refactor(EventSubscriber): migrate event subscribers to AsEventListener attribute

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Event/DashboardUpdatedSubscriber.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Event/DashboardUpdatedSubscriber.php
@@ -31,9 +31,9 @@ use Core\Dashboard\Application\UseCase\AddDashboardThumbnail\AddDashboardThumbna
 use Core\Media\Application\UseCase\UpdateMedia\UpdateMedia;
 use Core\Media\Application\UseCase\UpdateMedia\UpdateMediaPresenterInterface;
 use Core\Media\Application\UseCase\UpdateMedia\UpdateMediaRequest;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-final readonly class DashboardUpdatedSubscriber implements EventSubscriberInterface
+final readonly class DashboardUpdatedSubscriber
 {
     /**
      * @param UpdateMedia $thumbnailUpdater
@@ -50,18 +50,11 @@ final readonly class DashboardUpdatedSubscriber implements EventSubscriberInterf
     }
 
     /**
-     * @inheritDoc
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [DashboardUpdatedEvent::class => 'createOrUpdateDashboardThumbnail'];
-    }
-
-    /**
      * @param DashboardUpdatedEvent $event
      *
      * @throws \Exception
      */
+    #[AsEventListener]
     public function createOrUpdateDashboardThumbnail(DashboardUpdatedEvent $event): void
     {
         if ($event->getThumbnailId() === null) {

--- a/centreon/src/EventSubscriber/FeatureFlagEventSubscriber.php
+++ b/centreon/src/EventSubscriber/FeatureFlagEventSubscriber.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace EventSubscriber;
 
 use Core\Common\Infrastructure\FeatureFlags;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -33,7 +33,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @see FeatureFlags
  */
-class FeatureFlagEventSubscriber implements EventSubscriberInterface
+class FeatureFlagEventSubscriber
 {
     /**
      * @param FeatureFlags $featureFlags
@@ -44,24 +44,11 @@ class FeatureFlagEventSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Returns an array of event names this subscriber wants to listen to.
-     *
-     * @return mixed[] The event names to listen to
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            KernelEvents::REQUEST => [
-                ['defineFeaturesInAttributes', 40],
-            ],
-        ];
-    }
-
-    /**
      * We inject in the request a TRUE attribute for each enabled feature of the feature flags system.
      *
      * @param RequestEvent $event
      */
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 40)]
     public function defineFeaturesInAttributes(RequestEvent $event): void
     {
         foreach ($this->featureFlags->getEnabled() as $name) {

--- a/centreon/src/EventSubscriber/UpdateEventSubscriber.php
+++ b/centreon/src/EventSubscriber/UpdateEventSubscriber.php
@@ -19,16 +19,18 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace EventSubscriber;
 
 use Centreon\Domain\Log\LoggerTrait;
 use Core\Platform\Application\Repository\ReadVersionRepositoryInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class UpdateEventSubscriber implements EventSubscriberInterface
+class UpdateEventSubscriber
 {
     use LoggerTrait;
     private const MINIMAL_INSTALLED_VERSION = '22.04.0';
@@ -42,30 +44,19 @@ class UpdateEventSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @inheritDoc
-     */
-    public static function getSubscribedEvents(): array
-    {
-        if (! file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')) {
-            return [];
-        }
-
-        return [
-            KernelEvents::REQUEST => [
-                ['validateCentreonWebVersionOrFail', 35],
-            ],
-        ];
-    }
-
-    /**
      * validate centreon web installed version when update endpoint is called.
      *
      * @param RequestEvent $event
      *
      * @throws \Exception
      */
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 35)]
     public function validateCentreonWebVersionOrFail(RequestEvent $event): void
     {
+        if (! file_exists(_CENTREON_ETC_ . DIRECTORY_SEPARATOR . 'centreon.conf.php')) {
+            return;
+        }
+
         $this->debug('Checking if route matches updates endpoint');
         if (
             $event->getRequest()->getMethod() === Request::METHOD_PATCH


### PR DESCRIPTION
## Description

Migrate 3 event subscriber classes from the legacy `EventSubscriberInterface` + `getSubscribedEvents()` pattern to the modern `#[AsEventListener]` attribute approach, already used elsewhere in the codebase. Future-proofs the code ahead of potential `EventSubscriberInterface` removal in Symfony 8.x.

Classes migrated:
- `EventSubscriber\FeatureFlagEventSubscriber`
- `EventSubscriber\UpdateEventSubscriber` (conditional `file_exists` check moved to method body as early return)
- `Core\Dashboard\Infrastructure\Event\DashboardUpdatedSubscriber`

**Fixes** MON-195030

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Refactoring / technical improvement (non-breaking)

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Verify feature flags still propagate correctly to request attributes on API calls
2. Verify the platform update endpoint still validates the Centreon version
3. Verify dashboard thumbnail creation/update still triggers on dashboard save

## Checklist

- [ ] I have followed the coding style guidelines provided by Centreon
- [ ] I have commented my code, especially new classes, functions or any legacy code modified.
- [ ] I have commented my code, especially hard-to-understand areas of the PR.
- [ ] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Migrated three event subscriber classes to AsEventListener attribute.
* Removed EventSubscriberInterface implementations and legacy getSubscribedEvents methods throughout.
* Moved file_exists config check into handler method as early return.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92167458?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->