### PR TITLE
refactor(validator): update custom Symfony constraints for 7.4/8.0 compatibility   

### DIFF
--- a/centreon/phpstan.legacy.src.baseline.neon
+++ b/centreon/phpstan.legacy.src.baseline.neon
@@ -30,24 +30,6 @@ parameters:
 			path: src/Centreon/Application/DataRepresenter/Topology/NavigationList.php
 
 		-
-			message: '#^Call to function is_array\(\) with array\<mixed\> will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Centreon/Application/Validation/Validator/UniqueEntityValidator.php
-
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 2
-			path: src/Centreon/Application/Validation/Validator/UniqueEntityValidator.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 2
-			path: src/Centreon/Application/Validation/Validator/UniqueEntityValidator.php
-
-		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) di must contain 3 or more characters\.$#'
 			count: 2
 			path: src/Centreon/Application/Webservice/AclGroupWebservice.php

--- a/centreon/src/Centreon/Application/Validation/Constraints/RepositoryCallback.php
+++ b/centreon/src/Centreon/Application/Validation/Constraints/RepositoryCallback.php
@@ -23,6 +23,7 @@ namespace Centreon\Application\Validation\Constraints;
 
 use Centreon\Application\Validation\Validator\RepositoryCallbackValidator;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 class RepositoryCallback extends Constraint
 {
@@ -35,20 +36,42 @@ class RepositoryCallback extends Constraint
         self::NOT_VALID_REPO_CALLBACK => 'NOT_VALID_REPO_CALLBACK',
     ];
 
-    /** @var string|null */
-    public $fieldAccessor = null;
+    /**
+     * @param string $errorMessage Validation error message
+     * @param mixed|null $payload
+     */
+    public function __construct(
+        public string $field,
+        public string $fieldAccessor,
+        public string $repository,
+        public string $repositoryMethod,
+        public string $errorMessage,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        $this->field = trim($this->field);
+        if ($this->field === '') {
+            throw new ConstraintDefinitionException('The field name cannot be empty.');
+        }
+        $this->fieldAccessor = trim($this->fieldAccessor);
+        if ($this->fieldAccessor === '') {
+            throw new ConstraintDefinitionException('The field accessor cannot be empty.');
+        }
+        $this->repository = trim($this->repository);
+        if ($this->repository === '') {
+            throw new ConstraintDefinitionException('The repository cannot be empty.');
+        }
+        $this->repositoryMethod = trim($this->repositoryMethod);
+        if ($this->repositoryMethod === '') {
+            throw new ConstraintDefinitionException('The repository method cannot be empty.');
+        }
+        $this->errorMessage = trim($this->errorMessage);
+        if ($this->errorMessage === '') {
+            throw new ConstraintDefinitionException('The validation error message cannot be empty.');
+        }
 
-    /** @var string|null */
-    public $repoMethod = null;
-
-    /** @var string|null */
-    public $repository = null;
-
-    /** @var string */
-    public $fields = '';
-
-    /** @var string */
-    public $message = 'Does not satisfy validation callback. Check Repository.';
+        parent::__construct(groups: $groups, payload: $payload);
+    }
 
     /**
      * {@inheritDoc}

--- a/centreon/src/Centreon/Application/Validation/Constraints/UniqueEntity.php
+++ b/centreon/src/Centreon/Application/Validation/Constraints/UniqueEntity.php
@@ -23,6 +23,7 @@ namespace Centreon\Application\Validation\Constraints;
 
 use Centreon\Application\Validation\Validator\UniqueEntityValidator;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 class UniqueEntity extends Constraint
 {
@@ -35,32 +36,24 @@ class UniqueEntity extends Constraint
         self::NOT_UNIQUE_ERROR => 'NOT_UNIQUE_ERROR',
     ];
 
-    /** @var string */
     public string $validatorClass = UniqueEntityValidator::class;
 
-    /** @var string */
-    public $message = 'This value is already used.';
-
-    /** @var string */
-    public $entityIdentificatorMethod = 'getId';
-
-    /** @var string */
-    public $entityIdentificatorColumn = 'id';
-
-    /** @var mixed */
-    public $repository = null;
-
-    /** @var string */
-    public $repositoryMethod = 'findOneBy';
-
-    /** @var array<mixed> */
-    public $fields = [];
-
-    /** @var string|null */
-    public $errorPath = null;
-
-    /** @var bool */
-    public $ignoreNull = true;
+    public function __construct(
+        public string $field,
+        public string $repository,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        $this->field = trim($this->field);
+        if ($this->field === '') {
+            throw new ConstraintDefinitionException('The field name cannot be empty.');
+        }
+        $this->repository = trim($this->repository);
+        if ($this->repository === '') {
+            throw new ConstraintDefinitionException('The repository name cannot be empty.');
+        }
+        parent::__construct(groups: $groups, payload: $payload);
+    }
 
     /**
      * {@inheritDoc}
@@ -71,17 +64,7 @@ class UniqueEntity extends Constraint
     }
 
     /**
-     * @return string
-     */
-    public function getDefaultOption(): string
-    {
-        return 'fields';
-    }
-
-    /**
-     * The validator class name.
-     *
-     * @return string
+     * {@inheritDoc}
      */
     public function validatedBy(): string
     {

--- a/centreon/src/Centreon/Application/Validation/Validator/RepositoryCallbackValidator.php
+++ b/centreon/src/Centreon/Application/Validation/Validator/RepositoryCallbackValidator.php
@@ -25,43 +25,52 @@ use App\Kernel;
 use Centreon\Application\Validation\Constraints\RepositoryCallback;
 use Centreon\Application\Validation\Validator\Interfaces\CentreonValidatorInterface;
 use Centreon\ServiceProvider;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\CallbackValidator;
+use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-class RepositoryCallbackValidator extends CallbackValidator implements CentreonValidatorInterface
+class RepositoryCallbackValidator extends ConstraintValidator implements CentreonValidatorInterface
 {
+    private ?ContainerInterface $container = null;
+
     /**
      * {@inheritDoc}
-     * @return void
      */
-    public function validate($object, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (! $constraint instanceof RepositoryCallback) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\RepositoryCallback');
+            throw new UnexpectedTypeException($constraint, RepositoryCallback::class);
         }
 
-        $method = $constraint->repoMethod;
-
-        $repository = (Kernel::createForWeb())
-            ->getContainer()
-            ->get($constraint->repository);
-
         $fieldAccessor = $constraint->fieldAccessor;
-        $value = $object->{$fieldAccessor}();
-        $field = $constraint->fields;
+        if (
+            $value === null
+            || ! (
+                is_object($value)
+                && method_exists($value, $fieldAccessor)
+            )
+        ) {
+            return;
+        }
 
-        if (! method_exists($constraint->repository, $method)) {
+        $repository = $this->getContainer()->get($constraint->repository);
+        $method = $constraint->repositoryMethod;
+        if (! method_exists($repository, $method)) {
             throw new ConstraintDefinitionException(sprintf(
                 '%s targeted by Callback constraint is not a valid callable in the repository',
                 json_encode($method)
             ));
         }
-        if ($object !== null && ! $repository->{$method}($object)) {
-            $this->context->buildViolation($constraint->message)
+
+        $fieldValue = $value->{$fieldAccessor}();
+        $field = $constraint->field;
+
+        if (! $repository->{$method}($value)) {
+            $this->context->buildViolation($constraint->errorMessage)
                 ->atPath($field)
-                ->setInvalidValue($value)
+                ->setInvalidValue($fieldValue)
                 ->setCode(RepositoryCallback::NOT_VALID_REPO_CALLBACK)
                 ->setCause('Not Satisfying method:' . $method)
                 ->addViolation();
@@ -78,5 +87,14 @@ class RepositoryCallbackValidator extends CallbackValidator implements CentreonV
         return [
             ServiceProvider::CENTREON_DB_MANAGER,
         ];
+    }
+
+    private function getContainer(): ContainerInterface
+    {
+        if (! $this->container instanceof ContainerInterface) {
+            $this->container = (Kernel::createForWeb())->getContainer();
+        }
+
+        return $this->container;
     }
 }

--- a/centreon/src/Centreon/Application/Validation/Validator/UniqueEntityValidator.php
+++ b/centreon/src/Centreon/Application/Validation/Validator/UniqueEntityValidator.php
@@ -25,86 +25,89 @@ use App\Kernel;
 use Centreon\Application\Validation\Constraints\UniqueEntity;
 use Centreon\Application\Validation\Validator\Interfaces\CentreonValidatorInterface;
 use Centreon\ServiceProvider;
-use LogicException;
-use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-use function is_array;
-use function is_string;
-
 class UniqueEntityValidator extends ConstraintValidator implements CentreonValidatorInterface
 {
+    private ?ContainerInterface $container = null;
+
     /**
-     * @param $entity
-     * @param Constraint $constraint
-     *
-     * @throws ConstraintDefinitionException
-     * @throws UnexpectedTypeException
-     * @throws LogicException
-     * @throws ServiceCircularReferenceException
-     * @throws ServiceNotFoundException
-     * @return void|null
+     * {@inheritDoc}
      */
-    public function validate($entity, Constraint $constraint)
+    public function validate(mixed $value, Constraint $constraint): void
     {
         if (! $constraint instanceof UniqueEntity) {
             throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\UniqueEntity');
         }
 
-        if (! is_array($constraint->fields) && ! is_string($constraint->fields)) {
-            throw new UnexpectedTypeException($constraint->fields, 'array');
+        $field = $constraint->field;
+        $methodValueGetter = 'get' . ucfirst($field);
+        if (
+            $value === null
+            || ! (
+                is_object($value)
+                && method_exists($value, $methodValueGetter)
+            )
+        ) {
+            return;
+        }
+        $repository = $this->getContainer()->get($constraint->repository);
+
+        $methodRepository = 'findOneBy';
+        if (! method_exists($repository, $methodRepository)) {
+            throw new ConstraintDefinitionException(sprintf(
+                'The repository "%s" must expose "%s()" for UniqueEntity validation.',
+                $constraint->repository,
+                $methodRepository
+            ));
         }
 
-        if ($constraint->errorPath !== null && ! is_string($constraint->errorPath)) {
-            throw new UnexpectedTypeException($constraint->errorPath, 'string or null');
+        $retrieveValue = $value->{$methodValueGetter}();
+        $result = $repository->{$methodRepository}([$field => $retrieveValue]);
+        if (! $result) {
+            return;
         }
 
-        // define fields to check
-        $fields = (array) $constraint->fields;
-        $methodRepository = $constraint->repositoryMethod;
-        $methodIdGetter = $constraint->entityIdentificatorMethod;
-
-        if ($fields === []) {
-            throw new ConstraintDefinitionException('At least one field has to be specified.');
-        }
-        if ($entity === null) {
-            return null;
+        $methodIdGetter = 'getId';
+        if (! method_exists($result, $methodIdGetter) || ! method_exists($value, $methodIdGetter)) {
+            throw new ConstraintDefinitionException(sprintf(
+                'The entity must expose a "%s()" method for UniqueEntity validation.',
+                $methodIdGetter
+            ));
         }
 
-        foreach ($fields as $field) {
-            $methodValueGetter = 'get' . ucfirst($field);
-            $value = $entity->{$methodValueGetter}();
+        $isSameEntity = $result->{$methodIdGetter}() === $value->{$methodIdGetter}();
 
-            $repository = (Kernel::createForWeb())
-                ->getContainer()
-                ->get($constraint->repository);
-
-            $result = $repository->{$methodRepository}([$field => $value]);
-
-            if ($result && $result->{$methodIdGetter}() !== $entity->{$methodIdGetter}()) {
-                $this->context->buildViolation($constraint->message)
-                    ->atPath($field)
-                    ->setInvalidValue($value)
-                    ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
-                    ->setCause($result)
-                    ->addViolation();
-            }
+        if (! $isSameEntity) {
+            $this->context->buildViolation('Name already in use')
+                ->atPath($field)
+                ->setInvalidValue($retrieveValue)
+                ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
+                ->setCause($result)
+                ->addViolation();
         }
     }
 
     /**
      * List of required services
-     *
-     * @return array
      */
     public static function dependencies(): array
     {
         return [
             ServiceProvider::CENTREON_DB_MANAGER,
         ];
+    }
+
+    private function getContainer(): ContainerInterface
+    {
+        if (! $this->container instanceof ContainerInterface) {
+            $this->container = (Kernel::createForWeb())->getContainer();
+        }
+
+        return $this->container;
     }
 }

--- a/centreon/src/Core/Common/Infrastructure/Validator/Constraints/WhenPlatform.php
+++ b/centreon/src/Core/Common/Infrastructure/Validator/Constraints/WhenPlatform.php
@@ -26,10 +26,7 @@ namespace Core\Common\Infrastructure\Validator\Constraints;
 use Core\Common\Domain\PlatformType;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Composite;
-use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
-use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Exception\LogicException;
-use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 /**
  * Strongly Inspired by Symfony\Component\Validator\Constraints\When
@@ -48,49 +45,22 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
 final class WhenPlatform extends Composite
 {
     /**
-     * @param string $platform
-     * @param Constraint[]|Constraint|null $constraints
+     * @param Constraint[] $constraints
      * @param null|string[] $groups
-     * @param mixed $payload
-     * @param array<mixed> $options
      *
      * @throws LogicException
-     * @throws ConstraintDefinitionException
-     * @throws InvalidOptionsException
-     * @throws MissingOptionsException
      */
     public function __construct(
         public string $platform,
-        public array|Constraint|null $constraints = null,
+        public array $constraints,
         ?array $groups = null,
-        $payload = null,
-        array $options = [],
+        mixed $payload = null,
     ) {
         if (! \in_array($platform, PlatformType::AVAILABLE_TYPES, true)) {
             throw new LogicException(\sprintf('The platform "%s" is not valid.', $platform));
         }
 
-        $options['platform'] = $platform;
-        $options['constraints'] = $constraints;
-
-        if (isset($options['constraints']) && ! \is_array($options['constraints'])) {
-            $options['constraints'] = [$options['constraints']];
-        }
-
-        if ($groups !== null) {
-            $options['groups'] = $groups;
-        }
-
-        if ($payload !== null) {
-            $options['payload'] = $payload;
-        }
-
-        parent::__construct($options);
-    }
-
-    public function getRequiredOptions(): array
-    {
-        return ['platform', 'constraints'];
+        parent::__construct(groups: $groups, payload: $payload);
     }
 
     /**

--- a/centreon/tests/php/Centreon/Application/Validation/Constraints/RepositoryCallbackTest.php
+++ b/centreon/tests/php/Centreon/Application/Validation/Constraints/RepositoryCallbackTest.php
@@ -1,0 +1,302 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Centreon\Application\Validation\Constraints;
+
+use Centreon\Application\Validation\Constraints\RepositoryCallback;
+use Centreon\Application\Validation\Validator\RepositoryCallbackValidator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<RepositoryCallbackValidator>
+ */
+final class RepositoryCallbackTest extends ConstraintValidatorTestCase
+{
+    private const FIELD = 'name';
+    private const FIELD_ACCESSOR = 'getName';
+    private const REPOSITORY = 'App\Repository\FooRepository';
+    private const REPOSITORY_METHOD = 'isValid';
+    private const ERROR_MESSAGE = 'This value is not valid.';
+
+    // -------------------------------------------------------------------------
+    // RepositoryCallback constraint tests
+    // -------------------------------------------------------------------------
+
+    public function testConstructorSetsAllProperties(): void
+    {
+        $constraint = new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+        );
+
+        $this->assertSame(self::FIELD, $constraint->field);
+        $this->assertSame(self::FIELD_ACCESSOR, $constraint->fieldAccessor);
+        $this->assertSame(self::REPOSITORY, $constraint->repository);
+        $this->assertSame(self::REPOSITORY_METHOD, $constraint->repositoryMethod);
+        $this->assertSame(self::ERROR_MESSAGE, $constraint->errorMessage);
+    }
+
+    public function testAllStringPropertiesAreTrimmed(): void
+    {
+        $constraint = new RepositoryCallback(
+            field: '  name  ',
+            fieldAccessor: '  getName  ',
+            repository: '  SomeRepo  ',
+            repositoryMethod: '  isValid  ',
+            errorMessage: '  Error  ',
+        );
+
+        $this->assertSame('name', $constraint->field);
+        $this->assertSame('getName', $constraint->fieldAccessor);
+        $this->assertSame('SomeRepo', $constraint->repository);
+        $this->assertSame('isValid', $constraint->repositoryMethod);
+        $this->assertSame('Error', $constraint->errorMessage);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('emptyStringProvider')]
+    public function testEmptyFieldThrowsConstraintDefinitionException(string $empty): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field name cannot be empty.');
+
+        new RepositoryCallback(
+            field: $empty,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('emptyStringProvider')]
+    public function testEmptyFieldAccessorThrowsConstraintDefinitionException(string $empty): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field accessor cannot be empty.');
+
+        new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: $empty,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('emptyStringProvider')]
+    public function testEmptyRepositoryThrowsConstraintDefinitionException(string $empty): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The repository cannot be empty.');
+
+        new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: $empty,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('emptyStringProvider')]
+    public function testEmptyRepositoryMethodThrowsConstraintDefinitionException(string $empty): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The repository method cannot be empty.');
+
+        new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: $empty,
+            errorMessage: self::ERROR_MESSAGE,
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('emptyStringProvider')]
+    public function testEmptyErrorMessageThrowsConstraintDefinitionException(string $empty): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The validation error message cannot be empty.');
+
+        new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: $empty,
+        );
+    }
+
+    public function testGroupsAreForwardedToParent(): void
+    {
+        $constraint = new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+            groups: ['MyGroup'],
+        );
+
+        $this->assertContains('MyGroup', $constraint->groups);
+    }
+
+    public function testPayloadIsForwardedToParent(): void
+    {
+        $payload = ['key' => 'value'];
+        $constraint = new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+            payload: $payload,
+        );
+
+        $this->assertSame($payload, $constraint->payload);
+    }
+
+    public function testGetTargetsReturnsClassConstraint(): void
+    {
+        $constraint = $this->buildConstraint();
+
+        $this->assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+
+    public function testValidatedByReturnsRepositoryCallbackValidatorClass(): void
+    {
+        $constraint = $this->buildConstraint();
+
+        $this->assertSame(RepositoryCallbackValidator::class, $constraint->validatedBy());
+    }
+
+    // -------------------------------------------------------------------------
+    // RepositoryCallbackValidator tests (cases that do not require the Kernel)
+    // -------------------------------------------------------------------------
+
+    public function testWrongConstraintTypeThrowsUnexpectedTypeException(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate('value', $this->createMock(Constraint::class));
+    }
+
+    public function testNullValueSkipsValidation(): void
+    {
+        $this->validator->validate(null, $this->buildConstraint());
+
+        $this->assertNoViolation();
+    }
+
+    public function testNonObjectValueSkipsValidation(): void
+    {
+        $this->validator->validate('a scalar value', $this->buildConstraint());
+
+        $this->assertNoViolation();
+    }
+
+    public function testObjectWithoutFieldAccessorSkipsValidation(): void
+    {
+        $this->validator->validate(new \stdClass(), $this->buildConstraint());
+
+        $this->assertNoViolation();
+    }
+
+    public function testMethodNotFoundInRepositoryThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        $repository = new class () {
+            // intentionally missing the 'nonExistentMethod' method
+        };
+
+        $this->injectContainer($this->mockContainerReturning($repository));
+
+        $value = new class () {
+            public function getName(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $constraint = new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: 'nonExistentMethod',
+            errorMessage: self::ERROR_MESSAGE,
+        );
+
+        $this->validator->validate($value, $constraint);
+    }
+
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return \Generator<string, array{string}>
+     */
+    public static function emptyStringProvider(): \Generator
+    {
+        yield 'empty string' => [''];
+
+        yield 'whitespace only' => ['   '];
+    }
+
+    protected function createValidator(): RepositoryCallbackValidator
+    {
+        return new RepositoryCallbackValidator();
+    }
+
+    private function injectContainer(ContainerInterface $container): void
+    {
+        $ref = new \ReflectionProperty(RepositoryCallbackValidator::class, 'container');
+        $ref->setValue($this->validator, $container);
+    }
+
+    private function mockContainerReturning(object $repository): ContainerInterface
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($repository);
+
+        return $container;
+    }
+
+    private function buildConstraint(): RepositoryCallback
+    {
+        return new RepositoryCallback(
+            field: self::FIELD,
+            fieldAccessor: self::FIELD_ACCESSOR,
+            repository: self::REPOSITORY,
+            repositoryMethod: self::REPOSITORY_METHOD,
+            errorMessage: self::ERROR_MESSAGE,
+        );
+    }
+}

--- a/centreon/tests/php/Centreon/Application/Validation/Constraints/UniqueEntityTest.php
+++ b/centreon/tests/php/Centreon/Application/Validation/Constraints/UniqueEntityTest.php
@@ -1,0 +1,365 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Centreon\Application\Validation\Constraints;
+
+use Centreon\Application\Validation\Constraints\UniqueEntity;
+use Centreon\Application\Validation\Validator\UniqueEntityValidator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<UniqueEntityValidator>
+ */
+final class UniqueEntityTest extends ConstraintValidatorTestCase
+{
+    // -------------------------------------------------------------------------
+    // UniqueEntity constraint tests
+    // -------------------------------------------------------------------------
+
+    public function testConstructorSetsFieldAndRepository(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'App\Repository\FooRepository');
+
+        $this->assertSame('name', $constraint->field);
+        $this->assertSame('App\Repository\FooRepository', $constraint->repository);
+    }
+
+    public function testFieldIsTrimmed(): void
+    {
+        $constraint = new UniqueEntity(field: '  name  ', repository: 'SomeRepo');
+
+        $this->assertSame('name', $constraint->field);
+    }
+
+    public function testRepositoryIsTrimmed(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: '  SomeRepo  ');
+
+        $this->assertSame('SomeRepo', $constraint->repository);
+    }
+
+    public function testEmptyFieldThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field name cannot be empty.');
+
+        new UniqueEntity(field: '', repository: 'SomeRepo');
+    }
+
+    public function testWhitespaceOnlyFieldThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field name cannot be empty.');
+
+        new UniqueEntity(field: '   ', repository: 'SomeRepo');
+    }
+
+    public function testEmptyRepositoryThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The repository name cannot be empty.');
+
+        new UniqueEntity(field: 'name', repository: '');
+    }
+
+    public function testWhitespaceOnlyRepositoryThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The repository name cannot be empty.');
+
+        new UniqueEntity(field: 'name', repository: '   ');
+    }
+
+    public function testGroupsAreForwardedToParent(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo', groups: ['MyGroup']);
+
+        $this->assertContains('MyGroup', $constraint->groups);
+    }
+
+    public function testPayloadIsForwardedToParent(): void
+    {
+        $payload = ['key' => 'value'];
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo', payload: $payload);
+
+        $this->assertSame($payload, $constraint->payload);
+    }
+
+    public function testGetTargetsReturnsClassConstraint(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo');
+
+        $this->assertSame(Constraint::CLASS_CONSTRAINT, $constraint->getTargets());
+    }
+
+    public function testValidatedByReturnsUniqueEntityValidatorClass(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo');
+
+        $this->assertSame(UniqueEntityValidator::class, $constraint->validatedBy());
+    }
+
+    // -------------------------------------------------------------------------
+    // UniqueEntityValidator tests (cases that do not require the Kernel)
+    // -------------------------------------------------------------------------
+
+    public function testNullValueSkipsValidation(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo');
+
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testWrongConstraintTypeThrowsUnexpectedTypeException(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate('value', $this->createMock(Constraint::class));
+    }
+
+    public function testScalarValueSkipsValidation(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo');
+
+        $this->validator->validate('a-string-value', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testObjectWithoutGetterSkipsValidation(): void
+    {
+        $constraint = new UniqueEntity(field: 'name', repository: 'SomeRepo');
+        $value = new class () {
+        };
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testDependenciesReturnsCentreonDbManager(): void
+    {
+        $this->assertSame(
+            ['centreon.db-manager'],
+            UniqueEntityValidator::dependencies()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // UniqueEntityValidator tests (cases using a mocked container)
+    // -------------------------------------------------------------------------
+
+    public function testRepositoryWithoutFindOneByThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        $repository = new class () {
+            // intentionally missing findOneBy
+        };
+
+        $this->injectContainer($this->mockContainerReturning($repository));
+
+        $value = new class () {
+            public function getName(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $this->validator->validate($value, new UniqueEntity(field: 'name', repository: 'SomeRepo'));
+    }
+
+    public function testNoResultSkipsValidation(): void
+    {
+        $repository = new class () {
+            public function findOneBy(array $criteria): mixed
+            {
+                return null;
+            }
+        };
+
+        $this->injectContainer($this->mockContainerReturning($repository));
+
+        $value = new class () {
+            public function getName(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $this->validator->validate($value, new UniqueEntity(field: 'name', repository: 'SomeRepo'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testResultWithoutGetIdThrowsConstraintDefinitionException(): void
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+
+        $result = new class () {
+            // intentionally missing getId
+        };
+
+        $repository = new class ($result) {
+            public function __construct(private readonly mixed $result)
+            {
+            }
+
+            public function findOneBy(array $criteria): mixed
+            {
+                return $this->result;
+            }
+        };
+
+        $this->injectContainer($this->mockContainerReturning($repository));
+
+        $value = new class () {
+            public function getName(): string
+            {
+                return 'foo';
+            }
+
+            public function getId(): int
+            {
+                return 1;
+            }
+        };
+
+        $this->validator->validate($value, new UniqueEntity(field: 'name', repository: 'SomeRepo'));
+    }
+
+    public function testSameEntitySkipsValidation(): void
+    {
+        $result = new class () {
+            public function getId(): int
+            {
+                return 1;
+            }
+
+            public function findOneBy(array $criteria): mixed
+            {
+                return $this;
+            }
+        };
+
+        $repository = new class ($result) {
+            public function __construct(private readonly mixed $result)
+            {
+            }
+
+            public function findOneBy(array $criteria): mixed
+            {
+                return $this->result;
+            }
+        };
+
+        $this->injectContainer($this->mockContainerReturning($repository));
+
+        $value = new class () {
+            public function getName(): string
+            {
+                return 'foo';
+            }
+
+            public function getId(): int
+            {
+                return 1;
+            }
+        };
+
+        $this->validator->validate($value, new UniqueEntity(field: 'name', repository: 'SomeRepo'));
+
+        $this->assertNoViolation();
+    }
+
+    public function testDifferentEntityAddsViolation(): void
+    {
+        $result = new class () {
+            public function getId(): int
+            {
+                return 99;
+            }
+        };
+
+        $repository = new class ($result) {
+            public function __construct(private readonly mixed $result)
+            {
+            }
+
+            public function findOneBy(array $criteria): mixed
+            {
+                return $this->result;
+            }
+        };
+
+        $this->injectContainer($this->mockContainerReturning($repository));
+
+        $value = new class () {
+            public function getName(): string
+            {
+                return 'foo';
+            }
+
+            public function getId(): int
+            {
+                return 1;
+            }
+        };
+
+        $this->validator->validate($value, new UniqueEntity(field: 'name', repository: 'SomeRepo'));
+
+        $this->buildViolation('Name already in use')
+            ->atPath('property.path.name')
+            ->setInvalidValue('foo')
+            ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
+            ->setCause($result)
+            ->assertRaised();
+    }
+
+    // -------------------------------------------------------------------------
+
+    protected function createValidator(): UniqueEntityValidator
+    {
+        return new UniqueEntityValidator();
+    }
+
+    private function injectContainer(ContainerInterface $container): void
+    {
+        $ref = new \ReflectionProperty(UniqueEntityValidator::class, 'container');
+        $ref->setValue($this->validator, $container);
+    }
+
+    private function mockContainerReturning(object $repository): ContainerInterface
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($repository);
+
+        return $container;
+    }
+}

--- a/centreon/tests/php/Core/Common/Infrastructure/Validator/Constraints/WhenPlatformTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Validator/Constraints/WhenPlatformTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Common\Infrastructure\Validator\Constraints;
+
+use Core\Common\Domain\PlatformType;
+use Core\Common\Infrastructure\Validator\Constraints\WhenPlatform;
+use Core\Common\Infrastructure\Validator\Constraints\WhenPlatformValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\LogicException;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class WhenPlatformTest extends TestCase
+{
+    public function testValidPlatformCloud(): void
+    {
+        $constraint = new WhenPlatform(
+            platform: PlatformType::CLOUD,
+            constraints: [new NotBlank()]
+        );
+
+        $this->assertSame(PlatformType::CLOUD, $constraint->platform);
+    }
+
+    public function testValidPlatformOnPrem(): void
+    {
+        $constraint = new WhenPlatform(
+            platform: PlatformType::ON_PREM,
+            constraints: [new NotBlank()]
+        );
+
+        $this->assertSame(PlatformType::ON_PREM, $constraint->platform);
+    }
+
+    public function testInvalidPlatformThrowsLogicException(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The platform "invalid" is not valid.');
+
+        new WhenPlatform(platform: 'invalid', constraints: [new NotBlank()]);
+    }
+
+    public function testGroupsAreForwardedToParent(): void
+    {
+        $constraint = new WhenPlatform(
+            platform: PlatformType::CLOUD,
+            constraints: [new NotBlank()],
+            groups: ['MyGroup']
+        );
+
+        $this->assertContains('MyGroup', $constraint->groups ?? []);
+    }
+
+    public function testPayloadIsForwardedToParent(): void
+    {
+        $payload = ['key' => 'value'];
+        $constraint = new WhenPlatform(
+            platform: PlatformType::CLOUD,
+            constraints: [new NotBlank()],
+            payload: $payload
+        );
+
+        $this->assertSame($payload, $constraint->payload);
+    }
+
+    public function testValidationPassesWhenPlatformMatchesAndValueIsValid(): void
+    {
+        $validator = $this->buildValidator(isCloudPlatform: true);
+
+        $violations = $validator->validate('hello', new WhenPlatform(
+            platform: PlatformType::CLOUD,
+            constraints: [new NotBlank()]
+        ));
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testValidationFailsWhenPlatformMatchesAndValueIsInvalid(): void
+    {
+        $validator = $this->buildValidator(isCloudPlatform: true);
+
+        $violations = $validator->validate('', new WhenPlatform(
+            platform: PlatformType::CLOUD,
+            constraints: [new NotBlank()]
+        ));
+
+        $this->assertCount(1, $violations);
+    }
+
+    public function testValidationIsSkippedWhenPlatformDoesNotMatch(): void
+    {
+        $validator = $this->buildValidator(isCloudPlatform: false);
+
+        $violations = $validator->validate('', new WhenPlatform(
+            platform: PlatformType::CLOUD,
+            constraints: [new NotBlank()]
+        ));
+
+        $this->assertCount(0, $violations);
+    }
+
+    private function buildValidator(bool $isCloudPlatform): ValidatorInterface
+    {
+        $defaultFactory = new ConstraintValidatorFactory();
+
+        return Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory(
+                new class ($isCloudPlatform, $defaultFactory) implements ConstraintValidatorFactoryInterface {
+                    public function __construct(
+                        private readonly bool $isCloudPlatform,
+                        private readonly ConstraintValidatorFactory $defaultFactory,
+                    ) {
+                    }
+
+                    public function getInstance(Constraint $constraint): ConstraintValidatorInterface
+                    {
+                        if ($constraint instanceof WhenPlatform) {
+                            return new WhenPlatformValidator($this->isCloudPlatform);
+                        }
+
+                        return $this->defaultFactory->getInstance($constraint);
+                    }
+                }
+            )
+            ->getValidator();
+    }
+}


### PR DESCRIPTION
## Description

Update three custom Symfony constraints to remove Symfony 7.4 deprecations and prepare for Symfony 8.0 compatibility. 

### WhenPlatform                                                                                                                                                                                                                                                                                                                                        
                  
  - Replace the options-as-array pattern with typed promoted constructor properties                                                                                                                                                                                                                                                                   
  - Remove deprecated getRequiredOptions() method
  - Use named arguments for parent::__construct(groups:, payload:)                                                                                                                                                                                                                                                                                    
  - Add WhenPlatformTest (instantiation, groups/payload forwarding, validator behaviour)
                                                                                                                                                                                                                                                                                                                                                      
### UniqueEntity
                                                                                                                                                                                                                                                                                                                                                      
  - Replace untyped public properties with typed promoted constructor properties
  - Remove deprecated getDefaultOption() method
  - Add validation guards on field and repository (ConstraintDefinitionException)
  - Use named arguments for parent::__construct(groups:, payload:)          
  - Update validate() signature: mixed $value + : void                                                                                                                                                                                                                                                                                                
  - Add UniqueEntityTest
                                                                                                                                                                                                                                                                                                                                                      
### RepositoryCallback

  - Replace untyped public properties with typed promoted constructor properties                                                                                                                                                                                                                                                                      
  - Add validation guards on all 5 required parameters
  - Fix guard order in validate(): instanceof check before null guard                                                                                                                                                                                                                                                                                 
  - Update validate() signature: mixed $value + : void
  - Use named arguments for parent::__construct(groups:, payload:)
  - Add RepositoryCallbackTest   

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Refactored WhenPlatform constraint to use promoted properties and tests
* Refactored UniqueEntity constraint and validator to typed constructors and tests
* Refactored RepositoryCallback constraint and validator to typed constructors, guards, tests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101115641?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->