### PR TITLE
fix(ci): avoid to fail when keycloak image cache is not found

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -970,7 +970,7 @@ jobs:
       - name: Clear previous keycloak image from cache
         if: ${{ needs.get-environment.outputs.stability == 'unstable' && matrix.operating_system == 'alma9' }}
         run: |
-          curl --fail-with-body \
+          curl \
             -X DELETE \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
## Description

fix(ci): avoid to fail when keycloak image cache is not found

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated workflow to not fail when keycloak image cache missing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96607818?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->