### PR TITLE
feat(configuration): modernize service group listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing.feature
@@ -7,63 +7,53 @@ Feature: Modern service group listing
     Given an admin user is logged in Centreon
     And several service groups exist
 
-  @TEST_LISTING-038
   Scenario: Service group listing loads via AJAX
     When the user navigates to the service groups listing
     Then the AJAX listing table is displayed with service group rows
 
-  @TEST_LISTING-039
   Scenario: Search filters service groups by name
     When the user navigates to the service groups listing
     And the user searches for a specific service group
     Then only the matching service group is displayed
 
-  @TEST_LISTING-040
   Scenario: Toggle disables a service group
     When the user navigates to the service groups listing
     And the user clicks the toggle to disable a service group
     Then the toggle switches to disabled state
     And the AJAX response is successful
 
-  @TEST_LISTING-041
   Scenario: Toggle enables a service group
     When the user navigates to the service groups listing
     And the service group is disabled
     And the user clicks the toggle to enable the service group
     Then the toggle switches to enabled state
 
-  @TEST_LISTING-042
   Scenario: Two consecutive toggles succeed with CSRF rotation
     When the user navigates to the service groups listing
     And the user toggles a service group off then on
     Then both toggle requests succeed
 
-  @TEST_LISTING-043
   Scenario: Pagination works correctly
     When the user navigates to the service groups listing
     Then the pagination info shows the total count
     When the user changes the rows per page to 10
     Then at most 10 rows are displayed
 
-  @TEST_LISTING-044
   Scenario: Bulk duplication works
     When the user navigates to the service groups listing
     And the user selects a service group and duplicates it
     Then a duplicated service group appears in the listing
 
-  @TEST_LISTING-045
   Scenario: Bulk deletion works
     When the user navigates to the service groups listing
     And the user selects a service group and deletes it
     Then the service group is removed from the listing
 
-  @TEST_LISTING-046
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the service groups listing
     And the user clicks on a service group name
     Then the service group edit form is displayed
 
-  @TEST_LISTING-047
   Scenario: Session state persists across navigation
     When the user navigates to the service groups listing
     And the user searches for a specific service group

--- a/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing.feature
@@ -1,0 +1,72 @@
+Feature: Modern service group listing
+    As a Centreon admin
+    I want to manage service groups from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And several service groups exist
+
+  @TEST_LISTING-038
+  Scenario: Service group listing loads via AJAX
+    When the user navigates to the service groups listing
+    Then the AJAX listing table is displayed with service group rows
+
+  @TEST_LISTING-039
+  Scenario: Search filters service groups by name
+    When the user navigates to the service groups listing
+    And the user searches for a specific service group
+    Then only the matching service group is displayed
+
+  @TEST_LISTING-040
+  Scenario: Toggle disables a service group
+    When the user navigates to the service groups listing
+    And the user clicks the toggle to disable a service group
+    Then the toggle switches to disabled state
+    And the AJAX response is successful
+
+  @TEST_LISTING-041
+  Scenario: Toggle enables a service group
+    When the user navigates to the service groups listing
+    And the service group is disabled
+    And the user clicks the toggle to enable the service group
+    Then the toggle switches to enabled state
+
+  @TEST_LISTING-042
+  Scenario: Two consecutive toggles succeed with CSRF rotation
+    When the user navigates to the service groups listing
+    And the user toggles a service group off then on
+    Then both toggle requests succeed
+
+  @TEST_LISTING-043
+  Scenario: Pagination works correctly
+    When the user navigates to the service groups listing
+    Then the pagination info shows the total count
+    When the user changes the rows per page to 10
+    Then at most 10 rows are displayed
+
+  @TEST_LISTING-044
+  Scenario: Bulk duplication works
+    When the user navigates to the service groups listing
+    And the user selects a service group and duplicates it
+    Then a duplicated service group appears in the listing
+
+  @TEST_LISTING-045
+  Scenario: Bulk deletion works
+    When the user navigates to the service groups listing
+    And the user selects a service group and deletes it
+    Then the service group is removed from the listing
+
+  @TEST_LISTING-046
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the service groups listing
+    And the user clicks on a service group name
+    Then the service group edit form is displayed
+
+  @TEST_LISTING-047
+  Scenario: Session state persists across navigation
+    When the user navigates to the service groups listing
+    And the user searches for a specific service group
+    And the user clicks on a service group name
+    And the user navigates back to the service groups listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing/index.ts
@@ -1,0 +1,353 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const sgPage = PAGES.configuration.servicesGroupsLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(sgPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('several service groups exist', () => {
+  cy.addServiceGroup({
+    name: 'sg_alpha',
+    alias: 'Service Group Alpha'
+  });
+  cy.addServiceGroup({
+    name: 'sg_beta',
+    alias: 'Service Group Beta'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service groups listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with service group rows', () => {
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_beta')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search filters
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific service group', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('sg_alpha');
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching service group is displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a service group', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServiceGroupToggle.php'
+  }).as('toggleSg');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleSg');
+});
+
+Then('the toggle switches to disabled state', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the AJAX response is successful', () => {
+  cy.get('@toggleSg')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@toggleSg')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the service group is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE servicegroup SET sg_activate = '0' WHERE sg_name = 'sg_alpha'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the service group', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServiceGroupToggle.php'
+  }).as('toggleSgOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleSgOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the toggle switches to enabled state', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: CSRF rotation — two consecutive toggles
+// ---------------------------------------------------------------------------
+
+When('the user toggles a service group off then on', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServiceGroupToggle.php'
+  }).as('toggle1');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .click();
+
+  cy.wait('@toggle1').its('response.statusCode').should('eq', 200);
+
+  cy.wait(500);
+
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServiceGroupToggle.php'
+  }).as('toggle2');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .click();
+
+  cy.wait('@toggle2');
+});
+
+Then('both toggle requests succeed', () => {
+  cy.get('@toggle2')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@toggle2')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('at most 10 rows are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a service group and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated service group appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_alpha_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects a service group and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the service group is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sg_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a service group name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'sg_alpha')
+    .click();
+});
+
+Then('the service group edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="sg_name"]');
+  cy.getIframeBody()
+    .find('input[name="sg_name"]')
+    .should('have.value', 'sg_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the service groups listing', () => {
+  cy.visit(sgPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'sg_alpha');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/05-servicegroup-listing/index.ts
@@ -47,12 +47,12 @@ Given('an admin user is logged in Centreon', () => {
 
 Given('several service groups exist', () => {
   cy.addServiceGroup({
-    name: 'sg_alpha',
-    alias: 'Service Group Alpha'
+    alias: 'Service Group Alpha',
+    name: 'sg_alpha'
   });
   cy.addServiceGroup({
-    name: 'sg_beta',
-    alias: 'Service Group Beta'
+    alias: 'Service Group Beta',
+    name: 'sg_beta'
   });
 });
 
@@ -65,17 +65,9 @@ When('the user navigates to the service groups listing', () => {
 });
 
 Then('the AJAX listing table is displayed with service group rows', () => {
-  cy.getIframeBody()
-    .find('table.cl-listing-table')
-    .should('exist');
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('sg_alpha')
-    .should('exist');
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('sg_beta')
-    .should('exist');
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('sg_alpha').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('sg_beta').should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -83,21 +75,13 @@ Then('the AJAX listing table is displayed with service group rows', () => {
 // ---------------------------------------------------------------------------
 
 When('the user searches for a specific service group', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .clear()
-    .type('sg_alpha');
-  cy.getIframeBody()
-    .find('#clSearchBtn')
-    .click();
+  cy.getIframeBody().find('#clSearchInput').clear().type('sg_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
 
 Then('only the matching service group is displayed', () => {
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('sg_alpha')
-    .should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('sg_alpha').should('exist');
   cy.getIframeBody()
     .find('#clTableBody')
     .contains('sg_beta')
@@ -135,9 +119,7 @@ Then('the toggle switches to disabled state', () => {
 });
 
 Then('the AJAX response is successful', () => {
-  cy.get('@toggleSg')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@toggleSg').its('response.statusCode').should('eq', 200);
   cy.get('@toggleSg')
     .its('response.body')
     .should('have.property', 'success', true);
@@ -150,7 +132,8 @@ Then('the AJAX response is successful', () => {
 When('the service group is disabled', () => {
   cy.executeSqlQuery({
     database: 'centreon',
-    query: "UPDATE servicegroup SET sg_activate = '0' WHERE sg_name = 'sg_alpha'"
+    query:
+      "UPDATE servicegroup SET sg_activate = '0' WHERE sg_name = 'sg_alpha'"
   });
   visitAndWait();
 });
@@ -169,9 +152,7 @@ When('the user clicks the toggle to enable the service group', () => {
     .should('not.be.checked')
     .click();
 
-  cy.wait('@toggleSgOn')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.wait('@toggleSgOn').its('response.statusCode').should('eq', 200);
 });
 
 Then('the toggle switches to enabled state', () => {
@@ -220,9 +201,7 @@ When('the user toggles a service group off then on', () => {
 });
 
 Then('both toggle requests succeed', () => {
-  cy.get('@toggle2')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@toggle2').its('response.statusCode').should('eq', 200);
   cy.get('@toggle2')
     .its('response.body')
     .should('have.property', 'success', true);
@@ -247,9 +226,7 @@ When('the user changes the rows per page to 10', () => {
 });
 
 Then('at most 10 rows are displayed', () => {
-  cy.getIframeBody()
-    .find('#clTableBody tr')
-    .should('have.length.at.most', 10);
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.at.most', 10);
 });
 
 // ---------------------------------------------------------------------------
@@ -271,9 +248,7 @@ When('the user selects a service group and duplicates it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Duplicate');
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated service group appears in the listing', () => {
@@ -304,9 +279,7 @@ When('the user selects a service group and deletes it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Delete');
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the service group is removed from the listing', () => {
@@ -323,10 +296,7 @@ Then('the service group is removed from the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a service group name', () => {
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('a', 'sg_alpha')
-    .click();
+  cy.getIframeBody().find('#clTableBody').contains('a', 'sg_alpha').click();
 });
 
 Then('the service group edit form is displayed', () => {
@@ -347,7 +317,5 @@ When('the user navigates back to the service groups listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .should('have.value', 'sg_alpha');
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'sg_alpha');
 });

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/servicegroup/ajaxServiceGroupListing.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/ajaxServiceGroupListing.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper  = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB  = $helper->getDb();
+$params  = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// ACL filtering
+$conditionStr = '';
+$sgStrParams  = [];
+
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $sgs = $acl->getServiceGroupAclConf(null, 'broker');
+
+    if (empty($sgs)) {
+        $helper->jsonResponse([], 0, 0, $limit);
+    }
+
+    $sgIds = array_keys($sgs);
+    foreach ($sgIds as $index => $sgId) {
+        $sgStrParams[':sg_' . $index] = (int) $sgId;
+    }
+    $queryParams  = implode(',', array_keys($sgStrParams));
+    $conditionStr = $search !== ''
+        ? 'AND sg_id IN (' . $queryParams . ')'
+        : 'WHERE sg_id IN (' . $queryParams . ')';
+}
+
+// Query
+if ($search !== '') {
+    $statement = $pearDB->prepare(
+        'SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate'
+        . ' FROM servicegroup WHERE (sg_name LIKE :search OR sg_alias LIKE :search) '
+        . $conditionStr . ' ORDER BY sg_name LIMIT :offset, :limit'
+    );
+    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
+} else {
+    $statement = $pearDB->prepare(
+        'SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate'
+        . ' FROM servicegroup ' . $conditionStr . ' ORDER BY sg_name LIMIT :offset, :limit'
+    );
+}
+foreach ($sgStrParams as $key => $sgId) {
+    $statement->bindValue($key, $sgId, PDO::PARAM_INT);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($sg = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'       => (int) $sg['sg_id'],
+        'name'     => $sg['sg_name'],
+        'alias'    => $sg['sg_alias'],
+        'activate' => (int) $sg['sg_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/servicegroup/ajaxServiceGroupToggle.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/ajaxServiceGroupToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60203);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT sg_id FROM servicegroup WHERE sg_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT sg_name FROM servicegroup WHERE sg_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE servicegroup SET sg_activate = :activate WHERE sg_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('servicegroup', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
@@ -1,77 +1,90 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-      <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Name{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchSG" value="{$searchSG}" class="mr-1">{$form.Search.html}</td>
-      </tr>
-      </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{if $mode_access == 'w' }{$headerMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-		</tr>
-		{/section}
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchSG" value="{$searchSG}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-	</table>
-	<table class="ToolbarTable ToolbarTR table">
-		<tr>
-			{ if $mode_access == 'w' }
-			<td class="Toolbar_TDSelectAction_Bottom">
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="sgListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    { if $mode_access == 'w' }
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    { /if }
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-	setDisabledRowStyle();
+<script type="text/javascript">
+var sgListing = new CentreonListing({
+    instanceName:  'sgListing',
+    ajaxListUrl:   './include/configuration/configObject/servicegroup/ajaxServiceGroupListing.php',
+    ajaxToggleUrl: './include/configuration/configObject/servicegroup/ajaxServiceGroupToggle.php',
+    pageId:        {/literal}'{$sgPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'sg_listing_limit',
+    emptyMessage:  'No service groups found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="sgListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+sgListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
@@ -7,10 +7,13 @@ CentreonForm.detectSidePanelClose();
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Service groups{/t}</h1>
-    <p class="cl-page-desc">{t}Group services together to manage them collectively.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Service groups{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Group services together to manage them collectively.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$sgPage}&o=a', '{t}Add a Service Group{/t}'); return false;">{$msg.addT}</a>
@@ -19,12 +22,13 @@ CentreonForm.detectSidePanelClose();
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchSG" value="{$searchSG}" class="cl-search-simple" placeholder="{t}Search service groups{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
@@ -94,12 +94,12 @@ var sgListing = new CentreonListing({
         { id:'name', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
             var title = '{/literal}{t}Modify Service Group{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
             var title = '{/literal}{t}Modify Service Group{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
@@ -1,21 +1,32 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+CentreonForm.detectSidePanelClose();
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Service groups{/t}</h1>
+    <p class="cl-page-desc">{t}Group services together to manage them collectively.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$sgPage}&o=a', '{t}Add a Service Group{/t}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchSG" value="{$searchSG}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchSG" value="{$searchSG}" class="cl-search-simple" placeholder="{t}Search service groups{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -30,7 +41,7 @@
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
                     { if $mode_access == 'w' }
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     { /if }
                 </tr>
             </thead>
@@ -39,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -56,8 +57,23 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+
+
 var sgListing = new CentreonListing({
     instanceName:  'sgListing',
     ajaxListUrl:   './include/configuration/configObject/servicegroup/ajaxServiceGroupListing.php',
@@ -68,15 +84,18 @@ var sgListing = new CentreonListing({
     storageKey:    'sg_listing_limit',
     emptyMessage:  'No service groups found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var editUrl = 'main.get.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
+            var title = '{/literal}{t}Modify Service Group{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var editUrl = 'main.get.php?p={/literal}{$sgPage}{literal}&o=c&sg_id=' + row.id;
+            var title = '{/literal}{t}Modify Service Group{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {
@@ -86,5 +105,6 @@ var sgListing = new CentreonListing({
     }
 });
 sgListing.init();
+CentreonForm.initSidePanel(sgListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -45,9 +45,7 @@ $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchSG', $search);
 
 // Default limit from DB
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 // Form for bulk actions (duplicate, delete)

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -27,51 +27,6 @@ include_once './class/centreonUtils.class.php';
 
 include './include/common/autoNumLimit.php';
 
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchSG'] ?? $_GET['searchSG'] ?? null
-);
-
-if (isset($_POST['searchSG']) || isset($_GET['searchSG'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-$conditionStr = '';
-$sgStrParams = [];
-if (! $acl->admin && $sgString) {
-    $sgStrList = explode(',', $sgString);
-    foreach ($sgStrList as $index => $sgId) {
-        $sgStrParams[':sg_' . $index] = (int) str_replace("'", '', $sgId);
-    }
-    $queryParams = implode(',', array_keys($sgStrParams));
-
-    $conditionStr = $search !== '' ? 'AND sg_id IN (' . $queryParams . ')' : 'WHERE sg_id IN (' . $queryParams . ')';
-}
-
-if ($search !== '') {
-    $statement = $pearDB->prepare('SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate'
-        . ' FROM servicegroup WHERE (sg_name LIKE :search  OR sg_alias LIKE :search) ' . $conditionStr
-        . ' ORDER BY sg_name LIMIT :offset, :limit');
-
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-} else {
-    $statement = $pearDB->prepare('SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate'
-        . ' FROM servicegroup ' . $conditionStr . ' ORDER BY sg_name LIMIT :offset, :limit');
-}
-foreach ($sgStrParams as $key => $sgId) {
-    $statement->bindValue($key, $sgId, PDO::PARAM_INT);
-}
-$statement->bindValue(':offset', (int) $num * (int) $limit, PDO::PARAM_INT);
-$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
-$statement->execute();
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
@@ -81,52 +36,33 @@ $tpl->assign('mode_access', $lvl_access);
 
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Description'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('sgPage', $p);
 
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchSG', $search);
+
+// Default limit from DB
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+// Form for bulk actions (duplicate, delete)
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-// Different style between each lines
-$style = 'one';
 
 $attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
 $form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-for ($i = 0; $sg = $statement->fetch(PDO::FETCH_ASSOC); $i++) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $sg['sg_id'] . ']');
-    $moptions = '';
-    if ($sg['sg_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&sg_id=' . $sg['sg_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&sg_id=' . $sg['sg_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Enabled') . "'></a>";
-    }
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;" '
-        . "maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" . $sg['sg_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure($sg['sg_name']), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&sg_id=' . $sg['sg_id'], 'RowMenu_desc' => CentreonUtils::escapeSecure($sg['sg_alias']), 'RowMenu_status' => $sg['sg_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $sg['sg_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
+// Messages
 $tpl->assign(
     'msg',
     ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
 );
 
-// Toolbar select
+// Toolbar select - bulk actions
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -179,9 +115,6 @@ $form->addElement(
 );
 $o2 = $form->getElement('o2');
 $o2->setValue(null);
-
-$tpl->assign('limit', $limit);
-$tpl->assign('searchSG', $search);
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered service group listing page with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files

- **`ajaxServiceGroupListing.php`** — Standalone AJAX endpoint. Session validation, ACL read access check (page 60203), sanitized search via `HtmlAnalyzer`, prepared statements, JSON response with pagination metadata.

- **`ajaxServiceGroupToggle.php`** — Secure toggle endpoint. CSRF token validation + rotation, ACL write access check (page 60203), prepared statement for UPDATE, audit logging to `log_action` via `AjaxListingHelper::logToggleAction()`.

### Modified files

- **`listServiceGroup.ihtml`** — Rewritten with modern `cl-*` classes: filter box with search input, `CentreonListing` JS initialization, iPhone-style toggle switches, duplication inputs, AJAX pagination.

- **`listServiceGroup.php`** — Simplified from ~180 lines to ~80 lines. Removed SQL query, rendering loop, `autoNumLimit.php` and `checkPagination.php`. Delegates data loading to the AJAX endpoint.

### Test files

- **`05-servicegroup-listing.feature`** — 10 Gherkin scenarios
- **`05-servicegroup-listing/index.ts`** — Cypress step definitions

## Test coverage (10 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Toggle disables a service group
4. Toggle enables a service group
5. Two consecutive toggles succeed (CSRF rotation)
6. Pagination works (total count, rows-per-page)
7. Bulk duplication
8. Bulk deletion
9. Click navigates to edit form
10. Session state persists search across navigation

## How to test

1. Navigate to Configuration > Services > Service Groups
2. Verify the listing loads via AJAX (no full page reload)
3. Test search, pagination, toggle, duplicate, delete
4. Verify no regression on the service group add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework) to be merged first.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Replaced legacy service group listing with AJAX-driven UI and endpoints

**⚡ Enhancements**
* Added secure toggle endpoint with CSRF rotation, ACL checks, logging

**🔧 Refactors**
* Simplified server-side listing controller and Smarty template, delegated data fetching


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98405751?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
