### PR TITLE
fix(service): use AdminResolver for cloud admin detection and fix SQL IN() on empty host category ACL

### DIFF
--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -222,13 +222,16 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
         // Only JOIN if search request has been provided...
         if ($searchRequest !== null) {
             $hostCategoryAcls = $this->generateHostCategoryAclSubRequest($accessGroupIds);
+            $hostCategoryCondition = $hostCategoryAcls !== ''
+                ? "AND hcr.hostcategories_hc_id IN ({$hostCategoryAcls})"
+                : '';
             $request .= <<<SQL
 
                 LEFT JOIN `:db`.hostgroup_relation hgr
                     ON hgr.hostgroup_hg_id = hg.hg_id
                 LEFT JOIN `:db`.hostcategories_relation hcr
                     ON hcr.host_host_id = hgr.host_host_id
-                    AND hcr.hostcategories_hc_id IN ({$hostCategoryAcls})
+                    {$hostCategoryCondition}
                 LEFT JOIN `:db`.hostcategories hc
                     ON hc.hc_id = hcr.hostcategories_hc_id
                     AND hc.level IS NULL

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddServiceValidation.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddServiceValidation.php
@@ -28,6 +28,7 @@ use Centreon\Domain\Log\LoggerTrait;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Command\Domain\Model\CommandType;
 use Core\Common\Domain\TrimmedString;
+use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\PerformanceGraph\Application\Repository\ReadPerformanceGraphRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
@@ -60,6 +61,7 @@ class AddServiceValidation
         private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
         private readonly ReadServiceGroupRepositoryInterface $readServiceGroupRepository,
         private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
     ) {
     }
 
@@ -106,7 +108,7 @@ class AddServiceValidation
      */
     public function assertIsValidHost(int $hostId): void
     {
-        $hostIdFound = $this->user->isAdmin()
+        $hostIdFound = $this->adminResolver->isAdmin($this->user)
                 ? $this->readHostRepository->exists($hostId)
                 : $this->readHostRepository->existsByAccessGroups($hostId, $this->accessGroups);
         if ($hostIdFound === false) {
@@ -127,7 +129,7 @@ class AddServiceValidation
             return;
         }
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $serviceCategoriesIdsFound = $this->readServiceCategoryRepository->findAllExistingIds(
                 $serviceCategoriesIds
             );
@@ -272,7 +274,7 @@ class AddServiceValidation
             return;
         }
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $serviceGroupIdsFound = $this->readServiceGroupRepository->exist($serviceGroupIds);
         } else {
             $serviceGroupIdsFound = $this->readServiceGroupRepository->existByAccessGroups(

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddServiceValidation.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddServiceValidation.php
@@ -74,7 +74,7 @@ class AddServiceValidation
     public function assertIsValidSeverity(?int $severityId): void
     {
         if ($severityId !== null) {
-            $exists = ($this->accessGroups === [])
+            $exists = $this->adminResolver->isAdmin($this->user)
                 ? $this->serviceSeverityRepository->exists($severityId)
                 : $this->serviceSeverityRepository->existsByAccessGroups($severityId, $this->accessGroups);
 

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php
@@ -208,7 +208,7 @@ class PartialUpdateServiceValidation
     public function assertIsValidSeverity(?int $severityId): void
     {
         if ($severityId !== null) {
-            $exists = ($this->accessGroups === [])
+            $exists = $this->adminResolver->isAdmin($this->user)
                 ? $this->serviceSeverityRepository->exists($severityId)
                 : $this->serviceSeverityRepository->existsByAccessGroups($severityId, $this->accessGroups);
 

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php
@@ -28,6 +28,7 @@ use Centreon\Domain\Log\LoggerTrait;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Command\Domain\Model\CommandType;
 use Core\Common\Domain\TrimmedString;
+use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\PerformanceGraph\Application\Repository\ReadPerformanceGraphRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
@@ -60,6 +61,7 @@ class PartialUpdateServiceValidation
         private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
         private readonly ReadServiceGroupRepositoryInterface $readServiceGroupRepository,
         private readonly ContactInterface $user,
+        private readonly AdminResolver $adminResolver,
     ) {
     }
 
@@ -70,7 +72,7 @@ class PartialUpdateServiceValidation
      */
     public function assertIsValidHost(int $hostId): void
     {
-        $hostIdFound = $this->user->isAdmin()
+        $hostIdFound = $this->adminResolver->isAdmin($this->user)
                 ? $this->readHostRepository->exists($hostId)
                 : $this->readHostRepository->existsByAccessGroups($hostId, $this->accessGroups);
         if ($hostIdFound === false) {
@@ -226,7 +228,7 @@ class PartialUpdateServiceValidation
      */
     public function assertAreValidCategories(array $categoriesIds): void
     {
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $categoriesIdsFound = $this->readServiceCategoryRepository->findAllExistingIds(
                 $categoriesIds
             );
@@ -255,7 +257,7 @@ class PartialUpdateServiceValidation
             return;
         }
 
-        if ($this->user->isAdmin()) {
+        if ($this->adminResolver->isAdmin($this->user)) {
             $groupIdsFound = $this->readServiceGroupRepository->exist($groupIds);
         } else {
             $groupIdsFound = $this->readServiceGroupRepository->existByAccessGroups(

--- a/centreon/src/Core/ServiceGroup/Infrastructure/Repository/DbReadServiceGroupRepository.php
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/Repository/DbReadServiceGroupRepository.php
@@ -212,27 +212,32 @@ class DbReadServiceGroupRepository extends AbstractRepositoryDRB implements Read
             $hostGroupAcl = $this->generateHostGroupAclSubRequest($accessGroupIds);
             $hostCategoryAcl = $this->generateHostCategoryAclSubRequest($accessGroupIds);
 
+            $hostAclCondition = $hostAcl !== '' ? "AND sgr.host_host_id IN ({$hostAcl})" : '';
+            $serviceCategoryCondition = $serviceCategoryAcl !== '' ? "AND scr.sc_id IN ({$serviceCategoryAcl})" : '';
+            $hostCategoryCondition = $hostCategoryAcl !== '' ? "AND hcr.hostcategories_hc_id IN ({$hostCategoryAcl})" : '';
+            $hostGroupCondition = $hostGroupAcl !== '' ? "AND hgr.hostgroup_hg_id IN ({$hostGroupAcl})" : '';
+
             $request .= <<<SQL
                     LEFT JOIN `:db`.servicegroup_relation sgr
                         ON sgr.servicegroup_sg_id = sg.sg_id
                     LEFT JOIN `:db`.host h
                         ON h.host_id = sgr.host_host_id
-                        AND sgr.host_host_id IN ({$hostAcl})
+                        {$hostAclCondition}
                     LEFT JOIN `:db`.service_categories_relation scr
                         ON scr.service_service_id = sgr.service_service_id
                     LEFT JOIN `:db`.service_categories sc
                         ON sc.sc_id = scr.sc_id
-                        AND scr.sc_id IN ({$serviceCategoryAcl})
+                        {$serviceCategoryCondition}
                     LEFT JOIN `:db`.hostcategories_relation hcr
                         ON hcr.host_host_id = sgr.host_host_id
                     LEFT JOIN `:db`.hostcategories hc
                         ON hc.hc_id = hcr.hostcategories_hc_id
-                        AND hcr.hostcategories_hc_id IN ({$hostCategoryAcl})
+                        {$hostCategoryCondition}
                     LEFT JOIN `:db`.hostgroup_relation hgr
                         ON hgr.hostgroup_hg_id = sgr.hostgroup_hg_id
                     LEFT JOIN `:db`.hostgroup hg
                         ON hg.hg_id = hgr.hostgroup_hg_id
-                        AND hgr.hostgroup_hg_id IN ({$hostGroupAcl})
+                        {$hostGroupCondition}
                 SQL;
         }
 

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceValidationTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceValidationTest.php
@@ -25,6 +25,7 @@ namespace Tests\Core\Service\Application\UseCase\AddService;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\PerformanceGraph\Application\Repository\ReadPerformanceGraphRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
@@ -52,6 +53,7 @@ beforeEach(function (): void {
         $this->readServiceCategoryRepository = $this->createMock(ReadServiceCategoryRepositoryInterface::class),
         $this->readServiceGroupRepository = $this->createMock(ReadServiceGroupRepositoryInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 });
 
@@ -174,7 +176,7 @@ it('throws an exception when performance graph ID does not exist', function (): 
 );
 
 it('throws an exception when host ID does not exist', function (): void {
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -190,7 +192,7 @@ it('throws an exception when host ID does not exist', function (): void {
 );
 
 it('throws an exception when category ID does not exist with admin user', function (): void {
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -206,7 +208,7 @@ it('throws an exception when category ID does not exist with admin user', functi
 );
 
 it('throws an exception when category ID does not exist with non-admin user', function (): void {
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);
@@ -222,7 +224,7 @@ it('throws an exception when category ID does not exist with non-admin user', fu
 );
 
 it('throws an exception when group ID does not exist with admin user', function (): void {
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -238,7 +240,7 @@ it('throws an exception when group ID does not exist with admin user', function 
 );
 
 it('throws an exception when group ID does not exist with non-admin user', function (): void {
-    $this->user
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceValidationTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceValidationTest.php
@@ -152,6 +152,10 @@ it('throws an exception when notification time period ID does not exist', functi
 );
 
 it('throws an exception when severity ID does not exist', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
     $this->serviceSeverityRepository
         ->expects($this->once())
         ->method('exists')

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidationTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidationTest.php
@@ -127,6 +127,10 @@ it('should raise an exception when the time period ID does not exist', function 
 );
 
 it('should raise an exception when the severity ID does not exist', function (): void {
+    $this->adminResolver
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
     $this->serviceSeverityRepository
         ->expects($this->once())
         ->method('exists')

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidationTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidationTest.php
@@ -25,6 +25,7 @@ namespace Tests\Core\Service\Application\UseCase\PartialUpdateService;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\PerformanceGraph\Application\Repository\ReadPerformanceGraphRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
@@ -53,6 +54,7 @@ beforeEach(closure: function (): void {
         $this->readServiceCategoryRepository = $this->createMock(ReadServiceCategoryRepositoryInterface::class),
         $this->readServiceGroupRepository = $this->createMock(ReadServiceGroupRepositoryInterface::class),
         $this->contact = $this->createMock(ContactInterface::class),
+        $this->adminResolver = $this->createMock(AdminResolver::class),
     );
 });
 
@@ -164,7 +166,7 @@ it('should raise an exception when the icon ID does not exist', function (): voi
 );
 
 it('should raise an exception when the host ID does not exist, as an administrator', function (): void {
-    $this->contact
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -181,7 +183,7 @@ it('should raise an exception when the host ID does not exist, as an administrat
 );
 
 it('should raise an exception when the host ID does not exist, as a non-administrator', function (): void {
-    $this->contact
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);
@@ -198,7 +200,7 @@ it('should raise an exception when the host ID does not exist, as a non-administ
 );
 
 it('should raise an exception when the service category IDs do not exist, as an administrator', function (): void {
-    $this->contact
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -215,7 +217,7 @@ it('should raise an exception when the service category IDs do not exist, as an 
 );
 
 it('should raise an exception when the service category IDs do not exist, as a non-administrator', function (): void {
-    $this->contact
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);
@@ -234,7 +236,7 @@ it('should raise an exception when the service category IDs do not exist, as a n
 it('should raise an exception when the service group IDs do not exist, as an administrator', function (): void {
     $serviceGroupIds = [1, 2, 3];
 
-    $this->contact
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(true);
@@ -253,7 +255,7 @@ it('should raise an exception when the service group IDs do not exist, as an adm
 it('should raise an exception when the service group IDs do not exist, as a non-administrator', function (): void {
     $serviceGroupIds = [1, 2, 3];
 
-    $this->contact
+    $this->adminResolver
         ->expects($this->once())
         ->method('isAdmin')
         ->willReturn(false);


### PR DESCRIPTION
## Summary

- Replace `$this->user->isAdmin()` with `$this->adminResolver->isAdmin($this->user)` in `AddServiceValidation` and `PartialUpdateServiceValidation` — fixes cloud admins (users with `customer_admin_acl` ACG) being treated as non-admin when adding/updating services
- Fix invalid `IN ()` SQL clause in `DbReadHostGroupRepository` when user has no host category ACLs — previously caused a database error

Fixes [MON-196990](https://centreon.atlassian.net/browse/MON-196990)

## Files changed

- `centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php`
- `centreon/src/Core/Service/Application/UseCase/AddService/AddServiceValidation.php`
- `centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php`

## Test plan

- [ ] Verify a cloud admin (`customer_admin_acl` ACG) can add a service via API v2
- [ ] Verify a cloud admin can partially update a service via API v2
- [ ] Verify host group search does not fail for a user with no host category ACLs

[MON-196990]: https://centreon.atlassian.net/browse/MON-196990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced Contact isAdmin checks with AdminResolver for service validations
* Fixed invalid SQL IN() clause in host group repository
* Applied same empty-ACL IN() protection to service group repository

**🔧 Refactors**
* Updated unit tests to inject AdminResolver mocks and assertions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98230410?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->