### PR TITLE
fix(docker): remove DATABASE_PARTITIONING env var in docker entrypoint

### DIFF
--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/15-installation.sh
@@ -48,10 +48,8 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
     echo "Inserting base configuration..."
     su apache -s /bin/bash -c "SERVER_ADDR='127.0.0.1' php insertBaseConf.php"
 
-    if [ "$DATABASE_PARTITIONING" = "1" ]; then
-      echo "Creating database partition tables..."
-      su apache -s /bin/bash -c "php partitionTables.php"
-    fi
+    echo "Creating database partition tables..."
+    su apache -s /bin/bash -c "php partitionTables.php"
 
     mysql -h"${MYSQL_HOST}" -uroot centreon -e "UPDATE cfg_centreonbroker_info SET config_value = '${MYSQL_HOST}' WHERE config_key = 'db_host'"
     mysql -h"${MYSQL_HOST}" -uroot -e "GRANT ALL ON *.* to 'centreon'@'%' WITH GRANT OPTION"

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/15-installation.sh
@@ -51,10 +51,8 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
     echo "Inserting base configuration..."
     su www-data -s /bin/bash -c "SERVER_ADDR='127.0.0.1' php insertBaseConf.php"
 
-    if [ "$DATABASE_PARTITIONING" = "1" ]; then
-      echo "Creating database partition tables..."
-      su www-data -s /bin/bash -c "php partitionTables.php"
-    fi
+    echo "Creating database partition tables..."
+    su www-data -s /bin/bash -c "php partitionTables.php"
 
     mysql -h"${MYSQL_HOST}" -uroot centreon -e "UPDATE cfg_centreonbroker_info SET config_value = '${MYSQL_HOST}' WHERE config_key = 'db_host'"
     mysql -h"${MYSQL_HOST}" -uroot -e "GRANT ALL ON *.* to 'centreon'@'%' WITH GRANT OPTION"

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       LDAP_HOST: openldap
       CENTREON_DATASET: ${CENTREON_DATASET:-1}
       CENTREON_LANG: ${CENTREON_LANG:-en_US}
-      DATABASE_PARTITIONING: ${DATABASE_PARTITIONING:-1}
       DEBUG: ${DEBUG:-0}
     healthcheck:
       test: bash -c "[ -f /tmp/docker.ready ]" && curl --fail http://localhost/centreon/api/latest/platform/versions || exit 1


### PR DESCRIPTION
## Description

fix(docker): remove DATABASE_PARTITIONING env var in docker entrypoint

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Made database partition table creation unconditional in two entrypoint scripts.

**🔧 Refactors**
* Removed DATABASE_PARTITIONING environment variable from docker-compose configuration.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96621975?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->