### PR TITLE
fix(service_group): decode HTML entities before unserializing form payload

### DIFF
--- a/centreon/www/class/centreonUtils.class.php
+++ b/centreon/www/class/centreonUtils.class.php
@@ -216,7 +216,7 @@ class CentreonUtils
         try {
             $initForm = $form->getElement('initialValues');
             $initForm = HtmlAnalyzer::sanitizeAndRemoveTags($initForm->getValue());
-            $initialValues = unserialize($initForm, ['allowed_classes' => false]);
+            $initialValues = unserialize(html_entity_decode($initForm), ['allowed_classes' => false]);
             if (! empty($initialValues) && isset($initialValues[$key])) {
                 $init = $initialValues[$key];
             }


### PR DESCRIPTION
## Description

Backport of #9858

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Decoded HTML entities before unserializing form payload to prevent errors


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92588700?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->