### PR TITLE
test(e2e): web: Adding temporary a ignore case on Update platform test

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update.feature
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update.feature
@@ -1,5 +1,5 @@
 @execTimeout(300000)
-@REQ_MON-22132 @system @update
+@REQ_MON-22132 @system @update @ignore
 Feature: Update platform from version A to version B of the same MAJOR
   An admin user can update a platform, from a version A to version B
   which is higher than version A, within the same MAJOR.


### PR DESCRIPTION
test(e2e): web: Added a temporary skip condition to the platform update test

To resolve the deadlock in the platform update E2E test, I have added an ignore tag to this test. It is therefore necessary to run it manually to verify that the update from a stable version to the next release is still successful. An analysis ticket to resolve the issue is currently being investigated.

Refs: MON-196568

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
