### PR TITLE
chore(release) bump oss 25.10 2026-03-24

### DIFF
--- a/.version.centreon-awie
+++ b/.version.centreon-awie
@@ -1,1 +1,1 @@
-MINOR=5
+MINOR=6

--- a/.version.centreon-dsm
+++ b/.version.centreon-dsm
@@ -1,1 +1,1 @@
-MINOR=2
+MINOR=3

--- a/.version.centreon-open-tickets
+++ b/.version.centreon-open-tickets
@@ -1,1 +1,1 @@
-MINOR=5
+MINOR=6

--- a/.version.centreon-web
+++ b/.version.centreon-web
@@ -1,1 +1,1 @@
-MINOR=10
+MINOR=11

--- a/centreon-awie/www/modules/centreon-awie/conf.php
+++ b/centreon-awie/www/modules/centreon-awie/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-awie']['rname'] = 'Centreon Api Web Import Export';
 $module_conf['centreon-awie']['name'] = 'centreon-awie';
-$module_conf['centreon-awie']['mod_release'] = '25.10.5';
+$module_conf['centreon-awie']['mod_release'] = '25.10.6';
 $module_conf['centreon-awie']['infos'] = 'The Centreon AWIE (Application Web Import Export) module has been '
     . 'designed to help users configure several Centreon Web platforms in a faster and easier way, thanks to its '
     . 'import/export mechanism.
@@ -35,7 +35,7 @@ Centreon AWIE is based on CLAPI commands but its added value is to allow using C
 $module_conf['centreon-awie']['is_removeable'] = '1';
 $module_conf['centreon-awie']['author'] = 'Centreon';
 $module_conf['centreon-awie']['stability'] = 'stable';
-$module_conf['centreon-awie']['last_update'] = '2026-02-09';
+$module_conf['centreon-awie']['last_update'] = '2026-03-24';
 $module_conf['centreon-awie']['images'] = [
     'images/image1.png',
 ];

--- a/centreon-dsm/www/modules/centreon-dsm/conf.php
+++ b/centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -22,7 +22,7 @@
 // Be Careful with internal_name, it's case sensitive (with directory module name)
 $module_conf['centreon-dsm']['name'] = 'centreon-dsm';
 $module_conf['centreon-dsm']['rname'] = 'Dynamic Services Management';
-$module_conf['centreon-dsm']['mod_release'] = '25.10.2';
+$module_conf['centreon-dsm']['mod_release'] = '25.10.3';
 $module_conf['centreon-dsm']['infos'] = 'Centreon Dynamic Service Management (Centreon-DSM) is a module to manage '
     . 'alarms with an event logs system. With DSM, Centreon can receive events such as SNMP traps resulting from the '
     . 'detection of a problem and assign events dynamically to a slot defined in Centreon, like a tray events.
@@ -37,7 +37,7 @@ The goal of this module is to overhead the basic trap management system of Centr
 $module_conf['centreon-dsm']['is_removeable'] = '1';
 $module_conf['centreon-dsm']['author'] = 'Centreon';
 $module_conf['centreon-dsm']['stability'] = 'stable';
-$module_conf['centreon-dsm']['last_update'] = '2025-02-09';
+$module_conf['centreon-dsm']['last_update'] = '2026-03-24';
 $module_conf['centreon-dsm']['images'] = [
     'images/dsm_snmp_events_tray.png',
 ];

--- a/centreon-open-tickets/widgets/open-tickets/configs.xml
+++ b/centreon-open-tickets/widgets/open-tickets/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>This widget is associated to the Open Tickets Module and allows for selecting hosts or services events for which to create tickets in your favorite ITSM tools. This widget can also list already created tickets with their ID and datetime.</description>
-  <version>25.10.5</version>
+  <version>25.10.6</version>
   <keywords>centreon, widget, tickets</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/open-tickets/resources/centreon-logo.png</thumbnail>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-open-tickets']['rname'] = 'Centreon Open Tickets';
 $module_conf['centreon-open-tickets']['name'] = 'centreon-open-tickets';
-$module_conf['centreon-open-tickets']['mod_release'] = '25.10.5';
+$module_conf['centreon-open-tickets']['mod_release'] = '25.10.6';
 $module_conf['centreon-open-tickets']['infos'] = 'Centreon Open Tickets is a community module developed to '
     . "create tickets to your favorite ITSM tools using API.
 
@@ -36,7 +36,7 @@ Regarding the widget configuration, it is possible to see the created tickets by
 $module_conf['centreon-open-tickets']['is_removeable'] = '1';
 $module_conf['centreon-open-tickets']['author'] = 'Centreon';
 $module_conf['centreon-open-tickets']['stability'] = 'stable';
-$module_conf['centreon-open-tickets']['last_update'] = '2026-03-03';
+$module_conf['centreon-open-tickets']['last_update'] = '2026-03-24';
 $module_conf['centreon-open-tickets']['images'] = [
     'images/image1.png',
     'images/image2.png',

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '25.10.10');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '25.10.11');
 
 --
 -- Contenu de la table `contact`


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-196840


Bump OSS versions to 25.10 (2026-03-24):
- centreon-awie: 25.10.6
- centreon-dsm: 25.10.3
- centreon-open-tickets: 25.10.6
- centreon-web: 25.10.11


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped module release numbers and updated their last_update timestamps.
* Updated Centreon web base configuration version from 25.10.10 to 25.10.11.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96257553?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->