### PR TITLE
fix(event-logs): fix ACL query incompatible with MySQL 8 ONLY_FULL_GROUP_BY

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -1186,7 +1186,7 @@ class CentreonACL
             if ($withServiceDescription) {
                 $query = 'SELECT acl.host_id, acl.service_id, s.description '
                     . 'FROM centreon_acl acl '
-                    . 'LEFT JOIN services s on acl.service_id = s.service_id '
+                    . 'LEFT JOIN services s ON acl.host_id = s.host_id AND acl.service_id = s.service_id '
                     . 'WHERE group_id IN (' . $this->getAccessGroupsString() . ') '
                     . 'GROUP BY acl.host_id, acl.service_id ';
             } else {


### PR DESCRIPTION
## Summary

- Fix event logs not displayed for restricted (non-admin) users on MySQL 8
- The `getHostsServices()` LEFT JOIN on the `services` table only matched on `service_id`, but the table has a composite unique key `(host_id, service_id)`
- MySQL 8 enables `ONLY_FULL_GROUP_BY` by default, rejecting the query because `s.description` was not functionally dependent on the GROUP BY columns
- Adding `host_id` to the JOIN condition resolves the functional dependency and also fixes a correctness issue (wrong description could be returned on MariaDB)

## Jira

MON-182452

## Test plan

- [ ] On a MySQL 8 instance, log in as a non-admin user with ACL resources assigned
- [ ] Navigate to Monitoring > Event Logs and verify logs are displayed
- [ ] Verify the export (CSV) also works for a non-admin user
- [ ] Verify no regression on MariaDB with the same steps
- [ ] Verify admin users still see event logs normally

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed ACL query JOIN to include host_id for MySQL 8


<sup>[More info](https://app.aikido.dev/featurebranch/scan/95940575?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->