### PR TITLE
feat(apiv2): Add GetMedia and DeleteMedia endpoints (#9888)

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/Media/DeleteMedia.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/DeleteMedia.yaml
@@ -1,0 +1,17 @@
+delete:
+  tags:
+    - Media
+  summary: "Delete a media configuration"
+  description: |
+    Delete a media configuration
+  parameters:
+    - $ref: 'QueryParameter/mediaId.yaml'
+  responses:
+    '204':
+      $ref: '../../Common/Response/NoContent.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/GetMedia.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/GetMedia.yaml
@@ -1,0 +1,22 @@
+get:
+  tags:
+    - Media
+  summary: "Get a media"
+  description: |
+    Get an existing media.
+
+  parameters:
+    - $ref: 'QueryParameter/mediaId.yaml'
+  responses:
+    '200':
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            $ref: 'Schema/GetMediaResponse.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/GetMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/GetMediaResponse.yaml
@@ -1,0 +1,23 @@
+
+type: object
+properties:
+  id:
+    type: integer
+    nullable: false
+    example: 1
+  filename:
+    type: string
+    nullable: false
+    example: "centreon_logo.jpg"
+  directory:
+    type: string
+    nullable: false
+    example: "logos"
+  md5:
+    type: string
+    nullable: false
+    example: "f7d5fc06a33946703054046c7174bbf4"
+  comment:
+    type: string
+    nullable: false
+    example: "Company logo"

--- a/centreon/src/Core/Media/Application/Exception/MediaException.php
+++ b/centreon/src/Core/Media/Application/Exception/MediaException.php
@@ -93,4 +93,20 @@ class MediaException extends \Exception
     {
         return new self(_('This operation requires an admin user'));
     }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileDeletingMedia(): self
+    {
+        return new self(_('Error while deleting a media'));
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileRetrieving(): self
+    {
+        return new self(_('Error while retrieving a media'));
+    }
 }

--- a/centreon/src/Core/Media/Application/Repository/ReadMediaRepositoryInterface.php
+++ b/centreon/src/Core/Media/Application/Repository/ReadMediaRepositoryInterface.php
@@ -86,4 +86,16 @@ interface ReadMediaRepositoryInterface
      * @return array<int,Media>
      */
     public function findByIds(array $mediaIds): array;
+
+    /**
+     * Return true if media is found the provided access groups
+     *
+     * @param int $mediaId
+     * @param AccessGroup[] $accessGroups
+     *
+     * @throws \Throwable
+     *
+     * @return bool
+     */
+    public function existsByAccessGroups(int $mediaId, array $accessGroups): bool;
 }

--- a/centreon/src/Core/Media/Application/UseCase/DeleteMedia/DeleteMedia.php
+++ b/centreon/src/Core/Media/Application/UseCase/DeleteMedia/DeleteMedia.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Media\Application\UseCase\DeleteMedia;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Contact\Domain\AdminResolver;
+use Core\Media\Application\Exception\MediaException;
+use Core\Media\Application\Repository\ReadImageFolderRepositoryInterface;
+use Core\Media\Application\Repository\ReadMediaRepositoryInterface;
+use Core\Media\Application\Repository\WriteMediaRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+
+final class DeleteMedia
+{
+    use LoggerTrait;
+
+    /**
+     * @param ReadMediaRepositoryInterface $readMediaRepository
+     * @param WriteMediaRepositoryInterface $writeMediaRepository
+     * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepository
+     * @param ReadImageFolderRepositoryInterface $readImageFolderRepository
+     * @param ContactInterface $user
+     * @param AdminResolver $adminResolver
+     */
+    public function __construct(
+        private readonly ReadMediaRepositoryInterface $readMediaRepository,
+        private readonly WriteMediaRepositoryInterface $writeMediaRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ReadImageFolderRepositoryInterface $readImageFolderRepository,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    /**
+     * @param int $mediaId
+     * @param PresenterInterface $presenter
+     */
+    public function __invoke(int $mediaId, PresenterInterface $presenter): void
+    {
+        try {
+            $media = null;
+
+            if ($this->adminResolver->isAdmin($this->user)) {
+                $media = $this->readMediaRepository->findById($mediaId);
+            } else {
+                $accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+
+                if (
+                    $this->readImageFolderRepository->hasAccessToAllImageFolders($accessGroups)
+                    || $this->readMediaRepository->existsByAccessGroups($mediaId, $accessGroups)
+                ) {
+                    $media = $this->readMediaRepository->findById($mediaId);
+                }
+            }
+
+            if ($media === null) {
+                $this->error('Media not found', ['media_id' => $mediaId]);
+                $presenter->setResponseStatus(new NotFoundResponse('Media'));
+
+                return;
+            }
+
+            $this->info(message: "Delete media #{$mediaId}");
+            $this->writeMediaRepository->delete($media);
+
+            $presenter->setResponseStatus(new NoContentResponse());
+            $this->info(
+                'Media deleted',
+                [
+                    'media_id' => $mediaId,
+                    'user_id' => $this->user->getId(),
+                ]
+            );
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(new ErrorResponse(MediaException::errorWhileDeletingMedia()));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        }
+    }
+}

--- a/centreon/src/Core/Media/Application/UseCase/GetMedia/GetMedia.php
+++ b/centreon/src/Core/Media/Application/UseCase/GetMedia/GetMedia.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Media\Application\UseCase\GetMedia;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Contact\Domain\AdminResolver;
+use Core\Media\Application\Exception\MediaException;
+use Core\Media\Application\Repository\ReadImageFolderRepositoryInterface;
+use Core\Media\Application\Repository\ReadMediaRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+
+final class GetMedia
+{
+    use LoggerTrait;
+
+    /**
+     * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepository
+     * @param ReadMediaRepositoryInterface $readMediaRepository
+     * @param ReadImageFolderRepositoryInterface $readImageFolderRepository
+     * @param ContactInterface $user
+     * @param AdminResolver $adminResolver
+     */
+    public function __construct(
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ReadMediaRepositoryInterface $readMediaRepository,
+        private readonly ReadImageFolderRepositoryInterface $readImageFolderRepository,
+        private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
+    ) {
+    }
+
+    public function __invoke(int $mediaId): GetMediaResponse|ResponseStatusInterface
+    {
+        try {
+            $media = null;
+
+            if ($this->adminResolver->isAdmin($this->user)) {
+                $media = $this->readMediaRepository->findById($mediaId);
+
+            } else {
+                $accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+
+                if (
+                    $this->readImageFolderRepository->hasAccessToAllImageFolders($accessGroups)
+                    || $this->readMediaRepository->existsByAccessGroups($mediaId, $accessGroups)
+                ) {
+                    $media = $this->readMediaRepository->findById($mediaId);
+                }
+            }
+
+            if ($media === null) {
+                return new NotFoundResponse('Media');
+            }
+
+            return new GetMediaResponse($media);
+        } catch (\Throwable $ex) {
+            $this->error(
+                "Error while retrieving a media: {$ex->getMessage()}",
+                [
+                    'user_id' => $this->user->getId(),
+                    'media_id' => $mediaId,
+                    'exception' => ['message' => $ex->getMessage(), 'trace' => $ex->getTraceAsString()],
+                ]
+            );
+
+            return new ErrorResponse(MediaException::errorWhileRetrieving());
+        }
+    }
+}

--- a/centreon/src/Core/Media/Application/UseCase/GetMedia/GetMediaResponse.php
+++ b/centreon/src/Core/Media/Application/UseCase/GetMedia/GetMediaResponse.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Media\Application\UseCase\GetMedia;
+
+use Core\Application\Common\UseCase\StandardResponseInterface;
+use Core\Media\Domain\Model\Media;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+final class GetMediaResponse implements StandardResponseInterface
+{
+    #[Groups(['Media:Get'])]
+    public int $id;
+
+    #[Groups(['Media:Get'])]
+    public string $comment;
+
+    #[Groups(['Media:Get'])]
+    public string $directory;
+
+    #[Groups(['Media:Get'])]
+    public string $filename;
+
+    #[Groups(['Media:Get'])]
+    public string $md5;
+
+    /**
+     * @param Media $media
+     */
+    public function __construct(
+        Media $media,
+    ) {
+        $this->id = $media->getId();
+        $this->comment = $media->getComment() ?? '';
+        $this->directory = $media->getDirectory();
+        $this->filename = $media->getFilename();
+        $this->md5 = $media->getEqualityHash();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData(): mixed
+    {
+        return $this;
+    }
+}

--- a/centreon/src/Core/Media/Infrastructure/API/DeleteMedia/DeleteMediaController.php
+++ b/centreon/src/Core/Media/Infrastructure/API/DeleteMedia/DeleteMediaController.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Media\Infrastructure\API\DeleteMedia;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Media\Application\UseCase\DeleteMedia\DeleteMedia;
+use Core\Media\Infrastructure\API\Voters\MediaVoters;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class DeleteMediaController extends AbstractController
+{
+    #[IsGranted(MediaVoters::DELETE_MEDIA, null, 'You are not allowed to delete media', Response::HTTP_FORBIDDEN)]
+    public function __invoke(DeleteMedia $useCase, DefaultPresenter $presenter, int $mediaId): Response
+    {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($mediaId, $presenter);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/Media/Infrastructure/API/DeleteMedia/DeleteMediaRoute.yaml
+++ b/centreon/src/Core/Media/Infrastructure/API/DeleteMedia/DeleteMediaRoute.yaml
@@ -1,0 +1,7 @@
+DeleteMedia:
+  methods: DELETE
+  path: /configuration/medias/{mediaId}
+  requirements:
+    mediaId: '\d+'
+  controller: 'Core\Media\Infrastructure\API\DeleteMedia\DeleteMediaController'
+  condition: "request.attributes.get('version') >= 25.10"

--- a/centreon/src/Core/Media/Infrastructure/API/GetMedia/GetMedia/GetMediaRoute.yaml
+++ b/centreon/src/Core/Media/Infrastructure/API/GetMedia/GetMedia/GetMediaRoute.yaml
@@ -1,0 +1,7 @@
+GetMedia:
+  methods: GET
+  path: /configuration/medias/{mediaId}
+  requirements:
+    mediaId: '\d+'
+  controller: 'Core\Media\Infrastructure\API\GetMedia\GetMediaController'
+  condition: "request.attributes.get('version') >= 25.10"

--- a/centreon/src/Core/Media/Infrastructure/API/GetMedia/GetMediaController.php
+++ b/centreon/src/Core/Media/Infrastructure/API/GetMedia/GetMediaController.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Media\Infrastructure\API\GetMedia;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Infrastructure\Common\Api\StandardPresenter;
+use Core\Media\Application\UseCase\GetMedia\GetMedia;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class GetMediaController extends AbstractController
+{
+    public function __invoke(
+        int $mediaId,
+        GetMedia $useCase,
+        StandardPresenter $presenter,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $response = $useCase($mediaId);
+
+        if ($response instanceof ResponseStatusInterface) {
+            return $this->createResponse($response);
+        }
+
+        return JsonResponse::fromJsonString($presenter->present(
+            $response,
+            ['groups' => ['Media:Get']]
+        ));
+    }
+}

--- a/centreon/src/Core/Media/Infrastructure/API/Voters/MediaVoters.php
+++ b/centreon/src/Core/Media/Infrastructure/API/Voters/MediaVoters.php
@@ -35,13 +35,14 @@ final class MediaVoters extends Voter
 {
     public const CREATE_MEDIA = 'create_media';
     public const UPDATE_MEDIA = 'update_media';
+    public const DELETE_MEDIA = 'delete_media';
 
     /**
      * {@inheritDoc}
      */
     protected function supports(string $attribute, $subject): bool
     {
-        return in_array($attribute, [self::CREATE_MEDIA, self::UPDATE_MEDIA], true);
+        return in_array($attribute, [self::CREATE_MEDIA, self::UPDATE_MEDIA, self::DELETE_MEDIA], true);
     }
 
     /**
@@ -56,7 +57,7 @@ final class MediaVoters extends Voter
         }
 
         return match ($attribute) {
-            self::CREATE_MEDIA, self::UPDATE_MEDIA => $user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_PARAMETERS_IMAGES_RW),
+            self::CREATE_MEDIA, self::UPDATE_MEDIA, self::DELETE_MEDIA => $user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_PARAMETERS_IMAGES_RW),
             default => throw new \LogicException('Action on media not handled'),
         };
     }

--- a/centreon/src/Core/Media/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Media/Infrastructure/Configuration/symfony.yaml
@@ -48,6 +48,15 @@ services:
             $dataStorageEngine: '@Core\Common\Infrastructure\Repository\DataStorageObserver'
             $readMediaRepository: '@Core\Media\Infrastructure\Repository\DbReadMediaRepository'
 
+    Core\Media\Application\UseCase\DeleteMedia\DeleteMedia:
+        arguments:
+            $writeMediaRepository: '@Core\Media\Infrastructure\Repository\FileProxyWriteMediaRepository'
+            $readMediaRepository: '@Core\Media\Infrastructure\Repository\DbReadMediaRepository'
+
+    Core\Media\Application\UseCase\GetMedia\GetMedia:
+        arguments:
+            $readMediaRepository: '@Core\Media\Infrastructure\Repository\DbReadMediaRepository'
+
     Core\Media\Infrastructure\Repository\ApiReadMediaRepository:
         arguments:
             $logger: '@Centreon\Domain\Log\Logger'

--- a/centreon/src/Core/Media/Infrastructure/Repository/ApiReadMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/ApiReadMediaRepository.php
@@ -123,6 +123,14 @@ class ApiReadMediaRepository implements ReadMediaRepositoryInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function existsByAccessGroups(int $mediaId, array $accessGroups): bool
+    {
+        throw new RepositoryException('Not yet implemented');
+    }
+
+    /**
      * @param array{id: int, filename: string, directory: string} $data
      *
      * @throws AssertionFailedException

--- a/centreon/src/Core/Media/Infrastructure/Repository/DbReadMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/DbReadMediaRepository.php
@@ -424,6 +424,54 @@ class DbReadMediaRepository extends AbstractRepositoryRDB implements ReadMediaRe
     }
 
     /**
+     * @inheritDoc
+     */
+    public function existsByAccessGroups(
+        int $mediaId,
+        array $accessGroups,
+    ): bool {
+        if ($accessGroups === []) {
+            $this->logger->debug('Access groups array empty');
+
+            return false;
+        }
+
+        $accessGroupIds = array_map(
+            static fn (AccessGroup $accessGroup): int => $accessGroup->getId(),
+            $accessGroups
+        );
+
+        [$bindValues, $bindQuery] = $this->createMultipleBindQuery($accessGroupIds, ':access_group_id');
+
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<SQL
+                SELECT 1
+                FROM `:db`.`view_img` img
+                INNER JOIN `:db`.`view_img_dir_relation` rel
+                    ON rel.img_img_id = img.img_id
+                INNER JOIN `:db`.`view_img_dir` dir
+                    ON dir.dir_id = rel.dir_dir_parent_id
+                INNER JOIN `:db`.acl_resources_image_folder_relations amdr
+                    ON amdr.dir_id = dir.dir_id
+                INNER JOIN `:db`.acl_res_group_relations argr
+                    ON argr.acl_res_id = amdr.acl_res_id
+                    AND argr.acl_group_id IN ({$bindQuery})
+                WHERE `img`.img_id = :mediaId
+                LIMIT 1
+                SQL
+        ));
+
+        $statement->bindValue(':mediaId', $mediaId, \PDO::PARAM_INT);
+        foreach ($bindValues as $bindKey => $bindValue) {
+            $statement->bindValue($bindKey, $bindValue, \PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+
+        return (bool) $statement->fetchColumn();
+    }
+
+    /**
      * @param array<string, int|string> $data
      *
      * @throws AssertionFailedException

--- a/centreon/src/Core/Media/Infrastructure/Repository/FileProxyReadMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/FileProxyReadMediaRepository.php
@@ -125,6 +125,14 @@ class FileProxyReadMediaRepository implements ReadMediaRepositoryInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function existsByAccessGroups(int $mediaId, array $accessGroups): bool
+    {
+        return $this->dbReadMediaRepository->existsByAccessGroups($mediaId, $accessGroups);
+    }
+
+    /**
      * @param \Traversable<int, Media> $medias
      *
      * @return \Traversable<int, Media>

--- a/centreon/tests/php/Core/Media/Application/UseCase/DeleteMedia/DeleteMediaTest.php
+++ b/centreon/tests/php/Core/Media/Application/UseCase/DeleteMedia/DeleteMediaTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Media\Application\UseCase\DeleteMedia;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Media\Application\Exception\MediaException;
+use Core\Media\Application\Repository\ReadImageFolderRepositoryInterface;
+use Core\Media\Application\Repository\ReadMediaRepositoryInterface;
+use Core\Media\Application\Repository\WriteMediaRepositoryInterface;
+use Core\Media\Application\UseCase\DeleteMedia\DeleteMedia;
+use Core\Media\Domain\Model\Media;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+beforeEach(function (): void {
+    $this->useCase = new DeleteMedia(
+        $this->readMediaRepository = $this->createMock(ReadMediaRepositoryInterface::class),
+        $this->writeMediaRepository = $this->createMock(WriteMediaRepositoryInterface::class),
+        $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        $this->readImageFolderRepository = $this->createMock(ReadImageFolderRepositoryInterface::class),
+        $this->user = $this->createMock(ContactInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
+    );
+
+    $this->presenter = new DefaultPresenter($this->createMock(PresenterFormatterInterface::class));
+
+    $this->media = new Media(
+        id: 1,
+        filename: 'test.jpg',
+        directory: 'test',
+        comment: 'A test image',
+        data: null,
+    );
+});
+
+it('should present an ErrorResponse when an exception is thrown', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->writeMediaRepository
+        ->expects($this->once())
+        ->method('delete')
+        ->willThrowException(new \Exception());
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    ($this->useCase)($this->media->getId(), $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->getResponseStatus()?->getMessage())
+        ->toBe(MediaException::errorWhileDeletingMedia()->getMessage());
+});
+
+it('should present a NotFoundResponse when media is not found as admin', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn(null);
+
+    ($this->useCase)($this->media->getId(), $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($this->presenter->getResponseStatus()?->getMessage())
+        ->toBe('Media not found');
+});
+
+it('should present a NoContentResponse when media is successfully deleted as admin', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->writeMediaRepository
+        ->expects($this->once())
+        ->method('delete');
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    ($this->useCase)($this->media->getId(), $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should present a NoContentResponse when media is successfully deleted as non-admin with access groups', function (): void {
+    $accessGroup = new AccessGroup(1, 'group1', 'group1_alias');
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([$accessGroup]);
+
+    $this->readImageFolderRepository
+        ->expects($this->once())
+        ->method('hasAccessToAllImageFolders')
+        ->willReturn(false);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    $this->writeMediaRepository
+        ->expects($this->once())
+        ->method('delete');
+
+    ($this->useCase)($this->media->getId(), $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should present a NoContentResponse when media is successfully deleted as non-admin with access to all image folders', function (): void {
+    $accessGroup = new AccessGroup(1, 'group1', 'group1_alias');
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([$accessGroup]);
+
+    $this->readImageFolderRepository
+        ->expects($this->once())
+        ->method('hasAccessToAllImageFolders')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->never())
+        ->method('existsByAccessGroups');
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    $this->writeMediaRepository
+        ->expects($this->once())
+        ->method('delete');
+
+    ($this->useCase)($this->media->getId(), $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should present a NotFoundResponse as non-admin when media is not accessible via access groups', function (): void {
+    $accessGroup = new AccessGroup(1, 'group1', 'group1_alias');
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([$accessGroup]);
+
+    $this->readImageFolderRepository
+        ->expects($this->once())
+        ->method('hasAccessToAllImageFolders')
+        ->willReturn(false);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(false);
+
+    $this->readMediaRepository
+        ->expects($this->never())
+        ->method('findById');
+
+    $this->writeMediaRepository
+        ->expects($this->never())
+        ->method('delete');
+
+    ($this->useCase)($this->media->getId(), $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($this->presenter->getResponseStatus()?->getMessage())
+        ->toBe('Media not found');
+});

--- a/centreon/tests/php/Core/Media/Application/UseCase/GetMedia/GetMediaTest.php
+++ b/centreon/tests/php/Core/Media/Application/UseCase/GetMedia/GetMediaTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Media\Application\UseCase\GetMedia;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Contact\Domain\AdminResolver;
+use Core\Media\Application\Exception\MediaException;
+use Core\Media\Application\Repository\ReadImageFolderRepositoryInterface;
+use Core\Media\Application\Repository\ReadMediaRepositoryInterface;
+use Core\Media\Application\UseCase\GetMedia\GetMedia;
+use Core\Media\Application\UseCase\GetMedia\GetMediaResponse;
+use Core\Media\Domain\Model\Media;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+beforeEach(function (): void {
+    $this->useCase = new GetMedia(
+        $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        $this->readMediaRepository = $this->createMock(ReadMediaRepositoryInterface::class),
+        $this->readImageFolderRepository = $this->createMock(ReadImageFolderRepositoryInterface::class),
+        $this->user = $this->createMock(ContactInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
+    );
+
+    $this->media = new Media(
+        id: 1,
+        filename: 'test.jpg',
+        directory: 'test',
+        comment: 'A test image',
+        data: null,
+    );
+});
+
+it('should present an ErrorResponse when an exception is thrown', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    $response = ($this->useCase)($this->media->getId());
+
+    expect($response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($response->getMessage())
+        ->toBe(MediaException::errorWhileRetrieving()->getMessage());
+});
+
+it('should present an NotFoundResponse; when media is not found', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn(null);
+
+    $response = ($this->useCase)($this->media->getId());
+
+    expect($response)
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($response->getMessage())
+        ->toBe('Media not found');
+});
+
+it('should present a GetMediaResponse as admin', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    $response = ($this->useCase)($this->media->getId());
+
+    expect($response)
+        ->toBeInstanceOf(GetMediaResponse::class)
+        ->and($response->id)
+        ->toEqual($this->media->getId())
+        ->and($response->filename)
+        ->toEqual($this->media->getFilename())
+        ->and($response->comment)
+        ->toEqual($this->media->getComment())
+        ->and($response->directory)
+        ->toEqual($this->media->getDirectory())
+        ->and($response->md5)
+        ->toEqual($this->media->getEqualityHash());
+});
+
+it('should present a GetMediaResponse as non-admin user with access to specific media via access groups', function (): void {
+    $accessGroup = new AccessGroup(1, 'group1', 'group1_alias');
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([$accessGroup]);
+
+    $this->readImageFolderRepository
+        ->expects($this->once())
+        ->method('hasAccessToAllImageFolders')
+        ->willReturn(false);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    $response = ($this->useCase)($this->media->getId());
+
+    expect($response)
+        ->toBeInstanceOf(GetMediaResponse::class)
+        ->and($response->id)
+        ->toEqual($this->media->getId())
+        ->and($response->filename)
+        ->toEqual($this->media->getFilename())
+        ->and($response->comment)
+        ->toEqual($this->media->getComment())
+        ->and($response->directory)
+        ->toEqual($this->media->getDirectory())
+        ->and($response->md5)
+        ->toEqual($this->media->getEqualityHash());
+});
+
+it('should present a GetMediaResponse as non-admin user with access to all image folders', function (): void {
+    $accessGroup = new AccessGroup(1, 'group1', 'group1_alias');
+
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([$accessGroup]);
+
+    $this->readImageFolderRepository
+        ->expects($this->once())
+        ->method('hasAccessToAllImageFolders')
+        ->willReturn(true);
+
+    $this->readMediaRepository
+        ->expects($this->never())
+        ->method('existsByAccessGroups');
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->media);
+
+    $response = ($this->useCase)($this->media->getId());
+
+    expect($response)
+        ->toBeInstanceOf(GetMediaResponse::class)
+        ->and($response->id)
+        ->toEqual($this->media->getId())
+        ->and($response->filename)
+        ->toEqual($this->media->getFilename())
+        ->and($response->comment)
+        ->toEqual($this->media->getComment())
+        ->and($response->directory)
+        ->toEqual($this->media->getDirectory())
+        ->and($response->md5)
+        ->toEqual($this->media->getEqualityHash());
+});
+
+it('should present a NotFoundResponse as non-admin user when media is not accessible via access groups', function (): void {
+    $accessGroup = new AccessGroup(1, 'group1', 'group1_alias');
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([$accessGroup]);
+
+    $this->readImageFolderRepository
+        ->expects($this->once())
+        ->method('hasAccessToAllImageFolders')
+        ->willReturn(false);
+
+    $this->readMediaRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(false);
+
+    $this->readMediaRepository
+        ->expects($this->never())
+        ->method('findById');
+
+    $response = ($this->useCase)($this->media->getId());
+
+    expect($response)
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($response->getMessage())
+        ->toBe('Media not found');
+});


### PR DESCRIPTION
## Description

Backport of #9888

[MON-196888](https://centreon.atlassian.net/browse/MON-196888)

[MON-196888]: https://centreon.atlassian.net/browse/MON-196888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GetMedia API endpoint with controller, use case, response.
* Added DeleteMedia API endpoint with controller and use case.

**⚡ Enhancements**
* Extended ReadMediaRepository interface and implementations with existsByAccessGroups for access control checks.
* Updated media voter to include delete permission and MediaException messages added.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97301996?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->