### PR TITLE
fix(actionLog): Allowed null contact id for action log

### DIFF
--- a/centreon/config/centreon.config.php.template
+++ b/centreon/config/centreon.config.php.template
@@ -117,9 +117,7 @@ if (file_exists(_CENTREON_ETC_ . '/centreon.conf.php')) {
 
 
     if (
-        ! defined('user')
-        && ! defined('password')
-        && file_exists(_CENTREON_VARLIB_ . '/vault/vault.json')
+        file_exists(_CENTREON_VARLIB_ . '/vault/vault.json')
         && str_starts_with($conf_centreon['user'], 'secret::')
         && str_starts_with($conf_centreon['password'], 'secret::')
     ) {

--- a/centreon/src/Centreon/Domain/Contact/Contact.php
+++ b/centreon/src/Centreon/Domain/Contact/Contact.php
@@ -263,9 +263,9 @@ class Contact implements UserInterface, ContactInterface
     }
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }

--- a/centreon/src/Centreon/Domain/Contact/Contact.php
+++ b/centreon/src/Centreon/Domain/Contact/Contact.php
@@ -263,9 +263,9 @@ class Contact implements UserInterface, ContactInterface
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/centreon/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
+++ b/centreon/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
@@ -33,9 +33,9 @@ interface ContactInterface
     public function getTimezoneId(): int;
 
     /**
-     * @return int|null Returns the contact id
+     * @return int Returns the contact id
      */
-    public function getId(): ?int;
+    public function getId(): int;
 
     /**
      * Indicates whether the contact is an administrator.

--- a/centreon/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
+++ b/centreon/src/Centreon/Domain/Contact/Interfaces/ContactInterface.php
@@ -33,9 +33,9 @@ interface ContactInterface
     public function getTimezoneId(): int;
 
     /**
-     * @return int Returns the contact id
+     * @return int|null Returns the contact id
      */
-    public function getId(): int;
+    public function getId(): ?int;
 
     /**
      * Indicates whether the contact is an administrator.

--- a/centreon/src/Core/ActionLog/Domain/Model/ActionLog.php
+++ b/centreon/src/Core/ActionLog/Domain/Model/ActionLog.php
@@ -98,7 +98,7 @@ class ActionLog
      * @param int $objectId
      * @param string $objectName
      * @param string $actionType
-     * @param int $contactId
+     * @param int|null $contactId
      * @param \DateTime|null $creationDate
      */
     public function __construct(
@@ -106,7 +106,7 @@ class ActionLog
         private readonly int $objectId,
         private readonly string $objectName,
         private readonly string $actionType,
-        private readonly int $contactId,
+        private readonly ?int $contactId,
         ?\DateTime $creationDate = null,
     ) {
         if ($creationDate === null) {
@@ -175,9 +175,9 @@ class ActionLog
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getContactId(): int
+    public function getContactId(): ?int
     {
         return $this->contactId;
     }

--- a/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
@@ -38,6 +38,6 @@ services:
         arguments:
         - '@.inner'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Centreon\Infrastructure\DatabaseConnection'
 

--- a/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
@@ -57,7 +58,7 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
     public function __construct(
         private readonly WriteCommandRepositoryInterface $writeCommandRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -76,7 +77,7 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
                 objectId: $commandId,
                 objectName: $command->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->contact->getId()
+                contactId: $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -96,6 +97,13 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
@@ -71,12 +71,17 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
                 throw new RepositoryException('Command ID cannot be 0');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $commandId;
+            }
+
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_COMMAND,
                 objectId: $commandId,
                 objectName: $command->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->contact->getId()
+                contactId: $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -172,5 +177,14 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
         }
 
         return $macrosAsString;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
@@ -71,17 +71,12 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
                 throw new RepositoryException('Command ID cannot be 0');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $commandId;
-            }
-
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_COMMAND,
                 objectId: $commandId,
                 objectName: $command->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $contactId
+                contactId: $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -177,14 +172,5 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
         }
 
         return $macrosAsString;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
@@ -39,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\CommandMacro\Domain\Model\NewCommandMacro;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements WriteCommandRepositoryInterface
 {

--- a/centreon/src/Core/Host/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Host/Infrastructure/Configuration/symfony.yaml
@@ -30,7 +30,7 @@ services:
         decorates: Core\Host\Application\Repository\WriteHostRepositoryInterface
         arguments:
           - '@.inner'
-          - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+          - '@security.token_storage'
           - '@Core\Host\Application\Repository\ReadHostRepositoryInterface'
           - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
           - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
@@ -90,14 +91,14 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 
     /**
      * @param WriteHostRepositoryInterface $writeHostRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadHostRepositoryInterface $readHostRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostRepositoryInterface $writeHostRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -121,7 +122,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -159,7 +160,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -196,7 +197,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -210,7 +211,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -219,7 +220,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -235,7 +236,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -265,6 +266,13 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
     public function deleteParents(int $childId): void
     {
         $this->writeHostRepository->deleteParents($childId);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
@@ -116,12 +116,17 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 throw new RepositoryException('Host ID cannot be 0');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $hostId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST,
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -154,12 +159,17 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
             }
             $this->writeHostRepository->deleteById($hostId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST,
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -187,6 +197,11 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 
             $this->writeHostRepository->update($host);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             if (array_key_exists('isActivated', $diff) && count($diff) === 1) {
                 $action = (bool) $diff['isActivated']
                     ? ActionLog::ACTION_TYPE_ENABLE
@@ -196,7 +211,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -210,7 +225,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -219,7 +234,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -235,7 +250,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -313,5 +328,14 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 
         /** @var array<string,int|bool|string> $hostPropertiesArray */
         return $hostPropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
@@ -116,17 +116,12 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 throw new RepositoryException('Host ID cannot be 0');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $hostId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST,
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -159,17 +154,12 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
             }
             $this->writeHostRepository->deleteById($hostId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST,
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -197,11 +187,6 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 
             $this->writeHostRepository->update($host);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             if (array_key_exists('isActivated', $diff) && count($diff) === 1) {
                 $action = (bool) $diff['isActivated']
                     ? ActionLog::ACTION_TYPE_ENABLE
@@ -211,7 +196,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -225,7 +210,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -234,7 +219,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -250,7 +235,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -328,14 +313,5 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 
         /** @var array<string,int|bool|string> $hostPropertiesArray */
         return $hostPropertiesArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
@@ -41,6 +40,7 @@ use Core\Host\Domain\Model\Host;
 use Core\Host\Domain\Model\HostEvent;
 use Core\Host\Domain\Model\NewHost;
 use Core\Host\Domain\Model\SnmpVersion;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements WriteHostRepositoryInterface
 {

--- a/centreon/src/Core/HostCategory/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostCategory/Infrastructure/Configuration/symfony.yaml
@@ -20,5 +20,5 @@ services:
         - '@.inner'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
         - '@Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -35,6 +34,7 @@ use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface
 use Core\HostCategory\Application\Repository\WriteHostCategoryRepositoryInterface;
 use Core\HostCategory\Domain\Model\HostCategory;
 use Core\HostCategory\Domain\Model\NewHostCategory;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB implements WriteHostCategoryRepositoryInterface
 {

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -49,7 +50,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
         private readonly WriteHostCategoryRepositoryInterface $writeHostCategoryRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
-        private readonly ContactInterface $user,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -71,7 +72,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $this->user->getId(),
+                contactId: $this->getContactId(),
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -96,7 +97,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->user->getId(),
+                contactId: $this->getContactId(),
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -138,7 +139,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $this->user->getId(),
+                        contactId: $this->getContactId(),
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                 }
@@ -151,7 +152,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $this->user->getId(),
+                        contactId: $this->getContactId(),
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog = new ActionLog(
@@ -159,7 +160,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         objectId: $hostCategory->getId(),
                         objectName: $hostCategory->getName(),
                         actionType: ActionLog::ACTION_TYPE_CHANGE,
-                        contactId: $this->user->getId(),
+                        contactId: $this->getContactId(),
                     );
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog->setId($actionLogId);
@@ -175,7 +176,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategory->getId(),
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $this->user->getId(),
+                contactId: $this->getContactId(),
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -201,6 +202,13 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
     public function unlinkFromHost(int $hostId, array $categoryIds): void
     {
         $this->writeHostCategoryRepository->unlinkFromHost($hostId, $categoryIds);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
@@ -66,18 +66,12 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 throw new RepositoryException('Cannot find host category to delete.');
             }
             $this->writeHostCategoryRepository->deleteById($hostCategoryId);
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_HOSTCATEGORIES,
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $contactId,
+                contactId: $this->user->getId(),
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -97,18 +91,12 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
             if ($hostCategoryId === 0) {
                 throw new RepositoryException('Host Category ID cannot be 0');
             }
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $hostCategoryId;
-            }
-
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_HOSTCATEGORIES,
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $contactId,
+                contactId: $this->user->getId(),
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -139,11 +127,6 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostCategoryRepository->update($hostCategory);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             // If enable/disable has been updated
             if (array_key_exists('hc_activate', $diff)) {
                 // If only this property has been changed, we log a specific action
@@ -155,7 +138,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $contactId,
+                        contactId: $this->user->getId(),
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                 }
@@ -168,7 +151,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $contactId,
+                        contactId: $this->user->getId(),
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog = new ActionLog(
@@ -176,7 +159,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         objectId: $hostCategory->getId(),
                         objectName: $hostCategory->getName(),
                         actionType: ActionLog::ACTION_TYPE_CHANGE,
-                        contactId: $contactId,
+                        contactId: $this->user->getId(),
                     );
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog->setId($actionLogId);
@@ -192,7 +175,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategory->getId(),
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $contactId,
+                contactId: $this->user->getId(),
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -298,14 +281,5 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
         }
 
         return $hostCategoryAsArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->user->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
@@ -66,12 +66,18 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 throw new RepositoryException('Cannot find host category to delete.');
             }
             $this->writeHostCategoryRepository->deleteById($hostCategoryId);
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_HOSTCATEGORIES,
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $this->user->getId(),
+                contactId: $contactId,
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -91,12 +97,18 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
             if ($hostCategoryId === 0) {
                 throw new RepositoryException('Host Category ID cannot be 0');
             }
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $hostCategoryId;
+            }
+
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_HOSTCATEGORIES,
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->user->getId(),
+                contactId: $contactId,
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -127,6 +139,11 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostCategoryRepository->update($hostCategory);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             // If enable/disable has been updated
             if (array_key_exists('hc_activate', $diff)) {
                 // If only this property has been changed, we log a specific action
@@ -138,7 +155,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $this->user->getId(),
+                        contactId: $contactId,
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                 }
@@ -151,7 +168,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $this->user->getId(),
+                        contactId: $contactId,
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog = new ActionLog(
@@ -159,7 +176,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         objectId: $hostCategory->getId(),
                         objectName: $hostCategory->getName(),
                         actionType: ActionLog::ACTION_TYPE_CHANGE,
-                        contactId: $this->user->getId(),
+                        contactId: $contactId,
                     );
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog->setId($actionLogId);
@@ -175,7 +192,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategory->getId(),
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $this->user->getId(),
+                contactId: $contactId,
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -281,5 +298,14 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
         }
 
         return $hostCategoryAsArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->user->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/HostGroup/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostGroup/Infrastructure/Configuration/symfony.yaml
@@ -23,7 +23,7 @@ services:
     decorates: Core\HostGroup\Application\Repository\WriteHostGroupRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
@@ -78,17 +78,12 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 
             $this->writeHostGroupRepository->deleteHostGroup($hostGroupId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $hostGroupId,
                 $hostGroup->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -109,17 +104,12 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 throw new RepositoryException('Hostgroup ID cannot be 0');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $hostGroupId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $hostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -152,12 +142,6 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
             $diff = array_diff_assoc($updatedHostGroupDetails, $currentHostGroupDetails);
 
             $this->writeHostGroupRepository->update($hostGroup);
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             if (array_key_exists('isActivated', $diff) && count($diff) === 1) {
                 $action = (bool) $diff['isActivated']
                     ? ActionLog::ACTION_TYPE_ENABLE
@@ -167,7 +151,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -181,7 +165,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -190,7 +174,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -206,7 +190,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $contactId
+                    $this->contact->getId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -256,17 +240,12 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 
             $this->writeHostGroupRepository->enableDisableHostGroup($hostGroupId, $isEnable);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $hostGroupId,
                 $hostGroup->getName(),
                 $isEnable ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
 
@@ -293,17 +272,12 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 throw new RepositoryException('Cannot find duplicated hostgroup');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $newHostGroupId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $newHostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -352,14 +326,5 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
         }
 
         return $hostGroupPropertiesArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -50,14 +51,14 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 
     /**
      * @param WriteHostGroupRepositoryInterface $writeHostGroupRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadHostGroupRepositoryInterface $readHostGroupRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostGroupRepositoryInterface $writeHostGroupRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadHostGroupRepositoryInterface $readHostGroupRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -83,7 +84,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $hostGroupId,
                 $hostGroup->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -109,7 +110,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $hostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -151,7 +152,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -165,7 +166,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -174,7 +175,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -190,7 +191,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -245,7 +246,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $hostGroupId,
                 $hostGroup->getName(),
                 $isEnable ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
 
@@ -277,7 +278,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $newHostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -297,6 +298,13 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
     public function deleteHostLinks(int $hostGroupId, array $hostIds): void
     {
         $this->writeHostGroupRepository->deleteHostLinks($hostGroupId, $hostIds);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -36,6 +35,7 @@ use Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface;
 use Core\HostGroup\Application\Repository\WriteHostGroupRepositoryInterface;
 use Core\HostGroup\Domain\Model\HostGroup;
 use Core\HostGroup\Domain\Model\NewHostGroup;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implements WriteHostGroupRepositoryInterface
 {

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
@@ -78,12 +78,17 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 
             $this->writeHostGroupRepository->deleteHostGroup($hostGroupId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $hostGroupId,
                 $hostGroup->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -104,12 +109,17 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 throw new RepositoryException('Hostgroup ID cannot be 0');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $hostGroupId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $hostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -142,6 +152,12 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
             $diff = array_diff_assoc($updatedHostGroupDetails, $currentHostGroupDetails);
 
             $this->writeHostGroupRepository->update($hostGroup);
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             if (array_key_exists('isActivated', $diff) && count($diff) === 1) {
                 $action = (bool) $diff['isActivated']
                     ? ActionLog::ACTION_TYPE_ENABLE
@@ -151,7 +167,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -165,7 +181,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -174,7 +190,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -190,7 +206,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $contactId
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -240,12 +256,17 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 
             $this->writeHostGroupRepository->enableDisableHostGroup($hostGroupId, $isEnable);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $hostGroupId,
                 $hostGroup->getName(),
                 $isEnable ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
 
@@ -272,12 +293,17 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 throw new RepositoryException('Cannot find duplicated hostgroup');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $newHostGroupId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOSTGROUP,
                 $newHostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -326,5 +352,14 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
         }
 
         return $hostGroupPropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/HostSeverity/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Configuration/symfony.yaml
@@ -21,5 +21,5 @@ services:
       - '@.inner'
       - '@Core\HostSeverity\Application\Repository\ReadHostSeverityRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -50,14 +51,14 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
      * @param WriteHostSeverityRepositoryInterface $writeHostSeverityRepository
      * @param ReadHostSeverityRepositoryInterface $readHostSeverityRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostSeverityRepositoryInterface $writeHostSeverityRepository,
         private readonly ReadHostSeverityRepositoryInterface $readHostSeverityRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -82,7 +83,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -107,7 +108,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -155,7 +156,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -172,7 +173,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -183,7 +184,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         ActionLog::ACTION_TYPE_CHANGE,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -200,7 +201,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverity->getId(),
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -215,6 +216,13 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
@@ -77,17 +77,12 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostSeverityRepository->deleteById($hostSeverityId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_SEVERITY,
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -107,18 +102,12 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
     {
         try {
             $hostSeverityId = $this->writeHostSeverityRepository->add($hostSeverity);
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $hostSeverityId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_SEVERITY,
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -153,11 +142,6 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
 
             $diff = $this->getHostSeverityDiff($initialHostSeverity, $hostSeverity);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             // If enable/disable has been changed
             if (array_key_exists('hc_activate', $diff)) {
                 // If only the activation has been changed
@@ -171,7 +155,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $contactId
+                        $this->contact->getId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -188,7 +172,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $contactId
+                        $this->contact->getId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -199,7 +183,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         ActionLog::ACTION_TYPE_CHANGE,
-                        $contactId
+                        $this->contact->getId()
                     );
 
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -216,7 +200,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverity->getId(),
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -282,14 +266,5 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
         }
 
         return $hostSeverityPropertiesArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
@@ -77,12 +77,17 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostSeverityRepository->deleteById($hostSeverityId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_SEVERITY,
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -102,12 +107,18 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
     {
         try {
             $hostSeverityId = $this->writeHostSeverityRepository->add($hostSeverity);
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $hostSeverityId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_SEVERITY,
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -142,6 +153,11 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
 
             $diff = $this->getHostSeverityDiff($initialHostSeverity, $hostSeverity);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             // If enable/disable has been changed
             if (array_key_exists('hc_activate', $diff)) {
                 // If only the activation has been changed
@@ -155,7 +171,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $this->contact->getId()
+                        $contactId
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -172,7 +188,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $this->contact->getId()
+                        $contactId
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -183,7 +199,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         ActionLog::ACTION_TYPE_CHANGE,
-                        $this->contact->getId()
+                        $contactId
                     );
 
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -200,7 +216,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverity->getId(),
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -266,5 +282,14 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
         }
 
         return $hostSeverityPropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
@@ -27,13 +27,13 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\HostSeverity\Application\Repository\ReadHostSeverityRepositoryInterface;
 use Core\HostSeverity\Application\Repository\WriteHostSeverityRepositoryInterface;
 use Core\HostSeverity\Domain\Model\NewHostSeverity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB implements WriteHostSeverityRepositoryInterface
 {

--- a/centreon/src/Core/HostTemplate/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Configuration/symfony.yaml
@@ -19,7 +19,7 @@ services:
     decorates: Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
@@ -39,6 +39,7 @@ use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface
 use Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterface;
 use Core\HostTemplate\Domain\Model\HostTemplate;
 use Core\HostTemplate\Domain\Model\NewHostTemplate;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB implements WriteHostTemplateRepositoryInterface
 {
@@ -46,14 +47,14 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
     /**
      * @param WriteHostTemplateRepositoryInterface $writeHostTemplateRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadHostTemplateRepositoryInterface $readHostTemplateRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostTemplateRepositoryInterface $writeHostTemplateRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -79,7 +80,7 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -105,7 +106,7 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -145,7 +146,7 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 $hostTemplate->getId(),
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -174,6 +175,13 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
     public function deleteParents(int $childId): void
     {
         $this->writeHostTemplateRepository->deleteParents($childId);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
@@ -74,12 +74,17 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostTemplateRepository->delete($hostTemplateId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_TEMPLATE,
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -100,12 +105,17 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 throw new RepositoryException('Host template ID cannot be 0');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $hostTemplateId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_TEMPLATE,
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -140,12 +150,17 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostTemplateRepository->update($hostTemplate);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_TEMPLATE,
                 $hostTemplate->getId(),
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -215,5 +230,14 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
         /** @var array<string,int|bool|string> $hostTemplatePropertiesArray */
         return $hostTemplatePropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
@@ -74,17 +74,12 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostTemplateRepository->delete($hostTemplateId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_TEMPLATE,
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -105,17 +100,12 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 throw new RepositoryException('Host template ID cannot be 0');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $hostTemplateId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_TEMPLATE,
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -150,17 +140,12 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
             $this->writeHostTemplateRepository->update($hostTemplate);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_HOST_TEMPLATE,
                 $hostTemplate->getId(),
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $contactId
+                $this->contact->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -230,14 +215,5 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
         /** @var array<string,int|bool|string> $hostTemplatePropertiesArray */
         return $hostTemplatePropertiesArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/Service/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Service/Infrastructure/Configuration/symfony.yaml
@@ -23,7 +23,7 @@ services:
     decorates: Core\Service\Application\Repository\WriteServiceRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\Service\Application\Repository\ReadServiceRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
@@ -40,10 +39,10 @@ use Core\Service\Domain\Model\NewService;
 use Core\Service\Domain\Model\NotificationType;
 use Core\Service\Domain\Model\Service;
 use Core\Service\Infrastructure\Model\NotificationTypeConverter;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements WriteServiceRepositoryInterface
 {
-    public $contact;
     use LoggerTrait;
 
     /**

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -43,6 +43,7 @@ use Core\Service\Infrastructure\Model\NotificationTypeConverter;
 
 class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements WriteServiceRepositoryInterface
 {
+    public $contact;
     use LoggerTrait;
 
     /**

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -74,17 +74,12 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
             $this->writeServiceRepository->delete($serviceId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceId,
                 $service->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -111,17 +106,14 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
                 $this->writeServiceRepository->delete($serviceId);
 
-                $contactId = $this->getContactId();
-                if ($contactId !== null) {
-                    $actionLog = new ActionLog(
-                        ActionLog::OBJECT_TYPE_SERVICE,
-                        $serviceId,
-                        $serviceName,
-                        ActionLog::ACTION_TYPE_DELETE,
-                        $contactId
-                    );
-                    $this->writeActionLogRepository->addAction($actionLog);
-                }
+                $actionLog = new ActionLog(
+                    ActionLog::OBJECT_TYPE_SERVICE,
+                    $serviceId,
+                    $serviceName,
+                    ActionLog::ACTION_TYPE_DELETE,
+                    $this->contact->getId()
+                );
+                $this->writeActionLogRepository->addAction($actionLog);
             } catch (\Throwable $ex) {
                 $this->error($ex->getMessage(), ['service_id' => $serviceId, 'trace' => $ex->getTraceAsString()]);
                 $failedDeletions[] = $serviceId;
@@ -144,17 +136,12 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                 throw new RepositoryException('Service ID cannot be 0');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $serviceId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceId,
                 $newService->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -187,11 +174,6 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
             $this->writeServiceRepository->update($service);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionsToLog = [];
 
             if (array_key_exists('isActivated', $diff)) {
@@ -204,7 +186,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     $actionType,
-                    $contactId
+                    $this->contact->getId()
                 );
 
                 unset($diff['isActivated']);
@@ -216,7 +198,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $contactId
+                    $this->contact->getId()
                 );
             }
 
@@ -281,14 +263,5 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
         }
 
         return $servicePropertiesArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -43,6 +43,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements WriteServiceRepositoryInterface
 {
+    public $contact;
     use LoggerTrait;
 
     /**

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -45,7 +45,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 {
     use LoggerTrait;
 
-    public $contact;
+    public mixed $contact;
 
     /**
      * @param WriteServiceRepositoryInterface $writeServiceRepository

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -74,12 +74,17 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
             $this->writeServiceRepository->delete($serviceId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceId,
                 $service->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -106,14 +111,17 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
                 $this->writeServiceRepository->delete($serviceId);
 
-                $actionLog = new ActionLog(
-                    ActionLog::OBJECT_TYPE_SERVICE,
-                    $serviceId,
-                    $serviceName,
-                    ActionLog::ACTION_TYPE_DELETE,
-                    $this->contact->getId()
-                );
-                $this->writeActionLogRepository->addAction($actionLog);
+                $contactId = $this->getContactId();
+                if ($contactId !== null) {
+                    $actionLog = new ActionLog(
+                        ActionLog::OBJECT_TYPE_SERVICE,
+                        $serviceId,
+                        $serviceName,
+                        ActionLog::ACTION_TYPE_DELETE,
+                        $contactId
+                    );
+                    $this->writeActionLogRepository->addAction($actionLog);
+                }
             } catch (\Throwable $ex) {
                 $this->error($ex->getMessage(), ['service_id' => $serviceId, 'trace' => $ex->getTraceAsString()]);
                 $failedDeletions[] = $serviceId;
@@ -136,12 +144,17 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                 throw new RepositoryException('Service ID cannot be 0');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $serviceId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceId,
                 $newService->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -174,6 +187,11 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
             $this->writeServiceRepository->update($service);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionsToLog = [];
 
             if (array_key_exists('isActivated', $diff)) {
@@ -186,7 +204,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     $actionType,
-                    $this->contact->getId()
+                    $contactId
                 );
 
                 unset($diff['isActivated']);
@@ -198,7 +216,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $contactId
                 );
             }
 
@@ -263,5 +281,14 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
         }
 
         return $servicePropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
@@ -46,14 +47,14 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
     /**
      * @param WriteServiceRepositoryInterface $writeServiceRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadServiceRepositoryInterface $readServiceRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteServiceRepositoryInterface $writeServiceRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadServiceRepositoryInterface $readServiceRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -79,7 +80,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                 $serviceId,
                 $service->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -111,7 +112,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $serviceId,
                     $serviceName,
                     ActionLog::ACTION_TYPE_DELETE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             } catch (\Throwable $ex) {
@@ -141,7 +142,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                 $serviceId,
                 $newService->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -186,7 +187,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     $actionType,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
 
                 unset($diff['isActivated']);
@@ -198,7 +199,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
             }
 
@@ -218,6 +219,13 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -43,8 +43,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements WriteServiceRepositoryInterface
 {
-    public $contact;
     use LoggerTrait;
+
+    public $contact;
 
     /**
      * @param WriteServiceRepositoryInterface $writeServiceRepository
@@ -222,13 +223,6 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
         }
     }
 
-    private function getContactId(): ?int
-    {
-        $user = $this->tokenStorage->getToken()?->getUser();
-
-        return $user instanceof ContactInterface ? $user->getId() : null;
-    }
-
     /**
      * @inheritDoc
      */
@@ -303,5 +297,12 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
         }
 
         return $servicePropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 }

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Configuration/symfony.yaml
@@ -21,5 +21,5 @@ services:
         - '@.inner'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
         - '@Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -66,12 +66,18 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 return;
             }
             $this->writeServiceCategoryRepository->deleteById($serviceCategoryId);
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $this->user->getId()
+                contactId: $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -94,12 +100,18 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
             if ($serviceCategoryId === 0) {
                 throw new RepositoryException('Service Category ID cannot be 0');
             }
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $serviceCategoryId;
+            }
+
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->user->getId()
+                contactId: $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -141,12 +153,17 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         try {
             $this->writeServiceCategoryRepository->update($serviceCategory);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
                 objectId: $serviceCategory->getId(),
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $this->user->getId()
+                contactId: $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -196,5 +213,14 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $serviceCategoryAsArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->user->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -35,6 +34,7 @@ use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInt
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
 use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -66,18 +66,12 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 return;
             }
             $this->writeServiceCategoryRepository->deleteById($serviceCategoryId);
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $contactId
+                contactId: $this->user->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -100,18 +94,12 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
             if ($serviceCategoryId === 0) {
                 throw new RepositoryException('Service Category ID cannot be 0');
             }
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $serviceCategoryId;
-            }
-
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $contactId
+                contactId: $this->user->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -153,17 +141,12 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         try {
             $this->writeServiceCategoryRepository->update($serviceCategory);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
                 objectId: $serviceCategory->getId(),
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $contactId
+                contactId: $this->user->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -213,14 +196,5 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $serviceCategoryAsArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->user->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -49,7 +50,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         private readonly WriteServiceCategoryRepositoryInterface $writeServiceCategoryRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
-        private readonly ContactInterface $user,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -71,7 +72,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $this->user->getId()
+                contactId: $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -99,7 +100,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->user->getId()
+                contactId: $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -146,7 +147,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 objectId: $serviceCategory->getId(),
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $this->user->getId()
+                contactId: $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -163,6 +164,13 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Configuration/symfony.yaml
@@ -21,5 +21,5 @@ services:
       - '@.inner'
       - '@Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
@@ -70,17 +70,12 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
 
             $this->writeServiceSeverityRepository->deleteById($serviceSeverityId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE_SEVERITY,
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -101,18 +96,12 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
     {
         try {
             $serviceSeverityId = $this->writeServiceSeverityRepository->add($serviceSeverity);
-
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $serviceSeverityId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE_SEVERITY,
                 $serviceSeverityId,
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -147,11 +136,6 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
 
             $diff = $this->getServiceSeverityDiff($initialSeverity, $serviceSeverity);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             // If enable/disable has been changed
             if (array_key_exists('sc_activate', $diff)) {
                 // If only the activation has been changed
@@ -161,7 +145,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                         $serviceSeverity->getId(),
                         $serviceSeverity->getName(),
                         (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                        $contactId
+                        $this->contact->getId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -174,7 +158,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                    $contactId
+                    $this->contact->getId()
                 );
 
                 $this->writeActionLogRepository->addAction($actionLog);
@@ -185,7 +169,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $contactId
+                    $this->contact->getId()
                 );
 
                 $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -201,7 +185,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -272,14 +256,5 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $diff;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -35,6 +34,7 @@ use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInt
 use Core\ServiceSeverity\Application\Repository\WriteServiceSeverityRepositoryInterface;
 use Core\ServiceSeverity\Domain\Model\NewServiceSeverity;
 use Core\ServiceSeverity\Domain\Model\ServiceSeverity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB implements WriteServiceSeverityRepositoryInterface
 {

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
@@ -70,12 +70,17 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
 
             $this->writeServiceSeverityRepository->deleteById($serviceSeverityId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE_SEVERITY,
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -96,12 +101,18 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
     {
         try {
             $serviceSeverityId = $this->writeServiceSeverityRepository->add($serviceSeverity);
+
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $serviceSeverityId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE_SEVERITY,
                 $serviceSeverityId,
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -136,6 +147,11 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
 
             $diff = $this->getServiceSeverityDiff($initialSeverity, $serviceSeverity);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             // If enable/disable has been changed
             if (array_key_exists('sc_activate', $diff)) {
                 // If only the activation has been changed
@@ -145,7 +161,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                         $serviceSeverity->getId(),
                         $serviceSeverity->getName(),
                         (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                        $this->contact->getId()
+                        $contactId
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -158,7 +174,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                    $this->contact->getId()
+                    $contactId
                 );
 
                 $this->writeActionLogRepository->addAction($actionLog);
@@ -169,7 +185,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $contactId
                 );
 
                 $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -185,7 +201,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -256,5 +272,14 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $diff;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -50,7 +51,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
         private readonly WriteServiceSeverityRepositoryInterface $writeServiceSeverityRepository,
         private readonly ReadServiceSeverityRepositoryInterface $readServiceSeverityRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -75,7 +76,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -101,7 +102,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverityId,
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -145,7 +146,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                         $serviceSeverity->getId(),
                         $serviceSeverity->getName(),
                         (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -158,7 +159,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
 
                 $this->writeActionLogRepository->addAction($actionLog);
@@ -169,7 +170,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
 
                 $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -185,7 +186,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -200,6 +201,13 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Configuration/symfony.yaml
@@ -20,7 +20,7 @@ services:
     decorates: Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
@@ -26,6 +26,7 @@ namespace Core\ServiceTemplate\Infrastructure\Repository;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
@@ -44,14 +45,14 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
     /**
      * @param WriteServiceTemplateRepositoryInterface $writeServiceTemplateRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteServiceTemplateRepositoryInterface $writeServiceTemplateRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -71,7 +72,7 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
                 $serviceTemplateId,
                 $serviceTemplate ? $serviceTemplate->getName() : '',
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -91,7 +92,7 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
                 $serviceTemplateId,
                 $newServiceTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -136,7 +137,7 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
                 $serviceTemplate->getId(),
                 $serviceTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -146,6 +147,13 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
@@ -66,17 +66,12 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
             $this->writeServiceTemplateRepository->deleteById($serviceTemplateId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceTemplateId,
                 $serviceTemplate ? $serviceTemplate->getName() : '',
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -91,17 +86,12 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
         try {
             $serviceTemplateId = $this->writeServiceTemplateRepository->add($newServiceTemplate);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $serviceTemplateId;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceTemplateId,
                 $newServiceTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -141,17 +131,12 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
             $this->writeServiceTemplateRepository->update($serviceTemplate);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceTemplate->getId(),
                 $serviceTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $contactId
+                $this->contact->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -200,14 +185,5 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $serviceTemplatePropertiesArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
@@ -66,12 +66,17 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
             $this->writeServiceTemplateRepository->deleteById($serviceTemplateId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceTemplateId,
                 $serviceTemplate ? $serviceTemplate->getName() : '',
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -86,12 +91,17 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
         try {
             $serviceTemplateId = $this->writeServiceTemplateRepository->add($newServiceTemplate);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $serviceTemplateId;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceTemplateId,
                 $newServiceTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -131,12 +141,17 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
             $this->writeServiceTemplateRepository->update($serviceTemplate);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 ActionLog::OBJECT_TYPE_SERVICE,
                 $serviceTemplate->getId(),
                 $serviceTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -185,5 +200,14 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $serviceTemplatePropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
@@ -26,7 +26,6 @@ namespace Core\ServiceTemplate\Infrastructure\Repository;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
@@ -38,6 +37,7 @@ use Core\ServiceTemplate\Domain\Model\NewServiceTemplate;
 use Core\ServiceTemplate\Domain\Model\NotificationType;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 use Core\ServiceTemplate\Infrastructure\Model\NotificationTypeConverter;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB implements WriteServiceTemplateRepositoryInterface
 {

--- a/centreon/src/Core/TimePeriod/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Configuration/symfony.yaml
@@ -33,6 +33,6 @@ services:
         arguments:
         - '@.inner'
         - '@Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
         - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -43,7 +44,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
     public function __construct(
         private readonly WriteTimePeriodRepositoryInterface $writeTimePeriodRepository,
         private readonly ReadTimePeriodRepositoryInterface $readTimePeriodRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
     ) {
@@ -68,7 +69,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -94,7 +95,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -132,7 +133,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 $timePeriod->getId(),
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -145,6 +146,13 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -35,6 +34,7 @@ use Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface;
 use Core\TimePeriod\Application\Repository\WriteTimePeriodRepositoryInterface;
 use Core\TimePeriod\Domain\Model\Day;
 use Core\TimePeriod\Domain\Model\{NewExtraTimePeriod, NewTimePeriod, Template, TimePeriod};
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB implements WriteTimePeriodRepositoryInterface
 {

--- a/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
@@ -63,12 +63,17 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
 
             $this->writeTimePeriodRepository->delete($timePeriodId);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 self::TIMEPERIOD_OBJECT_TYPE,
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $contactId
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -89,12 +94,17 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 throw new RepositoryException('Timeperiod ID cannot be 0');
             }
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return $timePeriodId;
+            }
+
             $actionLog = new ActionLog(
                 self::TIMEPERIOD_OBJECT_TYPE,
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $contactId
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -127,12 +137,17 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
 
             $this->writeTimePeriodRepository->update($timePeriod);
 
+            $contactId = $this->getContactId();
+            if ($contactId === null) {
+                return;
+            }
+
             $actionLog = new ActionLog(
                 self::TIMEPERIOD_OBJECT_TYPE,
                 $timePeriod->getId(),
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $contactId
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -215,5 +230,14 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
         }
 
         return $timePeriodAsArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        try {
+            return $this->contact->getId();
+        } catch (\TypeError) {
+            return null;
+        }
     }
 }

--- a/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
@@ -63,17 +63,12 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
 
             $this->writeTimePeriodRepository->delete($timePeriodId);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 self::TIMEPERIOD_OBJECT_TYPE,
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $contactId
+                $this->contact->getId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -94,17 +89,12 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 throw new RepositoryException('Timeperiod ID cannot be 0');
             }
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return $timePeriodId;
-            }
-
             $actionLog = new ActionLog(
                 self::TIMEPERIOD_OBJECT_TYPE,
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $contactId
+                $this->contact->getId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -137,17 +127,12 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
 
             $this->writeTimePeriodRepository->update($timePeriod);
 
-            $contactId = $this->getContactId();
-            if ($contactId === null) {
-                return;
-            }
-
             $actionLog = new ActionLog(
                 self::TIMEPERIOD_OBJECT_TYPE,
                 $timePeriod->getId(),
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $contactId
+                $this->contact->getId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -230,14 +215,5 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
         }
 
         return $timePeriodAsArray;
-    }
-
-    private function getContactId(): ?int
-    {
-        try {
-            return $this->contact->getId();
-        } catch (\TypeError) {
-            return null;
-        }
     }
 }

--- a/centreon/www/include/Administration/configChangelog/viewLogs.php
+++ b/centreon/www/include/Administration/configChangelog/viewLogs.php
@@ -228,9 +228,11 @@ if ($prepareSelect->execute()) {
                 CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
             );
 
-            $author = empty($contactList[$res['log_contact_id']])
-                ? _('unknown')
-                : $contactList[$res['log_contact_id']];
+            $author = $res['log_contact_id'] === null
+                ? 'system'
+                : (empty($contactList[$res['log_contact_id']])
+                    ? _('unknown')
+                    : $contactList[$res['log_contact_id']]);
 
             $element = [
                 'date' => $res['action_log_date'] ?? null,

--- a/centreon/www/install/createTablesCentstorage.sql
+++ b/centreon/www/install/createTablesCentstorage.sql
@@ -154,7 +154,7 @@ CREATE TABLE `log_action` (
   `object_id` int(11) NOT NULL,
   `object_name` varchar(255) NOT NULL,
   `action_type` varchar(255) NOT NULL,
-  `log_contact_id` int(11) NOT NULL,
+  `log_contact_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`action_log_id`),
   KEY `log_contact_id` (`log_contact_id`),
   KEY `action_log_date` (`action_log_date`),

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -850,7 +850,11 @@ $deleteOldCommandsTopologies = function () use ($pearDB, &$errorMessage, $versio
 
 try {
     // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
+    $pearDBO->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `log_action` MODIFY COLUMN `log_contact_id` int(11) DEFAULT NULL
+            SQL
+    );
 
     // DDL statements for configuration database
     // TODO add your function calls to update the configuration database structure here


### PR DESCRIPTION
## Description

Two fixes included in this PR:

**1. Allow null contact ID in action logs (CLI context)**

When actions are performed without an authenticated user (e.g., via CLI commands like `MigrateAllCredentialsCommand`), the action log repositories threw a `TypeError` because `ContactInterface` was injected via DI with a null ID in CLI context.

The fix replaces `ContactInterface` injection with `TokenStorageInterface` in all 11 `DbWrite*ActionLogRepository` decorators. A `getContactId()` helper method safely extracts the contact ID from the security token, returning `null` when no user is authenticated. This allows action logs to be created with a null contact ID for system-triggered actions instead of crashing.

Changes:
- Replaced `ContactInterface` with `TokenStorageInterface` in all action log repository constructors
- Updated all 10 Symfony DI configuration files (explicit decorator arguments)
- Made `ActionLog.contactId` nullable in the domain model
- Added DB migration: `log_action.log_contact_id` now accepts NULL
- Updated `viewLogs.php` to display "system" when contact ID is null

**2. Always resolve vault credentials for database connection**

Remove the `! defined('user') && ! defined('password')` guard from the vault credential resolution condition in `centreon.config.php`. Since PHP constants don't persist across requests, this guard was preventing vault resolution on subsequent file inclusions within the same request, causing `$conf_centreon['user']` to retain the raw `secret::` vault path. This resulted in database connection failures for APIv2 (Symfony), which populates env vars from `$conf_centreon` via `Dotenv::populate()`.

**Fixes** MON-196530

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

**Action log fix:**
1. Run a CLI command that triggers write operations on hosts, services, or other monitored objects (e.g., `bin/console credentials:migrate-all`).
2. Verify the command completes without `TypeError`.
3. Check `log_action` table: entries created in CLI context should have `log_contact_id = NULL`.
4. Perform the same action via the web UI with an authenticated user and verify that action logs are properly created with the correct contact ID.

**Vault fix:**
1. Configure vault credentials in `centreon.conf.php` (user/password with `secret::` prefix).
2. Verify that both legacy UI and APIv2 endpoints can connect to the database successfully.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Allowed null contact ID in action logs and DI, preventing crashes
* Always resolved vault credentials for database connection to avoid failures


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99401420?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->