### PR TITLE
fix(contact): fix SQL syntax error when unblocking contacts (#9897)

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -355,11 +355,12 @@ function unblockContactInDB(int|array|null $contact = null): void
 
     try {
         // Build IN() clause safely
-        [$inClause, $queryParameters] = createMultipleBindParameters(
+        ['placeholderList' => $inClause, 'parameters' => $parameters] = createMultipleBindParameters(
             $contactIds,
             'contact_id_',
             QueryParameterTypeEnum::INTEGER,
         );
+        $queryParameters = QueryParameters::create($parameters);
 
         // Retrieve contacts for logging
         $selectQuery = <<<SQL


### PR DESCRIPTION
## Description
BACKPORT #9897

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed SQL syntax error when unblocking contacts in DB functions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/94931378?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->