### PR TITLE
fix(saml): requestedAuthnRequest value by default become false to fix saml connection post migration (#9989)

### DIFF
--- a/centreon/www/install/php/Update-25.10.6.php
+++ b/centreon/www/install/php/Update-25.10.6.php
@@ -85,7 +85,7 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
 
     if (isset($customConfiguration['requested_authn_context'])) {
         $customConfiguration['requested_authn_context_comparison'] = $customConfiguration['requested_authn_context'];
-        $customConfiguration['requested_authn_context'] = true;
+        $customConfiguration['requested_authn_context'] = false;
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,


### PR DESCRIPTION
backport of #9989 

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Set requested_authn_context default to false during SAML migration


<sup>[More info](https://app.aikido.dev/featurebranch/scan/95924624?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->