### PR TITLE
feat(apiv2): add Get & Update service category endpoints (#9817)

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/GetServiceCategory.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/GetServiceCategory.yaml
@@ -1,0 +1,22 @@
+get:
+  tags:
+    - Service category
+  summary: "Get a service category"
+  description: |
+    Get an existing service category.
+
+  parameters:
+    - $ref: 'QueryParameter/ServiceCategoryId.yaml'
+  responses:
+    '200':
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            $ref: 'Schema/ServiceCategoryResponse.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/QueryParameter/ServiceCategoryId.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/QueryParameter/ServiceCategoryId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: service_category_id
+required: true
+description: "Service category ID"
+schema:
+  type: integer
+  minimum: 1
+  example: 1

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+required: ["name", "alias"]
+properties:
+  name:
+    type: string
+    description: "Service category name"
+    example: "service-category"
+  alias:
+    type: string
+    description: "Service category alias"
+    example: "service-category"
+  is_activated:
+    type: boolean
+    description: "Indicates whether this service category is enabled or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryResponse.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: "Service category ID"
+    example: 1
+  name:
+    type: string
+    description: "Service category name"
+    example: "service-category"
+  alias:
+    type: string
+    description: "Service category alias"
+    example: "service-category"
+  is_activated:
+    type: boolean
+    description: "Indicates whether this service category is enabled or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/UpdateServiceCategory.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/UpdateServiceCategory.yaml
@@ -1,0 +1,27 @@
+put:
+  tags:
+    - Service category
+  summary: 'Update a service category'
+  description: |
+    Update a service category configuration
+  parameters:
+    - $ref: 'QueryParameter/ServiceCategoryId.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'Schema/ServiceCategoryRequest.yaml'
+  responses:
+    '204':
+      description: 'No Content'
+    '400':
+      $ref: '../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '409':
+      $ref: '../../Common/Response/Conflict.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+++ b/centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
@@ -25,6 +25,8 @@ namespace Core\ServiceCategory\Application\Exception;
 
 class ServiceCategoryException extends \Exception
 {
+    public const CODE_CONFLICT = 1;
+
     /**
      * @return self
      */
@@ -103,5 +105,39 @@ class ServiceCategoryException extends \Exception
     public static function errorWhileRetrievingRealTimeServiceCategories(\Throwable $exception): self
     {
         return new self(_('Error while searching service categories in real time context'), 0, $exception);
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileRetrieving(): self
+    {
+        return new self(_('Error while retrieving service category'));
+    }
+
+    /**
+     * @return self
+     */
+    public static function editNotAllowed(): self
+    {
+        return new self(_('You are not allowed to update service categories'));
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileUpdating(): self
+    {
+        return new self(_('Error while updating service category'));
+    }
+
+    /**
+     * @param string $serviceCategoryName
+     *
+     * @return self
+     */
+    public static function nameAlreadyExists(string $serviceCategoryName): self
+    {
+        return new self(sprintf(_("The service category name '%s' already exists"), $serviceCategoryName), self::CODE_CONFLICT);
     }
 }

--- a/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
+++ b/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\ServiceCategory\Application\Repository;
 
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 interface WriteServiceCategoryRepositoryInterface
 {
@@ -66,4 +67,13 @@ interface WriteServiceCategoryRepositoryInterface
      * @throws \Throwable
      */
     public function unlinkFromService(int $serviceId, array $serviceCategoriesIds): void;
+
+    /**
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceCategory $serviceCategory): void;
 }

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategory.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategory.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\GetServiceCategory;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Contact\Domain\AdminResolver;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+
+final class GetServiceCategory
+{
+    use LoggerTrait;
+
+    /** @var AccessGroup[] */
+    private array $accessGroups;
+
+    public function __construct(
+        private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    /**
+     * @param PresenterInterface $presenter
+     * @param int $serviceCategoryId
+     */
+    public function __invoke(PresenterInterface $presenter, int $serviceCategoryId): void
+    {
+        try {
+            if (
+                ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ)
+                && ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ_WRITE)
+            ) {
+                $this->error(
+                    "User doesn't have sufficient rights to see service categories",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceCategoryException::accessNotAllowed())
+                );
+
+                return;
+            }
+
+            $serviceCategory = null;
+            if ($this->adminResolver->isAdmin($this->user)) {
+                $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+
+            } else {
+                $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+                if ($this->readServiceCategoryRepository->existsByAccessGroups(
+                    $serviceCategoryId,
+                    $this->accessGroups
+                )) {
+                    $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+                }
+            }
+
+            if (! $serviceCategory) {
+                $this->error(
+                    'Service category not found',
+                    ['service_category_id' => $serviceCategoryId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('Service category'));
+
+                return;
+            }
+
+            $presenter->present($this->createResponse($serviceCategory));
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceCategoryException::errorWhileRetrieving())
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        }
+    }
+
+    /**
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws \Throwable
+     *
+     * @return GetServiceCategoryResponse
+     */
+    private function createResponse(ServiceCategory $serviceCategory): GetServiceCategoryResponse
+    {
+        $response = new GetServiceCategoryResponse();
+        $response->id = $serviceCategory->getId();
+        $response->name = $serviceCategory->getName();
+        $response->alias = $serviceCategory->getAlias();
+        $response->isActivated = $serviceCategory->isActivated();
+
+        return $response;
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryResponse.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\GetServiceCategory;
+
+final class GetServiceCategoryResponse
+{
+    public int $id = 0;
+
+    public string $name = '';
+
+    public string $alias = '';
+
+    public bool $isActivated = true;
+}

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategory.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategory.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\UpdateServiceCategory;
+
+use Assert\AssertionFailedException;
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Common\Application\Type\NoValue;
+use Core\Common\Domain\TrimmedString;
+use Core\Contact\Domain\AdminResolver;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+
+final class UpdateServiceCategory
+{
+    use LoggerTrait;
+
+    public function __construct(
+        private readonly WriteServiceCategoryRepositoryInterface $writeServiceCategoryRepository,
+        private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    /**
+     * @param UpdateServiceCategoryRequest $dto
+     * @param PresenterInterface $presenter
+     * @param int $serviceCategoryId
+     */
+    public function __invoke(
+        UpdateServiceCategoryRequest $dto,
+        PresenterInterface $presenter,
+        int $serviceCategoryId,
+    ): void {
+        try {
+            if (! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ_WRITE)) {
+                $this->error(
+                    "User doesn't have sufficient rights to edit service categories",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceCategoryException::editNotAllowed()->getMessage())
+                );
+
+                return;
+            }
+
+            $serviceCategory = null;
+
+            if ($this->adminResolver->isAdmin($this->user)) {
+                $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+            } elseif ($this->readServiceCategoryRepository->existsByAccessGroups(
+                $serviceCategoryId,
+                $this->readAccessGroupRepositoryInterface->findByContact($this->user)
+            )) {
+                $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+            }
+
+            if (! $serviceCategory) {
+                $this->error(
+                    'Service category not found',
+                    ['service_category_id' => $serviceCategoryId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('Service category'));
+
+                return;
+            }
+
+            $this->validateNameOrFail($dto->name, $serviceCategory);
+
+            $serviceCategory = new ServiceCategory(
+                $serviceCategory->getId(),
+                $dto->name,
+                $dto->alias,
+            );
+            if (! $dto->isActivated instanceof NoValue) {
+                $serviceCategory->setActivated($dto->isActivated);
+            } else {
+                $serviceCategory->setActivated($serviceCategory->isActivated());
+            }
+
+            $this->writeServiceCategoryRepository->update($serviceCategory);
+
+            $presenter->setResponseStatus(new NoContentResponse());
+        } catch (ServiceCategoryException $ex) {
+            $presenter->setResponseStatus(
+                match ($ex->getCode()) {
+                    ServiceCategoryException::CODE_CONFLICT => new ConflictResponse($ex),
+                    default => new ErrorResponse($ex),
+                }
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (AssertionFailedException $ex) {
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceCategoryException::errorWhileUpdating())
+            );
+            $this->error((string) $ex);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws ServiceCategoryException
+     */
+    private function validateNameOrFail(string $name, ServiceCategory $serviceCategory): void
+    {
+        $trimmedName = new TrimmedString($name);
+
+        if (
+            (string) $trimmedName !== $serviceCategory->getName()
+            && $this->readServiceCategoryRepository->existsByName($trimmedName)
+        ) {
+            $this->error(
+                'Service category name already exists',
+                ['service_category_name' => (string) $trimmedName]
+            );
+
+            throw ServiceCategoryException::nameAlreadyExists((string) $trimmedName);
+        }
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryRequest.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\UpdateServiceCategory;
+
+use Core\Common\Application\Type\NoValue;
+
+final class UpdateServiceCategoryRequest
+{
+    /**
+     * @param string $name
+     * @param string $alias
+     * @param bool $isActivated
+     */
+    public function __construct(
+        public string $name = '',
+        public string $alias = '',
+        public NoValue|bool $isActivated = new NoValue(),
+    ) {
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryController.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Infrastructure\API\GetServiceCategory;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategory;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class GetServiceCategoryController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param GetServiceCategory $useCase
+     * @param GetServiceCategoryPresenter $presenter
+     * @param int $serviceCategoryId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        GetServiceCategory $useCase,
+        GetServiceCategoryPresenter $presenter,
+        int $serviceCategoryId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($presenter, $serviceCategoryId);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryPresenter.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryPresenter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Infrastructure\API\GetServiceCategory;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategoryResponse;
+
+class GetServiceCategoryPresenter extends AbstractPresenter
+{
+    /**
+     * @inheritDoc
+     */
+    public function present(mixed $data): void
+    {
+        if ($data instanceof GetServiceCategoryResponse) {
+            $data = [
+                'id' => $data->id,
+                'name' => $data->name,
+                'alias' => $data->alias,
+                'is_activated' => $data->isActivated,
+            ];
+        }
+
+        parent::present($data);
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryRoute.yaml
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryRoute.yaml
@@ -1,0 +1,7 @@
+GetServiceCategory:
+  methods: GET
+  path: /configuration/services/categories/{serviceCategoryId}
+  requirements:
+    serviceCategoryId: '\d+'
+  controller: 'Core\ServiceCategory\Infrastructure\API\GetServiceCategory\GetServiceCategoryController'
+  condition: "request.attributes.get('version') >= 25.10"

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryController.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryController.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Infrastructure\API\UpdateServiceCategory;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategory;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategoryRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class UpdateServiceCategoryController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param Request $request
+     * @param UpdateServiceCategory $useCase
+     * @param DefaultPresenter $presenter
+     * @param int $serviceCategoryId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        Request $request,
+        UpdateServiceCategory $useCase,
+        DefaultPresenter $presenter,
+        int $serviceCategoryId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        try {
+            /** @var array{
+             *     name: string,
+             *     alias: string,
+             *     is_activated?: bool
+             * } $data
+             */
+            $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/UpdateServiceCategorySchema.json');
+        } catch (\InvalidArgumentException $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+
+            return $presenter->show();
+        }
+
+        $serviceCategoryRequest = $this->createRequestDto($data);
+        $useCase($serviceCategoryRequest, $presenter, $serviceCategoryId);
+
+        return $presenter->show();
+    }
+
+    /**
+     * @param array{
+     *     name: string,
+     *     alias: string,
+     *     is_activated?: bool
+     * } $data
+     *
+     * @return UpdateServiceCategoryRequest
+     */
+    private function createRequestDto(array $data): UpdateServiceCategoryRequest
+    {
+        $serviceCategoryRequest = new UpdateServiceCategoryRequest();
+        $serviceCategoryRequest->name = $data['name'];
+        $serviceCategoryRequest->alias = $data['alias'];
+        if (array_key_exists('is_activated', $data)) {
+            $serviceCategoryRequest->isActivated = $data['is_activated'];
+        }
+
+        return $serviceCategoryRequest;
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryRoute.yaml
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryRoute.yaml
@@ -1,0 +1,7 @@
+UpdateServiceCategory:
+  methods: PUT
+  path: /configuration/services/categories/{serviceCategoryId}
+  requirements:
+    serviceCategoryId: '\d+'
+  controller: 'Core\ServiceCategory\Infrastructure\API\UpdateServiceCategory\UpdateServiceCategoryController'
+  condition: "request.attributes.get('version') >= 25.10"

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategorySchema.json
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategorySchema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Update a service category",
+  "type": "object",
+  "required": [
+    "name",
+    "alias"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "alias": {
+      "type": "string"
+    },
+    "is_activated": {
+      "type": "boolean"
+    }
+  }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -33,11 +33,13 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {
     use LoggerTrait;
     public const SERVICE_CATEGORY_PROPERTIES_MAP = [
+        'id' => 'sc_id',
         'name' => 'sc_name',
         'alias' => 'sc_alias',
         'isActivated' => 'sc_activate',
@@ -132,6 +134,38 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
     }
 
     /**
+     * @inheritDoc
+     */
+    public function update(ServiceCategory $serviceCategory): void
+    {
+        try {
+            $this->writeServiceCategoryRepository->update($serviceCategory);
+
+            $actionLog = new ActionLog(
+                objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
+                objectId: $serviceCategory->getId(),
+                objectName: $serviceCategory->getName(),
+                actionType: ActionLog::ACTION_TYPE_CHANGE,
+                contactId: $this->user->getId()
+            );
+            $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
+            $actionLog->setId($actionLogId);
+            $details = $this->getServiceCategoryAsArray($serviceCategory);
+
+            $this->writeActionLogRepository->addActionDetails($actionLog, $details);
+
+            return;
+        } catch (\Throwable $ex) {
+            $this->error(
+                'Error while updating a service category',
+                ['serviceCategory' => $serviceCategory, 'trace' => (string) $ex]
+            );
+
+            throw $ex;
+        }
+    }
+
+    /**
      * Format the Service Category as property => value array.
      *
      * @param NewServiceCategory $serviceCategory
@@ -139,7 +173,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
      * @return array<string, string>
      */
     private function getServiceCategoryAsArray(
-        NewServiceCategory $serviceCategory,
+        NewServiceCategory|ServiceCategory $serviceCategory,
     ): array {
         $reflection = new \ReflectionClass($serviceCategory);
         $properties = $reflection->getProperties();
@@ -150,6 +184,9 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
             if ($property->getName() === 'isActivated') {
                 $serviceCategoryAsArray[self::SERVICE_CATEGORY_PROPERTIES_MAP[$property->getName()]]
                     = $property->getValue($serviceCategory) ? '1' : '0';
+            } elseif ($property->getName() === 'id') {
+                $serviceCategoryAsArray[self::SERVICE_CATEGORY_PROPERTIES_MAP[$property->getName()]]
+                    = (string) ($property->getValue($serviceCategory));
             } else {
                 $serviceCategoryAsArray[self::SERVICE_CATEGORY_PROPERTIES_MAP[$property->getName()]]
                     = is_string($property->getValue($serviceCategory))

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
@@ -29,6 +29,7 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {
@@ -172,5 +173,35 @@ class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements 
 
             throw $ex;
         }
+    }
+
+    /**
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceCategory $serviceCategory): void
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                UPDATE `:db`.service_categories
+                SET
+                    `sc_name` = :name,
+                    `sc_description` = :alias,
+                    `sc_activate` = :isActivated
+                WHERE sc_id = :id
+                SQL
+        );
+        $statement = $this->db->prepare($request);
+
+        $statement->bindValue(':name', $serviceCategory->getName(), \PDO::PARAM_STR);
+        $statement->bindValue(':alias', $serviceCategory->getAlias(), \PDO::PARAM_STR);
+        $statement->bindValue(':isActivated', (new BoolToEnumNormalizer())->normalize($serviceCategory->isActivated()), \PDO::PARAM_STR);
+        $statement->bindValue(':id', $serviceCategory->getId(), \PDO::PARAM_INT);
+
+        $statement->execute();
+
     }
 }

--- a/centreon/tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
+++ b/centreon/tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceCategory\Application\UseCase\GetServiceCategory;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategory;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategoryResponse;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+
+beforeEach(function (): void {
+    $this->readServiceCategoryRepository = $this->createMock(ReadServiceCategoryRepositoryInterface::class);
+    $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+    $this->user = $this->createMock(ContactInterface::class);
+    $this->presenter = new DefaultPresenter($this->presenterFormatter);
+    $this->adminResolver = $this->createMock(AdminResolver::class);
+    $this->useCase = new GetServiceCategory(
+        $this->readServiceCategoryRepository,
+        $this->readAccessGroupRepository,
+        $this->user,
+        $this->adminResolver
+    );
+    $this->serviceCategory = new ServiceCategory(
+        1,
+        'sg-name',
+        'sg-alias',
+    );
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and(value: $this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::errorWhileRetrieving()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::accessNotAllowed()->getMessage());
+});
+
+it('should present a GetServiceCategoryResponse with non-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceCategoryResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceCategory->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceCategory->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceCategory->isActivated());
+});
+
+it('should present a GetServiceCategoryResponse with admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceCategoryResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceCategory->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceCategory->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceCategory->isActivated());
+});

--- a/centreon/tests/php/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryTest.php
+++ b/centreon/tests/php/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceCategory\Application\UseCase\UpdateServiceCategory;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategory;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategoryRequest;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+
+beforeEach(function (): void {
+    $this->presenter = new DefaultPresenter(
+        $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class)
+    );
+    $this->useCase = new UpdateServiceCategory(
+        $this->writeServiceCategoryRepository = $this->createMock(WriteServiceCategoryRepositoryInterface::class),
+        $this->readServiceCategoryRepository = $this->createMock(ReadServiceCategoryRepositoryInterface::class),
+        $this->readAccessGroupRepositoryInterface = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        $this->user = $this->createMock(ContactInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class)
+    );
+
+    $this->serviceCategory = new ServiceCategory(
+        1,
+        'sc-name',
+        'sc-alias',
+    );
+
+    $this->request = new UpdateServiceCategoryRequest();
+    $this->request->name = $this->serviceCategory->getName() . '-edited';
+    $this->request->alias = $this->serviceCategory->getAlias() . '-edited';
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::errorWhileUpdating()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::editNotAllowed()->getMessage());
+});
+
+it('should present a ConflictResponse when name is already used', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByName')
+        ->willReturn(true);
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ConflictResponse::class)
+        ->and($this->presenter->getResponseStatus()?->getMessage())
+        ->toBe(ServiceCategoryException::nameAlreadyExists($this->request->name)->getMessage());
+});
+
+it('should return void on success when admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByName')
+        ->willReturn(false);
+
+    $this->writeServiceCategoryRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should return void on success when non-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepositoryInterface
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByName')
+        ->willReturn(false);
+
+    $this->writeServiceCategoryRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});


### PR DESCRIPTION
## Description

Backport of #9817

[MON-196421](https://centreon.atlassian.net/browse/MON-196421)


[MON-196421]: https://centreon.atlassian.net/browse/MON-196421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GET service category endpoint with controller, presenter, and route.
* Added PUT update service category endpoint with schema, controller, and request.

**⚡ Enhancements**
* Implemented repository update method and wired action log support.
* Extended ServiceCategoryException with conflict, retrieval, and edit messages.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92241878?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->