### PR TITLE
fix(widgets): fix ORDER BY compatibility with MySQL 8 in top10 cpu and memory widgets

### DIFF
--- a/centreon/www/widgets/live-top10-cpu-usage/index.php
+++ b/centreon/www/widgets/live-top10-cpu-usage/index.php
@@ -172,7 +172,7 @@ try {
                     i.host_name,
                     i.service_description,
                     s.state
-                ORDER BY current_value DESC
+                ORDER BY AVG(m.current_value) DESC
                 LIMIT :numberOfLines;
             SQL;
 

--- a/centreon/www/widgets/live-top10-memory-usage/index.php
+++ b/centreon/www/widgets/live-top10-memory-usage/index.php
@@ -178,7 +178,7 @@ try {
                     s.state,
                     m.current_value,
                     m.max
-                ORDER BY ratio DESC
+                ORDER BY m.current_value / m.max DESC
                 LIMIT :numberOfLines;
             SQL;
 


### PR DESCRIPTION
## Description

Fix MySQL 8 incompatibility in the `live-top10-cpu-usage` and `live-top10-memory-usage` widgets.

**Root cause**: MySQL 8 with `ONLY_FULL_GROUP_BY` mode (enabled by default) resolves ORDER BY expressions differently from MariaDB:

- **CPU widget**: `ORDER BY current_value DESC` where `current_value` is both a column in the `metrics` table AND the alias for `AVG(m.current_value)`. MySQL 8 docs: *"column names take precedence over alias names"* in ORDER BY. MySQL 8 therefore resolved it as the raw column `m.current_value`, which is not in GROUP BY and not an aggregate → error 1055.
- **Memory widget**: `ORDER BY ratio DESC` where `ratio` is a SELECT alias for a non-aggregate expression. MySQL 8 explicitly documents alias support in ORDER BY only for aggregate functions; non-aggregate expression aliases are not guaranteed to resolve correctly across all MySQL 8 versions.

**Fix**: Use expressions directly in ORDER BY, removing alias ambiguity entirely:
- `ORDER BY AVG(m.current_value) DESC`
- `ORDER BY m.current_value / m.max DESC`

**Fixes** MON-153925

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Install Centreon on a server running MySQL 8 (e.g. Debian 12)
2. Add a Custom View with the **Live Top 10 CPU Usage** and **Live Top 10 Memory Usage** widgets
3. Verify both widgets display data correctly
4. On MariaDB: verify widgets still work as before

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).