### PR TITLE
fix(export): include otel_server config only for agent-initiated mode

### DIFF
--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -123,13 +123,14 @@ class AgentConfiguration extends AbstractObjectJSON
     private function formatCmaConfiguration(array $data, ConnectionModeEnum $connectionMode): array
     {
         $tokens = $this->filterTokens($data['tokens'] ?? []);
-        $configuration = [
-            'otel_server' => $this->formatOtelConfiguration($data, $tokens, $connectionMode),
-            'centreon_agent' => [
-                'check_interval' => CmaConfigurationParameters::DEFAULT_CHECK_INTERVAL,
-                'export_period' => CmaConfigurationParameters::DEFAULT_EXPORT_PERIOD,
-                'create_host_auto' => $data['create_host_auto'] ?? false,
-            ],
+        $configuration = [];
+        if ($data['agent_initiated'] === true) {
+            $configuration['otel_server'] = $this->formatOtelConfiguration($data, $tokens, $connectionMode);
+        }
+        $configuration['centreon_agent'] = [
+            'check_interval' => CmaConfigurationParameters::DEFAULT_CHECK_INTERVAL,
+            'export_period' => CmaConfigurationParameters::DEFAULT_EXPORT_PERIOD,
+            'create_host_auto' => $data['create_host_auto'] ?? false,
         ];
 
         if ($data['poller_initiated'] === true) {


### PR DESCRIPTION
## Description

Backport of #9860

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Included otel_server configuration only when agent-initiated for CMA


<sup>[More info](https://app.aikido.dev/featurebranch/scan/93439542?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->