### PR TITLE
[Backport 24.10.x] fix(service): trigger ACL recalculation on service create/update

### DIFF
--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -40,6 +40,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Contact\Domain\AdminResolver;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
 use Core\Macro\Domain\Model\Macro;
@@ -48,6 +49,7 @@ use Core\Macro\Domain\Model\MacroManager;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
@@ -93,6 +95,9 @@ final class AddService
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly WriteRealTimeServiceRepositoryInterface $writeRealTimeServiceRepository,
+        private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
+        private readonly AdminResolver $adminResolver,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -116,7 +121,7 @@ final class AddService
                 return;
             }
 
-            if (! $this->user->isAdmin()) {
+            if (! $this->adminResolver->isAdmin($this->user)) {
                 $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $this->accessGroups;
             }
@@ -141,7 +146,7 @@ final class AddService
 
                 return;
             }
-            if ($this->user->isAdmin()) {
+            if ($this->adminResolver->isAdmin($this->user)) {
                 $serviceCategories = $this->readServiceCategoryRepository->findByService($newServiceId);
                 $serviceGroups = $this->readServiceGroupRepository->findByService($newServiceId);
             } else {
@@ -428,6 +433,10 @@ final class AddService
             if (($monitoringServer = $this->readMonitoringServerRepository->findByHost($request->hostId))) {
                 $this->writeMonitoringServerRepository->notifyConfigurationChange($monitoringServer->getId());
             }
+
+            $this->adminResolver->isAdmin($this->user)
+                ? $this->writeAccessGroupRepository->updateAclResourcesFlag()
+                : $this->writeAccessGroupRepository->updateAclGroupsFlag($this->accessGroups);
 
             $this->storageEngine->commitTransaction();
 

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
@@ -44,6 +44,7 @@ use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
@@ -53,6 +54,7 @@ use Core\Macro\Domain\Model\MacroManager;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Model\NotificationTypeConverter;
@@ -98,6 +100,9 @@ final class PartialUpdateService
         private readonly bool $isCloudPlatform,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
+        private readonly AdminResolver $adminResolver,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -122,14 +127,14 @@ final class PartialUpdateService
                 return;
             }
 
-            if (! $this->user->isAdmin()) {
+            if (! $this->adminResolver->isAdmin($this->user)) {
                 $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $this->accessGroups;
             }
 
             if (
                 (
-                    ! $this->user->isAdmin()
+                    ! $this->adminResolver->isAdmin($this->user)
                     && ! $this->readServiceRepository->existsByAccessGroups($serviceId, $this->accessGroups)
                 )
                 || ! ($service = $this->readServiceRepository->findById($serviceId))
@@ -176,9 +181,15 @@ final class PartialUpdateService
             $this->updateService($request, $service);
             $this->updateCategories($request, $service);
             // Groups MUST be updated after the service as they are dependent on host ID.
-            $this->updateGroups($request, $service);
+            $groupsChanged = $this->updateGroups($request, $service);
             // Macros PUST be updated after the service as they are dependent on the template ID.
             $this->updateMacros($request, $service);
+
+            if ($groupsChanged) {
+                $this->adminResolver->isAdmin($this->user)
+                    ? $this->writeAccessGroupRepository->updateAclResourcesFlag()
+                    : $this->writeAccessGroupRepository->updateAclGroupsFlag($this->accessGroups);
+            }
 
             $newMonitoringServer = $this->readMonitoringServerRepository->findByHost($service->getHostId());
             if ($newMonitoringServer !== null) {
@@ -393,7 +404,7 @@ final class PartialUpdateService
         $categoryIds = array_unique($dto->categories);
         $this->validation->assertAreValidCategories($categoryIds);
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $originalCategories = $this->readServiceCategoryRepository->findByService($service->getId());
         } else {
             $originalCategories = $this->readServiceCategoryRepository->findByServiceAndAccessGroups(
@@ -421,7 +432,7 @@ final class PartialUpdateService
      *
      * @throws \Throwable
      */
-    private function updateGroups(PartialUpdateServiceRequest $dto, Service $service): void
+    private function updateGroups(PartialUpdateServiceRequest $dto, Service $service): bool
     {
         $this->info(
             'PartialUpdateService: update groups',
@@ -431,12 +442,12 @@ final class PartialUpdateService
         if ($dto->groups instanceof NoValue) {
             $this->info('Groups not provided, nothing to update');
 
-            return;
+            return false;
         }
 
         $this->validation->assertAreValidGroups($dto->groups);
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $originalGroups = $this->readServiceGroupRepository->findByService($service->getId());
         } else {
             $originalGroups = $this->readServiceGroupRepository->findByServiceAndAccessGroups(
@@ -444,10 +455,17 @@ final class PartialUpdateService
                 $this->accessGroups
             );
         }
+        // Collect original and new group IDs to detect changes later.
+        $originalGroupIds = array_map(
+            static fn (array $group): int => $group['relation']->getServiceGroupId(),
+            $originalGroups
+        );
+        $newGroupIds = array_values(array_unique($dto->groups));
+
         $this->writeServiceGroupRepository->unlink(array_column($originalGroups, 'relation'));
 
         $groupRelations = [];
-        foreach (array_unique($dto->groups) as $groupId) {
+        foreach ($newGroupIds as $groupId) {
             $groupRelations[] = new ServiceGroupRelation(
                 $groupId,
                 $service->getId(),
@@ -456,6 +474,13 @@ final class PartialUpdateService
         }
 
         $this->writeServiceGroupRepository->link($groupRelations);
+
+        // Compare sorted IDs to determine if group membership actually changed
+        // (ignoring order). This drives whether ACL recalculation is needed.
+        sort($originalGroupIds);
+        sort($newGroupIds);
+
+        return $originalGroupIds !== $newGroupIds;
     }
 
     /**

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
@@ -34,6 +34,7 @@ use Core\CommandMacro\Application\Repository\ReadCommandMacroRepositoryInterface
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Domain\YesNoDefault;
+use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
@@ -42,6 +43,7 @@ use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryI
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Model\MonitoringServer;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteRealTimeServiceRepositoryInterface;
@@ -87,6 +89,9 @@ beforeEach(function (): void {
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
         $this->writeRealTimeServiceRepository = $this->createMock(WriteRealTimeServiceRepositoryInterface::class),
+        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 
     $this->request = new AddServiceRequest();
@@ -117,7 +122,7 @@ it('should present an ErrorResponse when the service name already exists', funct
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -150,7 +155,7 @@ it('should present a ConflictResponse when the severity ID is not valid', functi
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -177,7 +182,7 @@ it('should present a ConflictResponse when the performance graph ID is not valid
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -205,7 +210,7 @@ it('should present a ConflictResponse when the service template ID is not valid'
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -234,7 +239,7 @@ it('should present a ConflictResponse when the command ID is not valid', functio
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -264,7 +269,7 @@ it('should present a ConflictResponse when the event handler ID is not valid', f
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -305,7 +310,7 @@ it('should present a ConflictResponse when the time period ID is not valid', fun
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -348,7 +353,7 @@ it('should present a ConflictResponse when the icon ID is not valid', function (
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -392,7 +397,7 @@ it('should present a ConflictResponse when the host ID is not valid', function (
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -436,7 +441,7 @@ it('should present a ConflictResponse when the service category IDs are not vali
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -481,7 +486,7 @@ it('should present a ConflictResponse when the service group IDs are not valid',
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -525,7 +530,7 @@ it('should present an ErrorResponse when an exception is thrown', function (): v
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -629,8 +634,8 @@ it('should present an AddServiceResponse when everything has gone well', functio
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(2))
+    $this->adminResolver
+        ->expects($this->exactly(3))
         ->method('isAdmin')
         ->willReturn(true);
 
@@ -693,6 +698,10 @@ it('should present an AddServiceResponse when everything has gone well', functio
     $this->writeMonitoringServerRepository
         ->expects($this->once())
         ->method('notifyConfigurationChange');
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
 
     $this->readServiceRepository
         ->expects($this->once())

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
@@ -36,6 +36,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -44,6 +45,7 @@ use Core\Macro\Domain\Model\Macro;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
@@ -59,6 +61,7 @@ use Core\ServiceCategory\Domain\Model\ServiceCategory;
 use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Domain\Model\ServiceGroup;
+use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
 use Exception;
 
 beforeEach(closure: function (): void {
@@ -86,6 +89,9 @@ beforeEach(closure: function (): void {
         $this->isCloudPlatform = false,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 
     $this->service = new Service(id: 1, name: 'service-name', hostId: 2);
@@ -169,7 +175,7 @@ it('should present an ErrorResponse when an exception is thrown', function (): v
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);
@@ -191,7 +197,7 @@ it('should present a NotFoundResponse when the service does not exist', function
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -214,7 +220,7 @@ it('should present a ConflictResponse when the host ID does not exist', function
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -243,7 +249,7 @@ it('should present a ConflictResponse when a category does not exist', function 
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(2))
         ->method('isAdmin')
         ->willReturn(true);
@@ -279,7 +285,7 @@ it('should present a ConflictResponse when a group does not exist', function ():
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
+    $this->adminResolver
         ->expects($this->exactly(3))
         ->method('isAdmin')
         ->willReturn(true);
@@ -327,8 +333,8 @@ it('should present a NoContentResponse on success', function (): void {
         ->expects($this->once())
         ->method('hasTopologyRole')
         ->willReturn(true);
-    $this->user
-        ->expects($this->exactly(4))
+    $this->adminResolver
+        ->expects($this->exactly(5))
         ->method('isAdmin')
         ->willReturn(true);
     $this->readServiceRepository
@@ -372,7 +378,16 @@ it('should present a NoContentResponse on success', function (): void {
     $this->readServiceGroupRepository
         ->expects($this->once())
         ->method('findByService')
-        ->willReturn([$this->groupA]);
+        ->willReturn([
+            [
+                'relation' => new ServiceGroupRelation(
+                    $this->groupA->getId(),
+                    $this->service->getId(),
+                    $this->service->getHostId()
+                ),
+                'serviceGroup' => $this->groupA,
+            ],
+        ]);
     $this->writeServiceGroupRepository
         ->expects($this->once())
         ->method('unlink');
@@ -402,6 +417,10 @@ it('should present a NoContentResponse on success', function (): void {
     $this->writeServiceMacroRepository
         ->expects($this->once())
         ->method('update');
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
 
     ($this->useCase)($this->request, $this->presenter, $this->service->getId());
 


### PR DESCRIPTION
## Summary
- Backport of #9944 to `dev-24.10.x` (cherry-picked from `dev-25.10.x` backport)
- Triggers ACL recalculation when creating or updating a service via API v2
- Related Jira ticket: MON-146946
- Conflicts resolved: added missing constructor dependencies (`ReadCommandRepositoryInterface`, `WriteAccessGroupRepositoryInterface`, `AdminResolver`)

## Test plan
- [ ] Verify ACL recalculation is triggered on service create via API v2
- [ ] Verify ACL recalculation is triggered on service update via API v2
- [ ] Run unit tests for AddService and PartialUpdateService use cases

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added ReadCommandRepository, WriteAccessGroupRepository and AdminResolver constructor dependencies

**🐛 Bugfixes**
* Triggered ACL recalculation when services were created or updated via API v2

**🔧 Refactors**
* Replaced $this->user->isAdmin() checks with AdminResolver-based detection throughout use cases


<sup>[More info](https://app.aikido.dev/featurebranch/scan/93900939?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->