### PR TITLE
fix(open-tickets): fix URI parameters for deprecated pages

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -572,11 +572,11 @@ while ($row = $res->fetch()) {
     );
 
     $data[$row['host_id'] . '_' . $row['service_id']]['h_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20202&o=hd&host_name=' . $row['hostname']
         : $resourceController->buildHostDetailsUri($row['host_id']);
 
     $data[$row['host_id'] . '_' . $row['service_id']]['s_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20202&o=hd&host_name=' . $row['hostname']
             . '&service_description=' . $row['description']
         : $resourceController->buildServiceDetailsUri($row['host_id'], $row['service_id']);
 }

--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -576,7 +576,7 @@ while ($row = $res->fetch()) {
         : $resourceController->buildHostDetailsUri($row['host_id']);
 
     $data[$row['host_id'] . '_' . $row['service_id']]['s_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=20202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20201&o=svcd&host_name=' . $row['hostname']
             . '&service_description=' . $row['description']
         : $resourceController->buildServiceDetailsUri($row['host_id'], $row['service_id']);
 }


### PR DESCRIPTION
## Description

Fix URI parameters when clicking on a resource in the Open Ticket widget (custom views)

Fixes: https://centreon.atlassian.net/browse/MON-196676

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed incorrect URI parameters when opening resources from widget


<sup>[More info](https://app.aikido.dev/featurebranch/scan/95872598?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->