### PR TITLE
fix(export): include otel_server config only for agent-initiated mode

### DIFF
--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -124,7 +124,7 @@ class AgentConfiguration extends AbstractObjectJSON
     {
         $tokens = $this->filterTokens($data['tokens'] ?? []);
         $configuration = [];
-        if ($data['agent_initiated'] === true) {
+        if (! $data['is_reverse']) {
             $configuration['otel_server'] = $this->formatOtelConfiguration($data, $tokens, $connectionMode);
         }
         $configuration['centreon_agent'] = [

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -123,12 +123,13 @@ class AgentConfiguration extends AbstractObjectJSON
     private function formatCmaConfiguration(array $data, ConnectionModeEnum $connectionMode): array
     {
         $tokens = $this->filterTokens($data['tokens'] ?? []);
-        $configuration = [
-            'otel_server' => $this->formatOtelConfiguration($data, $tokens, $connectionMode),
-            'centreon_agent' => [
-                'check_interval' => CmaConfigurationParameters::DEFAULT_CHECK_INTERVAL,
-                'export_period' => CmaConfigurationParameters::DEFAULT_EXPORT_PERIOD,
-            ],
+        $configuration = [];
+        if ($data['agent_initiated'] === true) {
+            $configuration['otel_server'] = $this->formatOtelConfiguration($data, $tokens, $connectionMode);
+        }
+        $configuration['centreon_agent'] = [
+            'check_interval' => CmaConfigurationParameters::DEFAULT_CHECK_INTERVAL,
+            'export_period' => CmaConfigurationParameters::DEFAULT_EXPORT_PERIOD,
         ];
 
         if ($data['is_reverse']) {


### PR DESCRIPTION
## Description

Backport of #9860

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Included otel_server configuration only for agent-initiated mode in CMA


<sup>[More info](https://app.aikido.dev/featurebranch/scan/93439768?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->