### PR TITLE
fix(graphs): add max_height param to cap graph image size

### DIFF
--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1169,7 +1169,7 @@ class CentreonGraph
         }
 
         $imageData = $this->getImageData();
-        if ($imageData !== null) {
+        if ($imageData !== null && @getimagesizefromstring($imageData) !== false) {
             // Force no compress for image
             $this->setHeaders(false, mb_strlen($imageData, '8bit'));
             echo $imageData;

--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1267,9 +1267,9 @@ class CentreonGraph
             }
 
             return null;
-        } else {
-            return $commandLine;
         }
+
+        return $commandLine;
     }
 
     /**

--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1160,13 +1160,32 @@ class CentreonGraph
 
     /**
      * @throws Exception
-     * @return array|string|string[]|void|null
+     * @return string|void
      */
     public function displayImageFlow()
     {
-        $commandLine = '';
+        if ($this->checkcurve) {
+            return $this->getImageData();
+        }
 
-        // Send header
+        $imageData = $this->getImageData();
+        if ($imageData !== null) {
+            // Force no compress for image
+            $this->setHeaders(false, mb_strlen($imageData, '8bit'));
+            echo $imageData;
+        } else {
+            self::displayError();
+        }
+    }
+
+    /**
+     * Generate the graph image and return its binary PNG data.
+     *
+     * @return string|null PNG binary data, or the RRDtool command line when checkcurve is set
+     */
+    public function getImageData()
+    {
+        $commandLine = '';
 
         $this->flushRrdcached($this->listMetricsId);
 
@@ -1216,7 +1235,6 @@ class CentreonGraph
             $gmt_export = "export TZ='" . $timezone . "'; ";
         }
         $this->log($commandLine);
-        // Send Binary Data
         if (! $this->checkcurve) {
             if (is_writable($this->generalOpt['debug_path'])) {
                 $stderr = ['file', $this->generalOpt['debug_path'] . '/rrdtool.log', 'a'];
@@ -1245,10 +1263,10 @@ class CentreonGraph
                 $str = stream_get_contents($pipes[1]);
                 $return_value = proc_close($process);
 
-                // Force no compress for image
-                $this->setHeaders(false, mb_strlen($str, '8bit'));
-                echo $str;
+                return ($return_value === 0 && $str !== false) ? $str : null;
             }
+
+            return null;
         } else {
             return $commandLine;
         }

--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1169,7 +1169,11 @@ class CentreonGraph
         }
 
         $imageData = $this->getImageData();
-        if ($imageData !== null && @getimagesizefromstring($imageData) !== false) {
+        // Prevent PHP warnings from corrupting the binary image response (they still reach the error log).
+        ob_start();
+        $validImage = $imageData !== null && getimagesizefromstring($imageData) !== false;
+        ob_end_clean();
+        if ($validImage) {
             // Force no compress for image
             $this->setHeaders(false, mb_strlen($imageData, '8bit'));
             echo $imageData;

--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -286,14 +286,19 @@ if ($maxHeight > 0 && ! $obj->checkcurve) {
         CentreonGraph::displayError();
     }
 
-    $image = @imagecreatefromstring($imageData);
-    if ($image === false) {
+    $imageSize = @getimagesizefromstring($imageData);
+    if ($imageSize === false) {
         CentreonGraph::displayError();
     }
 
-    if (imagesy($image) > $maxHeight) {
-        $width = imagesx($image);
-        $height = imagesy($image);
+    [$width, $height] = $imageSize;
+    if ($height > $maxHeight) {
+        $image = @imagecreatefromstring($imageData);
+        if ($image === false) {
+            CentreonGraph::displayError();
+        }
+        unset($imageData);
+
         $newWidth = max(1, (int) round($width * $maxHeight / $height));
         $scaled = imagecreatetruecolor($newWidth, $maxHeight);
         if ($scaled === false) {
@@ -307,7 +312,6 @@ if ($maxHeight > 0 && ! $obj->checkcurve) {
         imagepng($scaled);
         imagedestroy($scaled);
     } else {
-        imagedestroy($image);
         $obj->setHeaders(false, mb_strlen($imageData, '8bit'));
         echo $imageData;
     }

--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -286,14 +286,20 @@ if ($maxHeight > 0 && ! $obj->checkcurve) {
         CentreonGraph::displayError();
     }
 
-    $imageSize = @getimagesizefromstring($imageData);
+    // Prevent PHP warnings from corrupting the binary image response (they still reach the error log).
+    ob_start();
+    $imageSize = getimagesizefromstring($imageData);
+    ob_end_clean();
     if ($imageSize === false) {
         CentreonGraph::displayError();
     }
 
     [$width, $height] = $imageSize;
     if ($height > $maxHeight) {
-        $image = @imagecreatefromstring($imageData);
+        // See comment above about ob_start().
+        ob_start();
+        $image = imagecreatefromstring($imageData);
+        ob_end_clean();
         if ($image === false) {
             CentreonGraph::displayError();
         }

--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -276,7 +276,44 @@ $obj->setColor('ARROW', '#FF0000');
 /**
  * Display Images Binary Data
  */
-$obj->displayImageFlow();
+$maxHeight = filter_var($_GET['max_height'] ?? 0, FILTER_VALIDATE_INT);
+if ($maxHeight > 0 && ! $obj->checkcurve) {
+    // Cap to prevent memory exhaustion from aspect-ratio scaling in imagecreatetruecolor().
+    $maxHeight = min($maxHeight, 4096);
+
+    $imageData = $obj->getImageData();
+    if ($imageData === null) {
+        CentreonGraph::displayError();
+    }
+
+    $image = @imagecreatefromstring($imageData);
+    if ($image === false) {
+        CentreonGraph::displayError();
+    }
+
+    if (imagesy($image) > $maxHeight) {
+        $width = imagesx($image);
+        $height = imagesy($image);
+        $newWidth = max(1, (int) round($width * $maxHeight / $height));
+        $scaled = imagecreatetruecolor($newWidth, $maxHeight);
+        if ($scaled === false) {
+            imagedestroy($image);
+            CentreonGraph::displayError();
+        }
+        imagecopyresampled($scaled, $image, 0, 0, 0, 0, $newWidth, $maxHeight, $width, $height);
+        imagedestroy($image);
+
+        $obj->setHeaders(false);
+        imagepng($scaled);
+        imagedestroy($scaled);
+    } else {
+        imagedestroy($image);
+        $obj->setHeaders(false, mb_strlen($imageData, '8bit'));
+        echo $imageData;
+    }
+} else {
+    $obj->displayImageFlow();
+}
 
 /**
  * Closing session


### PR DESCRIPTION
## Description

When a service has many metrics, the graph image generated by `generateImage.php`
can be very tall due to the legend listing all metrics. This oversized image breaks
page layout in report exports (the image overflows the page).

This adds an optional `max_height` GET parameter to `generateImage.php` that scales
down the image using GD when it exceeds the specified height. A new `getImageData()`
method is extracted from `displayImageFlow()` in `CentreonGraph` to provide access
to the raw PNG data without output buffering.

Fixes: [MON-24837](https://centreon.atlassian.net/browse/MON-24837)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

[MON-24837]: https://centreon.atlassian.net/browse/MON-24837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added optional max_height GET parameter to cap graph image size
* Optimized memory usage by deferring imagecreatefromstring() until resizing was required

**🐛 Bugfixes**
* Validated RRD output and prevented corrupt image echoing to avoid XSS

**🔧 Refactors**
* Extracted getImageData() from displayImageFlow() to expose raw PNG data
* Replaced error suppression with output buffering for safer error handling
* Removed useless else block to satisfy php-cs-fixer linting rule


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101841271?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->