### PR TITLE
fix(clapi): add members column to CG show command

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonContactGroup.class.php
+++ b/centreon/www/class/centreon-clapi/centreonContactGroup.class.php
@@ -172,10 +172,28 @@ class CentreonContactGroup extends CentreonObject
         }
         $params = ['cg_id', 'cg_name', 'cg_alias'];
         $paramString = str_replace('cg_', '', implode($this->delim, $params));
-        echo $paramString . "\n";
+        echo $paramString . $this->delim . 'members' . "\n";
         $elements = $this->object->getList($params, -1, 0, null, null, $filters);
+
+        $relObj = new Centreon_Object_Relation_Contact_Group_Contact($this->dependencyInjector);
+        $relations = $relObj->getMergedParameters(
+            ['cg_id'],
+            ['contact_alias'],
+            -1,
+            0,
+            null,
+            'ASC',
+            $filters,
+            'AND'
+        );
+        $membersMap = [];
+        foreach ($relations as $rel) {
+            $membersMap[$rel['cg_id']][] = $rel['contact_alias'];
+        }
+
         foreach ($elements as $tab) {
-            echo implode($this->delim, $tab) . "\n";
+            $members = isset($membersMap[$tab['cg_id']]) ? implode('|', $membersMap[$tab['cg_id']]) : '';
+            echo implode($this->delim, $tab) . $this->delim . $members . "\n";
         }
     }
 


### PR DESCRIPTION
## Description

The `CG;show` CLAPI action was missing a members column since the class was first introduced. 
Add it by fetching contact aliases from the contactgroup_contact_relation table in a single query and displaying them as a pipe-separated list.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added members column to CG show output and header
* Fetched contact aliases in a single query and aggregated them


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96670546?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->