### PR TITLE
[Backport 25.10.x] fix(service): trigger ACL recalculation on service create/update

### DIFF
--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -42,6 +42,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Contact\Domain\AdminResolver;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
 use Core\Macro\Domain\Model\Macro;
@@ -50,6 +51,7 @@ use Core\Macro\Domain\Model\MacroManager;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
@@ -96,6 +98,8 @@ final class AddService
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly WriteRealTimeServiceRepositoryInterface $writeRealTimeServiceRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
+        private readonly AdminResolver $adminResolver,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -119,7 +123,7 @@ final class AddService
                 return;
             }
 
-            if (! $this->user->isAdmin()) {
+            if (! $this->adminResolver->isAdmin($this->user)) {
                 $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $this->accessGroups;
             }
@@ -144,7 +148,7 @@ final class AddService
 
                 return;
             }
-            if ($this->user->isAdmin()) {
+            if ($this->adminResolver->isAdmin($this->user)) {
                 $serviceCategories = $this->readServiceCategoryRepository->findByService($newServiceId);
                 $serviceGroups = $this->readServiceGroupRepository->findByService($newServiceId);
             } else {
@@ -442,6 +446,10 @@ final class AddService
             if (($monitoringServer = $this->readMonitoringServerRepository->findByHost($request->hostId))) {
                 $this->writeMonitoringServerRepository->notifyConfigurationChange($monitoringServer->getId());
             }
+
+            $this->adminResolver->isAdmin($this->user)
+                ? $this->writeAccessGroupRepository->updateAclResourcesFlag()
+                : $this->writeAccessGroupRepository->updateAclGroupsFlag($this->accessGroups);
 
             $this->storageEngine->commitTransaction();
 

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
@@ -46,6 +46,7 @@ use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
@@ -55,6 +56,7 @@ use Core\Macro\Domain\Model\MacroManager;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Model\NotificationTypeConverter;
@@ -101,6 +103,8 @@ final class PartialUpdateService
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
+        private readonly AdminResolver $adminResolver,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -125,14 +129,14 @@ final class PartialUpdateService
                 return;
             }
 
-            if (! $this->user->isAdmin()) {
+            if (! $this->adminResolver->isAdmin($this->user)) {
                 $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $this->accessGroups;
             }
 
             if (
                 (
-                    ! $this->user->isAdmin()
+                    ! $this->adminResolver->isAdmin($this->user)
                     && ! $this->readServiceRepository->existsByAccessGroups($serviceId, $this->accessGroups)
                 )
                 || ! ($service = $this->readServiceRepository->findById($serviceId))
@@ -179,9 +183,15 @@ final class PartialUpdateService
             $this->updateService($request, $service);
             $this->updateCategories($request, $service);
             // Groups MUST be updated after the service as they are dependent on host ID.
-            $this->updateGroups($request, $service);
+            $groupsChanged = $this->updateGroups($request, $service);
             // Macros PUST be updated after the service as they are dependent on the template ID.
             $this->updateMacros($request, $service);
+
+            if ($groupsChanged) {
+                $this->adminResolver->isAdmin($this->user)
+                    ? $this->writeAccessGroupRepository->updateAclResourcesFlag()
+                    : $this->writeAccessGroupRepository->updateAclGroupsFlag($this->accessGroups);
+            }
 
             $newMonitoringServer = $this->readMonitoringServerRepository->findByHost($service->getHostId());
             if ($newMonitoringServer !== null) {
@@ -406,7 +416,7 @@ final class PartialUpdateService
         $categoryIds = array_unique($dto->categories);
         $this->validation->assertAreValidCategories($categoryIds);
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $originalCategories = $this->readServiceCategoryRepository->findByService($service->getId());
         } else {
             $originalCategories = $this->readServiceCategoryRepository->findByServiceAndAccessGroups(
@@ -434,7 +444,7 @@ final class PartialUpdateService
      *
      * @throws \Throwable
      */
-    private function updateGroups(PartialUpdateServiceRequest $dto, Service $service): void
+    private function updateGroups(PartialUpdateServiceRequest $dto, Service $service): bool
     {
         $this->info(
             'PartialUpdateService: update groups',
@@ -444,12 +454,12 @@ final class PartialUpdateService
         if ($dto->groups instanceof NoValue) {
             $this->info('Groups not provided, nothing to update');
 
-            return;
+            return false;
         }
 
         $this->validation->assertAreValidGroups($dto->groups);
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $originalGroups = $this->readServiceGroupRepository->findByService($service->getId());
         } else {
             $originalGroups = $this->readServiceGroupRepository->findByServiceAndAccessGroups(
@@ -457,10 +467,17 @@ final class PartialUpdateService
                 $this->accessGroups
             );
         }
+        // Collect original and new group IDs to detect changes later.
+        $originalGroupIds = array_map(
+            static fn (array $group): int => $group['relation']->getServiceGroupId(),
+            $originalGroups
+        );
+        $newGroupIds = array_values(array_unique($dto->groups));
+
         $this->writeServiceGroupRepository->unlink(array_column($originalGroups, 'relation'));
 
         $groupRelations = [];
-        foreach (array_unique($dto->groups) as $groupId) {
+        foreach ($newGroupIds as $groupId) {
             $groupRelations[] = new ServiceGroupRelation(
                 $groupId,
                 $service->getId(),
@@ -469,6 +486,13 @@ final class PartialUpdateService
         }
 
         $this->writeServiceGroupRepository->link($groupRelations);
+
+        // Compare sorted IDs to determine if group membership actually changed
+        // (ignoring order). This drives whether ACL recalculation is needed.
+        sort($originalGroupIds);
+        sort($newGroupIds);
+
+        return $originalGroupIds !== $newGroupIds;
     }
 
     /**

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
@@ -36,6 +36,7 @@ use Core\CommandMacro\Application\Repository\ReadCommandMacroRepositoryInterface
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Domain\YesNoDefault;
+use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
@@ -44,6 +45,7 @@ use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryI
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Model\MonitoringServer;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteRealTimeServiceRepositoryInterface;
@@ -91,6 +93,8 @@ beforeEach(function (): void {
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
         $this->writeRealTimeServiceRepository = $this->createMock(WriteRealTimeServiceRepositoryInterface::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 
     $this->request = new AddServiceRequest();
@@ -121,7 +125,7 @@ it('should present an ErrorResponse when the service name already exists', funct
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -154,7 +158,7 @@ it('should present a ConflictResponse when the severity ID is not valid', functi
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -181,7 +185,7 @@ it('should present a ConflictResponse when the performance graph ID is not valid
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -209,7 +213,7 @@ it('should present a ConflictResponse when the service template ID is not valid'
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -238,7 +242,7 @@ it('should present a ConflictResponse when the command ID is not valid', functio
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -268,7 +272,7 @@ it('should present a ConflictResponse when the event handler ID is not valid', f
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -309,7 +313,7 @@ it('should present a ConflictResponse when the time period ID is not valid', fun
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -352,7 +356,7 @@ it('should present a ConflictResponse when the icon ID is not valid', function (
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -396,7 +400,7 @@ it('should present a ConflictResponse when the host ID is not valid', function (
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -440,7 +444,7 @@ it('should present a ConflictResponse when the service category IDs are not vali
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -485,7 +489,7 @@ it('should present a ConflictResponse when the service group IDs are not valid',
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -529,7 +533,7 @@ it('should present an ErrorResponse when an exception is thrown', function (): v
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -641,8 +645,8 @@ it('should present an AddServiceResponse when everything has gone well', functio
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(2))
+    $this->adminResolver
+        ->expects($this->exactly(3))
         ->method('isAdmin')
         ->willReturn(true);
 
@@ -705,6 +709,10 @@ it('should present an AddServiceResponse when everything has gone well', functio
     $this->writeMonitoringServerRepository
         ->expects($this->once())
         ->method('notifyConfigurationChange');
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
 
     $this->readServiceRepository
         ->expects($this->once())

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
@@ -38,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -46,6 +47,7 @@ use Core\Macro\Domain\Model\Macro;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
@@ -61,6 +63,7 @@ use Core\ServiceCategory\Domain\Model\ServiceCategory;
 use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Domain\Model\ServiceGroup;
+use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
 use Exception;
 
 beforeEach(closure: function (): void {
@@ -89,6 +92,8 @@ beforeEach(closure: function (): void {
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 
     $this->service = new Service(id: 1, name: 'service-name', hostId: 2);
@@ -172,7 +177,7 @@ it('should present an ErrorResponse when an exception is thrown', function (): v
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);
@@ -194,7 +199,7 @@ it('should present a NotFoundResponse when the service does not exist', function
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -217,7 +222,7 @@ it('should present a ConflictResponse when the host ID does not exist', function
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -247,7 +252,7 @@ it('should present a ConflictResponse when a category does not exist', function 
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -284,7 +289,7 @@ it('should present a ConflictResponse when a group does not exist', function ():
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(3))
         ->method('isAdmin')
         ->willReturn(true);
@@ -332,8 +337,8 @@ it('should present a NoContentResponse on success', function (): void {
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(4))
+    $this->adminResolver
+        ->expects($this->exactly(5))
         ->method('isAdmin')
         ->willReturn(true);
     $this->readServiceRepository
@@ -385,7 +390,16 @@ it('should present a NoContentResponse on success', function (): void {
     $this->readServiceGroupRepository
         ->expects($this->once())
         ->method('findByService')
-        ->willReturn([$this->groupA]);
+        ->willReturn([
+            [
+                'relation' => new ServiceGroupRelation(
+                    $this->groupA->getId(),
+                    $this->service->getId(),
+                    $this->service->getHostId()
+                ),
+                'serviceGroup' => $this->groupA,
+            ],
+        ]);
     $this->writeServiceGroupRepository
         ->expects($this->once())
         ->method('unlink');
@@ -415,6 +429,10 @@ it('should present a NoContentResponse on success', function (): void {
     $this->writeServiceMacroRepository
         ->expects($this->once())
         ->method('update');
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
 
     ($this->useCase)($this->request, $this->presenter, $this->service->getId());
     expect($this->presenter->getResponseStatus())


### PR DESCRIPTION
## Summary
- Backport of #9944 to `dev-25.10.x`
- Triggers ACL recalculation when creating or updating a service via API v2
- Related Jira ticket: MON-196758

## Test plan
- [ ] Verify ACL recalculation is triggered on service create via API v2
- [ ] Verify ACL recalculation is triggered on service update via API v2
- [ ] Run unit tests for AddService and PartialUpdateService use cases

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Injected WriteAccessGroupRepository and AdminResolver into constructors
* Ensured non-admin flows loaded contact access groups for validation

**🔧 Refactors**
* Replaced direct isAdmin() checks with AdminResolver calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/93900874?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->