### PR TITLE
fix(backup): add --single-transaction to mysqldump to fix LOCK TABLES error on recent MariaDB versions

### DIFF
--- a/centreon/cron/centreon-backup.pl
+++ b/centreon/cron/centreon-backup.pl
@@ -389,6 +389,7 @@ sub gzippedSqlDump {
     my $mysqldump_pid = eval {
         open3('<&INPUT', \*FROM_MYSQLDUMP, '>&STDERR',
             mysqldump => (
+                '--single-transaction',
                 '-u', $mysql_user,
                 '-p'.$mysql_passwd,
                 '-h', $mysql_host,


### PR DESCRIPTION
## Summary

- Adds `--single-transaction` option to the `mysqldump` command in `centreon-backup.pl`
- Fixes an `Access denied` error when using `LOCK TABLES` that appears on recent MariaDB versions (10.11.15+)
- This option uses an InnoDB transaction snapshot instead of table locks, avoiding the need for the `LOCK TABLES` privilege on the `centreon` user.

Thanks to @cedricmeschin for fixing the bug

Fixes MON-196068

## Test plan

- [ ] Run a backup on a Centreon instance using MariaDB 10.11.15+
- [ ] Verify that the dump completes without `Access denied for user ... when using LOCK TABLES` error
- [ ] Verify that the generated `.sql.gz` backup file is valid and restorable

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added --single-transaction to mysqldump to avoid LOCK TABLES error on MariaDB 10.11.15+


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96975737?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->