### PR TITLE
fix(ceip): rm harcoded db name

### DIFF
--- a/centreon/www/api/class/centreon_ceip.class.php
+++ b/centreon/www/api/class/centreon_ceip.class.php
@@ -124,9 +124,8 @@ class CentreonCeip extends CentreonWebService
                     SELECT `poller_id`, `enabled`, `infos`
                     FROM `agent_information`
                 SQL;
-            $statement = $this->pearDBO->executeStatement($query);
 
-            $rows = $this->pearDBO->fetchAllAssociative($statement);
+            $rows = $this->pearDBO->fetchAllAssociative($query);
             foreach ($rows as $row) {
                 /** @var array{poller_id:int,enabled:int,infos:string} $row */
                 if ((bool) $row['enabled'] === false) {

--- a/centreon/www/api/class/centreon_ceip.class.php
+++ b/centreon/www/api/class/centreon_ceip.class.php
@@ -55,6 +55,9 @@ class CentreonCeip extends CentreonWebService
     /** @var FeatureFlags */
     private FeatureFlags $featureFlags;
 
+    /** @var CentreonDB */
+    private $pearDBO;
+
     /**
      * CentreonCeip constructor
      *
@@ -64,6 +67,8 @@ class CentreonCeip extends CentreonWebService
      */
     public function __construct()
     {
+        $this->pearDBO = new CentreonDB('centstorage');
+
         parent::__construct();
 
         global $centreon;
@@ -117,11 +122,11 @@ class CentreonCeip extends CentreonWebService
         try {
             $query = <<<'SQL'
                     SELECT `poller_id`, `enabled`, `infos`
-                    FROM `centreon_storage`.`agent_information`
+                    FROM `agent_information`
                 SQL;
-            $statement = $this->pearDB->executeStatement($query);
+            $statement = $this->pearDBO->executeStatement($query);
 
-            $rows = $this->pearDB->fetchAllAssociative($statement);
+            $rows = $this->pearDBO->fetchAllAssociative($statement);
             foreach ($rows as $row) {
                 /** @var array{poller_id:int,enabled:int,infos:string} $row */
                 if ((bool) $row['enabled'] === false) {


### PR DESCRIPTION
## Description

[MON-195833](https://centreon.atlassian.net/browse/MON-195833)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

[MON-195833]: https://centreon.atlassian.net/browse/MON-195833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Removed hardcoded schema from agent_information query and used pearDBO fetchAllAssociative

**🔧 Refactors**
* Added pearDBO property and initialized CentreonDB('centstorage') in constructor


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96986620?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->