### PR TITLE
[Backport dev-24.10.x] fix(event-logs): fix ACL query incompatible with MySQL 8 ONLY_FULL_GROUP_BY

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -1164,7 +1164,7 @@ class CentreonACL
             if ($withServiceDescription) {
                 $query = 'SELECT acl.host_id, acl.service_id, s.description '
                     . 'FROM centreon_acl acl '
-                    . 'LEFT JOIN services s on acl.service_id = s.service_id '
+                    . 'LEFT JOIN services s ON acl.host_id = s.host_id AND acl.service_id = s.service_id '
                     . 'WHERE group_id IN (' . $this->getAccessGroupsString() . ') '
                     . 'GROUP BY acl.host_id, acl.service_id ';
             } else {


### PR DESCRIPTION
Backport of #9995 to `dev-24.10.x`.

Jira: MON-197485

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed ACL SQL LEFT JOIN to include host_id for MySQL


<sup>[More info](https://app.aikido.dev/featurebranch/scan/95960602?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->