### PR TITLE
fix(vault): Correct logs in script migration

### DIFF
--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\Security\Vault\Application\UseCase\MigrateAllCredentials;
 
 use Centreon\Domain\Log\LoggerTrait;
+use CentreonLog;
 use Core\AdditionalConnectorConfiguration\Application\Repository\ReadAccRepositoryInterface;
 use Core\AdditionalConnectorConfiguration\Application\Repository\WriteAccRepositoryInterface;
 use Core\AdditionalConnectorConfiguration\Domain\Model\Acc;
@@ -32,7 +33,6 @@ use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
-use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
@@ -173,7 +173,7 @@ final class MigrateAllCredentials
             );
             $presenter->presentResponse($this->response);
         } catch (\Throwable $e) {
-            ExceptionLogger::create()->log($e);
+            CentreonLog::create()->error(logTypeId: CentreonLog::TYPE_BUSINESS_LOG, message: $e->getMessage(), exception: $e);
             $presenter->presentResponse(new ErrorResponse(VaultException::unableToMigrateCredentials()));
         }
     }


### PR DESCRIPTION
## Description

Backport of the log fix in the MigrateAllCredentials script.
Replaces the obsolete ExceptionLogger with CentreonLog.

**Fixes** MON-196935

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

Verify that the MigrateAllCredentials script logs use CentreonLog instead of the obsolete ExceptionLogger.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Replaced obsolete ExceptionLogger usages with CentreonLog in migration script


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97312331?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->