### PR TITLE
enh(auth): use session_name() instead of hardcoded PHPSESSID

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/Local/LoginController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/Local/LoginController.php
@@ -74,7 +74,7 @@ final class LoginController extends AbstractController
         }
 
         $presenter->setResponseHeaders(
-            ['Set-Cookie' => 'PHPSESSID=' . $requestStack->getSession()->getId()]
+            ['Set-Cookie' => session_name() . '=' . $requestStack->getSession()->getId()]
         );
 
         return $presenter->show();

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/CallbackController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/CallbackController.php
@@ -81,7 +81,7 @@ final class CallbackController extends AbstractController
                 if ($response->redirectIsReact()) {
                     return View::createRedirect(
                         $this->getBaseUrl() . $response->getRedirectUri(),
-                        headers: ['Set-Cookie' => 'PHPSESSID=' . $requestStack->getSession()->getId()]
+                        headers: ['Set-Cookie' => session_name() . '=' . $requestStack->getSession()->getId()]
                     );
                 }
 

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionController.php
@@ -45,7 +45,20 @@ final class LogoutSessionController extends AbstractController
         Request $request,
         LogoutSessionPresenterInterface $presenter,
     ): object {
-        $useCase($request->cookies->get('PHPSESSID'), $presenter);
+        $basePath = ltrim($request->getBasePath(), '/');
+        $sessionName = session_name() ?: 'PHPSESSID';
+
+        $sessionId = null;
+
+        if ($basePath !== '') {
+            $sessionId = $request->cookies->get($sessionName . '_' . $basePath);
+        }
+
+        if ($sessionId === null) {
+            $sessionId = $request->cookies->get($sessionName);
+        }
+
+        $useCase($sessionId, $presenter);
 
         return $this->redirect($this->getBaseUrl() . '/login');
     }

--- a/centreon/src/Security/WebSSOAuthenticator.php
+++ b/centreon/src/Security/WebSSOAuthenticator.php
@@ -261,7 +261,7 @@ class WebSSOAuthenticator extends AbstractAuthenticator
                 $authenticatedUser,
                 $request->getClientIp() ?? '' // @todo: what should happen if no IP was found?
             );
-            $request->headers->set('Set-Cookie', 'PHPSESSID=' . $sessionId);
+            $request->headers->set('Set-Cookie', session_name() . '=' . $sessionId);
         }
     }
 

--- a/centreon/tests/php/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionControllerTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionControllerTest.php
@@ -63,7 +63,7 @@ class LogoutSessionControllerTest extends TestCase
     {
         $logoutSessionController = new LogoutSessionController();
 
-        $this->request->cookies = new InputBag(['PHPSESSID' => 'token']);
+        $this->request->cookies = new InputBag([session_name() => 'token']);
 
         $this->logoutSessionPresenter->setResponseStatus(new NoContentResponse());
 

--- a/centreon/www/class/centreonSession.class.php
+++ b/centreon/www/class/centreonSession.class.php
@@ -206,9 +206,9 @@ class CentreonSession
             if (isset($_COOKIE[$sessionName]) && is_string($_COOKIE[$sessionName])) {
                 $sessionId = $_COOKIE[$sessionName];
             } else {
-                // Last resort: find any cookie starting with PHPSESSID (e.g., PHPSESSID_{SITE})
+                // Last resort: find any cookie starting with session name (e.g., PHPSESSID_{SITE})
                 foreach ($_COOKIE as $cookieKey => $cookieVal) {
-                    if (is_string($cookieKey) && str_starts_with($cookieKey, 'PHPSESSID') && is_string($cookieVal)) {
+                    if (is_string($cookieKey) && str_starts_with($cookieKey, $sessionName) && is_string($cookieVal)) {
                         $sessionName = $cookieKey;
                         $sessionId = $cookieVal;
                         break;


### PR DESCRIPTION
## Description

Backport of MON-194586 from develop to dev-25.10.x.

Replaces hardcoded `PHPSESSID` cookie name with `session_name()` in authentication controllers (login, logout, SAML callback, WebSSO). This ensures the correct session cookie is used when PHP's `session.name` is customized or when a base path prefix is configured.

**Fixes** MON-196932

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Configure a custom `session.name` in PHP config (e.g., `session.name = CENTREON_SESSID`)
2. Log in to the Centreon web interface
3. Verify that login, logout, SAML callback, and WebSSO authentication work correctly
4. Check that the session cookie name matches the configured `session.name`

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced hardcoded PHPSESSID with session_name() in login controller.
* Replaced hardcoded PHPSESSID with session_name() in SAML callback redirects.
* Updated logout flow to resolve session cookie using session_name and basepath.
* Refactored centreonSession session resolution to prefer session_name-based cookies.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97302290?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->