### PR TITLE
fix(virtualMetrics): validate RPN syntax with rrdtool before saving

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24915,7 +24915,3 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
-
-#: www/include/views/virtualMetrics/formVirtualMetrics.php
-msgid "Invalid VDEF RPN syntax. Expression must end with a valid aggregation function (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN, LSLSLOPE, LSLINT, LSLCORREL)."
-msgstr "Syntaxe RPN VDEF invalide. L'expression doit se terminer par une fonction d'agrégation valide (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN, LSLSLOPE, LSLINT, LSLCORREL)."

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24915,3 +24915,7 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
+
+#: www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Invalid VDEF RPN syntax. Expression must end with a valid aggregation function (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN, LSLSLOPE, LSLINT, LSLCORREL)."
+msgstr "Syntaxe RPN VDEF invalide. L'expression doit se terminer par une fonction d'agrégation valide (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN, LSLSLOPE, LSLINT, LSLCORREL)."

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -110,7 +110,7 @@ function testRpnSyntaxWithRrdtool(array $fields): array|true
         $lastLine = end($output) ?: 'unknown error';
         $rrdtoolError = preg_replace('/^ERROR:\s*/', '', $lastLine);
 
-        return ['rpn_function' => _('Invalid RPN syntax') . ' (RRDtool: ' . $rrdtoolError . ')'];
+        return ['rpn_function' => 'Invalid RPN syntax (RRDtool: ' . $rrdtoolError . ')'];
     }
 
     return true;

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -69,6 +69,49 @@ function testVdefRpnSyntax()
     return in_array($lastPart, $validVdefFunctions, true);
 }
 
+/**
+ * Validates that the RPN function syntax is valid for the CDEF DEF type.
+ * Each token must be a metric name, a number, or a valid CDEF RPN operator.
+ * VDEF-only functions (AVERAGE, MINIMUM, etc.) are rejected.
+ *
+ * @return bool
+ */
+function testCdefRpnSyntax()
+{
+    global $form;
+    $gsvs = null;
+    if (isset($form)) {
+        $gsvs = $form->getSubmitValues();
+    }
+
+    // Only validate for CDEF type (def_type = 0)
+    if (! isset($gsvs['def_type']) || (int) $gsvs['def_type'] !== 0) {
+        return true;
+    }
+
+    $rpnFunction = trim($gsvs['rpn_function'] ?? '');
+    if ($rpnFunction === '') {
+        return true; // the 'required' rule handles empty values
+    }
+
+    // VDEF-only functions that must be rejected in CDEF context
+    $vdefOnlyFunctions = [
+        'MAXIMUM', 'MINIMUM', 'AVERAGE', 'LAST', 'FIRST', 'TOTAL',
+        'PERCENT', 'PERCENTNAN', 'LSLSLOPE', 'LSLINT', 'LSLCORREL',
+    ];
+
+    $parts = array_map('trim', explode(',', $rpnFunction));
+
+    foreach ($parts as $part) {
+        $upper = strtoupper($part);
+        if (in_array($upper, $vdefOnlyFunctions, true)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 function _TestRPNInfinityLoop()
 {
     global $form;

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -66,7 +66,7 @@ function testRpnSyntaxWithRrdtool(array $fields): array|true
         $metrics[$row['metric_name']] = $row['metric_id'];
     }
 
-    if (empty($metrics)) {
+    if ($metrics === []) {
         return true;
     }
 
@@ -92,7 +92,7 @@ function testRpnSyntaxWithRrdtool(array $fields): array|true
 
     $rpnResolved = implode(',', $rpnParts);
 
-    if ($defType === 'VDEF' && empty($defArgs)) {
+    if ($defType === 'VDEF' && $defArgs === []) {
         return true;
     }
 

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -24,8 +24,8 @@ if (! isset($oreon)) {
 }
 
 /**
- * Validates that the RPN function syntax is valid for the selected DEF type.
- * For VDEF, the expression must end with a valid aggregation function.
+ * Validates the RPN function syntax for VDEF type.
+ * The expression must end with a valid VDEF aggregation function.
  *
  * @return bool
  */
@@ -70,9 +70,8 @@ function testVdefRpnSyntax()
 }
 
 /**
- * Validates that the RPN function syntax is valid for the CDEF DEF type.
- * Each token must be a metric name, a number, or a valid CDEF RPN operator.
- * VDEF-only functions (AVERAGE, MINIMUM, etc.) are rejected.
+ * Validates the RPN function syntax for CDEF type by simulating the RPN stack.
+ * Rejects VDEF-only functions and detects stack underflows/overflows.
  *
  * @return bool
  */
@@ -94,22 +93,74 @@ function testCdefRpnSyntax()
         return true; // the 'required' rule handles empty values
     }
 
-    // VDEF-only functions that must be rejected in CDEF context
-    $vdefOnlyFunctions = [
-        'MAXIMUM', 'MINIMUM', 'AVERAGE', 'LAST', 'FIRST', 'TOTAL',
-        'PERCENT', 'PERCENTNAN', 'LSLSLOPE', 'LSLINT', 'LSLCORREL',
-    ];
+    // Operators that pop 2 values, push 1
+    $binaryOps = ['+', '-', '*', '/', '%', 'LT', 'LE', 'GT', 'GE', 'EQ', 'NE', 'MIN', 'MAX', 'ADDNAN', 'ATAN2'];
+    // Operators that pop 1 value, push 1
+    $unaryOps = ['UN', 'ISINF', 'SIN', 'COS', 'LOG', 'EXP', 'SQRT', 'ATAN', 'FLOOR', 'CEIL', 'ABS', 'DEG2RAD', 'RAD2DEG', 'DUP'];
+    // Operators that pop 3 values, push 1
+    $ternaryOps = ['IF', 'LIMIT'];
+    // Operators that push 1 value (no pop)
+    $constantOps = ['UNKN', 'INF', 'NEGINF', 'NOW', 'TIME', 'LTIME', 'STEPWIDTH', 'NEWDAY', 'NEWWEEK', 'NEWMONTH', 'NEWYEAR', 'COUNT', 'PREV'];
+    // Operators that pop 1 value, push 0
+    $sinkOps = ['POP'];
+    // Operators that pop 2 values, push 2 (swap)
+    $swapOps = ['EXC'];
+    // VDEF-only functions that are invalid in CDEF context
+    $vdefOnlyFunctions = ['MAXIMUM', 'MINIMUM', 'AVERAGE', 'LAST', 'FIRST', 'TOTAL', 'PERCENT', 'PERCENTNAN', 'LSLSLOPE', 'LSLINT', 'LSLCORREL'];
+    // Set operations that consume N values from stack based on count prefix
+    $setOps = ['SORT', 'REV', 'AVG', 'SMIN', 'SMAX', 'STDEV', 'MEDIAN'];
 
     $parts = array_map('trim', explode(',', $rpnFunction));
+    $stack = 0;
 
     foreach ($parts as $part) {
         $upper = strtoupper($part);
+
         if (in_array($upper, $vdefOnlyFunctions, true)) {
             return false;
         }
+
+        if (in_array($upper, $binaryOps, true)) {
+            if ($stack < 2) {
+                return false;
+            }
+            $stack--;
+        } elseif (in_array($upper, $unaryOps, true)) {
+            if ($stack < 1) {
+                return false;
+            }
+        } elseif (in_array($upper, $ternaryOps, true)) {
+            if ($stack < 3) {
+                return false;
+            }
+            $stack -= 2;
+        } elseif (in_array($upper, $constantOps, true)) {
+            $stack++;
+        } elseif (in_array($upper, $sinkOps, true)) {
+            if ($stack < 1) {
+                return false;
+            }
+            $stack--;
+        } elseif (in_array($upper, $swapOps, true)) {
+            if ($stack < 2) {
+                return false;
+            }
+        } elseif (in_array($upper, $setOps, true)) {
+            // Set ops expect a count on top of stack + that many values below
+            if ($stack < 1) {
+                return false;
+            }
+            // We can't know the runtime count at validation time, just check stack isn't empty
+        } elseif (is_numeric($part)) {
+            $stack++;
+        } else {
+            // Metric name reference: pushes 1 value onto the stack
+            $stack++;
+        }
     }
 
-    return true;
+    // Valid CDEF must leave exactly 1 value on the stack
+    return $stack === 1;
 }
 
 function _TestRPNInfinityLoop()

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -23,6 +23,54 @@ if (! isset($oreon)) {
     exit;
 }
 
+/**
+ * Validates that the RPN function syntax is valid for the selected DEF type.
+ * For VDEF, the expression must end with a valid aggregation function.
+ *
+ * @return bool
+ */
+function testVdefRpnSyntax()
+{
+    global $form;
+    $gsvs = null;
+    if (isset($form)) {
+        $gsvs = $form->getSubmitValues();
+    }
+
+    // Only validate for VDEF type (def_type = 1)
+    if (! isset($gsvs['def_type']) || (int) $gsvs['def_type'] !== 1) {
+        return true;
+    }
+
+    $rpnFunction = trim($gsvs['rpn_function'] ?? '');
+    if ($rpnFunction === '') {
+        return true; // the 'required' rule handles empty values
+    }
+
+    $validVdefFunctions = [
+        'MAXIMUM', 'MINIMUM', 'AVERAGE', 'STDEV', 'LAST', 'FIRST', 'TOTAL',
+        'PERCENT', 'PERCENTNAN', 'LSLSLOPE', 'LSLINT', 'LSLCORREL',
+    ];
+
+    $parts = array_map('trim', explode(',', $rpnFunction));
+    $partCount = count($parts);
+
+    if ($partCount < 2) {
+        return false;
+    }
+
+    $lastPart = strtoupper($parts[$partCount - 1]);
+
+    // PERCENT and PERCENTNAN take an extra numeric argument: metric,N,PERCENT
+    if (is_numeric($lastPart) && $partCount >= 3) {
+        $functionPart = strtoupper($parts[$partCount - 2]);
+
+        return in_array($functionPart, ['PERCENT', 'PERCENTNAN'], true);
+    }
+
+    return in_array($lastPart, $validVdefFunctions, true);
+}
+
 function _TestRPNInfinityLoop()
 {
     global $form;

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -61,11 +61,9 @@ function testVdefRpnSyntax()
 
     $lastPart = strtoupper($parts[$partCount - 1]);
 
-    // PERCENT and PERCENTNAN take an extra numeric argument: metric,N,PERCENT
-    if (is_numeric($lastPart) && $partCount >= 3) {
-        $functionPart = strtoupper($parts[$partCount - 2]);
-
-        return in_array($functionPart, ['PERCENT', 'PERCENTNAN'], true);
+    // PERCENT and PERCENTNAN require a numeric argument before the function: metric,N,PERCENT
+    if (in_array($lastPart, ['PERCENT', 'PERCENTNAN'], true)) {
+        return $partCount >= 3 && is_numeric($parts[$partCount - 2]);
     }
 
     return in_array($lastPart, $validVdefFunctions, true);

--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -24,143 +24,96 @@ if (! isset($oreon)) {
 }
 
 /**
- * Validates the RPN function syntax for VDEF type.
- * The expression must end with a valid VDEF aggregation function.
+ * Validates the RPN function syntax by building a minimal rrdtool command
+ * and executing it. Works for both CDEF (def_type=0) and VDEF (def_type=1).
  *
- * @return bool
+ * @param array<string,mixed> $fields Form fields
+ *
+ * @return true|array<string,string>
  */
-function testVdefRpnSyntax()
+function testRpnSyntaxWithRrdtool(array $fields): array|true
 {
-    global $form;
-    $gsvs = null;
-    if (isset($form)) {
-        $gsvs = $form->getSubmitValues();
-    }
+    global $pearDBO, $oreon;
 
-    // Only validate for VDEF type (def_type = 1)
-    if (! isset($gsvs['def_type']) || (int) $gsvs['def_type'] !== 1) {
+    if (! isset($fields['def_type'])) {
         return true;
     }
 
-    $rpnFunction = trim($gsvs['rpn_function'] ?? '');
+    $rpnFunction = trim($fields['rpn_function'] ?? '');
     if ($rpnFunction === '') {
-        return true; // the 'required' rule handles empty values
-    }
-
-    $validVdefFunctions = [
-        'MAXIMUM', 'MINIMUM', 'AVERAGE', 'STDEV', 'LAST', 'FIRST', 'TOTAL',
-        'PERCENT', 'PERCENTNAN', 'LSLSLOPE', 'LSLINT', 'LSLCORREL',
-    ];
-
-    $parts = array_map('trim', explode(',', $rpnFunction));
-    $partCount = count($parts);
-
-    if ($partCount < 2) {
-        return false;
-    }
-
-    $lastPart = strtoupper($parts[$partCount - 1]);
-
-    // PERCENT and PERCENTNAN require a numeric argument before the function: metric,N,PERCENT
-    if (in_array($lastPart, ['PERCENT', 'PERCENTNAN'], true)) {
-        return $partCount >= 3 && is_numeric($parts[$partCount - 2]);
-    }
-
-    return in_array($lastPart, $validVdefFunctions, true);
-}
-
-/**
- * Validates the RPN function syntax for CDEF type by simulating the RPN stack.
- * Rejects VDEF-only functions and detects stack underflows/overflows.
- *
- * @return bool
- */
-function testCdefRpnSyntax()
-{
-    global $form;
-    $gsvs = null;
-    if (isset($form)) {
-        $gsvs = $form->getSubmitValues();
-    }
-
-    // Only validate for CDEF type (def_type = 0)
-    if (! isset($gsvs['def_type']) || (int) $gsvs['def_type'] !== 0) {
         return true;
     }
 
-    $rpnFunction = trim($gsvs['rpn_function'] ?? '');
-    if ($rpnFunction === '') {
-        return true; // the 'required' rule handles empty values
+    $defType = (int) $fields['def_type'] === 1 ? 'VDEF' : 'CDEF';
+    $hostServiceId = $fields['host_id'] ?? '';
+
+    $indexId = getIndexIdFromHostServiceId($pearDBO, $hostServiceId);
+    if ($indexId === null) {
+        return true;
     }
 
-    // Operators that pop 2 values, push 1
-    $binaryOps = ['+', '-', '*', '/', '%', 'LT', 'LE', 'GT', 'GE', 'EQ', 'NE', 'MIN', 'MAX', 'ADDNAN', 'ATAN2'];
-    // Operators that pop 1 value, push 1
-    $unaryOps = ['UN', 'ISINF', 'SIN', 'COS', 'LOG', 'EXP', 'SQRT', 'ATAN', 'FLOOR', 'CEIL', 'ABS', 'DEG2RAD', 'RAD2DEG', 'DUP'];
-    // Operators that pop 3 values, push 1
-    $ternaryOps = ['IF', 'LIMIT'];
-    // Operators that push 1 value (no pop)
-    $constantOps = ['UNKN', 'INF', 'NEGINF', 'NOW', 'TIME', 'LTIME', 'STEPWIDTH', 'NEWDAY', 'NEWWEEK', 'NEWMONTH', 'NEWYEAR', 'COUNT', 'PREV'];
-    // Operators that pop 1 value, push 0
-    $sinkOps = ['POP'];
-    // Operators that pop 2 values, push 2 (swap)
-    $swapOps = ['EXC'];
-    // VDEF-only functions that are invalid in CDEF context
-    $vdefOnlyFunctions = ['MAXIMUM', 'MINIMUM', 'AVERAGE', 'LAST', 'FIRST', 'TOTAL', 'PERCENT', 'PERCENTNAN', 'LSLSLOPE', 'LSLINT', 'LSLCORREL'];
-    // Set operations that consume N values from stack based on count prefix
-    $setOps = ['SORT', 'REV', 'AVG', 'SMIN', 'SMAX', 'STDEV', 'MEDIAN'];
+    $config = $pearDBO->fetchAssociative('SELECT RRDdatabase_path FROM config LIMIT 1');
+    $rrdPath = rtrim($config['RRDdatabase_path'] ?? '/var/lib/centreon/metrics', '/') . '/';
 
-    $parts = array_map('trim', explode(',', $rpnFunction));
-    $stack = 0;
+    $metricsStmt = $pearDBO->prepare(
+        'SELECT metric_id, metric_name FROM metrics WHERE index_id = :index_id'
+    );
+    $metricsStmt->bindValue(':index_id', (int) $indexId, PDO::PARAM_INT);
+    $metricsStmt->execute();
 
-    foreach ($parts as $part) {
-        $upper = strtoupper($part);
-
-        if (in_array($upper, $vdefOnlyFunctions, true)) {
-            return false;
-        }
-
-        if (in_array($upper, $binaryOps, true)) {
-            if ($stack < 2) {
-                return false;
-            }
-            $stack--;
-        } elseif (in_array($upper, $unaryOps, true)) {
-            if ($stack < 1) {
-                return false;
-            }
-        } elseif (in_array($upper, $ternaryOps, true)) {
-            if ($stack < 3) {
-                return false;
-            }
-            $stack -= 2;
-        } elseif (in_array($upper, $constantOps, true)) {
-            $stack++;
-        } elseif (in_array($upper, $sinkOps, true)) {
-            if ($stack < 1) {
-                return false;
-            }
-            $stack--;
-        } elseif (in_array($upper, $swapOps, true)) {
-            if ($stack < 2) {
-                return false;
-            }
-        } elseif (in_array($upper, $setOps, true)) {
-            // Set ops expect a count on top of stack + that many values below
-            if ($stack < 1) {
-                return false;
-            }
-            // We can't know the runtime count at validation time, just check stack isn't empty
-        } elseif (is_numeric($part)) {
-            $stack++;
-        } else {
-            // Metric name reference: pushes 1 value onto the stack
-            $stack++;
-        }
+    $metrics = [];
+    while ($row = $metricsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $metrics[$row['metric_name']] = $row['metric_id'];
     }
 
-    // Valid CDEF must leave exactly 1 value on the stack
-    return $stack === 1;
+    if (empty($metrics)) {
+        return true;
+    }
+
+    $rpnParts = explode(',', $rpnFunction);
+    $defArgs = [];
+    $usedMetrics = [];
+
+    foreach ($rpnParts as &$part) {
+        $trimmed = trim($part);
+        if (isset($metrics[$trimmed]) && ! isset($usedMetrics[$trimmed])) {
+            $metricId = $metrics[$trimmed];
+            $rrdFile = $rrdPath . $metricId . '.rrd';
+            if (file_exists($rrdFile)) {
+                $defArgs[] = 'DEF:v' . $metricId . '=' . $rrdFile . ':value:AVERAGE';
+                $usedMetrics[$trimmed] = 'v' . $metricId;
+            }
+        }
+        if (isset($usedMetrics[$trimmed])) {
+            $part = $usedMetrics[$trimmed];
+        }
+    }
+    unset($part);
+
+    $rpnResolved = implode(',', $rpnParts);
+
+    if ($defType === 'VDEF' && empty($defArgs)) {
+        return true;
+    }
+
+    $rrdtoolBin = $oreon->optGen['rrdtool_path_bin'] ?? '/usr/bin/rrdtool';
+    $cmd = escapeshellarg($rrdtoolBin) . ' graph /dev/null --start now-1h';
+    foreach ($defArgs as $def) {
+        $cmd .= ' ' . escapeshellarg($def);
+    }
+    $cmd .= ' ' . escapeshellarg($defType . ':vtest=' . $rpnResolved);
+    $cmd .= ' 2>&1';
+
+    exec($cmd, $output, $rc);
+
+    if ($rc !== 0) {
+        $lastLine = end($output) ?: 'unknown error';
+        $rrdtoolError = preg_replace('/^ERROR:\s*/', '', $lastLine);
+
+        return ['rpn_function' => _('Invalid RPN syntax') . ' (RRDtool: ' . $rrdtoolError . ')'];
+    }
+
+    return true;
 }
 
 function _TestRPNInfinityLoop()

--- a/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+++ b/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
@@ -141,6 +141,7 @@ $form->addRule('host_id', _('Required service'), 'required');
 
 $form->registerRule('existName', 'callback', 'hasVirtualNameNeverUsed');
 $form->registerRule('RPNInfinityLoop', 'callback', '_TestRPNInfinityLoop');
+$form->registerRule('validVdefRpn', 'callback', 'testVdefRpnSyntax');
 $form->addRule(
     'vmetric_name',
     _('Name already in use for this Host/Service'),
@@ -153,6 +154,13 @@ $form->addRule(
             ? htmlentities($_POST['vmetric_name'], ENT_QUOTES, 'UTF-8')
             : '') . "' In This RPN Function"),
     'RPNInfinityLoop'
+);
+$form->addRule(
+    'rpn_function',
+    _('Invalid VDEF RPN syntax. Expression must end with a valid aggregation function'
+        . ' (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN,'
+        . ' LSLSLOPE, LSLINT, LSLCORREL).'),
+    'validVdefRpn'
 );
 
 $form->setRequiredNote("<font style='color: red;'>*</font>" . _(' Required fields'));

--- a/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+++ b/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
@@ -141,8 +141,6 @@ $form->addRule('host_id', _('Required service'), 'required');
 
 $form->registerRule('existName', 'callback', 'hasVirtualNameNeverUsed');
 $form->registerRule('RPNInfinityLoop', 'callback', '_TestRPNInfinityLoop');
-$form->registerRule('validVdefRpn', 'callback', 'testVdefRpnSyntax');
-$form->registerRule('validCdefRpn', 'callback', 'testCdefRpnSyntax');
 $form->addRule(
     'vmetric_name',
     _('Name already in use for this Host/Service'),
@@ -156,19 +154,7 @@ $form->addRule(
             : '') . "' In This RPN Function"),
     'RPNInfinityLoop'
 );
-$form->addRule(
-    'rpn_function',
-    _('Invalid VDEF RPN syntax. Expression must end with a valid aggregation function'
-        . ' (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN,'
-        . ' LSLSLOPE, LSLINT, LSLCORREL).'),
-    'validVdefRpn'
-);
-$form->addRule(
-    'rpn_function',
-    _('Invalid CDEF RPN syntax: expression contains invalid operators or produces a stack error'
-        . ' (e.g. underflow or result count != 1).'),
-    'validCdefRpn'
-);
+$form->addFormRule('testRpnSyntaxWithRrdtool');
 
 $form->setRequiredNote("<font style='color: red;'>*</font>" . _(' Required fields'));
 

--- a/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+++ b/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
@@ -165,8 +165,8 @@ $form->addRule(
 );
 $form->addRule(
     'rpn_function',
-    _('Invalid CDEF RPN syntax. VDEF-only functions (AVERAGE, MINIMUM, MAXIMUM, LAST, FIRST,'
-        . ' TOTAL, PERCENT, PERCENTNAN, LSLSLOPE, LSLINT, LSLCORREL) cannot be used in CDEF expressions.'),
+    _('Invalid CDEF RPN syntax: expression contains invalid operators or produces a stack error'
+        . ' (e.g. underflow or result count != 1).'),
     'validCdefRpn'
 );
 

--- a/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+++ b/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
@@ -142,6 +142,7 @@ $form->addRule('host_id', _('Required service'), 'required');
 $form->registerRule('existName', 'callback', 'hasVirtualNameNeverUsed');
 $form->registerRule('RPNInfinityLoop', 'callback', '_TestRPNInfinityLoop');
 $form->registerRule('validVdefRpn', 'callback', 'testVdefRpnSyntax');
+$form->registerRule('validCdefRpn', 'callback', 'testCdefRpnSyntax');
 $form->addRule(
     'vmetric_name',
     _('Name already in use for this Host/Service'),
@@ -161,6 +162,12 @@ $form->addRule(
         . ' (MAXIMUM, MINIMUM, AVERAGE, STDEV, LAST, FIRST, TOTAL, PERCENT, PERCENTNAN,'
         . ' LSLSLOPE, LSLINT, LSLCORREL).'),
     'validVdefRpn'
+);
+$form->addRule(
+    'rpn_function',
+    _('Invalid CDEF RPN syntax. VDEF-only functions (AVERAGE, MINIMUM, MAXIMUM, LAST, FIRST,'
+        . ' TOTAL, PERCENT, PERCENTNAN, LSLSLOPE, LSLINT, LSLCORREL) cannot be used in CDEF expressions.'),
+    'validCdefRpn'
 );
 
 $form->setRequiredNote("<font style='color: red;'>*</font>" . _(' Required fields'));


### PR DESCRIPTION
## Description

Add form-level RPN syntax validation for virtual metrics (both CDEF and VDEF) by executing rrdtool directly before any database write. This prevents saving malformed expressions that would cause errors at graph rendering time.

When validation fails, the actual rrdtool error message is displayed in the form (e.g., "RPN stack underflow", "don't understand 'average'") instead of a generic error.

**Fixes** MON-192065

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Go to Monitoring > Performances > Virtual Metrics
2. Create or edit a virtual metric linked to a service with known metrics
3. Test CDEF with invalid RPN (e.g., `cpu_0,+`) — form should show the rrdtool error and prevent saving
4. Test CDEF with unknown operator (e.g., `cpu_0,average`) — form should show "don't understand 'average'"
5. Test VDEF with valid expression (e.g., `cpu_0,AVERAGE`) — form should save successfully
6. Test CDEF with valid expression (e.g., `cpu_0,cpu_1,+`) — form should save successfully

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Validated VDEF/CDEF RPN syntax using rrdtool execution and dynamic error messages
* Hooked RPN validation into virtual metric form submission server-side


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98681452?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->