### PR TITLE
fix(unattended): fix MariaDB password setup and URL-encode passwords in wizard

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -758,7 +758,8 @@ function secure_dbms_setup() {
 		systemctl restart mariadb
 		log "INFO" "Executing SQL requests for $dbms"
 		mysql -u root --verbose <<-EOF
-			UPDATE mysql.global_priv SET priv=json_set(priv, '$.plugin', 'caching_sha2_password', '$.authentication_string', PASSWORD('$db_root_password')) WHERE User='root';
+			ALTER USER 'root'@'localhost' IDENTIFIED BY '${db_root_password//\'/\'\'}';
+
 			DELETE FROM mysql.global_priv WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
 			DELETE FROM mysql.global_priv WHERE User='';
 			DROP DATABASE IF EXISTS test;
@@ -909,6 +910,24 @@ function setup_before_installation() {
 }
 #========= end of function setup_before_installation()
 
+#========= begin of function urlencode()
+# URL-encode a string for use in application/x-www-form-urlencoded POST data
+#
+function urlencode() {
+	local string="$1"
+	local encoded="" char hex
+	local i
+	for (( i=0; i<${#string}; i++ )); do
+		char="${string:$i:1}"
+		case "$char" in
+			[a-zA-Z0-9._~-]) encoded+="$char" ;;
+			*) printf -v hex '%%%02X' "'$char"; encoded+="$hex" ;;
+		esac
+	done
+	printf '%s' "$encoded"
+}
+#========= end of function urlencode()
+
 #========= begin of function install_wizard_post()
 # execute a post request of the install wizard
 # - session cookie
@@ -925,6 +944,11 @@ function install_wizard_post() {
 function play_install_wizard() {
 	log "INFO" "Playing install wizard"
 
+	local enc_db_root_password enc_db_centreon_password enc_centreon_admin_password
+	enc_db_root_password=$(urlencode "$db_root_password")
+	enc_db_centreon_password=$(urlencode "$db_centreon_password")
+	enc_centreon_admin_password=$(urlencode "$centreon_admin_password")
+
 	sessionID=$(curl -s -v "http://${central_ip}/centreon/install/install.php" 2>&1 | grep Set-Cookie | awk '{print $3}')
 	curl -s "http://${central_ip}/centreon/install/steps/step.php?action=stepContent" -H "Cookie: ${sessionID}" >/dev/null
 	install_wizard_post ${sessionID} "process_step3.php" 'centreon_engine_stats_binary=%2Fusr%2Fsbin%2Fcentenginestats&monitoring_var_lib=%2Fvar%2Flib%2Fcentreon-engine&centreon_engine_connectors=%2Fusr%2Flib64%2Fcentreon-connector&centreon_engine_lib=%2Fusr%2Flib64%2Fcentreon-engine&centreonplugins=%2Fusr%2Flib%2Fcentreon%2Fplugins%2F'
@@ -936,8 +960,8 @@ function play_install_wizard() {
         install_wizard_post ${sessionID} "process_step4.php" 'centreonbroker_etc=%2Fetc%2Fcentreon-broker&centreonbroker_log=%2Fvar%2Flog%2Fcentreon-broker&centreonbroker_varlib=%2Fvar%2Flib%2Fcentreon-broker&centreonbroker_lib=%2Fusr%2Fshare%2Fcentreon%2Flib%2Fcentreon-broker'
     ;;
     esac
-	install_wizard_post ${sessionID} "process_step5.php" "admin_password=${centreon_admin_password}&confirm_password=${centreon_admin_password}&firstname=${centreon_admin_firstname}&lastname=${centreon_admin_lastname}&email=${centreon_admin_email}"
-	install_wizard_post ${sessionID} "process_step6.php" "address=&port=3306&root_user=root&root_password=${db_root_password}&db_configuration=centreon&db_storage=centreon_storage&db_user=centreon&db_password=${db_centreon_password}&db_password_confirm=${db_centreon_password}"
+	install_wizard_post ${sessionID} "process_step5.php" "admin_password=${enc_centreon_admin_password}&confirm_password=${enc_centreon_admin_password}&firstname=${centreon_admin_firstname}&lastname=${centreon_admin_lastname}&email=${centreon_admin_email}"
+	install_wizard_post ${sessionID} "process_step6.php" "address=&port=3306&root_user=root&root_password=${enc_db_root_password}&db_configuration=centreon&db_storage=centreon_storage&db_user=centreon&db_password=${enc_db_centreon_password}&db_password_confirm=${enc_db_centreon_password}"
 	if [[ -v use_vault ]]; then
 	  install_wizard_post ${sessionID} "process_step_vault.php" "address=${vault_address}&port=${vault_port}&role_id=${vault_role_id}&secret_id=${vault_secret_id}&root_path=${vault_root_path}"
 	fi
@@ -948,7 +972,7 @@ function play_install_wizard() {
 	install_wizard_post ${sessionID} "insertBaseConf.php"
 	install_wizard_post ${sessionID} "partitionTables.php"
 	install_wizard_post ${sessionID} "generationCache.php"
-	INSTALLED_EXTENSIONS='modules%5B%5D=centreon-license-manager&modules%5B%5D=centreon-pp-manager&modules%5B%5D=centreon-it-edition-extensions&modules%5B%5D=centreon-autodiscovery-server&widgets%5B%5D=engine-status&widgets%5B%5D=global-health&widgets%5B%5D=graph-monitoring&widgets%5B%5D=grid-map&widgets%5B%5D=host-monitoring&widgets%5B%5D=hostgroup-monitoring&widgets%5B%5D=httploader&widgets%5B%5D=live-top10-cpu-usage&widgets%5B%5D=live-top10-memory-usage&widgets%5B%5D=service-monitoring&widgets%5B%5D=servicegroup-monitoring&widgets%5B%5D=tactical-overview&widgets%5B%5D=single-metric'
+	INSTALLED_EXTENSIONS='modules%5B%5D=centreon-license-manager&modules%5B%5D=centreon-pp-manager&modules%5B%5D=centreon-it-edition-extensions&modules%5B%5D=centreon-autodiscovery-server'
 	install_wizard_post ${sessionID} "process_step8.php" "$INSTALLED_EXTENSIONS"
 	install_wizard_post ${sessionID} "process_step9.php" 'send_statistics=1'
 }


### PR DESCRIPTION
## Summary

Backport of #9936 (`dev-24.10.x`) for `release-24.10-next`.

- **MariaDB `secure_dbms_setup()`**: replace the broken `UPDATE mysql.global_priv SET priv=json_set(...)` with `ALTER USER 'root'@'localhost' IDENTIFIED BY '...'`. This caused `Access denied` in `process_step6.php` when the PDO connection was attempted.
- **URL-encoding passwords in `play_install_wizard()`**: add a pure-bash `urlencode()` function and apply it to passwords before passing them as `application/x-www-form-urlencoded` POST data.
- **Widgets installation (step 8)**: widgets do not need to be installed manually at step 8 — they are already installed via `insertBaseConf.php`.

## Test plan

- [ ] Run `unattended.sh install` on AlmaLinux 9 with MariaDB — verify first login works without `Access denied`
- [ ] Run `unattended.sh install` with a password containing `?` or `&` — verify step 6 succeeds
- [ ] Run `unattended.sh install` on Debian 12 (MySQL path) — verify no regression

Jira: [MON-196493](https://centreon.atlassian.net/browse/MON-196493)

[MON-196493]: https://centreon.atlassian.net/browse/MON-196493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced broken MariaDB privilege update with ALTER USER command.
* Added bash urlencode and URL-encoded passwords before POSTing.

**🔧 Refactors**
* Removed manual widgets installation at step eight as redundant.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92504385?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->