### PR TITLE
fix(upgrade): skip event_script CMA output insertion on Remote Server

### DIFF
--- a/centreon/src/Adaptation/Database/Connection/ValueObject/QueryParameter.php
+++ b/centreon/src/Adaptation/Database/Connection/ValueObject/QueryParameter.php
@@ -174,7 +174,7 @@ final readonly class QueryParameter implements ValueObjectInterface, \Stringable
         return [
             'name' => $this->name,
             'value' => $this->value,
-            'type' => $this->type,
+            'type' => $this->type?->name,
         ];
     }
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -421,6 +421,24 @@ $insertEventScriptOutputForCMA = function () use ($pearDB, &$errorMessage, $vers
         message: "UPGRADE - {$version}: Inserting Broker output 'central-broker-master-event-script' for CMA",
     );
 
+    // This output is specific to the Central broker. On Remote Servers, cfg_centreonbroker
+    // does not have a 'central-broker-master' entry — inserting with config_id = 1 would
+    // violate the foreign key constraint. Skip if not running on a Central server.
+    if (! $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT 1 FROM `cfg_centreonbroker`
+            WHERE `config_id` = 1
+            AND `config_name` = 'central-broker-master'
+            SQL
+    )) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Not running on a Central server, skipping insertion of 'central-broker-master-event-script'",
+        );
+
+        return;
+    }
+
     if ($pearDB->fetchOne(
         <<<'SQL'
             SELECT 1 FROM `cfg_centreonbroker_info`


### PR DESCRIPTION
## Description

Fix upgrade failure from 24.10.9 to 25.10.10 on Remote Server during step 4.

Two bugs combined:

1. `QueryParameter::jsonSerialize()` serialized `$this->type` (a non-backed enum) directly, causing a `JsonException` when logging errors — masking the real root cause in the upgrade logs.
2. `$insertEventScriptOutputForCMA` hardcoded `config_id = 1` assuming a `central-broker-master` broker exists locally, which is not the case on Remote Servers — causing a foreign key violation on `cfg_centreonbroker_info`.

The fix adds a guard to skip the insertion on Remote Servers (where `central-broker-master` is not present in `cfg_centreonbroker`), and fixes the JSON serialization of `QueryParameterTypeEnum` so future errors are properly surfaced in logs.

**Fixes** MON-196620

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Set up a Remote Server running 24.10.9
2. Upgrade to 25.10.10
3. Verify step 4 completes without error
4. Verify `central-broker-master-event-script` is NOT inserted in `cfg_centreonbroker_info` on the Remote Server

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed JSON serialization of QueryParameter type to avoid JsonException
* Skipped inserting event_script CMA output on remote servers to prevent FK violation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/94166720?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->