### PR TITLE
fix(web): convert SQL queries to prepared statements

### DIFF
--- a/centreon/phpstan.legacy.www.baseline.neon
+++ b/centreon/phpstan.legacy.www.baseline.neon
@@ -380,12 +380,6 @@ parameters:
 			path: www/include/options/accessLists/menusACL/DB-Func.php
 
 		-
-			message: '#^Undefined variable\: \$acl_res_name$#'
-			identifier: variable.undefined
-			count: 1
-			path: www/include/options/accessLists/resourcesACL/DB-Func.php
-
-		-
 			message: '#^Instantiated class graph not found\.$#'
 			identifier: class.notFound
 			count: 1

--- a/centreon/www/class/centreonConfigEngine.php
+++ b/centreon/www/class/centreonConfigEngine.php
@@ -50,13 +50,21 @@ class CentreonConfigEngine
      */
     public function insertBrokerDirectives($serverId, $directives = []): void
     {
-        $this->db->query('DELETE FROM cfg_nagios_broker_module
-                WHERE cfg_nagios_id = ' . $this->db->escape($serverId));
+        $deleteStmt = $this->db->prepare(
+            'DELETE FROM cfg_nagios_broker_module WHERE cfg_nagios_id = :serverId'
+        );
+        $deleteStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+        $deleteStmt->execute();
 
+        $insertStmt = $this->db->prepare(
+            'INSERT INTO cfg_nagios_broker_module (broker_module, cfg_nagios_id)
+            VALUES (:brokerModule, :serverId)'
+        );
         foreach ($directives as $value) {
             if ($value != '') {
-                $this->db->query("INSERT INTO cfg_nagios_broker_module (`broker_module`, `cfg_nagios_id`) 
-                                VALUES ('" . $this->db->escape($value) . "', " . $this->db->escape($serverId) . ')');
+                $insertStmt->bindValue(':brokerModule', $value, PDO::PARAM_STR);
+                $insertStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+                $insertStmt->execute();
             }
         }
     }
@@ -74,10 +82,12 @@ class CentreonConfigEngine
         $arr = [];
         $i = 0;
         if (! isset($_REQUEST['in_broker']) && $serverId) {
-            $res = $this->db->query('SELECT broker_module
-                                FROM cfg_nagios_broker_module
-                                WHERE cfg_nagios_id = ' . $this->db->escape($serverId));
-            while ($row = $res->fetchRow()) {
+            $stmt = $this->db->prepare(
+                'SELECT broker_module FROM cfg_nagios_broker_module WHERE cfg_nagios_id = :serverId'
+            );
+            $stmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+            $stmt->execute();
+            while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                 $arr[$i]['in_broker_#index#'] = $row['broker_module'];
                 $i++;
             }
@@ -105,19 +115,22 @@ class CentreonConfigEngine
             return $timezone;
         }
 
-        $query = 'SELECT timezone FROM ('
+        $stmt = $this->db->prepare(
+            'SELECT timezone FROM ('
             . 'SELECT timezone_name as timezone '
             . 'FROM cfg_nagios, timezone '
-            . 'WHERE nagios_id = ' . $this->db->escape($engineId) . ' '
+            . 'WHERE nagios_id = :engineId '
             . 'AND use_timezone = timezone_id '
             . 'UNION '
             . 'SELECT timezone_name as timezone '
             . 'FROM options, timezone '
             . "WHERE options.key = 'gmt' "
             . 'AND options.value = timezone_id '
-            . ') as t LIMIT 1';
-        $result = $this->db->query($query);
-        if ($row = $result->fetchRow()) {
+            . ') as t LIMIT 1'
+        );
+        $stmt->bindValue(':engineId', (int) $engineId, PDO::PARAM_INT);
+        $stmt->execute();
+        if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $timezone = $row['timezone'];
         }
 

--- a/centreon/www/class/centreonMeta.class.php
+++ b/centreon/www/class/centreonMeta.class.php
@@ -91,18 +91,15 @@ class CentreonMeta
             return $services[$metaId];
         }
 
-        $sql = 'SELECT s.service_id '
-            . 'FROM service s '
-            . 'WHERE s.service_description = "meta_' . $metaId . '" ';
+        $stmt = $this->db->prepare(
+            'SELECT s.service_id FROM service s WHERE s.service_description = :desc ORDER BY s.service_id DESC LIMIT 1'
+        );
+        $stmt->bindValue(':desc', 'meta_' . $metaId, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch();
+        $services[$metaId] = $row !== false ? (int) $row['service_id'] : 0;
 
-        $res = $this->db->query($sql);
-        if ($res->rowCount()) {
-            while ($row = $res->fetchRow()) {
-                $services[$metaId] = $row['service_id'];
-            }
-        }
-
-        return $services[$metaId] ?? 0;
+        return $services[$metaId];
     }
 
     /**
@@ -116,15 +113,14 @@ class CentreonMeta
     public function getMetaIdFromServiceDisplayName($serviceDisplayName)
     {
         $metaId = null;
-        $query = 'SELECT service_description '
-            . 'FROM service '
-            . 'WHERE display_name = "' . $serviceDisplayName . '" ';
-        $res = $this->db->query($query);
-        if ($res->rowCount()) {
-            $row = $res->fetchRow();
-            if (preg_match('/meta_(\d+)/', $row['service_description'], $matches)) {
-                $metaId = $matches[1];
-            }
+        $stmt = $this->db->prepare(
+            'SELECT service_description FROM service WHERE display_name = :displayName LIMIT 1'
+        );
+        $stmt->bindValue(':displayName', $serviceDisplayName, PDO::PARAM_STR);
+        $stmt->execute();
+        $row = $stmt->fetch();
+        if ($row !== false && preg_match('/meta_(\d+)/', $row['service_description'], $matches)) {
+            $metaId = (int) $matches[1];
         }
 
         return $metaId;
@@ -258,18 +254,20 @@ class CentreonMeta
             return [];
         }
 
-        if (count($parameters) > 0) {
-            $sElement = implode(',', $parameters);
+        $sanitized = array_filter($parameters, fn ($col) => preg_match('/^[a-zA-Z0-9_]+$/', $col));
+        if ($sanitized === []) {
+            return [];
         }
+        $sElement = implode(',', $sanitized);
 
-        $query = 'SELECT ' . $sElement . ' '
-            . 'FROM meta_service '
-            . 'WHERE meta_id = ' . $this->db->escape($id) . ' ';
-
-        $res = $this->db->query($query);
-
-        if ($res->rowCount()) {
-            $values = $res->fetchRow();
+        $stmt = $this->db->prepare(
+            'SELECT ' . $sElement . ' FROM meta_service WHERE meta_id = :id LIMIT 1'
+        );
+        $stmt->bindValue(':id', (int) $id, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch();
+        if ($row !== false) {
+            $values = $row;
         }
 
         return $values;
@@ -291,37 +289,47 @@ class CentreonMeta
 
         $composedName = 'meta_' . $metaId;
 
-        $queryService = 'SELECT service_id, display_name FROM service '
-            . 'WHERE service_register = "2" AND service_description = "' . $composedName . '" ';
-        $res = $this->db->query($queryService);
-        if ($res->rowCount()) {
-            $row = $res->fetchRow();
+        $selectStmt = $this->db->prepare(
+            'SELECT service_id, display_name FROM service
+            WHERE service_register = :register AND service_description = :description'
+        );
+        $selectStmt->bindValue(':register', '2', PDO::PARAM_STR);
+        $selectStmt->bindValue(':description', $composedName, PDO::PARAM_STR);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        if ($row !== false) {
             $serviceId = $row['service_id'];
             if ($row['display_name'] !== $metaName) {
-                $query = 'UPDATE service SET display_name = :display_name WHERE service_id = :service_id';
-                $statement = $this->db->prepare($query);
-                $statement->bindValue(':display_name', $metaName, PDO::PARAM_STR);
-                $statement->bindValue(':service_id', (int) $serviceId, PDO::PARAM_INT);
-                $statement->execute();
+                $updateStmt = $this->db->prepare(
+                    'UPDATE service SET display_name = :display_name WHERE service_id = :service_id'
+                );
+                $updateStmt->bindValue(':display_name', $metaName, PDO::PARAM_STR);
+                $updateStmt->bindValue(':service_id', (int) $serviceId, PDO::PARAM_INT);
+                $updateStmt->execute();
             }
         } else {
-            $query = 'INSERT INTO service (service_description, display_name, service_register) '
-                . 'VALUES '
-                . '("' . $composedName . '", "' . $metaName . '", "2")';
-            $this->db->query($query);
-            $query = 'INSERT INTO host_service_relation(host_host_id, service_service_id) '
-                . 'VALUES (:host_id,'
-                . '(SELECT service_id 
-                    FROM service 
-                    WHERE service_description = :service_description AND service_register = "2" LIMIT 1)'
-                . ')';
-            $statement = $this->db->prepare($query);
-            $statement->bindValue(':host_id', (int) $hostId, PDO::PARAM_INT);
-            $statement->bindValue(':service_description', $composedName, PDO::PARAM_STR);
-            $statement->execute();
-            $res = $this->db->query($queryService);
-            if ($res->rowCount()) {
-                $row = $res->fetchRow();
+            $insertStmt = $this->db->prepare(
+                'INSERT INTO service (service_description, display_name, service_register)
+                VALUES (:description, :display_name, :register)'
+            );
+            $insertStmt->bindValue(':description', $composedName, PDO::PARAM_STR);
+            $insertStmt->bindValue(':display_name', $metaName, PDO::PARAM_STR);
+            $insertStmt->bindValue(':register', '2', PDO::PARAM_STR);
+            $insertStmt->execute();
+
+            $relStmt = $this->db->prepare(
+                'INSERT INTO host_service_relation (host_host_id, service_service_id)
+                VALUES (:host_id,
+                (SELECT service_id
+                    FROM service
+                    WHERE service_description = :service_description AND service_register = "2" LIMIT 1))'
+            );
+            $relStmt->bindValue(':host_id', (int) $hostId, PDO::PARAM_INT);
+            $relStmt->bindValue(':service_description', $composedName, PDO::PARAM_STR);
+            $relStmt->execute();
+            $selectStmt->execute();
+            $row = $selectStmt->fetch();
+            if ($row !== false) {
                 $serviceId = $row['service_id'];
             }
         }

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -34,57 +34,59 @@ function testExistence($name = null)
 {
     global $pearDB, $centreon;
 
-    $query = "SELECT contact_name, contact_id FROM contact WHERE contact_name = '"
-        . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $contact = $dbResult->fetch();
-    // Modif case
-    if ($dbResult->rowCount() >= 1 && $contact['contact_id'] == $centreon->user->get_id()) {
-        return true;
-    }
+    $userId = (int) $centreon->user->get_id();
+    $statement = $pearDB->prepare(
+        'SELECT 1 FROM contact WHERE contact_name = :name AND contact_id <> :userId LIMIT 1'
+    );
+    $statement->bindValue(':name', $name, PDO::PARAM_STR);
+    $statement->bindValue(':userId', $userId, PDO::PARAM_INT);
+    $statement->execute();
 
-    return ! ($dbResult->rowCount() >= 1 && $contact['contact_id'] != $centreon->user->get_id());
-    // Duplicate entry
-
+    return $statement->fetchColumn() === false;
 }
 
 function testAliasExistence($alias = null)
 {
     global $pearDB, $centreon;
 
-    $query = 'SELECT contact_alias, contact_id FROM contact '
-        . "WHERE contact_alias = '" . htmlentities($alias, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $contact = $dbResult->fetch();
+    $userId = (int) $centreon->user->get_id();
+    $statement = $pearDB->prepare(
+        'SELECT 1 FROM contact WHERE contact_alias = :alias AND contact_id <> :userId LIMIT 1'
+    );
+    $statement->bindValue(':alias', $alias, PDO::PARAM_STR);
+    $statement->bindValue(':userId', $userId, PDO::PARAM_INT);
+    $statement->execute();
 
-    // Modif case
-    if ($dbResult->rowCount() >= 1 && $contact['contact_id'] == $centreon->user->get_id()) {
-        return true;
-    }
-
-    return ! ($dbResult->rowCount() >= 1 && $contact['contact_id'] != $centreon->user->get_id());
-    // Duplicate entry
-
+    return $statement->fetchColumn() === false;
 }
 
 function updateNotificationOptions($userIdConnected)
 {
     global $form, $pearDB;
 
-    $pearDB->query('DELETE FROM contact_param
-        WHERE cp_contact_id = ' . $pearDB->escape($userIdConnected) . "
-        AND cp_key LIKE 'monitoring%notification%'");
+    $deleteStmt = $pearDB->prepare(
+        "DELETE FROM contact_param WHERE cp_contact_id = :contact_id AND cp_key LIKE 'monitoring%notification%'"
+    );
+    $deleteStmt->bindValue(':contact_id', (int) $userIdConnected, PDO::PARAM_INT);
+    $deleteStmt->execute();
+
     $data = $form->getSubmitValues();
+
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO contact_param (cp_key, cp_value, cp_contact_id) VALUES (:cp_key, :cp_value, :contact_id)'
+    );
+
     foreach ($data as $k => $v) {
         if (preg_match('/^monitoring_(host|svc)_notification/', $k)) {
-            $query = 'INSERT INTO contact_param (cp_key, cp_value, cp_contact_id) '
-                . "VALUES ('" . $pearDB->escape($k) . "', '1', " . $pearDB->escape($userIdConnected) . ')';
-            $pearDB->query($query);
+            $insertStmt->bindValue(':cp_key', $k, PDO::PARAM_STR);
+            $insertStmt->bindValue(':cp_value', '1', PDO::PARAM_STR);
+            $insertStmt->bindValue(':contact_id', (int) $userIdConnected, PDO::PARAM_INT);
+            $insertStmt->execute();
         } elseif (preg_match('/^monitoring_sound/', $k)) {
-            $query = 'INSERT INTO contact_param (cp_key, cp_value, cp_contact_id) '
-                . "VALUES ('" . $pearDB->escape($k) . "', '" . $pearDB->escape($v) . "', "
-                . $pearDB->escape($userIdConnected) . ')';
-            $pearDB->query($query);
+            $insertStmt->bindValue(':cp_key', $k, PDO::PARAM_STR);
+            $insertStmt->bindValue(':cp_value', $v, PDO::PARAM_STR);
+            $insertStmt->bindValue(':contact_id', (int) $userIdConnected, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
     unset($_SESSION['centreon_notification_preferences']);

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -138,32 +138,31 @@ function updateNagiosConfigData($gopt_id = null)
 {
     global $form, $pearDB, $centreon;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
 
     updateOption(
         $pearDB,
         'nagios_path_plugins',
         isset($ret['nagios_path_plugins']) && $ret['nagios_path_plugins'] != null
-            ? $pearDB->escape($ret['nagios_path_plugins']) : 'NULL'
+            ? $ret['nagios_path_plugins'] : 'NULL'
     );
     updateOption(
         $pearDB,
         'mailer_path_bin',
         isset($ret['mailer_path_bin']) && $ret['mailer_path_bin'] != null
-            ? $pearDB->escape($ret['mailer_path_bin']) : 'NULL'
+            ? $ret['mailer_path_bin'] : 'NULL'
     );
     updateOption(
         $pearDB,
         'interval_length',
         isset($ret['interval_length']) && $ret['interval_length'] != null
-            ? $pearDB->escape($ret['interval_length']) : 'NULL'
+            ? $ret['interval_length'] : 'NULL'
     );
     updateOption(
         $pearDB,
         'broker',
         isset($ret['broker']) && $ret['broker'] != null
-            ? $pearDB->escape($ret['broker']) : 'broker'
+            ? $ret['broker'] : 'broker'
     );
     $pearDB->query('UPDATE acl_resources SET changed = 1');
 
@@ -204,13 +203,13 @@ function updateNagiosConfigData($gopt_id = null)
         $pearDB,
         'monitoring_dwt_duration',
         isset($ret['monitoring_dwt_duration']) && $ret['monitoring_dwt_duration']
-            ? $pearDB->escape($ret['monitoring_dwt_duration']) : 3600
+            ? $ret['monitoring_dwt_duration'] : 3600
     );
     updateOption(
         $pearDB,
         'monitoring_dwt_duration_scale',
         isset($ret['monitoring_dwt_duration_scale']) && $ret['monitoring_dwt_duration_scale']
-            ? $pearDB->escape($ret['monitoring_dwt_duration_scale']) : 's'
+            ? $ret['monitoring_dwt_duration_scale'] : 's'
     );
     updateOption(
         $pearDB,
@@ -320,7 +319,6 @@ function updateSNMPConfigData($gopt_id = null)
 {
     global $form, $pearDB, $centreon;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
 
     updateOption(
@@ -365,7 +363,6 @@ function updateDebugConfigData($gopt_id = null)
 {
     global $form, $pearDB, $centreon;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
 
     updateOption(
@@ -493,7 +490,6 @@ function updateGeneralConfigData()
 {
     global $form, $pearDB, $centreon;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
 
     if (! isset($ret['AjaxTimeReloadStatistic'])) {
@@ -679,7 +675,6 @@ function updateRRDToolConfigData($gopt_id = null)
 {
     global $form, $pearDB, $centreon;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
 
     updateOption(
@@ -730,7 +725,6 @@ function updateODSConfigData()
 {
     global $form, $pearDBO, $pearDB;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
     if (! isset($ret['audit_log_option'])) {
         $ret['audit_log_option'] = '0';
@@ -766,24 +760,50 @@ function updateODSConfigData()
     if (! isset($ret['audit_log_retention'])) {
         $ret['audit_log_retention'] = 0;
     }
+    if (! isset($ret['archive_retention'])) {
+        $ret['archive_retention'] = 0;
+    }
+    if (! isset($ret['reporting_retention'])) {
+        $ret['reporting_retention'] = 0;
+    }
 
-    $rq = "UPDATE `config` SET `RRDdatabase_path` = '" . $ret['RRDdatabase_path'] . "',
-        `RRDdatabase_status_path` = '" . $ret['RRDdatabase_status_path'] . "',
-        `RRDdatabase_nagios_stats_path` = '" . $ret['RRDdatabase_nagios_stats_path'] . "',
-        `len_storage_rrd` = '" . $ret['len_storage_rrd'] . "',
-        `len_storage_mysql` = '" . $ret['len_storage_mysql'] . "',
-        `autodelete_rrd_db` = '" . $ret['autodelete_rrd_db'] . "',
-        `purge_interval` = '" . $ret['purge_interval'] . "',
-        `archive_log` = '" . $ret['archive_log'] . "',
-        `archive_retention` = '" . $ret['archive_retention'] . "',
-        `reporting_retention` = '" . $ret['reporting_retention'] . "',
-        `audit_log_option` = '" . $ret['audit_log_option'] . "',
-        `storage_type` = " . ($ret['storage_type'] ?? 'NULL') . ",
-        `len_storage_downtimes` = '" . $ret['len_storage_downtimes'] . "',
-        `audit_log_retention` = '" . $ret['audit_log_retention'] . "',
-        `len_storage_comments` = '" . $ret['len_storage_comments'] . "' "
-        . ' WHERE `id` = 1 LIMIT 1 ;';
-    $DBRESULT = $pearDBO->query($rq);
+    $statement = $pearDBO->prepare(
+        'UPDATE `config` SET
+        `RRDdatabase_path` = :rrdPath,
+        `RRDdatabase_status_path` = :rrdStatusPath,
+        `RRDdatabase_nagios_stats_path` = :rrdStatsPath,
+        `len_storage_rrd` = :lenRrd,
+        `len_storage_mysql` = :lenMysql,
+        `autodelete_rrd_db` = :autodeleteRrd,
+        `purge_interval` = :purgeInterval,
+        `archive_log` = :archiveLog,
+        `archive_retention` = :archiveRetention,
+        `reporting_retention` = :reportingRetention,
+        `audit_log_option` = :auditLogOption,
+        `storage_type` = :storageType,
+        `len_storage_downtimes` = :lenDowntimes,
+        `audit_log_retention` = :auditLogRetention,
+        `len_storage_comments` = :lenComments
+        WHERE `id` = 1 LIMIT 1'
+    );
+    $statement->bindValue(':rrdPath', $ret['RRDdatabase_path'], PDO::PARAM_STR);
+    $statement->bindValue(':rrdStatusPath', $ret['RRDdatabase_status_path'], PDO::PARAM_STR);
+    $statement->bindValue(':rrdStatsPath', $ret['RRDdatabase_nagios_stats_path'], PDO::PARAM_STR);
+    $statement->bindValue(':lenRrd', (int) $ret['len_storage_rrd'], PDO::PARAM_INT);
+    $statement->bindValue(':lenMysql', (int) $ret['len_storage_mysql'], PDO::PARAM_INT);
+    $statement->bindValue(':autodeleteRrd', $ret['autodelete_rrd_db'], PDO::PARAM_STR);
+    $statement->bindValue(':purgeInterval', (int) $ret['purge_interval'], PDO::PARAM_INT);
+    $statement->bindValue(':archiveLog', $ret['archive_log'], PDO::PARAM_STR);
+    $statement->bindValue(':archiveRetention', (int) $ret['archive_retention'], PDO::PARAM_INT);
+    $statement->bindValue(':reportingRetention', (int) $ret['reporting_retention'], PDO::PARAM_INT);
+    $statement->bindValue(':auditLogOption', $ret['audit_log_option'], PDO::PARAM_STR);
+    $rawStorageType = $ret['storage_type'] ?? null;
+    $storageType = ($rawStorageType === null || $rawStorageType === '') ? null : (int) $rawStorageType;
+    $statement->bindValue(':storageType', $storageType, $storageType === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+    $statement->bindValue(':lenDowntimes', (int) $ret['len_storage_downtimes'], PDO::PARAM_INT);
+    $statement->bindValue(':auditLogRetention', (int) $ret['audit_log_retention'], PDO::PARAM_INT);
+    $statement->bindValue(':lenComments', (int) $ret['len_storage_comments'], PDO::PARAM_INT);
+    $statement->execute();
 
     updateOption(
         $pearDB,
@@ -795,7 +815,7 @@ function updateODSConfigData()
     updateOption(
         $pearDB,
         'centstorage_drop_file',
-        isset($ret['centstorage_drop_file']) ? $pearDB->escape($ret['centstorage_drop_file']) : ''
+        $ret['centstorage_drop_file'] ?? ''
     );
 }
 
@@ -803,7 +823,6 @@ function updateCASConfigData($gopt_id = null)
 {
     global $form, $pearDB, $centreon;
 
-    $ret = [];
     $ret = $form->getSubmitValues();
 
     updateOption(

--- a/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
+++ b/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
@@ -42,15 +42,17 @@ function testExistence($name = null)
         $id = $form->getSubmitValue('id');
     }
 
-    $dbResult = $pearDB->query("SELECT config_name, config_id
-                                FROM `cfg_centreonbroker`
-                                WHERE `config_name` = '" . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'");
-    $ndomod = $dbResult->fetch();
-    if ($dbResult->rowCount() >= 1 && $ndomod['config_id'] == $id) {
+    $statement = $pearDB->prepare(
+        'SELECT config_name, config_id FROM `cfg_centreonbroker` WHERE `config_name` = :name'
+    );
+    $statement->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
+    $ndomod = $statement->fetch();
+    if ($statement->rowCount() >= 1 && $ndomod['config_id'] == $id) {
         return true;
     }
 
-    return ! ($dbResult->rowCount() >= 1 && $ndomod['config_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $ndomod['config_id'] != $id);
 }
 
 /**
@@ -143,11 +145,14 @@ function getCentreonBrokerInformation($id)
             event_queues_total_size, cache_directory, command_file, daemon, pool_size, log_directory, log_filename,
             log_max_size, bbdo_version
         FROM cfg_centreonbroker
-        WHERE config_id = ' . $id;
+        WHERE config_id = :config_id';
     try {
-        $res = $pearDB->query($query);
+        $statement = $pearDB->prepare($query);
+        $statement->bindValue(':config_id', (int) $id, PDO::PARAM_INT);
+        $statement->execute();
+        $res = $statement;
     } catch (PDOException $e) {
-        $brokerConf = [
+        return [
             'name' => '',
             'filename' => '',
             'log_directory' => '/var/log/centreon-broker/',
@@ -189,9 +194,12 @@ function getCentreonBrokerInformation($id)
             FROM `cb_log` log
             LEFT JOIN `cfg_centreonbroker_log` relation
                 ON relation.`id_log`  = log.`id`
-            WHERE relation.`id_centreonbroker` = ' . $id;
+            WHERE relation.`id_centreonbroker` = :config_id';
     try {
-        $res = $pearDB->query($query);
+        $statement = $pearDB->prepare($query);
+        $statement->bindValue(':config_id', (int) $id, PDO::PARAM_INT);
+        $statement->execute();
+        $res = $statement;
     } catch (PDOException $e) {
         return $brokerConf;
     }

--- a/centreon/www/include/configuration/configGenerate/DB-Func.php
+++ b/centreon/www/include/configuration/configGenerate/DB-Func.php
@@ -23,18 +23,24 @@
  * Get the configuration path for Centreon Broker
  *
  * @param int $ns_id The nagios server id
- * @return string
+ * @return string|null
  */
 function getCentreonBrokerDirCfg($ns_id)
 {
     global $pearDB;
-    $query = 'SELECT centreonbroker_cfg_path
+    $statement = $pearDB->prepare('SELECT centreonbroker_cfg_path
 	    	FROM nagios_server
-	    	WHERE id = ' . $ns_id;
-    $res = $pearDB->query($query);
-    $row = $res->fetch();
-    if (trim($row['centreonbroker_cfg_path']) != '') {
-        return trim($row['centreonbroker_cfg_path']);
+	    	WHERE id = :ns_id');
+    $statement->bindValue(':ns_id', (int) $ns_id, PDO::PARAM_INT);
+    $statement->execute();
+    $row = $statement->fetch(PDO::FETCH_ASSOC);
+    if ($row === false) {
+        return null;
+    }
+
+    $path = trim((string) $row['centreonbroker_cfg_path']);
+    if ($path !== '') {
+        return $path;
     }
 
     return null;

--- a/centreon/www/include/configuration/configNagios/DB-Func.php
+++ b/centreon/www/include/configuration/configNagios/DB-Func.php
@@ -28,16 +28,17 @@ function testExistence($name = null)
         $id = $form->getSubmitValue('nagios_id');
     }
 
-    $dbResult = $pearDB->query(
-        "SELECT nagios_name, nagios_id FROM cfg_nagios WHERE nagios_name = '"
-        . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'"
+    $statement = $pearDB->prepare(
+        'SELECT nagios_name, nagios_id FROM cfg_nagios WHERE nagios_name = :name'
     );
-    $nagios = $dbResult->fetch();
-    if ($dbResult->rowCount() >= 1 && $nagios['nagios_id'] == $id) {
+    $statement->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
+    $nagios = $statement->fetch();
+    if ($statement->rowCount() >= 1 && $nagios['nagios_id'] == $id) {
         return true;
     }
 
-    return ! ($dbResult->rowCount() >= 1 && $nagios['nagios_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $nagios['nagios_id'] != $id);
 }
 
 /**
@@ -51,10 +52,12 @@ function enableNagiosInDB($nagiosId = null)
         return;
     }
 
-    $dbResult = $pearDB->query(
-        "SELECT `nagios_server_id` FROM cfg_nagios WHERE nagios_id = '" . $nagiosId . "'"
+    $statement = $pearDB->prepare(
+        'SELECT `nagios_server_id` FROM cfg_nagios WHERE nagios_id = :nagios_id'
     );
-    $data = $dbResult->fetch();
+    $statement->bindValue(':nagios_id', (int) $nagiosId, PDO::PARAM_INT);
+    $statement->execute();
+    $data = $statement->fetch();
 
     $statement = $pearDB->prepare(
         "UPDATE `cfg_nagios`
@@ -64,9 +67,11 @@ function enableNagiosInDB($nagiosId = null)
     $statement->bindValue(':nagios_server_id', (int) $data['nagios_server_id'], PDO::PARAM_INT);
     $statement->execute();
 
-    $pearDB->query(
-        "UPDATE cfg_nagios SET nagios_activate = '1' WHERE nagios_id = '" . $nagiosId . "'"
+    $statement = $pearDB->prepare(
+        "UPDATE cfg_nagios SET nagios_activate = '1' WHERE nagios_id = :nagios_id"
     );
+    $statement->bindValue(':nagios_id', (int) $nagiosId, PDO::PARAM_INT);
+    $statement->execute();
 
     $query = "SELECT `id`, `name` FROM nagios_server WHERE `ns_activate` = '0' AND `id` = :id";
     $statement = $pearDB->prepare($query);
@@ -94,14 +99,18 @@ function disableNagiosInDB($nagiosId = null)
         return;
     }
 
-    $dbResult = $pearDB->query(
-        "SELECT `nagios_server_id` FROM cfg_nagios WHERE nagios_id = '" . $nagiosId . "'"
+    $statement = $pearDB->prepare(
+        'SELECT `nagios_server_id` FROM cfg_nagios WHERE nagios_id = :nagios_id'
     );
-    $data = $dbResult->fetch();
+    $statement->bindValue(':nagios_id', (int) $nagiosId, PDO::PARAM_INT);
+    $statement->execute();
+    $data = $statement->fetch();
 
-    $pearDB->query(
-        "UPDATE cfg_nagios SET nagios_activate = '0' WHERE `nagios_id` = '" . $nagiosId . "'"
+    $statement = $pearDB->prepare(
+        "UPDATE cfg_nagios SET nagios_activate = '0' WHERE `nagios_id` = :nagios_id"
     );
+    $statement->bindValue(':nagios_id', (int) $nagiosId, PDO::PARAM_INT);
+    $statement->execute();
 
     $query = "SELECT `nagios_id` FROM cfg_nagios WHERE `nagios_activate` = '1' "
              . 'AND `nagios_server_id` = :nagios_server_id';
@@ -131,12 +140,13 @@ function deleteNagiosInDB($nagios = [])
     global $pearDB;
 
     foreach ($nagios as $key => $value) {
-        $pearDB->query(
-            "DELETE FROM cfg_nagios WHERE nagios_id = '" . $key . "'"
-        );
-        $pearDB->query(
-            "DELETE FROM cfg_nagios_broker_module WHERE cfg_nagios_id = '" . $key . "'"
-        );
+        $statement = $pearDB->prepare('DELETE FROM cfg_nagios WHERE nagios_id = :nagios_id');
+        $statement->bindValue(':nagios_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
+
+        $statement = $pearDB->prepare('DELETE FROM cfg_nagios_broker_module WHERE cfg_nagios_id = :cfg_nagios_id');
+        $statement->bindValue(':cfg_nagios_id', (int) $key, PDO::PARAM_INT);
+        $statement->execute();
     }
     $dbResult = $pearDB->query(
         "SELECT nagios_id FROM cfg_nagios WHERE nagios_activate = '1'"
@@ -165,7 +175,7 @@ function multipleNagiosInDB($nagios = [], $nbrDup = [])
         $stmt->bindValue('nagiosId', (int) $originalNagiosId, PDO::PARAM_INT);
         $stmt->execute();
         $row = $stmt->fetch();
-        $row['nagios_id'] = '';
+        unset($row['nagios_id']);
         $row['nagios_activate'] = '0';
         $stmt->closeCursor();
 
@@ -178,21 +188,22 @@ function multipleNagiosInDB($nagios = [], $nbrDup = [])
         }
         $stmt->closeCursor();
 
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO cfg_nagios (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+
+        $originalName = $row['nagios_name'];
         for ($i = 1; $i <= $nbrDup[$originalNagiosId]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                $value2 = $pearDB->escape($value2);
-                if ($key2 == 'nagios_name') {
-                    $nagios_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-            }
+            $nagios_name = $originalName . '_' . $i;
+            $row['nagios_name'] = $nagios_name;
+
             if (testExistence($nagios_name)) {
-                $rq = $val ? 'INSERT INTO cfg_nagios VALUES (' . $val . ')' : null;
-                $dbResult = $pearDB->query($rq);
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
+                $insertStmt->execute();
                 // Find the new last nagios_id once
                 $dbResult = $pearDB->query('SELECT MAX(nagios_id) FROM cfg_nagios');
                 $nagiosId = $dbResult->fetch();
@@ -641,8 +652,9 @@ function updateNagios($nagiosId = null)
     $queryPieces = array_map(fn ($columnName) => "`{$columnName}` = :{$columnName}", array_keys($nagiosCfg));
 
     $statement = $pearDB->prepare(
-        'UPDATE cfg_nagios SET ' . implode(', ', $queryPieces) . " WHERE nagios_id = {$nagiosId}"
+        'UPDATE cfg_nagios SET ' . implode(', ', $queryPieces) . ' WHERE nagios_id = :nagios_id'
     );
+    $statement->bindValue(':nagios_id', (int) $nagiosId, PDO::PARAM_INT);
 
     array_walk(
         $nagiosCfg,

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1272,9 +1272,10 @@ function updateContact_MC(int $contact_id): void
         $stmt->execute();
 
         // Prepare Log
-        $query = "SELECT contact_name FROM `contact` WHERE contact_id='" . $contact_id . "' LIMIT 1";
-        $dbResult2 = $pearDB->query($query);
-        $row = $dbResult2->fetch();
+        $logStmt = $pearDB->prepare('SELECT contact_name FROM `contact` WHERE contact_id = :contactId LIMIT 1');
+        $logStmt->bindValue(':contactId', $contact_id, PDO::PARAM_INT);
+        $logStmt->execute();
+        $row = $logStmt->fetch();
     } catch (PDOException $e) {
         throw new RepositoryException(
             message: 'Database error while updating contact by massive change for contact id ' . $contact_id,
@@ -1670,8 +1671,10 @@ function updateContactContactGroup_MC(int $contactId): bool
     }
 
     try {
-        $query = "SELECT contactgroup_cg_id FROM contactgroup_contact_relation WHERE contact_contact_id = {$contactId}";
-        $contactGroupIdsFromDb = $pearDB->executeQueryFetchColumn($query);
+        $cgStmt = $pearDB->prepare('SELECT contactgroup_cg_id FROM contactgroup_contact_relation WHERE contact_contact_id = :contactId');
+        $cgStmt->bindValue(':contactId', $contactId, PDO::PARAM_INT);
+        $cgStmt->execute();
+        $contactGroupIdsFromDb = $cgStmt->fetchAll(PDO::FETCH_COLUMN);
 
         $query = 'INSERT INTO contactgroup_contact_relation (contact_contact_id, contactgroup_cg_id) VALUES (:contact_id, :contactgroup_id)';
         $pdoSth = $pearDB->prepareQuery($query);
@@ -1755,10 +1758,11 @@ function insertLdapContactInDB($tmpContacts = [])
             unset($tmpConf);
         }
         // Get the contact_id
-        $query = "SELECT contact_id FROM contact WHERE contact_ldap_dn = '"
-            . $pearDB->escape($tmpContacts['dn'][$select_key]) . "'";
         try {
-            $res = $pearDB->query($query);
+            $dnStmt = $pearDB->prepare('SELECT contact_id FROM contact WHERE contact_ldap_dn = :ldapDn');
+            $dnStmt->bindValue(':ldapDn', $tmpContacts['dn'][$select_key], PDO::PARAM_STR);
+            $dnStmt->execute();
+            $res = $dnStmt;
         } catch (PDOException $e) {
             return false;
         }
@@ -1776,22 +1780,37 @@ function insertLdapContactInDB($tmpContacts = [])
             $ldap = $ldapInstances[$arId];
         }
         if ($contact_id) {
-            $sqlUpdate = 'UPDATE contact SET ar_id = ' . $pearDB->escape($arId)
-                . ' %s  WHERE contact_id = ' . (int) $contact_id;
-            $tmplSql = '';
             if (isset($contactTemplates[$arId])) {
-                $tmplSql = ', contact_template_id = ' . $pearDB->escape($contactTemplates[$arId]);
+                $updateStmt = $pearDB->prepare(
+                    'UPDATE contact SET ar_id = :arId, contact_template_id = :tmplId WHERE contact_id = :contactId'
+                );
+                $updateStmt->bindValue(':tmplId', (int) $contactTemplates[$arId], PDO::PARAM_INT);
+            } else {
+                $updateStmt = $pearDB->prepare(
+                    'UPDATE contact SET ar_id = :arId WHERE contact_id = :contactId'
+                );
             }
-            $pearDB->query(sprintf($sqlUpdate, $tmplSql));
+            $updateStmt->bindValue(':arId', (int) $arId, PDO::PARAM_INT);
+            $updateStmt->bindValue(':contactId', (int) $contact_id, PDO::PARAM_INT);
+            $updateStmt->execute();
         }
         $listGroup = [];
         if ($ldap->connect() !== false) {
             $listGroup = $ldap->listGroupsForUser($tmpContacts['dn'][$select_key]);
         }
         if ($listGroup !== []) {
-            $query = "SELECT cg_id FROM contactgroup WHERE cg_name IN ('" . join("','", $listGroup) . "')";
+            $placeholders = [];
+            foreach ($listGroup as $idx => $groupName) {
+                $placeholders[] = ':cg_' . $idx;
+            }
+            $query = 'SELECT cg_id FROM contactgroup WHERE cg_name IN (' . implode(',', $placeholders) . ')';
             try {
-                $res = $pearDB->query($query);
+                $cgStmt = $pearDB->prepare($query);
+                foreach ($listGroup as $idx => $groupName) {
+                    $cgStmt->bindValue(':cg_' . $idx, $groupName, PDO::PARAM_STR);
+                }
+                $cgStmt->execute();
+                $res = $cgStmt;
             } catch (PDOException $e) {
                 return false;
             }

--- a/centreon/www/include/configuration/configObject/contact/ldapsearch.php
+++ b/centreon/www/include/configuration/configObject/contact/ldapsearch.php
@@ -128,6 +128,16 @@ foreach ($ids as $arId) {
         $searchResult = $ldap->search($ldap_search_filter, $ldap_base_dn, $ldap_search_limit, $ldap_search_timeout);
         $number_returned = count($searchResult);
         if ($number_returned) {
+            $resServer = $pearDB->prepare(
+                'SELECT `ar_id`, `ar_name` FROM auth_ressource WHERE ar_id = :arId'
+            );
+            $resServer->bindValue(':arId', (int) $arId, PDO::PARAM_INT);
+            $resServer->execute();
+            $serverRow = $resServer->fetch(PDO::FETCH_ASSOC);
+            if ($serverRow === false) {
+                continue;
+            }
+
             $buffer->writeElement('entries', $number_returned);
             for ($i = 0; $i < $number_returned; $i++) {
                 if (isset($searchResult[$i]['dn'])) {
@@ -153,13 +163,8 @@ foreach ($ids as $arId) {
                     $searchResult[$i]['name'] = str_replace("\'", "\\\'", $searchResult[$i]['name']);
 
                     $buffer->startElement('user');
-                    $query = 'SELECT `ar_id`, `ar_name`
-                              FROM auth_ressource
-                              WHERE ar_id = ' . $pearDB->escape($arId);
-                    $resServer = $pearDB->query($query);
-                    $row = $resServer->fetchRow();
-                    $buffer->writeAttribute('server', $row['ar_name']);
-                    $buffer->writeAttribute('ar_id', $row['ar_id']);
+                    $buffer->writeAttribute('server', $serverRow['ar_name']);
+                    $buffer->writeAttribute('ar_id', $serverRow['ar_id']);
                     $buffer->writeAttribute('isvalid', $isvalid);
                     $buffer->startElement('dn');
                     $buffer->writeAttribute('isvalid', (($searchResult[$i]['dn'] != '') ? '1' : '0'));

--- a/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
@@ -31,17 +31,19 @@ function testContactGroupExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('cg_id');
     }
-    $query = 'SELECT `cg_name`, `cg_id` FROM `contactgroup` '
-        . "WHERE `cg_name` = '" . htmlentities($centreon->checkIllegalChar($name)) . "'";
-    $dbResult = $pearDB->query($query);
-    $cg = $dbResult->fetch();
+    $stmt = $pearDB->prepare(
+        'SELECT `cg_name`, `cg_id` FROM `contactgroup` WHERE `cg_name` = :cgName'
+    );
+    $stmt->bindValue(':cgName', htmlentities($centreon->checkIllegalChar($name), ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $stmt->execute();
+    $cg = $stmt->fetch();
 
-    if ($dbResult->rowCount() >= 1 && $cg['cg_id'] == $id) {
+    if ($stmt->rowCount() >= 1 && $cg['cg_id'] == $id) {
         // Modif case
         return true;
     }
 
-    return ! ($dbResult->rowCount() >= 1 && $cg['cg_id'] != $id);
+    return ! ($stmt->rowCount() >= 1 && $cg['cg_id'] != $id);
     // Duplicate entry
 
 }
@@ -53,9 +55,14 @@ function enableContactGroupInDB($cg_id = null)
     if (! $cg_id) {
         return;
     }
-    $pearDB->query("UPDATE `contactgroup` SET `cg_activate` = '1' WHERE `cg_id` = '" . (int) $cg_id . "'");
+    $stmt = $pearDB->prepare("UPDATE `contactgroup` SET `cg_activate` = '1' WHERE `cg_id` = :cgId");
+    $stmt->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+    $stmt->execute();
 
-    $dbResult2 = $pearDB->query("SELECT cg_name FROM `contactgroup` WHERE `cg_id` = '" . (int) $cg_id . "' LIMIT 1");
+    $stmt2 = $pearDB->prepare('SELECT cg_name FROM `contactgroup` WHERE `cg_id` = :cgId LIMIT 1');
+    $stmt2->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+    $stmt2->execute();
+    $dbResult2 = $stmt2;
     $row = $dbResult2->fetch();
 
     $centreon->CentreonLogAction->insertLog('contactgroup', $cg_id, $row['cg_name'], 'enable');
@@ -68,9 +75,14 @@ function disableContactGroupInDB($cg_id = null)
     if (! $cg_id) {
         return;
     }
-    $pearDB->query("UPDATE `contactgroup` SET `cg_activate` = '0' WHERE `cg_id` = '" . (int) $cg_id . "'");
+    $stmt = $pearDB->prepare("UPDATE `contactgroup` SET `cg_activate` = '0' WHERE `cg_id` = :cgId");
+    $stmt->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+    $stmt->execute();
 
-    $dbResult2 = $pearDB->query("SELECT cg_name FROM `contactgroup` WHERE `cg_id` = '" . (int) $cg_id . "' LIMIT 1");
+    $stmt2 = $pearDB->prepare('SELECT cg_name FROM `contactgroup` WHERE `cg_id` = :cgId LIMIT 1');
+    $stmt2->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+    $stmt2->execute();
+    $dbResult2 = $stmt2;
     $row = $dbResult2->fetch();
 
     $centreon->CentreonLogAction->insertLog('contactgroup', $cg_id, $row['cg_name'], 'disable');
@@ -81,11 +93,14 @@ function deleteContactGroupInDB($contactGroups = [])
     global $pearDB, $centreon;
 
     foreach ($contactGroups as $key => $value) {
-        $query = "SELECT cg_name FROM `contactgroup` WHERE `cg_id` = '" . (int) $key . "' LIMIT 1";
-        $dbResult2 = $pearDB->query($query);
-        $row = $dbResult2->fetch();
+        $stmt = $pearDB->prepare('SELECT cg_name FROM `contactgroup` WHERE `cg_id` = :cgId LIMIT 1');
+        $stmt->bindValue(':cgId', (int) $key, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch();
 
-        $pearDB->query("DELETE FROM `contactgroup` WHERE `cg_id` = '" . (int) $key . "'");
+        $deleteStmt = $pearDB->prepare('DELETE FROM `contactgroup` WHERE `cg_id` = :cgId');
+        $deleteStmt->bindValue(':cgId', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
         $centreon->CentreonLogAction->insertLog('contactgroup', $key, $row['cg_name'], 'd');
     }
 }
@@ -95,39 +110,40 @@ function multipleContactGroupInDB($contactGroups = [], $nbrDup = [])
     global $pearDB, $centreon;
 
     foreach ($contactGroups as $key => $value) {
-        $dbResult = $pearDB->query("SELECT * FROM `contactgroup` WHERE `cg_id` = '" . (int) $key . "' LIMIT 1");
+        $selectStmt = $pearDB->prepare('SELECT * FROM `contactgroup` WHERE `cg_id` = :cgId LIMIT 1');
+        $selectStmt->bindValue(':cgId', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $dbResult = $selectStmt;
 
         $row = $dbResult->fetch();
-        $row['cg_id'] = null;
+        unset($row['cg_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO `contactgroup` (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+
+        $originalName = $row['cg_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'cg_name') {
-                    $cg_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
+            $cg_name = $originalName . '_' . $i;
+            $row['cg_name'] = $cg_name;
+
+            if (testContactGroupExistence($cg_name)) {
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
                 }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-                if ($key2 != 'cg_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($cg_name)) {
-                    $fields['cg_name'] = $cg_name;
-                }
-            }
-            if (isset($cg_name) && testContactGroupExistence($cg_name)) {
-                $rq = $val ? 'INSERT INTO `contactgroup` VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+                $insertStmt->execute();
 
                 $dbResult = $pearDB->query('SELECT MAX(cg_id) FROM `contactgroup`');
                 $maxId = $dbResult->fetch();
 
                 if (isset($maxId['MAX(cg_id)'])) {
-                    $query = 'SELECT DISTINCT `acl_group_id` FROM `acl_group_contactgroups_relations` '
-                        . 'WHERE `cg_cg_id` = ' . (int) $key;
-                    $dbResult = $pearDB->query($query);
+                    $aclStmt = $pearDB->prepare(
+                        'SELECT DISTINCT `acl_group_id` FROM `acl_group_contactgroups_relations` WHERE `cg_cg_id` = :cgId'
+                    );
+                    $aclStmt->bindValue(':cgId', (int) $key, PDO::PARAM_INT);
+                    $aclStmt->execute();
+                    $dbResult = $aclStmt;
                     $fields['cg_aclRelation'] = '';
                     $aclContactStatement = $pearDB->prepare('INSERT INTO `acl_group_contactgroups_relations` '
                         . 'VALUES (:maxId, :cgAcl)');
@@ -137,9 +153,13 @@ function multipleContactGroupInDB($contactGroups = [], $nbrDup = [])
                         $aclContactStatement->execute();
                         $fields['cg_aclRelation'] .= $cgAcl['acl_group_id'] . ',';
                     }
-                    $query = 'SELECT DISTINCT `cgcr`.`contact_contact_id` FROM `contactgroup_contact_relation` `cgcr`'
-                        . " WHERE `cgcr`.`contactgroup_cg_id` = '" . (int) $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $contactStmt = $pearDB->prepare(
+                        'SELECT DISTINCT `cgcr`.`contact_contact_id` FROM `contactgroup_contact_relation` `cgcr`'
+                        . ' WHERE `cgcr`.`contactgroup_cg_id` = :cgId'
+                    );
+                    $contactStmt->bindValue(':cgId', (int) $key, PDO::PARAM_INT);
+                    $contactStmt->execute();
+                    $dbResult = $contactStmt;
                     $fields['cg_contacts'] = '';
                     $contactStatement = $pearDB->prepare('INSERT INTO `contactgroup_contact_relation` '
                         . 'VALUES (:cct, :maxId)');
@@ -251,13 +271,14 @@ function updateContactGroup($cgId = null, $params = [])
 
     $stmt = $pearDB->prepare(
         'UPDATE `contactgroup` SET `cg_name` = :cgName, `cg_alias` = :cgAlias, `cg_comment` = :cgComment, '
-        . '`cg_activate` = :cgActivate  WHERE `cg_id` = ' . (int) $cgId
+        . '`cg_activate` = :cgActivate  WHERE `cg_id` = :cgId'
     );
 
     $stmt->bindValue(':cgName', $cgName, PDO::PARAM_STR);
     $stmt->bindValue(':cgAlias', $cgAlias, PDO::PARAM_STR);
     $stmt->bindValue(':cgComment', $cgComment, PDO::PARAM_STR);
     $stmt->bindValue(':cgActivate', $cgActivate, PDO::PARAM_STR);
+    $stmt->bindValue(':cgId', (int) $cgId, PDO::PARAM_INT);
     $stmt->execute();
 
     // Prepare value for changelog
@@ -272,16 +293,20 @@ function updateContactGroupContacts($cg_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM `contactgroup_contact_relation` WHERE `contactgroup_cg_id` = '" . (int) $cg_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM `contactgroup_contact_relation` WHERE `contactgroup_cg_id` = :cgId');
+    $deleteStmt->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
 
     $ret = $ret['cg_contacts'] ?? CentreonUtils::mergeWithInitialValues($form, 'cg_contacts');
     $counter = count($ret);
 
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO `contactgroup_contact_relation` (`contact_contact_id`, `contactgroup_cg_id`) VALUES (:contactId, :cgId)'
+    );
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO `contactgroup_contact_relation` (`contact_contact_id`, `contactgroup_cg_id`) ';
-        $rq .= "VALUES ('" . $ret[$i] . "', '" . (int) $cg_id . "')";
-        $dbResult = $pearDB->query($rq);
+        $insertStmt->bindValue(':contactId', (int) $ret[$i], PDO::PARAM_INT);
+        $insertStmt->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+        $insertStmt->execute();
 
         CentreonCustomView::syncContactGroupCustomView($centreon, $pearDB, $ret[$i]);
     }
@@ -295,8 +320,9 @@ function updateContactGroupAclGroups($cg_id, $ret = [])
         return;
     }
 
-    $rq = 'DELETE FROM `acl_group_contactgroups_relations` WHERE `cg_cg_id` = ' . (int) $cg_id;
-    $res = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM `acl_group_contactgroups_relations` WHERE `cg_cg_id` = :cgId');
+    $deleteStmt->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
 
     if (isset($ret['cg_acl_groups'])) {
         $ret = $ret['cg_acl_groups'];
@@ -305,10 +331,13 @@ function updateContactGroupAclGroups($cg_id, $ret = [])
     }
     $counter = count($ret);
 
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO `acl_group_contactgroups_relations` (`acl_group_id`, `cg_cg_id`) VALUES (:aclGroupId, :cgId)'
+    );
     for ($i = 0; $i < $counter; $i++) {
-        $rq = 'INSERT INTO `acl_group_contactgroups_relations` (`acl_group_id`, `cg_cg_id`) ';
-        $rq .= "VALUES ('" . $ret[$i] . "', '" . (int) $cg_id . "')";
-        $dbResult = $pearDB->query($rq);
+        $insertStmt->bindValue(':aclGroupId', (int) $ret[$i], PDO::PARAM_INT);
+        $insertStmt->bindValue(':cgId', (int) $cg_id, PDO::PARAM_INT);
+        $insertStmt->execute();
     }
 }
 
@@ -323,7 +352,10 @@ function getContactGroupIdByName($name)
     global $pearDB;
 
     $id = 0;
-    $res = $pearDB->query("SELECT cg_id FROM contactgroup WHERE cg_name = '" . CentreonDB::escape($name) . "'");
+    $stmt = $pearDB->prepare('SELECT cg_id FROM contactgroup WHERE cg_name = :cgName');
+    $stmt->bindValue(':cgName', $name, PDO::PARAM_STR);
+    $stmt->execute();
+    $res = $stmt;
     if ($res->rowCount()) {
         $row = $res->fetch();
         $id = $row['cg_id'];

--- a/centreon/www/include/configuration/configObject/escalation/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/escalation/DB-Func.php
@@ -257,10 +257,11 @@ function insertEscalation(CentreonDB $pearDB, array $data, bool $logAction = tru
 
     foreach ($params as $paramName => $paramType) {
         if ($paramType === PDO::PARAM_INT) {
+            $value = isset($data[$paramName]) && $data[$paramName] !== '' ? $data[$paramName] : null;
             $stmt->bindValue(
                 ':' . $paramName,
-                isset($data[$paramName]) && $data[$paramName] !== '' ? $data[$paramName] : null,
-                $paramType
+                $value,
+                $value === null ? PDO::PARAM_NULL : $paramType
             );
         } elseif ($paramType === PDO::PARAM_STR) {
             $value = isset($data[$paramName])
@@ -336,10 +337,11 @@ function updateEscalation(CentreonDB $pearDB, array $data, int $escalationId): v
 
     foreach ($params as $paramName => $paramType) {
         if ($paramType === PDO::PARAM_INT) {
+            $value = isset($data[$paramName]) && $data[$paramName] !== '' ? $data[$paramName] : null;
             $stmt->bindValue(
                 ':' . $paramName,
-                isset($data[$paramName]) && $data[$paramName] !== '' ? $data[$paramName] : null,
-                $paramType
+                $value,
+                $value === null ? PDO::PARAM_NULL : $paramType
             );
         } elseif ($paramType === PDO::PARAM_STR) {
             $value = isset($data[$paramName])

--- a/centreon/www/include/configuration/configObject/host/resolveHostName.php
+++ b/centreon/www/include/configuration/configObject/host/resolveHostName.php
@@ -28,7 +28,9 @@ session_start();
 $db = new CentreonDB();
 $sid = session_id();
 if (isset($sid)) {
-    $res = $db->query('SELECT * FROM session WHERE session_id = \'' . CentreonDB::escape($sid) . '\'');
+    $res = $db->prepare('SELECT * FROM session WHERE session_id = :sid');
+    $res->bindValue(':sid', $sid, PDO::PARAM_STR);
+    $res->execute();
     if (! $res->fetchRow()) {
         header($_SERVER['SERVER_PROTOCOL'] . ' 401 Unauthorized', true, 401);
 

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
@@ -71,13 +71,22 @@ $rq = 'SELECT SQL_CALC_FOUND_ROWS host_id, host_name, host_alias, host_template_
     . 'FROM host '
     . "WHERE host_register = '0' "
     . $lockedFilter;
+$bindParams = [];
 if ($search) {
-    $rq .= "AND (host_name LIKE '%" . CentreonDB::escape($search) . "%' OR host_alias LIKE '%"
-        . CentreonDB::escape($search) . "%')";
+    $rq .= 'AND (host_name LIKE :searchName OR host_alias LIKE :searchAlias)';
+    $searchValue = '%' . $search . '%';
+    $bindParams[':searchName'] = $searchValue;
+    $bindParams[':searchAlias'] = $searchValue;
 }
-$rq .= ' ORDER BY host_name LIMIT ' . $num * $limit . ', ' . $limit;
+$rq .= ' ORDER BY host_name LIMIT :paginationOffset, :paginationLimit';
 
-$DBRESULT = $pearDB->query($rq);
+$DBRESULT = $pearDB->prepare($rq);
+foreach ($bindParams as $param => $value) {
+    $DBRESULT->bindValue($param, $value);
+}
+$DBRESULT->bindValue(':paginationOffset', (int) ($num * $limit), PDO::PARAM_INT);
+$DBRESULT->bindValue(':paginationLimit', (int) $limit, PDO::PARAM_INT);
+$DBRESULT->execute();
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 
 include './include/common/checkPagination.php';

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
@@ -47,7 +47,7 @@ function testHostGroupDependencyExistence(?string $name = null): bool
             ->getQuery();
 
         $params = QueryParameters::create([
-            QueryParameter::string('depName', CentreonDB::escape($name)),
+            QueryParameter::string('depName', $name),
         ]);
 
         $row = $pearDB->fetchAssociative($query, $params);
@@ -155,42 +155,30 @@ function multipleHostGroupDependencyInDB(array $dependencies = [], array $nbrDup
             if (! $row) {
                 continue;
             }
-            $row['dep_id'] = null;
+            unset($row['dep_id']);
+
+            $columns = array_keys($row);
+            $insertQuery = $pearDB->createQueryBuilder()
+                ->insert('dependency')
+                ->values(array_combine(
+                    $columns,
+                    array_map(fn ($col) => ':' . $col, $columns)
+                ))
+                ->getQuery();
+
             for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-                $val = null;
-                foreach ($row as $key2 => $value2) {
-                    $value2 = is_int($value2) ? (string) $value2 : $value2;
-                    if ($key2 == 'dep_name') {
-                        $dep_name = $value2 . '_' . $i;
-                        $value2 = $value2 . '_' . $i;
-                    }
-                    $val
-                        ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                        : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-                    if ($key2 != 'dep_id') {
-                        $fields[$key2] = $value2;
-                    }
-                    if (isset($dep_name)) {
-                        $fields['dep_name'] = $dep_name;
-                    }
-                }
+                $dep_name = $row['dep_name'] . '_' . $i;
                 if (isset($dep_name) && testHostGroupDependencyExistence($dep_name)) {
-                    $columns = ['dep_id', 'dep_name', 'dep_description', 'inherits_parent', 'execution_failure_criteria',
-                        'notification_failure_criteria', 'dep_comment'];
+                    $dup = $row;
+                    $dup['dep_name'] = $dep_name;
 
-                    $qb = $pearDB->createQueryBuilder()
-                        ->insert('dependency')
-                        ->values(
-                            array_combine($columns,
-                                explode(
-                                    ', ',
-                                    $val
-                                )
-                            )
-                        )
-                        ->getQuery();
-
-                    $pearDB->executeStatement($qb);
+                    $insertParams = [];
+                    $fields = [];
+                    foreach ($dup as $col => $val) {
+                        $insertParams[] = QueryParameter::string($col, $val);
+                        $fields[$col] = $val;
+                    }
+                    $pearDB->insert($insertQuery, QueryParameters::create($insertParams));
 
                     $qb = $pearDB->createQueryBuilder()
                         ->select('MAX(dep_id) AS max_dep_id')

--- a/centreon/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -400,7 +400,7 @@ function multipleMetaServiceInDB($metas = [], $nbrDup = [])
                 $newMetaId = $pearDB->getLastInsertId();
                 if ($newMetaId) {
                     $metaObj = new CentreonMeta($pearDB);
-                    $metaObj->insertVirtualService($newMetaId, addslashes($metaName));
+                    $metaObj->insertVirtualService($newMetaId, $metaName);
 
                     // Duplicate contacts
                     $qbContacts = $pearDB->createQueryBuilder();
@@ -744,9 +744,9 @@ function insertMetaService($ret = [])
         return 0;
     }
     $fields = CentreonLogAction::prepareChanges($ret);
-    $centreon->CentreonLogAction->insertLog('meta', $metaId, addslashes($ret['meta_name']), 'a', $fields);
+    $centreon->CentreonLogAction->insertLog('meta', $metaId, $ret['meta_name'], 'a', $fields);
     $metaObj = new CentreonMeta($pearDB);
-    $metaObj->insertVirtualService($metaId, addslashes($ret['meta_name']));
+    $metaObj->insertVirtualService($metaId, $ret['meta_name']);
 
     return $metaId;
 }
@@ -829,9 +829,9 @@ function updateMetaService($metaId = null)
         );
     }
     $fields = CentreonLogAction::prepareChanges($ret);
-    $centreon->CentreonLogAction->insertLog('meta', $metaId, addslashes($ret['meta_name']), 'c', $fields);
+    $centreon->CentreonLogAction->insertLog('meta', $metaId, $ret['meta_name'], 'c', $fields);
     $metaObj = new CentreonMeta($pearDB);
-    $metaObj->insertVirtualService($metaId, addslashes($ret['meta_name']));
+    $metaObj->insertVirtualService($metaId, $ret['meta_name']);
 }
 
 /**
@@ -974,27 +974,52 @@ function updateAclResourcesMetaRelations(int $metaId): void
 
     // get ACL resources IDs for the current user
     $acl = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
+    $accessGroupIds = array_filter(
+        explode(',', $acl->getAccessGroupsString('ID')),
+        fn ($id) => is_numeric(trim($id))
+    );
+    $accessGroupIds = array_map(fn ($id) => (int) trim($id), $accessGroupIds);
+
+    if ($accessGroupIds === []) {
+        return;
+    }
+
+    $aclGroupParams = [];
+    $aclGroupPlaceholders = [];
+    foreach ($accessGroupIds as $idx => $groupId) {
+        $key = 'aclGroupId' . $idx;
+        $aclGroupPlaceholders[] = ':' . $key;
+        $aclGroupParams[] = QueryParameter::int($key, $groupId);
+    }
+
     $selectAclQuery = "SELECT DISTINCT ar.acl_res_id
             FROM acl_res_group_relations argr
             INNER JOIN acl_resources ar on ar.acl_res_id = argr.acl_res_id and ar.acl_res_activate = '1'
-            WHERE acl_group_id IN ({$acl->getAccessGroupsString('ID')})";
+            WHERE acl_group_id IN (" . implode(', ', $aclGroupPlaceholders) . ')';
     try {
-        $aclResIds = $pearDB->fetchAllAssociative($selectAclQuery);
+        $aclResIds = $pearDB->fetchAllAssociative($selectAclQuery, QueryParameters::create($aclGroupParams));
         if ($aclResIds !== []) {
-            $aclResIdsImploded = implode(',', array_map(fn ($row) => $row['acl_res_id'], $aclResIds));
-
             // clean old relations
-            $queryClean = "DELETE FROM acl_resources_meta_relations WHERE meta_id = :metaId AND acl_res_id IN ({$aclResIdsImploded})";
-            $pearDB->delete($queryClean, QueryParameters::create([
-                QueryParameter::int('metaId', (int) $metaId),
-            ]));
+            $deleteParams = [QueryParameter::int('metaId', (int) $metaId)];
+            $deletePlaceholders = [];
+            foreach ($aclResIds as $idx => $row) {
+                $key = 'aclResId' . $idx;
+                $deletePlaceholders[] = ':' . $key;
+                $deleteParams[] = QueryParameter::int($key, (int) $row['acl_res_id']);
+            }
+
+            $queryClean = 'DELETE FROM acl_resources_meta_relations WHERE meta_id = :metaId AND acl_res_id IN (' . implode(', ', $deletePlaceholders) . ')';
+            $pearDB->delete($queryClean, QueryParameters::create($deleteParams));
 
             // insert new relations
-            $paramsAcl = [QueryParameter::int('metaId', (int) $metaId)];
+            $paramsAcl = [];
             $values = [];
-            foreach ($aclResIds as $aclResId) {
-                $values[] = " (:acl_res_id_{$aclResId['acl_res_id']}, :metaId)";
-                $paramsAcl[] = QueryParameter::int("acl_res_id_{$aclResId['acl_res_id']}", (int) $aclResId['acl_res_id']);
+            foreach ($aclResIds as $idx => $aclResId) {
+                $key = 'aclResId' . $idx;
+                $metaKey = 'metaId' . $idx;
+                $values[] = " (:{$key}, :{$metaKey})";
+                $paramsAcl[] = QueryParameter::int($key, (int) $aclResId['acl_res_id']);
+                $paramsAcl[] = QueryParameter::int($metaKey, (int) $metaId);
             }
             // update acl_resources_meta_relations
             if ($values !== []) {

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -79,16 +79,7 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB;
     $selectStmt = $pearDB->prepare(
-        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                notification_failure_criteria, dep_comment
-        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
-    );
-    $insertStmt = $pearDB->prepare(
-        'INSERT INTO dependency
-        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-         notification_failure_criteria, dep_comment)
-        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-         :notification_failure_criteria, :dep_comment)'
+        'SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1'
     );
     $selectParentStmt = $pearDB->prepare(
         'SELECT DISTINCT meta_service_meta_id FROM dependency_metaserviceParent_relation '
@@ -110,19 +101,26 @@ function multipleMetaServiceDependencyInDB($dependencies = [], $nbrDup = [])
     foreach (array_keys($dependencies) as $key) {
         $selectStmt->bindValue(':dep_id', (int) $key, PDO::PARAM_INT);
         $selectStmt->execute();
-        $row = $selectStmt->fetch();
+        $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
         if ($row === false) {
             continue;
         }
+        unset($row['dep_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO dependency (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+        $originalName = $row['dep_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $dep_name = $row['dep_name'] . '_' . $i;
+            $dep_name = $originalName . '_' . $i;
             if (testExistence($dep_name)) {
-                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $row['dep_name'] = $dep_name;
+
+                foreach ($columns as $col) {
+                    $value = $row[$col];
+                    $insertStmt->bindValue(':' . $col, $value, $value === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {

--- a/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -88,16 +88,7 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB, $oreon;
     $selectStmt = $pearDB->prepare(
-        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                notification_failure_criteria, dep_comment
-        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
-    );
-    $insertStmt = $pearDB->prepare(
-        'INSERT INTO dependency
-        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-         notification_failure_criteria, dep_comment)
-        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-         :notification_failure_criteria, :dep_comment)'
+        'SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1'
     );
     $selectHostChildStmt = $pearDB->prepare(
         'SELECT host_host_id FROM dependency_hostChild_relation WHERE dependency_dep_id = :dep_id'
@@ -130,19 +121,26 @@ function multipleServiceDependencyInDB($dependencies = [], $nbrDup = [])
         if ($row === false) {
             continue;
         }
+        unset($row['dep_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO dependency (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+        $originalName = $row['dep_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $dep_name = $row['dep_name'] . '_' . $i;
+            $dep_name = $originalName . '_' . $i;
             $fields = [];
             foreach ($row as $key2 => $value2) {
                 $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceDependencyExistence($dep_name)) {
-                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $row['dep_name'] = $dep_name;
+
+                foreach ($columns as $col) {
+                    $value = $row[$col];
+                    $insertStmt->bindValue(':' . $col, $value, $value === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {

--- a/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -94,17 +94,22 @@ function removeRelationLastServicegroupDependency(int $servicegroupId): void
 {
     global $pearDB;
 
-    $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
-              FROM dependency_servicegroupParent_relation
-              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_servicegroupParent_relation
-                                         WHERE servicegroup_sg_id =  ' . $servicegroupId . ')
-              GROUP BY dependency_dep_id';
-    $dbResult = $pearDB->query($query);
-    $result = $dbResult->fetch();
+    $statement = $pearDB->prepare(
+        'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
+         FROM dependency_servicegroupParent_relation
+         WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_servicegroupParent_relation
+                                    WHERE servicegroup_sg_id = :sg_id)
+         GROUP BY dependency_dep_id'
+    );
+    $statement->bindValue(':sg_id', $servicegroupId, PDO::PARAM_INT);
+    $statement->execute();
+    $result = $statement->fetch();
 
     // is last parent
     if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
-        $pearDB->query('DELETE FROM dependency WHERE dep_id = ' . $result['id']);
+        $deleteStmt = $pearDB->prepare('DELETE FROM dependency WHERE dep_id = :dep_id');
+        $deleteStmt->bindValue(':dep_id', $result['id'], PDO::PARAM_INT);
+        $deleteStmt->execute();
     }
 }
 

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -88,16 +88,7 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
 {
     global $pearDB, $oreon;
     $selectStmt = $pearDB->prepare(
-        'SELECT dep_name, dep_description, inherits_parent, execution_failure_criteria,
-                notification_failure_criteria, dep_comment
-        FROM dependency WHERE dep_id = :dep_id LIMIT 1'
-    );
-    $insertStmt = $pearDB->prepare(
-        'INSERT INTO dependency
-        (dep_name, dep_description, inherits_parent, execution_failure_criteria,
-         notification_failure_criteria, dep_comment)
-        VALUES (:dep_name, :dep_description, :inherits_parent, :execution_failure_criteria,
-         :notification_failure_criteria, :dep_comment)'
+        'SELECT * FROM dependency WHERE dep_id = :dep_id LIMIT 1'
     );
     $selectParentStmt = $pearDB->prepare(
         'SELECT DISTINCT servicegroup_sg_id FROM dependency_servicegroupParent_relation '
@@ -123,19 +114,26 @@ function multipleServiceGroupDependencyInDB($dependencies = [], $nbrDup = [])
         if ($row === false) {
             continue;
         }
+        unset($row['dep_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO dependency (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+        $originalName = $row['dep_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $dep_name = $row['dep_name'] . '_' . $i;
+            $dep_name = $originalName . '_' . $i;
             $fields = [];
             foreach ($row as $key2 => $value2) {
                 $fields[$key2] = $key2 == 'dep_name' ? $dep_name : $value2;
             }
             if (testServiceGroupDependencyExistence($dep_name)) {
-                $insertStmt->bindValue(':dep_name', $dep_name, PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_description', $row['dep_description'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':inherits_parent', $row['inherits_parent'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':execution_failure_criteria', $row['execution_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':notification_failure_criteria', $row['notification_failure_criteria'], PDO::PARAM_STR);
-                $insertStmt->bindValue(':dep_comment', $row['dep_comment'], PDO::PARAM_STR);
+                $row['dep_name'] = $dep_name;
+
+                foreach ($columns as $col) {
+                    $value = $row[$col];
+                    $insertStmt->bindValue(':' . $col, $value, $value === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
                 $insertStmt->execute();
                 $lastId = (int) $pearDB->lastInsertId();
                 if ($lastId > 0) {

--- a/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -36,31 +36,27 @@ function includeExcludeTimeperiods($tpId, $includeTab = [], $excludeTab = [])
 
     // Insert inclusions
     if (isset($includeTab) && is_array($includeTab)) {
-        $str = '';
+        $includeStmt = $pearDB->prepare(
+            'INSERT INTO timeperiod_include_relations (timeperiod_id, timeperiod_include_id)
+            VALUES (:tpId, :tpIncludeId)'
+        );
         foreach ($includeTab as $tpIncludeId) {
-            if ($str != '') {
-                $str .= ', ';
-            }
-            $str .= "('" . $tpId . "', '" . $tpIncludeId . "')";
-        }
-        if (strlen($str)) {
-            $query = 'INSERT INTO timeperiod_include_relations (timeperiod_id, timeperiod_include_id ) VALUES ' . $str;
-            $pearDB->query($query);
+            $includeStmt->bindValue(':tpId', (int) $tpId, PDO::PARAM_INT);
+            $includeStmt->bindValue(':tpIncludeId', (int) $tpIncludeId, PDO::PARAM_INT);
+            $includeStmt->execute();
         }
     }
 
     // Insert exclusions
     if (isset($excludeTab) && is_array($excludeTab)) {
-        $str = '';
+        $excludeStmt = $pearDB->prepare(
+            'INSERT INTO timeperiod_exclude_relations (timeperiod_id, timeperiod_exclude_id)
+            VALUES (:tpId, :tpExcludeId)'
+        );
         foreach ($excludeTab as $tpExcludeId) {
-            if ($str != '') {
-                $str .= ', ';
-            }
-            $str .= "('" . $tpId . "', '" . $tpExcludeId . "')";
-        }
-        if (strlen($str)) {
-            $query = 'INSERT INTO timeperiod_exclude_relations (timeperiod_id, timeperiod_exclude_id ) VALUES ' . $str;
-            $pearDB->query($query);
+            $excludeStmt->bindValue(':tpId', (int) $tpId, PDO::PARAM_INT);
+            $excludeStmt->bindValue(':tpExcludeId', (int) $tpExcludeId, PDO::PARAM_INT);
+            $excludeStmt->execute();
         }
     }
 }
@@ -99,17 +95,20 @@ function multipleTimeperiodInDB($timeperiods = [], $nbrDup = [])
         global $pearDB;
 
         $fields = [];
-        $dbResult = $pearDB->query("SELECT * FROM timeperiod WHERE tp_id = '" . $key . "' LIMIT 1");
+        $stmt = $pearDB->prepare('SELECT * FROM timeperiod WHERE tp_id = :tpId LIMIT 1');
+        $stmt->bindValue(':tpId', (int) $key, PDO::PARAM_INT);
+        $stmt->execute();
 
-        $query = "SELECT days, timerange FROM timeperiod_exceptions WHERE timeperiod_id = '" . $key . "'";
-        $res = $pearDB->query($query);
-        while ($row = $res->fetch()) {
+        $exStmt = $pearDB->prepare('SELECT days, timerange FROM timeperiod_exceptions WHERE timeperiod_id = :tpId');
+        $exStmt->bindValue(':tpId', (int) $key, PDO::PARAM_INT);
+        $exStmt->execute();
+        while ($row = $exStmt->fetch()) {
             foreach ($row as $keyz => $valz) {
                 $fields[$keyz] = $valz;
             }
         }
 
-        $row = $dbResult->fetch();
+        $row = $stmt->fetch();
         $row['tp_id'] = null;
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $val = [];
@@ -200,9 +199,11 @@ function getTimeperiodIdByName($name)
     global $pearDB;
 
     $id = 0;
-    $res = $pearDB->query("SELECT tp_id FROM timeperiod WHERE tp_name = '" . $pearDB->escape($name) . "'");
-    if ($res->rowCount()) {
-        $row = $res->fetch();
+    $stmt = $pearDB->prepare('SELECT tp_id FROM timeperiod WHERE tp_name = :tpName');
+    $stmt->bindValue(':tpName', $name, PDO::PARAM_STR);
+    $stmt->execute();
+    if ($stmt->rowCount()) {
+        $row = $stmt->fetch();
         $id = $row['tp_id'];
     }
 

--- a/centreon/www/include/configuration/configObject/traps-manufacturer/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/traps-manufacturer/DB-Func.php
@@ -27,25 +27,32 @@ function testMnftrExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('id');
     }
-    $query = "SELECT name, id FROM traps_vendor WHERE name = '" . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $mnftr = $dbResult->fetch();
+    $encodedName = htmlentities($name ?? '', ENT_QUOTES, 'UTF-8');
+    $query = 'SELECT name, id FROM traps_vendor WHERE name = :name';
+    $statement = $pearDB->prepare($query);
+    $statement->bindValue(':name', $encodedName, PDO::PARAM_STR);
+    $statement->execute();
+    $mnftr = $statement->fetch();
     // Modif case
-    if ($dbResult->rowCount() >= 1 && $mnftr['id'] == $id) {
+    if ($statement->rowCount() >= 1 && $mnftr['id'] == $id) {
         return true;
     } // Duplicate entry
 
-    return ! ($dbResult->rowCount() >= 1 && $mnftr['id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $mnftr['id'] != $id);
 }
 
 function deleteMnftrInDB($mnftr = [])
 {
     global $pearDB, $oreon;
     foreach ($mnftr as $key => $value) {
-        $dbResult2 = $pearDB->query("SELECT name FROM `traps_vendor` WHERE `id` = '" . $key . "' LIMIT 1");
-        $row = $dbResult2->fetch();
+        $stmt = $pearDB->prepare('SELECT name FROM `traps_vendor` WHERE `id` = :id LIMIT 1');
+        $stmt->bindValue(':id', $key, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch();
 
-        $pearDB->query("DELETE FROM traps_vendor WHERE id = '" . htmlentities($key, ENT_QUOTES, 'UTF-8') . "'");
+        $stmt = $pearDB->prepare('DELETE FROM traps_vendor WHERE id = :id');
+        $stmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $stmt->execute();
         $oreon->CentreonLogAction->insertLog('manufacturer', $key, $row['name'], 'd');
     }
 }
@@ -54,30 +61,29 @@ function multipleMnftrInDB($mnftr = [], $nbrDup = [])
 {
     foreach ($mnftr as $key => $value) {
         global $pearDB, $oreon;
-        $query = "SELECT * FROM traps_vendor WHERE id = '" . htmlentities($key, ENT_QUOTES, 'UTF-8') . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
-        $row['id'] = null;
+        $stmt = $pearDB->prepare('SELECT * FROM traps_vendor WHERE id = :id LIMIT 1');
+        $stmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $stmt->execute();
+        $row = $stmt->fetch();
+        unset($row['id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO traps_vendor (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+
+        $originalName = $row['name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                $name = '';
-                if ($key2 == 'name') {
-                    $name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val
-                    ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-                if ($key2 != 'id') {
-                    $fields[$key2] = $value2;
-                }
-                $fields['name'] = $name;
-            }
+            $name = $originalName . '_' . $i;
+            $row['name'] = $name;
+
             if (testMnftrExistence($name)) {
-                $rq = $val ? 'INSERT INTO traps_vendor VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
+                $insertStmt->execute();
+
+                $fields = $row;
                 $oreon->CentreonLogAction->insertLog(
                     'manufacturer',
                     htmlentities($key, ENT_QUOTES, 'UTF-8'),
@@ -108,12 +114,14 @@ function updateMnftr($id = null)
 
     $ret = [];
     $ret = $form->getSubmitValues();
-    $rq = 'UPDATE traps_vendor ';
-    $rq .= "SET name = '" . htmlentities($ret['name'], ENT_QUOTES, 'UTF-8') . "', ";
-    $rq .= "alias = '" . htmlentities($ret['alias'], ENT_QUOTES, 'UTF-8') . "', ";
-    $rq .= "description = '" . htmlentities($ret['description'], ENT_QUOTES, 'UTF-8') . "' ";
-    $rq .= "WHERE id = '" . $id . "'";
-    $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        'UPDATE traps_vendor SET name = :name, alias = :alias, description = :description WHERE id = :id'
+    );
+    $statement->bindValue(':name', htmlentities($ret['name'], ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->bindValue(':alias', htmlentities($ret['alias'], ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->bindValue(':description', htmlentities($ret['description'], ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->bindValue(':id', (int) $id, PDO::PARAM_INT);
+    $statement->execute();
 
     // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($ret);
@@ -133,13 +141,13 @@ function insertMnftr($ret = [])
         $ret = $form->getSubmitValues();
     }
 
-    $rq = 'INSERT INTO traps_vendor ';
-    $rq .= '(name, alias, description) ';
-    $rq .= 'VALUES ';
-    $rq .= "('" . htmlentities($ret['name'], ENT_QUOTES, 'UTF-8') . "', ";
-    $rq .= "'" . htmlentities($ret['alias'], ENT_QUOTES, 'UTF-8') . "', ";
-    $rq .= "'" . htmlentities($ret['description'], ENT_QUOTES, 'UTF-8') . "')";
-    $dbResult = $pearDB->query($rq);
+    $statement = $pearDB->prepare(
+        'INSERT INTO traps_vendor (name, alias, description) VALUES (:name, :alias, :description)'
+    );
+    $statement->bindValue(':name', htmlentities($ret['name'], ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->bindValue(':alias', htmlentities($ret['alias'], ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->bindValue(':description', htmlentities($ret['description'], ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
     $dbResult = $pearDB->query('SELECT MAX(id) FROM traps_vendor');
     $mnftr_id = $dbResult->fetch();
 

--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -104,20 +104,21 @@ function deleteResourceInDB($resourceIds = []): void
 {
     global $pearDB;
 
+    $selectStmt = $pearDB->prepare(
+        'SELECT * FROM cfg_resource WHERE resource_id = :resourceId'
+    );
+    $deleteStmt = $pearDB->prepare('DELETE FROM cfg_resource WHERE resource_id = :resourceId');
+
     foreach (array_keys($resourceIds) as $currentResourceId) {
         if (is_int($currentResourceId)) {
-            $statement = $pearDB->prepare(
-                'SELECT *FROM cfg_resource WHERE resource_id = :resourceId'
-            );
-            $statement->bindValue(':resourceId', $currentResourceId);
-            $statement->execute();
+            $selectStmt->bindValue(':resourceId', $currentResourceId, PDO::PARAM_INT);
+            $selectStmt->execute();
 
-            if (false !== $data = $statement->fetch()) {
+            if (false !== $data = $selectStmt->fetch()) {
                 deleteFromVault($data);
 
-                $pearDB->query(
-                    "DELETE FROM cfg_resource WHERE resource_id = {$currentResourceId}"
-                );
+                $deleteStmt->bindValue(':resourceId', $currentResourceId, PDO::PARAM_INT);
+                $deleteStmt->execute();
             }
         }
     }
@@ -135,10 +136,11 @@ function enableResourceInDB($resourceId): void
     global $pearDB;
 
     if (is_int($resourceId)) {
-        $pearDB->query(
-            "UPDATE cfg_resource SET resource_activate = '1' "
-            . "WHERE resource_id = {$resourceId}"
+        $statement = $pearDB->prepare(
+            "UPDATE cfg_resource SET resource_activate = '1' WHERE resource_id = :resourceId"
         );
+        $statement->bindValue(':resourceId', $resourceId, PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 
@@ -153,10 +155,11 @@ function disableResourceInDB($resourceId): void
 {
     global $pearDB;
     if (is_int($resourceId)) {
-        $pearDB->query(
-            "UPDATE cfg_resource SET resource_activate = '0' "
-            . "WHERE resource_id = {$resourceId}"
+        $statement = $pearDB->prepare(
+            "UPDATE cfg_resource SET resource_activate = '0' WHERE resource_id = :resourceId"
         );
+        $statement->bindValue(':resourceId', $resourceId, PDO::PARAM_INT);
+        $statement->execute();
     }
 }
 /**
@@ -173,7 +176,9 @@ function multipleResourceInDB($resourceIds = [], $nbrDup = []): void
 
     foreach (array_keys($resourceIds) as $resourceId) {
         if (is_int($resourceId)) {
-            $dbResult = $pearDB->query("SELECT * FROM cfg_resource WHERE resource_id = {$resourceId} LIMIT 1");
+            $selectStmt = $pearDB->prepare('SELECT * FROM cfg_resource WHERE resource_id = :resourceId LIMIT 1');
+            $selectStmt->bindValue(':resourceId', $resourceId, PDO::PARAM_INT);
+            $selectStmt->execute();
             /**
              * @var array{
              *  resource_id:int,
@@ -184,7 +189,7 @@ function multipleResourceInDB($resourceIds = [], $nbrDup = []): void
              *  is_password:int
              * } $resourceConfiguration
              */
-            $resourceConfiguration = $dbResult->fetch();
+            $resourceConfiguration = $selectStmt->fetch();
 
             for ($newIndex = 1; $newIndex <= $nbrDup[$resourceId]; $newIndex++) {
                 $name = preg_match('/^\$(.*)\$$/', $resourceConfiguration['resource_name'])
@@ -220,12 +225,15 @@ function multipleResourceInDB($resourceIds = [], $nbrDup = []): void
                     $statement->execute();
 
                     $lastId = $pearDB->lastInsertId();
-                    $pearDB->query(
-                        'INSERT INTO cfg_resource_instance_relations ('
-                        . "SELECT {$lastId}, instance_id "
+                    $relStmt = $pearDB->prepare(
+                        'INSERT INTO cfg_resource_instance_relations (resource_id, instance_id) '
+                        . 'SELECT :newId, instance_id '
                         . 'FROM cfg_resource_instance_relations '
-                        . "WHERE resource_id = {$resourceId})"
+                        . 'WHERE resource_id = :oldId'
                     );
+                    $relStmt->bindValue(':newId', (int) $lastId, PDO::PARAM_INT);
+                    $relStmt->bindValue(':oldId', $resourceId, PDO::PARAM_INT);
+                    $relStmt->execute();
                 }
             }
         }
@@ -309,19 +317,19 @@ function updateResource(int $resourceId, array $submitedValues): void
 
     $prepare->bindValue(
         ':resource_name',
-        $pearDB->escape($submitedValues['resource_name']),
+        $submitedValues['resource_name'],
         PDO::PARAM_STR
     );
 
     $prepare->bindValue(
         ':resource_line',
-        $pearDB->escape($submitedValues['resource_line']),
+        $submitedValues['resource_line'],
         PDO::PARAM_STR
     );
 
     $prepare->bindValue(
         ':resource_comment',
-        $pearDB->escape($submitedValues['resource_comment']),
+        $submitedValues['resource_comment'],
         PDO::PARAM_STR
     );
 
@@ -416,7 +424,10 @@ function insertInstanceRelations($resourceId, $instanceId = null): void
 {
     if (is_numeric($resourceId)) {
         global $pearDB;
-        $pearDB->query('DELETE FROM cfg_resource_instance_relations WHERE resource_id = ' . (int) $resourceId);
+
+        $deleteStmt = $pearDB->prepare('DELETE FROM cfg_resource_instance_relations WHERE resource_id = :resourceId');
+        $deleteStmt->bindValue(':resourceId', (int) $resourceId, PDO::PARAM_INT);
+        $deleteStmt->execute();
 
         if (! is_null($instanceId)) {
             $instances = [$instanceId];
@@ -425,19 +436,15 @@ function insertInstanceRelations($resourceId, $instanceId = null): void
             $instances = CentreonUtils::mergeWithInitialValues($form, 'instance_id');
         }
 
-        $subQuery = '';
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO cfg_resource_instance_relations (resource_id, instance_id) VALUES (:resourceId, :instanceId)'
+        );
         foreach ($instances as $instanceId) {
             if (is_numeric($instanceId)) {
-                if (! empty($subQuery)) {
-                    $subQuery .= ', ';
-                }
-                $subQuery .= '(' . (int) $resourceId . ', ' . (int) $instanceId . ')';
+                $insertStmt->bindValue(':resourceId', (int) $resourceId, PDO::PARAM_INT);
+                $insertStmt->bindValue(':instanceId', (int) $instanceId, PDO::PARAM_INT);
+                $insertStmt->execute();
             }
-        }
-        if (! empty($subQuery)) {
-            $pearDB->query(
-                'INSERT INTO cfg_resource_instance_relations (resource_id, instance_id) VALUES ' . $subQuery
-            );
         }
     }
 }
@@ -447,14 +454,15 @@ function getLinkedPollerList($resource_id)
     global $pearDB;
 
     $str = '';
-    $query = 'SELECT ns.name, ns.id FROM cfg_resource_instance_relations nsr, cfg_resource r, nagios_server ns '
-        . "WHERE nsr.resource_id = r.resource_id AND nsr.instance_id = ns.id AND nsr.resource_id = '"
-        . $resource_id . "'";
-    $dbResult = $pearDB->query($query);
-    while ($data = $dbResult->fetch()) {
+    $statement = $pearDB->prepare(
+        'SELECT ns.name, ns.id FROM cfg_resource_instance_relations nsr, cfg_resource r, nagios_server ns '
+        . 'WHERE nsr.resource_id = r.resource_id AND nsr.instance_id = ns.id AND nsr.resource_id = :resource_id'
+    );
+    $statement->bindValue(':resource_id', (int) $resource_id, PDO::PARAM_INT);
+    $statement->execute();
+    while ($data = $statement->fetch()) {
         $str .= "<a href='main.php?p=60901&o=c&server_id=" . $data['id'] . "'>" . HtmlSanitizer::createFromString($data['name'])->sanitize()->getString() . '</a> ';
     }
-    unset($dbResult);
 
     return $str;
 }

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -176,23 +176,35 @@ function enableServerInDB(int $id): void
 {
     global $pearDB, $centreon;
 
-    $dbResult = $pearDB->query('SELECT name FROM `nagios_server` WHERE `id` = ' . $id . ' LIMIT 1');
-    $row = $dbResult->fetch();
+    $selectStmt = $pearDB->prepare('SELECT name FROM `nagios_server` WHERE `id` = :id LIMIT 1');
+    $selectStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $selectStmt->execute();
+    $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
 
-    $pearDB->query("UPDATE `nagios_server` SET `ns_activate` = '1' WHERE id = " . $id);
+    $updateStmt = $pearDB->prepare("UPDATE `nagios_server` SET `ns_activate` = '1' WHERE id = :id");
+    $updateStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $updateStmt->execute();
     $centreon->CentreonLogAction->insertLog('poller', $id, $row['name'], 'enable');
 
-    $query = 'SELECT MIN(`nagios_id`) AS idEngine FROM cfg_nagios WHERE `nagios_server_id` = ' . $id;
-    $dbResult = $pearDB->query($query);
-    $idEngine = $dbResult->fetch();
+    $engineStmt = $pearDB->prepare(
+        'SELECT MIN(`nagios_id`) AS idEngine FROM cfg_nagios WHERE `nagios_server_id` = :id'
+    );
+    $engineStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $engineStmt->execute();
+    $idEngine = $engineStmt->fetch(PDO::FETCH_ASSOC);
 
     if ($idEngine['idEngine']) {
-        $pearDB->query(
-            "UPDATE `cfg_nagios` SET `nagios_activate` = '0' WHERE `nagios_server_id` = " . $id
+        $disableStmt = $pearDB->prepare(
+            "UPDATE `cfg_nagios` SET `nagios_activate` = '0' WHERE `nagios_server_id` = :id"
         );
-        $pearDB->query(
-            "UPDATE cfg_nagios SET nagios_activate = '1' WHERE nagios_id = " . (int) $idEngine['idEngine']
+        $disableStmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $disableStmt->execute();
+
+        $enableStmt = $pearDB->prepare(
+            "UPDATE cfg_nagios SET nagios_activate = '1' WHERE nagios_id = :engineId"
         );
+        $enableStmt->bindValue(':engineId', (int) $idEngine['idEngine'], PDO::PARAM_INT);
+        $enableStmt->execute();
     }
 }
 
@@ -209,10 +221,14 @@ function disableServerInDB(int $id): void
 {
     global $pearDB, $centreon;
 
-    $dbResult = $pearDB->query('SELECT name FROM `nagios_server` WHERE `id` = ' . $id . ' LIMIT 1');
-    $row = $dbResult->fetch();
+    $selectStmt = $pearDB->prepare('SELECT name FROM `nagios_server` WHERE `id` = :id LIMIT 1');
+    $selectStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $selectStmt->execute();
+    $row = $selectStmt->fetch(PDO::FETCH_ASSOC);
 
-    $pearDB->query("UPDATE `nagios_server` SET `ns_activate` = '0' WHERE id = " . $id);
+    $updateStmt = $pearDB->prepare("UPDATE `nagios_server` SET `ns_activate` = '0' WHERE id = :id");
+    $updateStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $updateStmt->execute();
 
     $centreon->CentreonLogAction->insertLog(
         'poller',
@@ -221,9 +237,11 @@ function disableServerInDB(int $id): void
         'disable'
     );
 
-    $pearDB->query(
-        "UPDATE `cfg_nagios` SET `nagios_activate` = '0' WHERE `nagios_server_id` = " . $id
+    $cfgStmt = $pearDB->prepare(
+        "UPDATE `cfg_nagios` SET `nagios_activate` = '0' WHERE `nagios_server_id` = :id"
     );
+    $cfgStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $cfgStmt->execute();
 }
 
 /**
@@ -261,10 +279,12 @@ function deleteServerInDB(array $serverIds): void
             }
         }
 
-        $result = $pearDB->query(
-            'SELECT name, ns_ip_address AS ip FROM `nagios_server` WHERE `id` = ' . $serverId . ' LIMIT 1'
+        $selectServerStmt = $pearDB->prepare(
+            'SELECT name, ns_ip_address AS ip FROM `nagios_server` WHERE `id` = :serverId LIMIT 1'
         );
-        $row = $result->fetch();
+        $selectServerStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+        $selectServerStmt->execute();
+        $row = $selectServerStmt->fetch(PDO::FETCH_ASSOC);
 
         // Is a Remote Server?
         $statement = $pearDB->prepare(
@@ -281,20 +301,29 @@ function deleteServerInDB(array $serverIds): void
             $statement->bindValue(':id', $serverId, PDO::PARAM_INT);
             $statement->execute();
             // Delete all relation between this Remote Server and pollers
-            $pearDB->query(
-                "DELETE FROM rs_poller_relation WHERE remote_server_id = '" . $serverId . "'"
+            $deleteRelStmt = $pearDB->prepare(
+                'DELETE FROM rs_poller_relation WHERE remote_server_id = :serverId'
             );
+            $deleteRelStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+            $deleteRelStmt->execute();
         } else {
             // Delete all relation between this poller and Remote Servers
-            $pearDB->query(
-                "DELETE FROM rs_poller_relation WHERE poller_server_id = '" . $serverId . "'"
+            $deleteRelStmt = $pearDB->prepare(
+                'DELETE FROM rs_poller_relation WHERE poller_server_id = :serverId'
             );
+            $deleteRelStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+            $deleteRelStmt->execute();
         }
 
-        $pearDB->query('DELETE FROM `nagios_server` WHERE id = ' . $serverId);
-        $pearDBO->query(
-            "UPDATE `instances` SET deleted = '1' WHERE instance_id = " . $serverId
+        $deleteServerStmt = $pearDB->prepare('DELETE FROM `nagios_server` WHERE id = :serverId');
+        $deleteServerStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+        $deleteServerStmt->execute();
+
+        $updateInstanceStmt = $pearDBO->prepare(
+            "UPDATE `instances` SET deleted = '1' WHERE instance_id = :serverId"
         );
+        $updateInstanceStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+        $updateInstanceStmt->execute();
         deleteCentreonBrokerByPollerId($serverId);
 
         $centreon->CentreonLogAction->insertLog(
@@ -317,9 +346,9 @@ function deleteCentreonBrokerByPollerId(int $id)
 {
     global $pearDB;
 
-    $pearDB->query(
-        'DELETE FROM cfg_centreonbroker WHERE ns_nagios_server = ' . $id
-    );
+    $stmt = $pearDB->prepare('DELETE FROM cfg_centreonbroker WHERE ns_nagios_server = :id');
+    $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $stmt->execute();
 }
 
 /**
@@ -338,15 +367,20 @@ function duplicateServer(array $server, array $nbrDup): void
     $obj = new CentreonMainCfg();
 
     foreach (array_keys($server) as $serverId) {
-        $result = $pearDB->query(
-            'SELECT * FROM `nagios_server` WHERE id = ' . (int) $serverId . ' LIMIT 1'
+        $selectServerStmt = $pearDB->prepare(
+            'SELECT * FROM `nagios_server` WHERE id = :serverId LIMIT 1'
         );
-        $rowServer = $result->fetch();
+        $selectServerStmt->bindValue(':serverId', (int) $serverId, PDO::PARAM_INT);
+        $selectServerStmt->execute();
+        $rowServer = $selectServerStmt->fetch(PDO::FETCH_ASSOC);
+        $selectServerStmt->closeCursor();
+        if ($rowServer === false) {
+            continue;
+        }
         $rowServer['id'] = null;
         $rowServer['ns_activate'] = '0';
         $rowServer['is_default'] = '0';
         $rowServer['localhost'] = '0';
-        $result->closeCursor();
 
         if (! isset($rowServer['name'])) {
             continue;
@@ -360,28 +394,29 @@ function duplicateServer(array $server, array $nbrDup): void
         );
 
         foreach ($availableSuffix as $suffix) {
-            $queryValues = null;
             $serverName = null;
+            $columns = [];
+            $params = [];
+            $paramIndex = 0;
             foreach ($rowServer as $columnName => $columnValue) {
                 if ($columnName == 'name') {
                     $columnValue .= '_' . $suffix;
                     $serverName = $columnValue;
                 }
-
-                if (is_null($queryValues)) {
-                    $queryValues .= $columnValue != null
-                        ? ("'" . $columnValue . "'")
-                        : 'NULL';
-                } else {
-                    $queryValues .= $columnValue != null
-                        ? (", '" . $columnValue . "'")
-                        : ', NULL';
-                }
+                $columns[] = '`' . $columnName . '`';
+                $paramKey = ':p' . $paramIndex++;
+                $params[$paramKey] = $columnValue;
             }
-            if (! is_null($queryValues) && testExistence($serverName)) {
-                if ($queryValues) {
-                    $pearDB->query('INSERT INTO `nagios_server` VALUES (' . $queryValues . ')');
+            if ($columns !== [] && ! is_null($serverName) && testExistence($serverName)) {
+                $placeholders = implode(', ', array_keys($params));
+                $columnList = implode(', ', $columns);
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO `nagios_server` (' . $columnList . ') VALUES (' . $placeholders . ')'
+                );
+                foreach ($params as $paramKey => $paramValue) {
+                    $insertStmt->bindValue($paramKey, $paramValue, $paramValue === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
                 }
+                $insertStmt->execute();
 
                 $queryGetId = 'SELECT id FROM nagios_server WHERE name = :name';
                 try {
@@ -736,7 +771,6 @@ function addUserRessource(int $serverId): bool
 {
     global $pearDB, $centreon;
 
-    $queryInsert = 'INSERT INTO cfg_resource_instance_relations (resource_id, instance_id) VALUES (%d, %d)';
     $queryGetResources = 'SELECT resource_id, resource_name FROM cfg_resource ORDER BY resource_id';
 
     try {
@@ -744,16 +778,18 @@ function addUserRessource(int $serverId): bool
     } catch (PDOException $e) {
         return false;
     }
+
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO cfg_resource_instance_relations (resource_id, instance_id) VALUES (:resource_id, :instance_id)'
+    );
+
     $isInsert = [];
     while ($resource = $res->fetch()) {
         if (! in_array($resource['resource_name'], $isInsert)) {
             $isInsert[] = $resource['resource_name'];
-            $query = sprintf(
-                $queryInsert,
-                (int) $resource['resource_id'],
-                $serverId
-            );
-            $pearDB->query($query);
+            $insertStmt->bindValue(':resource_id', (int) $resource['resource_id'], PDO::PARAM_INT);
+            $insertStmt->bindValue(':instance_id', $serverId, PDO::PARAM_INT);
+            $insertStmt->execute();
 
             // Prepare value for changelog
             $fields = CentreonLogAction::prepareChanges($resource);

--- a/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+++ b/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
@@ -82,9 +82,11 @@ function testDowntimeNameExistence($downtimeName = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('dt_id');
     }
-    $res = $pearDB->query("SELECT dt_id FROM downtime WHERE dt_name = '" . $pearDB->escape($downtimeName) . "'");
-    $d = $res->fetchRow();
-    $nbRes = $res->rowCount();
+    $statement = $pearDB->prepare('SELECT dt_id FROM downtime WHERE dt_name = :dtName');
+    $statement->bindValue(':dtName', $downtimeName, PDO::PARAM_STR);
+    $statement->execute();
+    $d = $statement->fetch();
+    $nbRes = $statement->rowCount();
     if ($nbRes && $d['dt_id'] == $id) {
         return true;
     }

--- a/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -39,16 +39,19 @@ function testActionExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('acl_action_id');
     }
-    $query = 'SELECT acl_action_id, acl_action_name FROM acl_actions '
-        . "WHERE acl_action_name = '" . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $action = $dbResult->fetch();
+    $statement = $pearDB->prepare(
+        'SELECT acl_action_id, acl_action_name FROM acl_actions '
+        . 'WHERE acl_action_name = :name'
+    );
+    $statement->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
+    $action = $statement->fetch();
     // Modif case
-    if ($dbResult->rowCount() >= 1 && $action['acl_action_id'] == $id) {
+    if ($statement->rowCount() >= 1 && $action['acl_action_id'] == $id) {
         return true;
     } // Duplicate entry
 
-    return ! ($dbResult->rowCount() >= 1 && $action['acl_action_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $action['acl_action_id'] != $id);
 }
 
 /**
@@ -203,9 +206,15 @@ function deleteActionInDB($actions = [])
         while ($result = $statement->fetch()) {
             $aclGroupIds[] = (int) $result['acl_group_id'];
         }
-        $pearDB->query("DELETE FROM acl_actions WHERE acl_action_id = '" . $key . "'");
-        $pearDB->query("DELETE FROM acl_actions_rules WHERE acl_action_rule_id = '" . $key . "'");
-        $pearDB->query("DELETE FROM acl_group_actions_relations WHERE acl_action_id = '" . $key . "'");
+        $deleteStmt = $pearDB->prepare('DELETE FROM acl_actions WHERE acl_action_id = :id');
+        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
+        $deleteStmt = $pearDB->prepare('DELETE FROM acl_actions_rules WHERE acl_action_rule_id = :id');
+        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
+        $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_actions_relations WHERE acl_action_id = :id');
+        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
         $centreon->CentreonLogAction->insertLog('action access', $key, $row['acl_action_name'], 'd');
     }
     flagUpdatedAclForAuthentifiedUsers($aclGroupIds);
@@ -221,8 +230,10 @@ function multipleActionInDB($actions = [], $nbrDup = [])
     global $pearDB, $centreon;
 
     foreach (array_keys($actions) as $key) {
-        $dbResult = $pearDB->query("SELECT * FROM acl_actions WHERE acl_action_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
+        $selectStmt = $pearDB->prepare('SELECT * FROM acl_actions WHERE acl_action_id = :id LIMIT 1');
+        $selectStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
 
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $aclActionName = $row['acl_action_name'] . '_' . $i;
@@ -248,30 +259,35 @@ function multipleActionInDB($actions = [], $nbrDup = [])
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();
                 if (isset($maxId['MAX(acl_action_id)'])) {
-                    $query = 'SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations '
-                        . " WHERE acl_action_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectGroupStmt = $pearDB->prepare(
+                        'SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations '
+                        . 'WHERE acl_action_id = :id'
+                    );
+                    $selectGroupStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+                    $selectGroupStmt->execute();
                     $query = 'INSERT INTO acl_group_actions_relations VALUES (:acl_action_id, :acl_group_id)';
-                    $statement =  $pearDB->prepare($query);
-                    while ($cct = $dbResult->fetch()) {
+                    $statement = $pearDB->prepare($query);
+                    while ($cct = $selectGroupStmt->fetch()) {
                         $statement->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':acl_group_id', (int) $cct['acl_group_id'], PDO::PARAM_INT);
                         $statement->execute();
                     }
 
                     // Duplicate Actions
-                    $query = 'SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules '
-                        . "WHERE acl_action_rule_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectRulesStmt = $pearDB->prepare(
+                        'SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules '
+                        . 'WHERE acl_action_rule_id = :id'
+                    );
+                    $selectRulesStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+                    $selectRulesStmt->execute();
                     $query = 'INSERT INTO acl_actions_rules VALUES (NULL, :acl_action_id, :acl_action_name)';
                     $statement = $pearDB->prepare($query);
-                    while ($acl = $dbResult->fetch()) {
+                    while ($acl = $selectRulesStmt->fetch()) {
                         $statement->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':acl_action_name', $acl['acl_action_name'], PDO::PARAM_STR);
                         $statement->execute();
                     }
 
-                    $dbResult->closeCursor();
                     $centreon->CentreonLogAction->insertLog(
                         'action access',
                         $maxId['MAX(acl_action_id)'],
@@ -423,12 +439,14 @@ function updateGroupActions($aclActionId, $ret = [])
     $statement->bindValue(':acl_action_id', (int) $aclActionId, PDO::PARAM_INT);
     $statement->execute();
     if (isset($_POST['acl_groups'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_actions_relations (acl_group_id, acl_action_id) '
+            . 'VALUES (:acl_group_id, :acl_action_id)'
+        );
         foreach ($_POST['acl_groups'] as $id) {
-            $rq = 'INSERT INTO acl_group_actions_relations ';
-            $rq .= '(acl_group_id, acl_action_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $aclActionId . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':acl_group_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':acl_action_id', (int) $aclActionId, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -454,13 +472,15 @@ function updateRulesActions($aclActionId, $ret = [])
     $actions = [];
     $actions = listActions();
 
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO acl_actions_rules (acl_action_rule_id, acl_action_name) '
+        . 'VALUES (:acl_action_rule_id, :acl_action_name)'
+    );
     foreach ($actions as $action) {
         if (isset($_POST[$action])) {
-            $rq = 'INSERT INTO acl_actions_rules ';
-            $rq .= '(acl_action_rule_id, acl_action_name) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $aclActionId . "', '" . $action . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':acl_action_rule_id', (int) $aclActionId, PDO::PARAM_INT);
+            $insertStmt->bindValue(':acl_action_name', $action, PDO::PARAM_STR);
+            $insertStmt->execute();
         }
     }
 }

--- a/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -56,16 +56,18 @@ function testGroupExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('acl_group_id');
     }
-    $query = 'SELECT acl_group_id, acl_group_name '
-        . 'FROM acl_groups '
-        . "WHERE acl_group_name = '" . htmlentities($name, ENT_QUOTES, 'UTF-8') . "' ";
-    $dbResult = $pearDB->query($query);
-    $cg = $dbResult->fetch();
-    if ($dbResult->rowCount() >= 1 && $cg['acl_group_id'] == $id) {
+    $statement = $pearDB->prepare(
+        'SELECT acl_group_id, acl_group_name FROM acl_groups '
+        . 'WHERE acl_group_name = :name'
+    );
+    $statement->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
+    $cg = $statement->fetch();
+    if ($statement->rowCount() >= 1 && $cg['acl_group_id'] == $id) {
         return true;
     }
 
-    return ! ($dbResult->rowCount() >= 1 && $cg['acl_group_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $cg['acl_group_id'] != $id);
     // Duplicate entry
 
 }
@@ -89,7 +91,7 @@ function enableGroupInDB($acl_group_id = null, $groups = [])
     foreach ($groups as $key => $value) {
         $dbResult = $pearDB->prepare(
             <<<'SQL'
-                UPDATE acl_groups 
+                UPDATE acl_groups
                 SET acl_group_activate = '1',
                     acl_group_changed = '1'
                 WHERE acl_group_id = :aclGroupId
@@ -176,29 +178,24 @@ function multipleGroupInDB($groups = [], $nbrDup = [])
         $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
         $dbResult->execute();
         $row = $dbResult->fetch();
-        $row['acl_group_id'] = '';
+        unset($row['acl_group_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_groups (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
 
+        $originalName = $row['acl_group_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'acl_group_name') {
-                    $acl_group_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-                if ($key2 != 'acl_group_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($acl_group_name)) {
-                    $fields['acl_group_name'] = $acl_group_name;
-                }
-            }
+            $acl_group_name = $originalName . '_' . $i;
+            $row['acl_group_name'] = $acl_group_name;
 
             if (testGroupExistence($acl_group_name)) {
-                $rq = $val ? 'INSERT INTO acl_groups VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
+                $insertStmt->execute();
+                $fields = $row;
                 $dbResult = $pearDB->query('SELECT MAX(acl_group_id) FROM acl_groups');
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();
@@ -392,15 +389,18 @@ function updateGroupContacts($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_contacts_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_contacts_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['cg_contacts'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_contacts_relations (contact_contact_id, acl_group_id) '
+            . 'VALUES (:contact_id, :group_id)'
+        );
         foreach ($_POST['cg_contacts'] as $id) {
-            $rq = 'INSERT INTO acl_group_contacts_relations ';
-            $rq .= '(contact_contact_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':contact_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -418,10 +418,15 @@ function updateGroupContactGroups($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_contactgroups_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_contactgroups_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['cg_contactGroups'])) {
         $cg = new CentreonContactgroup($pearDB);
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_contactgroups_relations (cg_cg_id, acl_group_id) '
+            . 'VALUES (:cg_id, :group_id)'
+        );
         foreach ($_POST['cg_contactGroups'] as $id) {
             if (! is_numeric($id)) {
                 $res = $cg->insertLdapGroup($id);
@@ -431,11 +436,9 @@ function updateGroupContactGroups($acl_group_id, $ret = [])
                     continue;
                 }
             }
-            $rq = 'INSERT INTO acl_group_contactgroups_relations ';
-            $rq .= '(cg_cg_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':cg_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -453,15 +456,18 @@ function updateGroupActions($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_actions_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_actions_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['actionAccess'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_actions_relations (acl_action_id, acl_group_id) '
+            . 'VALUES (:action_id, :group_id)'
+        );
         foreach ($_POST['actionAccess'] as $id) {
-            $rq = 'INSERT INTO acl_group_actions_relations ';
-            $rq .= '(acl_action_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':action_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -479,15 +485,18 @@ function updateGroupMenus($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_topology_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_topology_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['menuAccess'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_topology_relations (acl_topology_id, acl_group_id) '
+            . 'VALUES (:topology_id, :group_id)'
+        );
         foreach ($_POST['menuAccess'] as $id) {
-            $rq = 'INSERT INTO acl_group_topology_relations ';
-            $rq .= '(acl_topology_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':topology_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -505,19 +514,23 @@ function updateGroupResources($acl_group_id, $ret = [])
         return;
     }
 
-    $query = 'DELETE argr '
-        . 'FROM acl_res_group_relations argr '
+    $deleteStmt = $pearDB->prepare(
+        'DELETE argr FROM acl_res_group_relations argr '
         . 'JOIN acl_resources ar ON argr.acl_res_id = ar.acl_res_id '
-        . 'WHERE argr.acl_group_id = ' . $acl_group_id . ' '
-        . 'AND ar.locked = 0 ';
-    $pearDB->query($query);
+        . 'WHERE argr.acl_group_id = :group_id '
+        . 'AND ar.locked = 0'
+    );
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['resourceAccess'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) '
+            . 'VALUES (:res_id, :group_id)'
+        );
         foreach ($_POST['resourceAccess'] as $id) {
-            $rq = 'INSERT INTO acl_res_group_relations ';
-            $rq .= '(acl_res_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $pearDB->query($rq);
+            $insertStmt->bindValue(':res_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }

--- a/centreon/www/include/options/accessLists/menusACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/menusACL/DB-Func.php
@@ -279,7 +279,7 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
                 $values[$column] = $value;
             }
 
-            if (! empty($values)) {
+            if ($values !== []) {
                 $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
                 $insertStmt = $pearDB->prepare(
                     'INSERT INTO acl_topology (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'

--- a/centreon/www/include/options/accessLists/menusACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/menusACL/DB-Func.php
@@ -254,9 +254,11 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
 
         $topology['acl_topo_id'] = '';
         for ($newIndex = 1; $newIndex <= $duplicateNbr[$currentTopologyId]; $newIndex++) {
-            $val = null;
             $aclName = null;
             $fields = [];
+            $columns = [];
+            $values = [];
+
             foreach ($topology as $column => $value) {
                 if ($column === 'acl_topo_name') {
                     $count = 1;
@@ -268,25 +270,28 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
                     $value = $aclName;
                     $fields['acl_topo_name'] = $aclName;
                 }
-                if (is_null($val)) {
-                    $val .= (is_null($value) || empty($value))
-                        ? 'NULL'
-                        : "'" . $pearDB->escape($value) . "'";
-                } else {
-                    $val .= (is_null($value) || empty($value))
-                        ? ', NULL'
-                        : ", '" . $pearDB->escape($value) . "'";
-                }
 
                 if ($column !== 'acl_topo_id' && $column !== 'acl_topo_name') {
                     $fields[$column] = $value;
                 }
+
+                $columns[] = $column;
+                $values[$column] = $value;
             }
 
-            if (! is_null($val)) {
-                $pearDB->query(
-                    "INSERT INTO acl_topology VALUES ({$val})"
+            if (! empty($values)) {
+                $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO acl_topology (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
                 );
+                foreach ($values as $col => $val) {
+                    if ($val === null || $val === '') {
+                        $insertStmt->bindValue(':' . $col, null, PDO::PARAM_NULL);
+                    } else {
+                        $insertStmt->bindValue(':' . $col, $val, PDO::PARAM_STR);
+                    }
+                }
+                $insertStmt->execute();
                 $newTopologyId = $pearDB->lastInsertId();
 
                 $prepareInsertRelation = $pearDB->prepare(

--- a/centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -62,16 +62,25 @@ function enableLCAInDB($aclResId = null, $acls = [])
         $acls = [$aclResId => '1'];
     }
 
+    $updateGroupStmt = $pearDB->prepare(
+        "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
+        . 'WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = :acl_res_id)'
+    );
+    $updateResourceStmt = $pearDB->prepare(
+        "UPDATE `acl_resources` SET acl_res_activate = '1', `changed` = '1' WHERE `acl_res_id` = :acl_res_id"
+    );
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1'
+    );
+
     foreach ($acls as $key => $value) {
-        $query = "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
-            . "WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = '{$key}')";
-        $pearDB->query($query);
-        $query = "UPDATE `acl_resources` SET acl_res_activate = '1', `changed` = '1' "
-            . "WHERE `acl_res_id` = '" . $key . "'";
-        $pearDB->query($query);
-        $query = "SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = '" . (int) $key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
+        $updateGroupStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateGroupStmt->execute();
+        $updateResourceStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateResourceStmt->execute();
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         $centreon->CentreonLogAction->insertLog('resource access', $key, $row['acl_res_name'], 'enable');
     }
 }
@@ -92,16 +101,25 @@ function disableLCAInDB($aclResId = null, $acls = [])
         $acls = [$aclResId => '1'];
     }
 
+    $updateGroupStmt = $pearDB->prepare(
+        "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
+        . 'WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = :acl_res_id)'
+    );
+    $updateResourceStmt = $pearDB->prepare(
+        "UPDATE `acl_resources` SET acl_res_activate = '0', `changed` = '1' WHERE `acl_res_id` = :acl_res_id"
+    );
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1'
+    );
+
     foreach ($acls as $key => $value) {
-        $query = "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
-            . "WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = '{$key}')";
-        $pearDB->query($query);
-        $query = "UPDATE `acl_resources` SET acl_res_activate = '0', `changed` = '1' "
-            . "WHERE `acl_res_id` = '" . $key . "'";
-        $pearDB->query($query);
-        $query = "SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = '" . (int) $key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
+        $updateGroupStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateGroupStmt->execute();
+        $updateResourceStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateResourceStmt->execute();
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         $centreon->CentreonLogAction->insertLog('resource access', $key, $row['acl_res_name'], 'disable');
     }
 }
@@ -114,15 +132,26 @@ function deleteLCAInDB($acls = [])
 {
     global $pearDB, $centreon;
 
-    foreach ($acls as $key => $value) {
-        $query = "SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = '" . (int) $key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
-        $query = "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
-            . "WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = '{$key}')";
-        $pearDB->query($query);
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1'
+    );
+    $updateGroupStmt = $pearDB->prepare(
+        "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
+        . 'WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = :acl_res_id)'
+    );
+    $deleteStmt = $pearDB->prepare(
+        'DELETE FROM `acl_resources` WHERE acl_res_id = :acl_res_id'
+    );
 
-        $pearDB->query("DELETE FROM `acl_resources` WHERE acl_res_id = '" . $key . "'");
+    foreach ($acls as $key => $value) {
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        $updateGroupStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateGroupStmt->execute();
+
+        $deleteStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
         $centreon->CentreonLogAction->insertLog('resource access', $key, $row['acl_res_name'], 'd');
     }
 }
@@ -137,34 +166,28 @@ function multipleLCAInDB($lcas = [], $nbrDup = [])
     global $pearDB, $centreon;
 
     foreach ($lcas as $key => $value) {
-        $dbResult = $pearDB->query("SELECT * FROM `acl_resources` WHERE acl_res_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row['acl_res_id'] = '';
+        $selectStmt = $pearDB->prepare('SELECT * FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1');
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        unset($row['acl_res_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_resources (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
 
+        $originalName = $row['acl_res_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $values = [];
-
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'acl_res_name') {
-                    $acl_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $values[] = $value2 != null
-                    ? "'" . $value2 . "'"
-                    : 'NULL';
-                if ($key2 != 'acl_res_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($acl_res_name)) {
-                    $fields['acl_res_name'] = $acl_res_name;
-                }
-            }
+            $acl_name = $originalName . '_' . $i;
+            $row['acl_res_name'] = $acl_name;
 
             if (testExistence($acl_name)) {
-                if ($values !== []) {
-                    $pearDB->query('INSERT INTO acl_resources VALUES (' . implode(',', $values) . ')');
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
                 }
+                $insertStmt->execute();
+                $fields = $row;
 
                 $dbResult = $pearDB->query('SELECT MAX(acl_res_id) FROM acl_resources');
                 $maxId = $dbResult->fetch();
@@ -269,9 +292,13 @@ function duplicateGroups($idTD, $acl_id, $pearDB)
  */
 function duplicateContactGroups($idTD, $acl_id, $pearDB)
 {
-    $query = 'INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) '
-        . "SELECT acl_res_id, '{$acl_id}' AS acl_group_id FROM acl_res_group_relations WHERE acl_group_id = '{$idTD}'";
-    $pearDB->query($query);
+    $statement = $pearDB->prepare(
+        'INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) '
+        . 'SELECT acl_res_id, :acl_id AS acl_group_id FROM acl_res_group_relations WHERE acl_group_id = :idTD'
+    );
+    $statement->bindValue(':acl_id', (int) $acl_id, PDO::PARAM_INT);
+    $statement->bindValue(':idTD', (int) $idTD, PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**

--- a/centreon/www/include/options/media/images/syncDir.php
+++ b/centreon/www/include/options/media/images/syncDir.php
@@ -34,15 +34,15 @@ $mediaLogInstance = CentreonLog::create();
 global $regCounter, $gdCounter, $fileRemoved, $dirCreated;
 
 $sid = session_id();
-if ($sid === false) {
+if ($sid === '' || $sid === false) {
     exit;
 }
 
-if (isset($sid)) {
-    $DBRESULT = $pearDB->query("SELECT * FROM session WHERE session_id = '" . $pearDB->escape($sid) . "'");
-    if ($DBRESULT->rowCount() === 0) {
-        exit();
-    }
+$DBRESULT = $pearDB->prepare('SELECT 1 FROM session WHERE session_id = :sid LIMIT 1');
+$DBRESULT->bindValue(':sid', $sid, PDO::PARAM_STR);
+$DBRESULT->execute();
+if ($DBRESULT->fetchColumn() === false) {
+    exit();
 }
 
 $dir = './img/media/';

--- a/centreon/www/include/reporting/dashboard/DB-Func.php
+++ b/centreon/www/include/reporting/dashboard/DB-Func.php
@@ -19,25 +19,23 @@
  *
  */
 
-// returns days of week taken in account for reporting in a string
-function getReportDaysStr($reportTimePeriod)
+/**
+ * Return days of the week taken in account for reporting as an array for use with prepared statement placeholders.
+ *
+ * @param array $reportTimePeriod
+ * @return string[]
+ */
+function getReportDaysArray($reportTimePeriod)
 {
     $tab = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
-    $str = '';
-    foreach ($tab as $key => $value) {
+    $days = [];
+    foreach ($tab as $value) {
         if (isset($reportTimePeriod['report_' . $value]) && $reportTimePeriod['report_' . $value]) {
-            if ($str != '') {
-                $str .= ", '" . $value . "'";
-            } else {
-                $str .= "'" . $value . "'";
-            }
+            $days[] = $value;
         }
     }
-    if ($str == '') {
-        $str = 'NULL';
-    }
 
-    return $str;
+    return $days;
 }
 
 /*
@@ -53,20 +51,34 @@ function getLogInDbForHost($host_id, $start_date, $end_date, $reportTimePeriod)
         $hostStats[$name] = 0;
     }
 
-    $days_of_week = getReportDaysStr($reportTimePeriod);
-    $rq = 'SELECT sum(`UPnbEvent`) as UP_A, sum(`UPTimeScheduled`) as UP_T, '
-        . ' sum(`DOWNnbEvent`) as DOWN_A, sum(`DOWNTimeScheduled`) as DOWN_T, '
-        . ' sum(`UNREACHABLEnbEvent`) as UNREACHABLE_A, sum(`UNREACHABLETimeScheduled`) as UNREACHABLE_T, '
-        . ' sum(`UNDETERMINEDTimeScheduled`) as UNDETERMINED_T, '
-        . ' sum(`MaintenanceTime`) as MAINTENANCE_T '
-        . 'FROM `log_archive_host` '
-        . 'WHERE `host_id` = ' . $host_id . ' AND `date_start` >=  ' . $start_date . ' AND `date_end` <= ' . $end_date
-        . ' ' . "AND DATE_FORMAT( FROM_UNIXTIME( `date_start`), '%W') IN (" . $days_of_week . ') '
-        . 'GROUP BY `host_id` ';
+    $days_of_week = getReportDaysArray($reportTimePeriod);
+    if ($days_of_week !== []) {
+        $dayPlaceholders = [];
+        foreach ($days_of_week as $i => $day) {
+            $dayPlaceholders[] = ':day' . $i;
+        }
+        $daysInClause = implode(', ', $dayPlaceholders);
+        $rq = 'SELECT sum(`UPnbEvent`) as UP_A, sum(`UPTimeScheduled`) as UP_T, '
+            . ' sum(`DOWNnbEvent`) as DOWN_A, sum(`DOWNTimeScheduled`) as DOWN_T, '
+            . ' sum(`UNREACHABLEnbEvent`) as UNREACHABLE_A, sum(`UNREACHABLETimeScheduled`) as UNREACHABLE_T, '
+            . ' sum(`UNDETERMINEDTimeScheduled`) as UNDETERMINED_T, '
+            . ' sum(`MaintenanceTime`) as MAINTENANCE_T '
+            . 'FROM `log_archive_host` '
+            . 'WHERE `host_id` = :host_id AND `date_start` >= :start_date AND `date_end` <= :end_date '
+            . "AND DATE_FORMAT(FROM_UNIXTIME(`date_start`), '%W') IN (" . $daysInClause . ') '
+            . 'GROUP BY `host_id` ';
 
-    $dbResult = $pearDBO->query($rq);
-    if ($row = $dbResult->fetch()) {
-        $hostStats = $row;
+        $dbResult = $pearDBO->prepare($rq);
+        $dbResult->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+        $dbResult->bindValue(':start_date', (int) $start_date, PDO::PARAM_INT);
+        $dbResult->bindValue(':end_date', (int) $end_date, PDO::PARAM_INT);
+        foreach ($days_of_week as $i => $day) {
+            $dbResult->bindValue(':day' . $i, $day, PDO::PARAM_STR);
+        }
+        $dbResult->execute();
+        if ($row = $dbResult->fetch()) {
+            $hostStats = $row;
+        }
     }
 
     /*
@@ -254,34 +266,57 @@ function getLogInDbForHostSVC($host_id, $start_date, $end_date, $reportTimePerio
         }
     }
 
-    $days_of_week = getReportDaysStr($reportTimePeriod);
-    $aclCondition = '';
-    if (! $centreon->user->admin) {
-        $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
-            . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-            . 'AND acl.group_id IN (' . $centreon->user->access->getAccessGroupsString() . ') LIMIT 1)';
-    }
-    $rq = 'SELECT DISTINCT las.service_id, '
-        . 'sum(OKTimeScheduled) as OK_T, '
-        . 'sum(OKnbEvent) as OK_A, '
-        . 'sum(WARNINGTimeScheduled)  as WARNING_T, '
-        . 'sum(WARNINGnbEvent) as WARNING_A, '
-        . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, '
-        . 'sum(UNKNOWNnbEvent) as UNKNOWN_A, '
-        . 'sum(CRITICALTimeScheduled) as CRITICAL_T, '
-        . 'sum(CRITICALnbEvent) as CRITICAL_A, '
-        . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
-        . 'sum(MaintenanceTime) as MAINTENANCE_T '
-        . 'FROM log_archive_service las '
-        . 'WHERE las.host_id = ' . $host_id . ' '
-        . $aclCondition . ' '
-        . 'AND date_start >= ' . $start_date . ' AND date_end <= ' . $end_date . ' '
-        . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $days_of_week . ') '
-        . 'GROUP BY las.service_id ';
-    $dbResult = $pearDBO->query($rq);
-    while ($row = $dbResult->fetch()) {
-        if (isset($hostServiceStats[$row['service_id']])) {
-            $hostServiceStats[$row['service_id']] = $row;
+    $days_of_week = getReportDaysArray($reportTimePeriod);
+    if ($days_of_week !== []) {
+        $dayPlaceholders = [];
+        foreach ($days_of_week as $i => $day) {
+            $dayPlaceholders[] = ':day' . $i;
+        }
+        $daysInClause = implode(', ', $dayPlaceholders);
+        $aclCondition = '';
+        $aclGroupIds = [];
+        if (! $centreon->user->admin) {
+            $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
+            $aclPlaceholders = [];
+            foreach ($aclGroupIds as $j => $id) {
+                $aclPlaceholders[] = ':aclGroup' . $j;
+            }
+            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
+        }
+        $rq = 'SELECT DISTINCT las.service_id, '
+            . 'sum(OKTimeScheduled) as OK_T, '
+            . 'sum(OKnbEvent) as OK_A, '
+            . 'sum(WARNINGTimeScheduled)  as WARNING_T, '
+            . 'sum(WARNINGnbEvent) as WARNING_A, '
+            . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, '
+            . 'sum(UNKNOWNnbEvent) as UNKNOWN_A, '
+            . 'sum(CRITICALTimeScheduled) as CRITICAL_T, '
+            . 'sum(CRITICALnbEvent) as CRITICAL_A, '
+            . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
+            . 'sum(MaintenanceTime) as MAINTENANCE_T '
+            . 'FROM log_archive_service las '
+            . 'WHERE las.host_id = :host_id '
+            . $aclCondition . ' '
+            . 'AND date_start >= :start_date AND date_end <= :end_date '
+            . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysInClause . ') '
+            . 'GROUP BY las.service_id ';
+        $dbResult = $pearDBO->prepare($rq);
+        $dbResult->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+        $dbResult->bindValue(':start_date', (int) $start_date, PDO::PARAM_INT);
+        $dbResult->bindValue(':end_date', (int) $end_date, PDO::PARAM_INT);
+        foreach ($days_of_week as $i => $day) {
+            $dbResult->bindValue(':day' . $i, $day, PDO::PARAM_STR);
+        }
+        foreach ($aclGroupIds as $j => $id) {
+            $dbResult->bindValue(':aclGroup' . $j, (int) $id, PDO::PARAM_INT);
+        }
+        $dbResult->execute();
+        while ($row = $dbResult->fetch()) {
+            if (isset($hostServiceStats[$row['service_id']])) {
+                $hostServiceStats[$row['service_id']] = $row;
+            }
         }
     }
     $i = 0;
@@ -392,97 +427,128 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
     foreach (getServicesStatsValueName() as $name) {
         $serviceStats[$name] = 0;
     }
-    $daysOfWeek = getReportDaysStr($reportTimePeriod);
-    $aclCondition = '';
-    if (! $centreon->user->admin) {
-        $aclCondition = 'AND EXISTS (SELECT * FROM centreon_acl acl '
-            . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-            . 'AND acl.group_id IN (' . $centreon->user->access->getAccessGroupsString() . ') )';
-    }
-
-    $bindValues = [
-        ':startDate' => [PDO::PARAM_STR, $startDate],
-        ':endDate' => [PDO::PARAM_STR, $endDate],
-    ];
-
-    $servicesConditions = [];
-    foreach ($services as $index => $service) {
-        $servicesConditions[] = "(las.host_id = :host{$index} AND las.service_id = :service{$index})";
-        $bindValues[':host' . $index] = [PDO::PARAM_INT, $service['hostId']];
-        $bindValues[':service' . $index] = [PDO::PARAM_INT, $service['serviceId']];
-    }
-    $servicesSubquery = 'AND (' . implode(' OR ', $servicesConditions) . ')';
-
-    // Use "like" instead of "=" to avoid mysql bug on partitioned tables
-    $rq = 'SELECT DISTINCT las.host_id, las.service_id, sum(OKTimeScheduled) as OK_T, sum(OKnbEvent) as OK_A, '
-        . 'sum(WARNINGTimeScheduled)  as WARNING_T, sum(WARNINGnbEvent) as WARNING_A, '
-        . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, sum(UNKNOWNnbEvent) as UNKNOWN_A, '
-        . 'sum(CRITICALTimeScheduled) as CRITICAL_T, sum(CRITICALnbEvent) as CRITICAL_A, '
-        . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
-        . 'sum(MaintenanceTime) as MAINTENANCE_T '
-        . 'FROM log_archive_service las '
-        . 'WHERE `date_start` >= :startDate '
-        . 'AND date_end <= :endDate '
-        . $aclCondition . ' '
-        . $servicesSubquery . ' '
-        . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysOfWeek . ') '
-        . 'GROUP BY las.host_id, las.service_id';
-    $statement = $pearDBO->prepare($rq);
-
-    foreach ($bindValues as $bindName => $bindParams) {
-        [$bindType, $bindValue] = $bindParams;
-        $statement->bindValue($bindName, $bindValue, $bindType);
-    }
-
-    $statement->execute();
+    $daysOfWeek = getReportDaysArray($reportTimePeriod);
     $servicesStats = [];
-    $timeTab = getTotalTimeFromInterval($startDate, $endDate, $reportTimePeriod);
-    while ($serviceStats = $statement->fetch()) {
-        if ($timeTab['reportTime']) {
-            $serviceStats['UNDETERMINED_T'] += $timeTab['reportTime']
-                - ($serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
-                    + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T']);
-        } else {
-            foreach ($status as $key => $value) {
-                $serviceStats[$value . '_T'] = 0;
-            }
-            $serviceStats['UNDETERMINED_T'] = $timeTab['totalTime'];
+    if ($daysOfWeek !== []) {
+        $dayPlaceholders = [];
+        foreach ($daysOfWeek as $i => $day) {
+            $dayPlaceholders[] = ':day' . $i;
         }
-        // Calculate percentage of time (_TP => Total time percentage) for each status
-        $serviceStats['TOTAL_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
-            + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T'];
-        $time = $serviceStats['TOTAL_TIME'];
-        foreach ($status as $value) {
-            $serviceStats[$value . '_TP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
-        }
-        // The same percentage (_MP => Mean Time percentage) is calculated ignoring undetermined time
-        $serviceStats['MEAN_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T']
-            + $serviceStats['CRITICAL_T'] + $serviceStats['UNKNOWN_T'];
-        $time = $serviceStats['MEAN_TIME'];
-        if ($serviceStats['MEAN_TIME'] <= 0) {
-            foreach ($status as $value) {
-                if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
-                    $serviceStats[$value . '_MP'] = 0;
-                }
+        $daysInClause = implode(', ', $dayPlaceholders);
+        $aclCondition = '';
+        $aclGroupIds = [];
+        if (! $centreon->user->admin) {
+            $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
+            $aclPlaceholders = [];
+            foreach ($aclGroupIds as $j => $id) {
+                $aclPlaceholders[] = ':aclGroup' . $j;
             }
-        } else {
-            foreach ($status as $value) {
-                if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
-                    $serviceStats[$value . '_MP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
-                }
-            }
-        }
-        // Format time for each status (_TF => Time Formated), mean time and total time
-        $serviceStats['MEAN_TIME_F'] = getTimeString($serviceStats['MEAN_TIME'], $reportTimePeriod);
-        $serviceStats['TOTAL_TIME_F'] = getTimeString($serviceStats['TOTAL_TIME'], $reportTimePeriod);
-        foreach ($status as $value) {
-            $serviceStats[$value . '_TF'] = getTimeString($serviceStats[$value . '_T'], $reportTimePeriod);
+            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') )';
         }
 
-        $serviceStats['TOTAL_ALERTS'] = $serviceStats['OK_A'] + $serviceStats['WARNING_A'] + $serviceStats['CRITICAL_A']
-            + $serviceStats['UNKNOWN_A'];
+        $bindValues = [
+            ':startDate' => [PDO::PARAM_INT, (int) $startDate],
+            ':endDate' => [PDO::PARAM_INT, (int) $endDate],
+        ];
 
-        $servicesStats[$serviceStats['host_id']][$serviceStats['service_id']] = $serviceStats;
+        $servicesConditions = [];
+        foreach ($services as $index => $service) {
+            $servicesConditions[] = "(las.host_id = :host{$index} AND las.service_id = :service{$index})";
+            $bindValues[':host' . $index] = [PDO::PARAM_INT, $service['hostId']];
+            $bindValues[':service' . $index] = [PDO::PARAM_INT, $service['serviceId']];
+        }
+        $servicesSubquery = 'AND (' . implode(' OR ', $servicesConditions) . ')';
+
+        // Use "like" instead of "=" to avoid mysql bug on partitioned tables
+        $rq = 'SELECT DISTINCT las.host_id, las.service_id, sum(OKTimeScheduled) as OK_T, sum(OKnbEvent) as OK_A, '
+            . 'sum(WARNINGTimeScheduled)  as WARNING_T, sum(WARNINGnbEvent) as WARNING_A, '
+            . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, sum(UNKNOWNnbEvent) as UNKNOWN_A, '
+            . 'sum(CRITICALTimeScheduled) as CRITICAL_T, sum(CRITICALnbEvent) as CRITICAL_A, '
+            . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
+            . 'sum(MaintenanceTime) as MAINTENANCE_T '
+            . 'FROM log_archive_service las '
+            . 'WHERE `date_start` >= :startDate '
+            . 'AND date_end <= :endDate '
+            . $aclCondition . ' '
+            . $servicesSubquery . ' '
+            . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysInClause . ') '
+            . 'GROUP BY las.host_id, las.service_id';
+        $statement = $pearDBO->prepare($rq);
+
+        foreach ($bindValues as $bindName => $bindParams) {
+            [$bindType, $bindValue] = $bindParams;
+            $statement->bindValue($bindName, $bindValue, $bindType);
+        }
+        foreach ($daysOfWeek as $i => $day) {
+            $statement->bindValue(':day' . $i, $day, PDO::PARAM_STR);
+        }
+        foreach ($aclGroupIds as $j => $id) {
+            $statement->bindValue(':aclGroup' . $j, (int) $id, PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+        $timeTab = getTotalTimeFromInterval($startDate, $endDate, $reportTimePeriod);
+        while ($serviceStats = $statement->fetch()) {
+            if ($timeTab['reportTime']) {
+                $serviceStats['UNDETERMINED_T'] += $timeTab['reportTime']
+                    - ($serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
+                        + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T']);
+            } else {
+                foreach ($status as $key => $value) {
+                    $serviceStats[$value . '_T'] = 0;
+                }
+                $serviceStats['UNDETERMINED_T'] = $timeTab['totalTime'];
+            }
+            // Calculate percentage of time (_TP => Total time percentage) for each status
+            $serviceStats['TOTAL_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
+                + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T'];
+            $time = $serviceStats['TOTAL_TIME'];
+            foreach ($status as $value) {
+                $serviceStats[$value . '_TP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
+            }
+            // The same percentage (_MP => Mean Time percentage) is calculated ignoring undetermined time
+            $serviceStats['MEAN_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T']
+                + $serviceStats['CRITICAL_T'] + $serviceStats['UNKNOWN_T'];
+            $time = $serviceStats['MEAN_TIME'];
+            if ($serviceStats['MEAN_TIME'] <= 0) {
+                foreach ($status as $value) {
+                    if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
+                        $serviceStats[$value . '_MP'] = 0;
+                    }
+                }
+            } else {
+                foreach ($status as $value) {
+                    if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
+                        $serviceStats[$value . '_MP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
+                    }
+                }
+            }
+            // Format time for each status (_TF => Time Formated), mean time and total time
+            $serviceStats['MEAN_TIME_F'] = getTimeString($serviceStats['MEAN_TIME'], $reportTimePeriod);
+            $serviceStats['TOTAL_TIME_F'] = getTimeString($serviceStats['TOTAL_TIME'], $reportTimePeriod);
+            foreach ($status as $value) {
+                $serviceStats[$value . '_TF'] = getTimeString($serviceStats[$value . '_T'], $reportTimePeriod);
+            }
+
+            $serviceStats['TOTAL_ALERTS'] = $serviceStats['OK_A'] + $serviceStats['WARNING_A'] + $serviceStats['CRITICAL_A']
+                + $serviceStats['UNKNOWN_A'];
+
+            $servicesStats[$serviceStats['host_id']][$serviceStats['service_id']] = $serviceStats;
+        }
+    } else {
+        // No reporting days selected: return zero entries for each service
+        // to preserve the same structure as when the query runs
+        foreach ($services as $service) {
+            $zeroStats = [];
+            foreach (getServicesStatsValueName() as $name) {
+                $zeroStats[$name] = 0;
+            }
+            $zeroStats['host_id'] = $service['hostId'];
+            $zeroStats['service_id'] = $service['serviceId'];
+            $servicesStats[$service['hostId']][$service['serviceId']] = $zeroStats;
+        }
     }
 
     return $servicesStats;
@@ -699,9 +765,10 @@ function getreportingTimePeriod()
 function getHostNameFromId($host_id)
 {
     global $pearDB;
-    $req = 'SELECT  `host_name` FROM `host` WHERE `host_id` = ' . $host_id;
-    $dbResult = $pearDB->query($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `host_name` FROM `host` WHERE `host_id` = :host_id');
+    $statement->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['host_name'];
     }
 
@@ -711,9 +778,10 @@ function getHostNameFromId($host_id)
 function getHostgroupNameFromId($hostgroup_id)
 {
     global $pearDB;
-    $req = 'SELECT  `hg_name` FROM `hostgroup` WHERE `hg_id` = ' . $hostgroup_id;
-    $dbResult = $pearDB->query($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `hg_name` FROM `hostgroup` WHERE `hg_id` = :hg_id');
+    $statement->bindValue(':hg_id', (int) $hostgroup_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['hg_name'];
     }
 
@@ -723,9 +791,10 @@ function getHostgroupNameFromId($hostgroup_id)
 function getServiceDescriptionFromId($service_id)
 {
     global $pearDB;
-    $req = 'SELECT  `service_description` FROM `service` WHERE `service_id` = ' . $service_id;
-    $dbResult = $pearDB->query($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `service_description` FROM `service` WHERE `service_id` = :service_id');
+    $statement->bindValue(':service_id', (int) $service_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['service_description'];
     }
 
@@ -735,13 +804,12 @@ function getServiceDescriptionFromId($service_id)
 function getServiceGroupNameFromId($sg_id)
 {
     global $pearDB;
-    $req = 'SELECT  `sg_name` FROM `servicegroup` WHERE `sg_id` = ' . $sg_id;
-    $dbResult = $pearDB->query($req);
-    unset($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `sg_name` FROM `servicegroup` WHERE `sg_id` = :sg_id');
+    $statement->bindValue(':sg_id', (int) $sg_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['sg_name'];
     }
-    $dbResult->closeCursor();
 
     return 'undefined';
 }

--- a/centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+++ b/centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
@@ -47,8 +47,10 @@ $pearDBO = new CentreonDB('centstorage');
 
 $sid = session_id();
 
-$DBRESULT = $pearDB->query("SELECT * FROM session WHERE session_id = '" . $pearDB->escape($sid) . "'");
-if (! $DBRESULT->rowCount()) {
+$DBRESULT = $pearDB->prepare('SELECT 1 FROM session WHERE session_id = :sid LIMIT 1');
+$DBRESULT->bindValue(':sid', $sid, PDO::PARAM_STR);
+$DBRESULT->execute();
+if ($DBRESULT->fetchColumn() === false) {
     exit();
 }
 

--- a/centreon/www/include/views/graphTemplates/DB-Func.php
+++ b/centreon/www/include/views/graphTemplates/DB-Func.php
@@ -31,16 +31,18 @@ function testExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('graph_id');
     }
-    $query = "SELECT graph_id, name FROM giv_graphs_template WHERE name = '"
-        . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $res = $pearDB->query($query);
-    $graph = $res->fetch();
+    $stmt = $pearDB->prepare(
+        'SELECT graph_id, name FROM giv_graphs_template WHERE name = :name'
+    );
+    $stmt->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $stmt->execute();
+    $graph = $stmt->fetch();
     // Modif case
-    if ($res->rowCount() >= 1 && $graph['graph_id'] == $id) {
+    if ($stmt->rowCount() >= 1 && $graph['graph_id'] == $id) {
         return true;
     }
 
-    return ! ($res->rowCount() >= 1 && $graph['graph_id'] != $id);
+    return ! ($stmt->rowCount() >= 1 && $graph['graph_id'] != $id);
     // duplicate entry
 
 }
@@ -81,23 +83,24 @@ function multipleGraphTemplateInDB($graphs = [], $nbrDup = []): void
             $stmt->bindValue(':graphTemplateId', $key, PDO::PARAM_INT);
             $stmt->execute();
             if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                $row['graph_id'] = '';
+                unset($row['graph_id']);
                 $row['default_tpl1'] = '0';
+                $columns = array_keys($row);
+                $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO giv_graphs_template (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+                );
+
+                $originalName = $row['name'];
                 for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-                    $val = null;
-                    foreach ($row as $key2 => $value2) {
-                        $value2 = is_int($value2) ? (string) $value2 : $value2;
-                        if ($key2 == 'name') {
-                            $name = $value2 . '_' . $i;
-                            $value2 = $value2 . '_' . $i;
-                        }
-                        $val
-                            ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                            : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-                    }
+                    $name = $originalName . '_' . $i;
+                    $row['name'] = $name;
+
                     if (testExistence($name)) {
-                        $rq = $val ? 'INSERT INTO giv_graphs_template VALUES (' . $val . ')' : null;
-                        $pearDB->query($rq);
+                        foreach ($columns as $col) {
+                            $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                        }
+                        $insertStmt->execute();
                     }
                 }
             }
@@ -156,7 +159,7 @@ function insertGraphTemplate(): int
             `scaled`, `stacked` , `comment`,
             `split_component`
         ) VALUES (
-            :name, :vertical_label, :width, :height, :base, :lower_limit, :upper_limit, :size_to_max, :default_tpl1, 
+            :name, :vertical_label, :width, :height, :base, :lower_limit, :upper_limit, :size_to_max, :default_tpl1,
             :scaled, :stacked, :comment, null
         )
         SQL;

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -151,10 +151,9 @@ function multipleVirtualMetricInDB($vmetrics = [], $nbrDup = [])
         }
 
         $vmConfiguration = $prepareStatement->fetch();
-        $vmConfiguration['vmetric_id'] = '';
+        unset($vmConfiguration['vmetric_id']);
 
         for ($newIndex = 1; $newIndex <= $nbrDup[$vmetricId]; $newIndex++) {
-            $val = null;
             $virtualMetricName = null;
             foreach ($vmConfiguration as $cfgName => $cfgValue) {
                 if ($cfgName == 'vmetric_name') {
@@ -165,25 +164,25 @@ function multipleVirtualMetricInDB($vmetrics = [], $nbrDup = [])
                         $count++;
                         $virtualMetricName = $cfgValue . '_' . $count;
                     }
-                    $cfgValue = $virtualMetricName;
-                }
-
-                if (is_null($val)) {
-                    $val .= ($cfgValue == null)
-                        ? 'NULL'
-                        : "'" . $pearDB->escape($cfgValue) . "'";
-                } else {
-                    $val .= ($cfgValue == null)
-                        ? ', NULL'
-                        : ", '" . $pearDB->escape($cfgValue) . "'";
+                    $vmConfiguration['vmetric_name'] = $virtualMetricName;
                 }
             }
-            if (! is_null($val)) {
-                try {
-                    $pearDB->query("INSERT INTO virtual_metrics VALUES ({$val})");
-                } catch (PDOException $e) {
-                    echo 'DB Error : ' . $e->getMessage();
-                }
+
+            $columns = array_keys($vmConfiguration);
+            $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+            $insertStmt = $pearDB->prepare(
+                'INSERT INTO virtual_metrics (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+            );
+
+            foreach ($columns as $col) {
+                $value = $vmConfiguration[$col];
+                $insertStmt->bindValue(':' . $col, $value, $value === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+            }
+
+            try {
+                $insertStmt->execute();
+            } catch (PDOException $e) {
+                echo 'DB Error : ' . $e->getMessage();
             }
         }
     }


### PR DESCRIPTION
## Description

(this replaces https://github.com/centreon/centreon/pull/9828 which went out of control)

Convert string-interpolated and concatenated SQL queries to prepared statements with bound parameters across 33 PHP files to prevent SQL injection vulnerabilities (CWE-89).

Changes include:
- Converting `$pearDB->query()` calls with variable interpolation to `$pearDB->prepare()` / `bindValue()` / `execute()` patterns
- Removing redundant `$pearDB->escape()` and `addslashes()` calls where values are now bound via parameters
- Parameterizing IN clauses with indexed placeholders
- Adding column name validation via `preg_match` where column names must be concatenated into query strings
- Converting duplication functions to use dynamic column-mapped prepared INSERT statements

Fixes: [MON-195882](https://centreon.atlassian.net/browse/MON-195882)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

[MON-195882]: https://centreon.atlassian.net/browse/MON-195882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ