### PR TITLE
feat(apiv2): add Get service severity endpoint (#9818)

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceSeverity/GetServiceSeverity.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceSeverity/GetServiceSeverity.yaml
@@ -1,0 +1,22 @@
+get:
+  tags:
+    - Service severity
+  summary: "Get a service severity"
+  description: |
+    Get an existing service severity.
+
+  parameters:
+    - $ref: 'QueryParameter/SeverityId.yaml'
+  responses:
+    '200':
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            $ref: 'Schema/SeverityResponse.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+++ b/centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
@@ -127,4 +127,12 @@ class ServiceSeverityException extends \Exception
             self::CODE_CONFLICT
         );
     }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileRetrieving(): self
+    {
+        return new self(_('Error while retrieving service severity'));
+    }
 }

--- a/centreon/src/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverity.php
+++ b/centreon/src/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverity.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceSeverity\Application\UseCase\GetServiceSeverity;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Contact\Domain\AdminResolver;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Core\ServiceSeverity\Application\Exception\ServiceSeverityException;
+use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInterface;
+use Core\ServiceSeverity\Domain\Model\ServiceSeverity;
+
+final class GetServiceSeverity
+{
+    use LoggerTrait;
+
+    /** @var AccessGroup[] */
+    private array $accessGroups;
+
+    public function __construct(
+        private readonly ReadServiceSeverityRepositoryInterface $readServiceSeverityRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    /**
+     * @param PresenterInterface $presenter
+     * @param int $serviceSeverityId
+     */
+    public function __invoke(PresenterInterface $presenter, int $serviceSeverityId): void
+    {
+        try {
+            if (
+                ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ)
+                && ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ_WRITE)
+            ) {
+                $this->error(
+                    "User doesn't have sufficient rights to see service severities",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceSeverityException::accessNotAllowed())
+                );
+
+                return;
+            }
+
+            $serviceSeverity = null;
+            if ($this->adminResolver->isAdmin($this->user)) {
+                if ($this->readServiceSeverityRepository->exists($serviceSeverityId)) {
+                    $serviceSeverity = $this->readServiceSeverityRepository->findById($serviceSeverityId);
+                }
+            } else {
+                $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+                if ($this->readServiceSeverityRepository->existsByAccessGroups(
+                    $serviceSeverityId,
+                    $this->accessGroups
+                )) {
+                    $serviceSeverity = $this->readServiceSeverityRepository->findById($serviceSeverityId);
+                }
+            }
+
+            if (! $serviceSeverity) {
+                $this->error(
+                    'Service Severity not found',
+                    ['service_severity_id' => $serviceSeverityId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('Service Severity'));
+
+                return;
+            }
+
+            $presenter->present($this->createResponse($serviceSeverity));
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceSeverityException::errorWhileRetrieving())
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        }
+    }
+
+    /**
+     * @param ServiceSeverity $serviceSeverity
+     *
+     * @throws \Throwable
+     *
+     * @return GetServiceSeverityResponse
+     */
+    private function createResponse(ServiceSeverity $serviceSeverity): GetServiceSeverityResponse
+    {
+        $response = new GetServiceSeverityResponse();
+        $response->id = $serviceSeverity->getId();
+        $response->name = $serviceSeverity->getName();
+        $response->alias = $serviceSeverity->getAlias();
+        $response->level = $serviceSeverity->getLevel();
+        $response->iconId = $serviceSeverity->getIconId();
+        $response->isActivated = $serviceSeverity->isActivated();
+
+        return $response;
+    }
+}

--- a/centreon/src/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityResponse.php
+++ b/centreon/src/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceSeverity\Application\UseCase\GetServiceSeverity;
+
+final class GetServiceSeverityResponse
+{
+    public int $id = 0;
+
+    public string $name = '';
+
+    public string $alias = '';
+
+    public int $level = 0;
+
+    public int $iconId = 0;
+
+    public bool $isActivated = true;
+}

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/API/GetServiceSeverity/GetServiceSeverityController.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/API/GetServiceSeverity/GetServiceSeverityController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceSeverity\Infrastructure\API\GetServiceSeverity;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\ServiceSeverity\Application\UseCase\GetServiceSeverity\GetServiceSeverity;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class GetServiceSeverityController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param GetServiceSeverity $useCase
+     * @param GetServiceSeverityPresenter $presenter
+     * @param int $serviceSeverityId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        GetServiceSeverity $useCase,
+        GetServiceSeverityPresenter $presenter,
+        int $serviceSeverityId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($presenter, $serviceSeverityId);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/API/GetServiceSeverity/GetServiceSeverityPresenter.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/API/GetServiceSeverity/GetServiceSeverityPresenter.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceSeverity\Infrastructure\API\GetServiceSeverity;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\ServiceSeverity\Application\UseCase\GetServiceSeverity\GetServiceSeverityResponse;
+
+class GetServiceSeverityPresenter extends AbstractPresenter
+{
+    /**
+     * @inheritDoc
+     */
+    public function present(mixed $data): void
+    {
+        if ($data instanceof GetServiceSeverityResponse) {
+            $data = [
+                'id' => $data->id,
+                'name' => $data->name,
+                'alias' => $data->alias,
+                'level' => $data->level,
+                'icon_id' => $data->iconId,
+                'is_activated' => $data->isActivated,
+            ];
+        }
+        parent::present($data);
+    }
+}

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/API/GetServiceSeverity/GetServiceSeverityRoute.yaml
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/API/GetServiceSeverity/GetServiceSeverityRoute.yaml
@@ -1,0 +1,7 @@
+GetServiceSeverity:
+  methods: GET
+  path: /configuration/services/severities/{serviceSeverityId}
+  requirements:
+    serviceSeverityId: '\d+'
+  controller: 'Core\ServiceSeverity\Infrastructure\API\GetServiceSeverity\GetServiceSeverityController'
+  condition: "request.attributes.get('version') >= 25.10"

--- a/centreon/tests/php/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityTest.php
+++ b/centreon/tests/php/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceSeverity\Application\UseCase\GetServiceSeverity;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceSeverity\Application\Exception\ServiceSeverityException;
+use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInterface;
+use Core\ServiceSeverity\Application\UseCase\GetServiceSeverity\GetServiceSeverity;
+use Core\ServiceSeverity\Application\UseCase\GetServiceSeverity\GetServiceSeverityResponse;
+use Core\ServiceSeverity\Domain\Model\ServiceSeverity;
+
+beforeEach(function (): void {
+    $this->readServiceSeverityRepository = $this->createMock(ReadServiceSeverityRepositoryInterface::class);
+    $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+    $this->user = $this->createMock(ContactInterface::class);
+    $this->presenter = new DefaultPresenter($this->presenterFormatter);
+    $this->adminResolver = $this->createMock(AdminResolver::class);
+    $this->useCase = new GetServiceSeverity(
+        $this->readServiceSeverityRepository,
+        $this->readAccessGroupRepository,
+        $this->user,
+        $this->adminResolver,
+    );
+    $this->serviceSeverity = new ServiceSeverity(
+        1,
+        'sc-name',
+        'sc-alias',
+        2,
+        1,
+    );
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('exists')
+        ->willReturn(true);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->presenter, $this->serviceSeverity->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and(value: $this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceSeverityException::errorWhileRetrieving()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->presenter, $this->serviceSeverity->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceSeverityException::accessNotAllowed()->getMessage());
+});
+
+it('should present a GetServiceSeverityResponse with non-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceSeverity);
+
+    ($this->useCase)($this->presenter, $this->serviceSeverity->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceSeverityResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceSeverity->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceSeverity->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceSeverity->isActivated())
+        ->and($dto->level)
+        ->toBe($this->serviceSeverity->getLevel())
+        ->and($dto->iconId)
+        ->toBe($this->serviceSeverity->getIconId());
+});
+
+it('should present a GetServiceSeverityResponse with admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('exists')
+        ->willReturn(true);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceSeverity);
+
+    ($this->useCase)($this->presenter, $this->serviceSeverity->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceSeverityResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceSeverity->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceSeverity->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceSeverity->isActivated())
+        ->and($dto->level)
+        ->toBe($this->serviceSeverity->getLevel())
+        ->and($dto->iconId)
+        ->toBe($this->serviceSeverity->getIconId());
+});
+
+it('should present a GetServiceResponse with non-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+    $this->readServiceSeverityRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceSeverity);
+
+    ($this->useCase)($this->presenter, $this->serviceSeverity->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceSeverityResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceSeverity->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceSeverity->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceSeverity->isActivated())
+        ->and($dto->level)
+        ->toBe($this->serviceSeverity->getLevel())
+        ->and($dto->iconId)
+        ->toBe($this->serviceSeverity->getIconId());
+});


### PR DESCRIPTION
## Description

Backport of #9818

[MON-196422](https://centreon.atlassian.net/browse/MON-196422)

[MON-196422]: https://centreon.atlassian.net/browse/MON-196422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GET service severity endpoint with controller, use case, presenter

**⚡ Enhancements**
* Added errorWhileRetrieving exception in ServiceSeverityException for retrieval errors


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92242458?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->