### PR TITLE
fix(open-tickets): fix wrong host/service redirection when using deprecated pages

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -572,11 +572,11 @@ while ($row = $res->fetch()) {
     );
 
     $data[$row['host_id'] . '_' . $row['service_id']]['h_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20202&o=hd&host_name=' . $row['hostname']
         : $resourceController->buildHostDetailsUri($row['host_id']);
 
     $data[$row['host_id'] . '_' . $row['service_id']]['s_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20201&o=svcd&host_name=' . $row['hostname']
             . '&service_description=' . $row['description']
         : $resourceController->buildServiceDetailsUri($row['host_id'], $row['service_id']);
 }


### PR DESCRIPTION
## Summary

- Fix wrong topology page numbers in the Open Tickets widget when redirecting to deprecated pages
- Host details URL: `p=0202` → `p=20202`
- Service details URL: `p=0202&o=hd` → `p=20201&o=svcd`
- Regression introduced in commit `5b65bfa6da` (PR #2321)

## Jira

MON-196676

## Test plan

- [ ] Create a custom view with an Open Tickets widget
- [ ] Share the view with a contact that has deprecated pages enabled
- [ ] Click on a host name → should redirect to `main.php?p=20202&o=hd&host_name=...`
- [ ] Click on a service → should redirect to `main.php?p=20201&o=svcd&host_name=...&service_description=...`

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed wrong host/service redirection to deprecated topology pages


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96267438?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->