### PR TITLE
chore(release) bump oss 24.04 2026-03-24

### DIFF
--- a/.version.centreon-web
+++ b/.version.centreon-web
@@ -1,1 +1,1 @@
-MINOR=25
+MINOR=26

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -1,7 +1,7 @@
 --
 -- Insert version
 --
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '24.04.25');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '24.04.26');
 --
 -- Contenu de la table `contact`
 --


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-196837


Bump OSS versions to 24.04 (2026-03-24):
- centreon-web: 24.04.26


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated embedded database version value to 24.04.26 release


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96238785?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->