### PR TITLE
technical(ci): prevent web jobs from running when a PR is only relate…

### DIFF
--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: ''
+      translation_paths:
+        required: false
+        type: string
+        default: ''
       is_nightly:
         required: true
         type: string
@@ -97,6 +101,7 @@ jobs:
           API_TEST_PATHS: ${{ inputs.api_test_paths }}
           E2E_TEST_PATHS: ${{ inputs.e2e_test_paths }}
           UPGRADE_TEST_PATHS: ${{ inputs.upgrade_test_paths }}
+          TRANSLATION_PATHS: ${{ inputs.translation_paths }}
         with:
           script: |
             const paths = {
@@ -107,6 +112,7 @@ jobs:
               api_test_paths: process.env.API_TEST_PATHS,
               e2e_test_paths: process.env.E2E_TEST_PATHS,
               upgrade_test_paths: process.env.UPGRADE_TEST_PATHS,
+              translation_paths: process.env.TRANSLATION_PATHS,
             };
 
             for (const [key, value] of Object.entries(paths)) {
@@ -142,6 +148,8 @@ jobs:
             ${{ steps.inline_inputs.outputs.e2e_test_paths }}
             upgrade_test:
             ${{ steps.inline_inputs.outputs.upgrade_test_paths }}
+            translation:
+            ${{ steps.inline_inputs.outputs.translation_paths }}
 
       - name: Determine triggers for event ${{ github.event_name }}
         if: github.event_name == 'pull_request' || inputs.base_sha != ''
@@ -156,6 +164,8 @@ jobs:
           HAS_API_TEST_CHANGES: ${{ steps.get_changed_files.outputs.api_test_any_changed }}
           HAS_E2E_TEST_CHANGES: ${{ steps.get_changed_files.outputs.e2e_test_any_changed }}
           HAS_UPGRADE_TEST_CHANGES: ${{ steps.get_changed_files.outputs.upgrade_test_any_changed }}
+          HAS_TRANSLATION_CHANGES: ${{ steps.get_changed_files.outputs.translation_any_changed }}
+          GITHUB_ACTOR: ${{ github.actor }}
           LABELS: ${{ inputs.labels }}
         with:
           script: |
@@ -193,37 +203,66 @@ jobs:
               core.warning(`Could not parse labels: ${e}`);
             }
 
+            // When weblate-service-account only changed translation files, skip all testing
+            // but keep packaging and delivery enabled.
+            const isWeblateTranslationOnly =
+              process.env.GITHUB_ACTOR === 'weblate-service-account'
+              && process.env.HAS_TRANSLATION_CHANGES === 'true'
+              && process.env.HAS_BACKEND_PRODUCTION_CHANGES !== 'true'
+              && process.env.HAS_FRONTEND_PRODUCTION_CHANGES !== 'true'
+              && process.env.HAS_BACKEND_TEST_CHANGES !== 'true'
+              && process.env.HAS_FRONTEND_TEST_CHANGES !== 'true'
+              && process.env.HAS_API_TEST_CHANGES !== 'true'
+              && process.env.HAS_E2E_TEST_CHANGES !== 'true'
+              && process.env.HAS_UPGRADE_TEST_CHANGES !== 'true';
+
+            if (isWeblateTranslationOnly) {
+              core.info('weblate-service-account with translation-only changes detected — skipping all test and lint triggers.');
+            }
+
             const outputs = {
               'trigger_backend_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_BACKEND_TEST_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_BACKEND_TEST_CHANGES === 'true'
+                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                ),
               'trigger_frontend_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_TEST_CHANGES === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_FRONTEND_TEST_CHANGES === 'true'
+                  || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
+                ),
               'trigger_packaging':
                 process.env.IS_NIGHTLY === 'true'
                 || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
                 || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
                 || process.env.HAS_API_TEST_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true',
+                || process.env.HAS_E2E_TEST_CHANGES === 'true'
+                || isWeblateTranslationOnly,
               'trigger_api_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_API_TEST_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                  || process.env.HAS_API_TEST_CHANGES === 'true'
+                ),
               'trigger_e2e_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
+                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                  || process.env.HAS_E2E_TEST_CHANGES === 'true'
+                ),
               'trigger_upgrade_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_UPGRADE_TEST_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_UPGRADE_TEST_CHANGES === 'true'
+                ),
               'trigger_delivery':
                 process.env.IS_NIGHTLY === 'true'
                 || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true',
+                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                || isWeblateTranslationOnly,
             };
 
             for (const [key, value] of Object.entries(outputs)) {

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -47,46 +47,6 @@ env:
   e2e_directory: centreon/tests/e2e
 
 jobs:
-  check-actor:
-    runs-on: ubuntu-24.04
-    outputs:
-      should_skip: ${{ steps.check.outputs.should_skip }}
-    steps:
-      - name: Check if weblate-service-account only changed translation files
-        id: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [[ "${{ github.actor }}" != "weblate-service-account" ]]; then
-            echo "Actor is not weblate-service-account — not skipping."
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
-              BASE="develop"
-            else
-              BASE="${{ github.event.before }}"
-            fi
-            FILES=$(gh api "repos/${{ github.repository }}/compare/${BASE}...${{ github.sha }}" --jq '.files[].filename')
-          else
-            echo "Event '${{ github.event_name }}' — not skipping."
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          NON_TRANSLATION=$(echo "$FILES" | grep -vE '\.pot?$' || true)
-          if [[ -z "$NON_TRANSLATION" ]]; then
-            echo "Only .po/.pot files changed by weblate-service-account — skipping lint and test jobs."
-            echo "should_skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Non-translation files detected — proceeding."
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   dependency-scan:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
 
@@ -142,7 +102,6 @@ jobs:
         "centreon/cron/**"
         "centreon/doc/API/**"
         "centreon/GPL_LIB/**"
-        "centreon/lang/**"
         "centreon/lib/**"
         "centreon/libinstall/**"
         "centreon/logrotate/**"
@@ -196,6 +155,8 @@ jobs:
         "centreon/www/install/**"
         "centreon/packaging/**"
         "centreon/tests/e2e/features/Platform-upgrade-update/**"
+      translation_paths: |
+        "centreon/lang/**"
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       base_sha: ${{ needs.get-environment.outputs.previous_release_bundle_tag }}
       labels: ${{ needs.get-environment.outputs.labels }}
@@ -455,9 +416,8 @@ jobs:
 
   frontend-web-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -474,9 +434,8 @@ jobs:
 
   frontend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -513,9 +472,8 @@ jobs:
           path: "centreon/junit.xml"
 
   frontend-component-test:
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -535,9 +493,8 @@ jobs:
 
   backend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -582,9 +539,8 @@ jobs:
 
   backend-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -724,9 +680,8 @@ jobs:
 
   gherkin-lint:
     runs-on: ubuntu-24.04
-    needs: [get-environment, changes, check-actor]
+    needs: [get-environment, changes]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -739,9 +694,8 @@ jobs:
 
   e2e-lint:
     runs-on: ubuntu-22.04
-    needs: [get-environment, changes, check-actor]
+    needs: [get-environment, changes]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -1068,11 +1022,9 @@ jobs:
         get-environment,
         changes,
         create-xray-test-plan-and-test-execution,
-        dockerize,
-        check-actor
+        dockerize
       ]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_api_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1110,9 +1062,8 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   legacy-e2e-test:
-    needs: [get-environment, changes, dockerize, check-actor]
+    needs: [get-environment, changes, dockerize]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1154,10 +1105,8 @@ jobs:
         create-xray-test-plan-and-test-execution,
         gherkin-lint,
         e2e-lint,
-        check-actor,
       ]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -47,10 +47,39 @@ env:
   e2e_directory: centreon/tests/e2e
 
 jobs:
+  check-actor:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Skip workflow if weblate-service-account only changed translation files
+        if: github.actor == 'weblate-service-account'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+              BASE="develop"
+            else
+              BASE="${{ github.event.before }}"
+            fi
+            FILES=$(gh api "repos/${{ github.repository }}/compare/${BASE}...${{ github.sha }}" --jq '.files[].filename')
+          else
+            echo "Event '${{ github.event_name }}' or initial push — not skipping."
+            exit 0
+          fi
+          NON_TRANSLATION=$(echo "$FILES" | grep -vE '\.pot?$' || true)
+          if [[ -z "$NON_TRANSLATION" ]]; then
+            echo "Only .po/.pot files changed by weblate-service-account — skipping workflow."
+            exit 1
+          fi
+          echo "Non-translation files detected — proceeding."
+
   dependency-scan:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
 
   dispatch-to-maintained-branches:
+    needs: [check-actor]
     if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' && github.repository == 'centreon/centreon' }}
     runs-on: ubuntu-24.04
     steps:
@@ -73,7 +102,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   get-environment:
-    needs: [dependency-scan]
+    needs: [dependency-scan, check-actor]
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -49,12 +49,20 @@ env:
 jobs:
   check-actor:
     runs-on: ubuntu-24.04
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
-      - name: Skip workflow if weblate-service-account only changed translation files
-        if: github.actor == 'weblate-service-account'
+      - name: Check if weblate-service-account only changed translation files
+        id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [[ "${{ github.actor }}" != "weblate-service-account" ]]; then
+            echo "Actor is not weblate-service-account — not skipping."
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
           elif [[ "${{ github.event_name }}" == "push" ]]; then
@@ -65,21 +73,24 @@ jobs:
             fi
             FILES=$(gh api "repos/${{ github.repository }}/compare/${BASE}...${{ github.sha }}" --jq '.files[].filename')
           else
-            echo "Event '${{ github.event_name }}' or initial push — not skipping."
+            echo "Event '${{ github.event_name }}' — not skipping."
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
           NON_TRANSLATION=$(echo "$FILES" | grep -vE '\.pot?$' || true)
           if [[ -z "$NON_TRANSLATION" ]]; then
-            echo "Only .po/.pot files changed by weblate-service-account — skipping workflow."
-            exit 1
+            echo "Only .po/.pot files changed by weblate-service-account — skipping lint and test jobs."
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-translation files detected — proceeding."
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "Non-translation files detected — proceeding."
 
   dependency-scan:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
 
   dispatch-to-maintained-branches:
-    needs: [check-actor]
     if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' && github.repository == 'centreon/centreon' }}
     runs-on: ubuntu-24.04
     steps:
@@ -102,7 +113,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   get-environment:
-    needs: [dependency-scan, check-actor]
+    needs: [dependency-scan]
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql
@@ -444,8 +455,9 @@ jobs:
 
   frontend-web-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -462,8 +474,9 @@ jobs:
 
   frontend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -500,8 +513,9 @@ jobs:
           path: "centreon/junit.xml"
 
   frontend-component-test:
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -521,8 +535,9 @@ jobs:
 
   backend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -567,8 +582,9 @@ jobs:
 
   backend-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -708,8 +724,9 @@ jobs:
 
   gherkin-lint:
     runs-on: ubuntu-24.04
-    needs: [get-environment, changes]
+    needs: [get-environment, changes, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -722,8 +739,9 @@ jobs:
 
   e2e-lint:
     runs-on: ubuntu-22.04
-    needs: [get-environment, changes]
+    needs: [get-environment, changes, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -1050,9 +1068,11 @@ jobs:
         get-environment,
         changes,
         create-xray-test-plan-and-test-execution,
-        dockerize
+        dockerize,
+        check-actor
       ]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_api_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1090,8 +1110,9 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   legacy-e2e-test:
-    needs: [get-environment, changes, dockerize]
+    needs: [get-environment, changes, dockerize, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1133,8 +1154,10 @@ jobs:
         create-xray-test-plan-and-test-execution,
         gherkin-lint,
         e2e-lint,
+        check-actor,
       ]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&


### PR DESCRIPTION
…d to translation stuff

## Description

This PR allows skipping web CI workflows when updates are only related to translations AND created by the related service account

See https://centreon.atlassian.net/browse/MON-196468


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

From this branch, update a .po file and try to run the web workflow
