### PR TITLE
[Backport 24.10.x] fix(host): trigger ACL recalculation when creating or updating a host via API v2

### DIFF
--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -41,6 +41,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
@@ -58,6 +59,7 @@ use Core\Macro\Domain\Model\MacroDifference;
 use Core\Macro\Domain\Model\MacroManager;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 
 final class AddHost
@@ -85,6 +87,9 @@ final class AddHost
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly WriteRealTimeHostRepositoryInterface $writeRealTimeHostRepository,
+        private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
+        private readonly AdminResolver $adminResolver,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -110,7 +115,7 @@ final class AddHost
 
             $accessGroups = [];
 
-            if (! $this->user->isAdmin()) {
+            if (! $this->adminResolver->isAdmin($this->user)) {
                 $accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $accessGroups;
             }
@@ -126,6 +131,10 @@ final class AddHost
                 if ($accessGroups !== []) {
                     $this->writeRealTimeHostRepository->addHostToResourceAcls($hostId, $accessGroups);
                 }
+                $this->adminResolver->isAdmin($this->user)
+                    ? $this->writeAccessGroupRepository->updateAclResourcesFlag()
+                    : $this->writeAccessGroupRepository->updateAclGroupsFlag($accessGroups);
+
                 $this->writeMonitoringServerRepository->notifyConfigurationChange($request->monitoringServerId);
 
                 $this->dataStorageEngine->commitTransaction();
@@ -421,7 +430,7 @@ final class AddHost
         if (! $host) {
             throw HostException::errorWhileRetrievingObject();
         }
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $hostCategories = $this->readHostCategoryRepository->findByHost($hostId);
             $hostGroups = $this->readHostGroupRepository->findByHost($hostId);
         } else {

--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -46,6 +46,7 @@ use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
@@ -67,6 +68,7 @@ use Core\Macro\Domain\Model\MacroDifference;
 use Core\Macro\Domain\Model\MacroManager;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Utility\Difference\BasicDifference;
@@ -98,6 +100,9 @@ final class PartialUpdateHost
         private readonly PartialUpdateHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
+        private readonly AdminResolver $adminResolver,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -125,14 +130,14 @@ final class PartialUpdateHost
                 return;
             }
 
-            if (! $this->user->isAdmin()) {
+            if (! $this->adminResolver->isAdmin($this->user)) {
                 $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $this->accessGroups;
             }
 
             if (
                 (
-                    ! $this->user->isAdmin()
+                    ! $this->adminResolver->isAdmin($this->user)
                     && ! $this->readHostRepository->existsByAccessGroups($hostId, $this->accessGroups)
                 )
                 || ! ($host = $this->readHostRepository->findById($hostId))
@@ -178,10 +183,16 @@ final class PartialUpdateHost
             $previousMonitoringServer = $host->getMonitoringServerId();
             $this->updateHost($request, $host);
             $this->updateHostCategories($request, $host);
-            $this->updateHostGroups($request, $host);
+            $hostGroupsChanged = $this->updateHostGroups($request, $host);
             $this->updateParentTemplates($request, $host);
             // Note: parent templates must be updated before macros for macro inheritance resolution
             $this->updateMacros($request, $host);
+
+            if ($hostGroupsChanged) {
+                $this->adminResolver->isAdmin($this->user)
+                    ? $this->writeAccessGroupRepository->updateAclResourcesFlag()
+                    : $this->writeAccessGroupRepository->updateAclGroupsFlag($this->accessGroups);
+            }
 
             $this->writeMonitoringServerRepository->notifyConfigurationChange($host->getMonitoringServerId());
             if ($previousMonitoringServer !== $host->getMonitoringServerId()) {
@@ -435,7 +446,7 @@ final class PartialUpdateHost
 
         $categoryIds = array_unique($dto->categories);
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $accessibleCategoryIds = $this->readHostCategoryRepository->exist($categoryIds);
             $originalCategories = $this->readHostCategoryRepository->findByHost($host->getId());
         } else {
@@ -475,7 +486,7 @@ final class PartialUpdateHost
      * @throws HostException
      * @throws \Throwable
      */
-    private function updateHostGroups(PartialUpdateHostRequest $dto, Host $host): void
+    private function updateHostGroups(PartialUpdateHostRequest $dto, Host $host): bool
     {
         $this->info(
             'PartialUpdateHost: update groups',
@@ -485,11 +496,11 @@ final class PartialUpdateHost
         if ($dto->groups instanceof NoValue) {
             $this->info('Groups not provided, nothing to update');
 
-            return;
+            return false;
         }
 
         $groupIds = array_unique($dto->groups);
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $accessibleGroupIds = $this->readHostGroupRepository->exist($groupIds);
             $originalGroups = $this->readHostGroupRepository->findByHost($host->getId());
         } else {
@@ -521,6 +532,8 @@ final class PartialUpdateHost
 
         $this->writeHostGroupRepository->linkToHost($host->getId(), $addedGroups);
         $this->writeHostGroupRepository->unlinkFromHost($host->getId(), $removedGroups);
+
+        return $addedGroups !== [] || $removedGroups !== [];
     }
 
     /**

--- a/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
@@ -38,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
@@ -64,6 +65,7 @@ use Core\Macro\Application\Repository\WriteHostMacroRepositoryInterface;
 use Core\Macro\Domain\Model\Macro;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Tests\Core\Host\Infrastructure\API\AddHost\AddHostPresenterStub;
 
 beforeEach(function (): void {
@@ -91,6 +93,9 @@ beforeEach(function (): void {
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
         writeRealTimeHostRepository: $this->writeRealTimeHostRepository = $this->createMock(WriteRealTimeHostRepositoryInterface::class),
+        readCommandRepository: $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        writeAccessGroupRepository: $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
+        adminResolver: $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 
     $this->inheritanceModeOption = new Option();
@@ -648,10 +653,15 @@ it('should return created object on success (with admin user)', function (): voi
         ->expects($this->once())
         ->method('notifyConfigurationChange');
 
-    $this->user
+    $this->adminResolver
         ->expects($this->any())
         ->method('isAdmin')
         ->willReturn(true);
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
+
     $this->readHostRepository
         ->expects($this->once())
         ->method('findById')
@@ -855,10 +865,15 @@ it('should return created object on success (with non-admin user)', function ():
         ->expects($this->once())
         ->method('notifyConfigurationChange');
 
-    $this->user
+    $this->adminResolver
         ->expects($this->any())
         ->method('isAdmin')
         ->willReturn(false);
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclGroupsFlag');
+
     $this->readHostRepository
         ->expects($this->once())
         ->method('findById')

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
@@ -38,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
@@ -60,6 +61,7 @@ use Core\Macro\Application\Repository\WriteHostMacroRepositoryInterface;
 use Core\Macro\Domain\Model\Macro;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Tests\Core\Host\Infrastructure\API\PartialUpdateHost\PartialUpdateHostPresenterStub;
 
 beforeEach(function (): void {
@@ -83,6 +85,9 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(PartialUpdateHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        readCommandRepository: $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        writeAccessGroupRepository: $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
+        adminResolver: $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 
     $this->inheritanceModeOption = new Option();
@@ -262,7 +267,7 @@ it('should present an ErrorResponse when an exception is thrown', function (): v
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);
@@ -284,7 +289,7 @@ it('should present a NotFoundResponse when the host does not exist', function ()
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -308,7 +313,7 @@ it('should present a ConflictResponse when name is already used', function (): v
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -345,7 +350,7 @@ it('should present a ConflictResponse when host severity ID is not valid', funct
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -374,7 +379,7 @@ it('should present a ConflictResponse when a host timezone ID is not valid', fun
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -403,7 +408,7 @@ it('should present a ConflictResponse when a timeperiod ID is not valid', functi
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -440,7 +445,7 @@ it('should present a ConflictResponse when a command ID is not valid', function 
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -477,7 +482,7 @@ it('should present a ConflictResponse when the host icon ID is not valid', funct
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -516,7 +521,7 @@ it('should present a ConflictResponse when a parent template ID is not valid', f
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(4))
         ->method('isAdmin')
         ->willReturn(true);
@@ -576,7 +581,7 @@ it('should present a ConflictResponse when a parent template creates a circular 
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(4))
         ->method('isAdmin')
         ->willReturn(true);
@@ -635,8 +640,8 @@ it('should present a NoContentResponse on success', function (): void {
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(4))
+    $this->adminResolver
+        ->expects($this->exactly(5))
         ->method('isAdmin')
         ->willReturn(true);
     $this->readHostRepository
@@ -695,6 +700,11 @@ it('should present a NoContentResponse on success', function (): void {
     $this->writeHostRepository
         ->expects($this->exactly(2))
         ->method('addParent');
+
+    // ACL flag
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
 
     // Macros
     $this->readHostRepository


### PR DESCRIPTION
## Summary
- Backport of #9942 to `dev-24.10.x` (cherry-picked from `dev-25.10.x` backport)
- Triggers ACL recalculation when creating or updating a host via API v2
- Related Jira ticket: MON-146946
- Conflicts resolved: added missing constructor dependencies (`ReadCommandRepositoryInterface`, `WriteAccessGroupRepositoryInterface`, `AdminResolver`)

## Test plan
- [ ] Verify ACL recalculation is triggered on host create via API v2
- [ ] Verify ACL recalculation is triggered on host update via API v2
- [ ] Run unit tests for AddHost and PartialUpdateHost use cases

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Triggered ACL recalculation flags when adding a host via API v2.
* Marked ACL-related changes when updating host groups in partial updates.

**🔧 Refactors**
* Replaced Contact::isAdmin() checks with AdminResolver::isAdmin calls.
* Added ReadCommand, WriteAccessGroup and AdminResolver constructor dependencies.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/93901800?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->