### PR TITLE
feat(configuration): modernize service categories listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing.feature
@@ -7,57 +7,48 @@ Feature: Modern service categories listing
     Given an admin user is logged in Centreon
     And several service categories exist
 
-  @TEST_LISTING-048
   Scenario: Service categories listing loads via AJAX
     When the user navigates to the service categories listing
     Then the AJAX listing table is displayed with service category rows
 
-  @TEST_LISTING-049
   Scenario: Search filters service categories by name
     When the user navigates to the service categories listing
     And the user searches for a specific service category
     Then only the matching service category is displayed
 
-  @TEST_LISTING-050
   Scenario: Toggle disables a service category
     When the user navigates to the service categories listing
     And the user clicks the toggle to disable a service category
     Then the toggle switches to disabled state
     And the AJAX toggle response is successful
 
-  @TEST_LISTING-051
   Scenario: Toggle enables a service category
     When the user navigates to the service categories listing
     And the service category is disabled
     And the user clicks the toggle to enable the service category
     Then the toggle switches to enabled state
 
-  @TEST_LISTING-052
   Scenario: Pagination and rows per page
     When the user navigates to the service categories listing
     Then the pagination info shows the total count
     When the user changes the rows per page to 10
     Then at most 10 rows are displayed
 
-  @TEST_LISTING-053
   Scenario: Bulk duplication works
     When the user navigates to the service categories listing
     And the user selects a service category and duplicates it
     Then a duplicated service category appears in the listing
 
-  @TEST_LISTING-054
   Scenario: Bulk deletion works
     When the user navigates to the service categories listing
     And the user selects a service category and deletes it
     Then the service category is removed from the listing
 
-  @TEST_LISTING-055
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the service categories listing
     And the user clicks on a service category name
     Then the service category edit form is displayed
 
-  @TEST_LISTING-056
   Scenario: Session state persists across navigation
     When the user navigates to the service categories listing
     And the user searches for a specific service category

--- a/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing.feature
@@ -1,0 +1,66 @@
+Feature: Modern service categories listing
+    As a Centreon admin
+    I want to manage service categories from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And several service categories exist
+
+  @TEST_LISTING-048
+  Scenario: Service categories listing loads via AJAX
+    When the user navigates to the service categories listing
+    Then the AJAX listing table is displayed with service category rows
+
+  @TEST_LISTING-049
+  Scenario: Search filters service categories by name
+    When the user navigates to the service categories listing
+    And the user searches for a specific service category
+    Then only the matching service category is displayed
+
+  @TEST_LISTING-050
+  Scenario: Toggle disables a service category
+    When the user navigates to the service categories listing
+    And the user clicks the toggle to disable a service category
+    Then the toggle switches to disabled state
+    And the AJAX toggle response is successful
+
+  @TEST_LISTING-051
+  Scenario: Toggle enables a service category
+    When the user navigates to the service categories listing
+    And the service category is disabled
+    And the user clicks the toggle to enable the service category
+    Then the toggle switches to enabled state
+
+  @TEST_LISTING-052
+  Scenario: Pagination and rows per page
+    When the user navigates to the service categories listing
+    Then the pagination info shows the total count
+    When the user changes the rows per page to 10
+    Then at most 10 rows are displayed
+
+  @TEST_LISTING-053
+  Scenario: Bulk duplication works
+    When the user navigates to the service categories listing
+    And the user selects a service category and duplicates it
+    Then a duplicated service category appears in the listing
+
+  @TEST_LISTING-054
+  Scenario: Bulk deletion works
+    When the user navigates to the service categories listing
+    And the user selects a service category and deletes it
+    Then the service category is removed from the listing
+
+  @TEST_LISTING-055
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the service categories listing
+    And the user clicks on a service category name
+    Then the service category edit form is displayed
+
+  @TEST_LISTING-056
+  Scenario: Session state persists across navigation
+    When the user navigates to the service categories listing
+    And the user searches for a specific service category
+    And the user clicks on a service category name
+    And the user navigates back to the service categories listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing/index.ts
@@ -1,0 +1,308 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const scPage = PAGES.configuration.servicesCategoriesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(scPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('several service categories exist', () => {
+  cy.addServiceCategory({
+    name: 'sc_alpha',
+    description: 'Service Category Alpha'
+  });
+  cy.addServiceCategory({
+    name: 'sc_beta',
+    description: 'Service Category Beta'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service categories listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with service category rows', () => {
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_beta')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search filters
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific service category', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('sc_alpha');
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching service category is displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a service category', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServiceCategoriesToggle.php'
+  }).as('toggleSc');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleSc');
+});
+
+Then('the toggle switches to disabled state', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the AJAX toggle response is successful', () => {
+  cy.get('@toggleSc')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@toggleSc')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the service category is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE service_categories SET sc_activate = '0' WHERE sc_name = 'sc_alpha'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the service category', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServiceCategoriesToggle.php'
+  }).as('toggleScOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleScOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the toggle switches to enabled state', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('at most 10 rows are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a service category and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated service category appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_alpha_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects a service category and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the service category is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('sc_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a service category name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'sc_alpha')
+    .click();
+});
+
+Then('the service category edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="sc_name"]');
+  cy.getIframeBody()
+    .find('input[name="sc_name"]')
+    .should('have.value', 'sc_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the service categories listing', () => {
+  cy.visit(scPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'sc_alpha');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/06-service-categories-listing/index.ts
@@ -47,12 +47,12 @@ Given('an admin user is logged in Centreon', () => {
 
 Given('several service categories exist', () => {
   cy.addServiceCategory({
-    name: 'sc_alpha',
-    description: 'Service Category Alpha'
+    description: 'Service Category Alpha',
+    name: 'sc_alpha'
   });
   cy.addServiceCategory({
-    name: 'sc_beta',
-    description: 'Service Category Beta'
+    description: 'Service Category Beta',
+    name: 'sc_beta'
   });
 });
 
@@ -65,17 +65,9 @@ When('the user navigates to the service categories listing', () => {
 });
 
 Then('the AJAX listing table is displayed with service category rows', () => {
-  cy.getIframeBody()
-    .find('table.cl-listing-table')
-    .should('exist');
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('sc_alpha')
-    .should('exist');
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('sc_beta')
-    .should('exist');
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('sc_alpha').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('sc_beta').should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -83,21 +75,13 @@ Then('the AJAX listing table is displayed with service category rows', () => {
 // ---------------------------------------------------------------------------
 
 When('the user searches for a specific service category', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .clear()
-    .type('sc_alpha');
-  cy.getIframeBody()
-    .find('#clSearchBtn')
-    .click();
+  cy.getIframeBody().find('#clSearchInput').clear().type('sc_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
 
 Then('only the matching service category is displayed', () => {
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('sc_alpha')
-    .should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('sc_alpha').should('exist');
   cy.getIframeBody()
     .find('#clTableBody')
     .contains('sc_beta')
@@ -135,9 +119,7 @@ Then('the toggle switches to disabled state', () => {
 });
 
 Then('the AJAX toggle response is successful', () => {
-  cy.get('@toggleSc')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@toggleSc').its('response.statusCode').should('eq', 200);
   cy.get('@toggleSc')
     .its('response.body')
     .should('have.property', 'success', true);
@@ -150,7 +132,8 @@ Then('the AJAX toggle response is successful', () => {
 When('the service category is disabled', () => {
   cy.executeSqlQuery({
     database: 'centreon',
-    query: "UPDATE service_categories SET sc_activate = '0' WHERE sc_name = 'sc_alpha'"
+    query:
+      "UPDATE service_categories SET sc_activate = '0' WHERE sc_name = 'sc_alpha'"
   });
   visitAndWait();
 });
@@ -169,9 +152,7 @@ When('the user clicks the toggle to enable the service category', () => {
     .should('not.be.checked')
     .click();
 
-  cy.wait('@toggleScOn')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.wait('@toggleScOn').its('response.statusCode').should('eq', 200);
 });
 
 Then('the toggle switches to enabled state', () => {
@@ -202,9 +183,7 @@ When('the user changes the rows per page to 10', () => {
 });
 
 Then('at most 10 rows are displayed', () => {
-  cy.getIframeBody()
-    .find('#clTableBody tr')
-    .should('have.length.at.most', 10);
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.at.most', 10);
 });
 
 // ---------------------------------------------------------------------------
@@ -226,9 +205,7 @@ When('the user selects a service category and duplicates it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Duplicate');
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated service category appears in the listing', () => {
@@ -259,9 +236,7 @@ When('the user selects a service category and deletes it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Delete');
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the service category is removed from the listing', () => {
@@ -278,10 +253,7 @@ Then('the service category is removed from the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a service category name', () => {
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('a', 'sc_alpha')
-    .click();
+  cy.getIframeBody().find('#clTableBody').contains('a', 'sc_alpha').click();
 });
 
 Then('the service category edit form is displayed', () => {
@@ -302,7 +274,5 @@ When('the user navigates back to the service categories listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .should('have.value', 'sc_alpha');
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'sc_alpha');
 });

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/service_categories/ajaxServiceCategoriesListing.php
+++ b/centreon/www/include/configuration/configObject/service_categories/ajaxServiceCategoriesListing.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $scString = $acl->getServiceCategoriesString();
+    if ($scString !== "''" && $scString !== '') {
+        $clause = $search !== '' ? ' AND ' : ' WHERE ';
+        $aclCond = $acl->queryBuilder($clause, 'sc_id', $scString);
+    } elseif (! $helper->isAdmin()) {
+        $helper->jsonResponse([], 0, 0, $limit);
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'WHERE (sc_name LIKE :search OR sc_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS sc.sc_id, sc.sc_name, sc.sc_description, sc.sc_activate, sc.level,'
+    . ' (SELECT COUNT(*) FROM service_categories_relation scr WHERE scr.sc_id = sc.sc_id) AS svc_count'
+    . ' FROM service_categories sc ' . $searchCond . $aclCond
+    . ' ORDER BY sc.sc_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($sc = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'          => (int) $sc['sc_id'],
+        'name'        => $sc['sc_name'],
+        'description' => $sc['sc_description'],
+        'activate'    => (int) $sc['sc_activate'],
+        'svc_count'   => (int) $sc['svc_count'],
+        'level'       => $sc['level'] ? (int) $sc['level'] : null,
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/service_categories/ajaxServiceCategoriesToggle.php
+++ b/centreon/www/include/configuration/configObject/service_categories/ajaxServiceCategoriesToggle.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$scId   = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $scId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+$helper->requireWriteAccess(60209);
+
+// Verify + get name for logging
+$checkStmt = $pearDB->prepare('SELECT sc_id, sc_name FROM service_categories WHERE sc_id = :id');
+$checkStmt->bindValue(':id', $scId, PDO::PARAM_INT);
+$checkStmt->execute();
+$row = $checkStmt->fetch(PDO::FETCH_ASSOC);
+if (! $row) {
+    AjaxListingHelper::jsonError('Service category not found', 404);
+}
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE service_categories SET sc_activate = :activate WHERE sc_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $scId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('service_categories', $scId, $row['sc_name'], $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Service categories{/t}</h1>
+    <p class="cl-page-desc">{t}Group services into categories to organize and filter your configuration.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$scPage}&o=a', '{t}Add a Service Category{/t}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchSC" value="{$searchSC}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchSC" value="{$searchSC}" class="cl-search-simple" placeholder="{t}Search service categories{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -32,7 +45,7 @@
                     <th class="cl-col-center">{$headerMenu_linked_svc}</th>
                     <th class="cl-col-center">{$headerMenu_sc_type}</th>
                     { if $mode_access == 'w' }
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     { /if }
                 </tr>
             </thead>
@@ -41,16 +54,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -58,8 +61,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    scListing.fetch(scListing.getState().num, scListing.getState().limit, scListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var scListing = new CentreonListing({
     instanceName:  'scListing',
     ajaxListUrl:   './include/configuration/configObject/service_categories/ajaxServiceCategoriesListing.php',
@@ -70,15 +123,18 @@ var scListing = new CentreonListing({
     storageKey:    'sc_listing_limit',
     emptyMessage:  'No service categories found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var editUrl = 'main.get.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
+            var title = '{/literal}{t}Modify a Service Category{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'description', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.description||'')+'</a>';
+            var editUrl = 'main.get.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
+            var title = '{/literal}{t}Modify a Service Category{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.description||'')+'</a>';
         }},
         { id:'svc_count', align:'center', render: function(row) { return row.svc_count; }},
         { id:'level', align:'center', render: function(row, l) {

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -1,81 +1,96 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Name{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchSC" value="{$searchSC}" class="mr-1">{$form.Search.html}</td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            { if $mode_access == 'w' }
-            <td>
-                {$form.o1.html}
-                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="ml-2">{$msg.ldap_importT}</a>{/if}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            { else }
-            <td>&nbsp;</td>
-            { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_desc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_linked_svc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_sc_type}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].sc_link}">{$elemArr[elem].sc_name}</a></td>
-            <td class="ListColCenter"><a href="{$elemArr[elem].sc_link}">{$elemArr[elem].sc_description}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].svc_linked}</td>
-            <td class="ListColCenter">{$elemArr[elem].sc_type}</td>
-            <td class="ListColCenter"><span
-                    class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].sc_activated}</span></td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
 
-    </table>
-    <table class="ToolbarTable ToolbarTR table">
-        <tr>
+<form name='form' method='POST'>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td class="Toolbar_TDSelectAction_Bottom">
-                {$form.o2.html}
-                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="ml-1">{$msg.ldap_importT}</a>{/if}
-                <a href="{$msg.addL}" class="btc bt_success ml-2" >{$msg.addT}</a>
-            </td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <input type='hidden' name='o' id='o' value='42'>
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchSC" value="{$searchSC}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="scListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-center">{$headerMenu_linked_svc}</th>
+                    <th class="cl-col-center">{$headerMenu_sc_type}</th>
+                    { if $mode_access == 'w' }
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    { /if }
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
+<script type="text/javascript">
+var scListing = new CentreonListing({
+    instanceName:  'scListing',
+    ajaxListUrl:   './include/configuration/configObject/service_categories/ajaxServiceCategoriesListing.php',
+    ajaxToggleUrl: './include/configuration/configObject/service_categories/ajaxServiceCategoriesToggle.php',
+    pageId:        {/literal}'{$scPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'sc_listing_limit',
+    emptyMessage:  'No service categories found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'description', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.description||'')+'</a>';
+        }},
+        { id:'svc_count', align:'center', render: function(row) { return row.svc_count; }},
+        { id:'level', align:'center', render: function(row, l) {
+            return row.level ? l.escape('Severity (' + row.level + ')') : 'Regular';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="scListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+scListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -95,12 +95,12 @@ var scListing = new CentreonListing({
         { id:'name', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
             var title = '{/literal}{t}Modify a Service Category{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'description', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$scPage}{literal}&o=c&sc_id=' + row.id;
             var title = '{/literal}{t}Modify a Service Category{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.description||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.description||'')+'</a>';
         }},
         { id:'svc_count', align:'center', render: function(row) { return row.svc_count; }},
         { id:'level', align:'center', render: function(row, l) {

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Service categories{/t}</h1>
-    <p class="cl-page-desc">{t}Group services into categories to organize and filter your configuration.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Service categories{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Group services into categories to organize and filter your configuration.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$scPage}&o=a', '{t}Add a Service Category{/t}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchSC" value="{$searchSC}" class="cl-search-simple" placeholder="{t}Search service categories{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -80,42 +80,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    scListing.fetch(scListing.getState().num, scListing.getState().limit, scListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var scListing = new CentreonListing({
     instanceName:  'scListing',
@@ -152,5 +116,6 @@ var scListing = new CentreonListing({
     }
 });
 scListing.init();
+CentreonForm.initSidePanel(scListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -47,9 +47,7 @@ $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchSC', $search);
 
 // Default limit from DB
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 // Form for bulk actions

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -23,41 +23,9 @@ if (! isset($oreon)) {
     exit();
 }
 
+include_once './class/centreonUtils.class.php';
+
 include './include/common/autoNumLimit.php';
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchSC'] ?? $_GET['searchSC'] ?? null
-);
-
-if (isset($_POST['searchSC']) || isset($_GET['searchSC'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$searchTool = null;
-if ($search) {
-    $searchTool .= "WHERE (sc_name LIKE '%" . $search . "%' "
-    . "OR sc_description LIKE '%" . $search . "%') ";
-}
-
-$aclCond = '';
-if (! $oreon->user->admin && $scString != "''") {
-    $clause = is_null($searchTool) ? ' WHERE ' : ' AND ';
-    $aclCond .= $acl->queryBuilder($clause, 'sc_id', $scString);
-}
-
-// Services Categories Lists
-$dbResult = $pearDB->query(
-    'SELECT SQL_CALC_FOUND_ROWS * FROM service_categories ' . $searchTool . $aclCond
-    . 'ORDER BY sc_name LIMIT ' . $num * $limit . ', ' . $limit
-);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
 
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
@@ -66,60 +34,30 @@ $tpl = SmartyBC::createSmartyTemplate($path);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Description'));
-$tpl->assign('headerMenu_status', _('Status'));
-$tpl->assign('headerMenu_linked_svc', _('Number of linked services'));
+$tpl->assign('headerMenu_linked_svc', _('Linked services'));
 $tpl->assign('headerMenu_sc_type', _('Type'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('scPage', $p);
 
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchSC', $search);
+
+// Default limit from DB
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+// Form for bulk actions
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Different style between each lines
-$style = 'one';
 
 $attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
 $form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-$statement = $pearDB->prepare('SELECT COUNT(*) FROM `service_categories_relation` WHERE `sc_id` = :sc_id');
-for ($i = 0; $sc = $dbResult->fetch(); $i++) {
-    $moptions = '';
-    $statement->bindValue(':sc_id', (int) $sc['sc_id'], PDO::PARAM_INT);
-    $statement->execute();
-    $nb_svc = $statement->fetch();
-
-    $selectedElements = $form->addElement('checkbox', 'select[' . $sc['sc_id'] . ']');
-
-    if ($sc['sc_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&sc_id=' . $sc['sc_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&sc_id=' . $sc['sc_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;';
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $sc['sc_id'] . "]' />";
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'sc_name' => htmlentities($sc['sc_name'], ENT_QUOTES, 'UTF-8'), 'sc_link' => 'main.php?p=' . $p . '&o=c&sc_id=' . $sc['sc_id'], 'sc_description' => htmlentities($sc['sc_description'], ENT_QUOTES, 'UTF-8'), 'svc_linked' => $nb_svc['COUNT(*)'], 'sc_type' => ($sc['level'] ? _('Severity') . ' (' . $sc['level'] . ')' : _('Regular')), 'sc_activated' => $sc['sc_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $sc['sc_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
 $tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
 ?>
@@ -139,8 +77,7 @@ $attrs1 = ['onchange' => 'javascript: '
     . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
     . _('Do you confirm the deletion ?') . "')) {"
     . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3 || this.form.elements['o1'].selectedIndex == 4 "
-    . "||this.form.elements['o1'].selectedIndex == 5){"
+    . "else if (this.form.elements['o1'].selectedIndex == 3 || this.form.elements['o1'].selectedIndex == 4){"
     . " 	setO(this.form.elements['o1'].value); submit();} "
     . "this.form.elements['o1'].selectedIndex = 0"];
 $form->addElement(
@@ -150,7 +87,8 @@ $form->addElement(
     [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')],
     $attrs1
 );
-$form->setDefaults(['o1' => null]);
+$o1 = $form->getElement('o1');
+$o1->setValue(null);
 
 $attrs2 = ['onchange' => 'javascript: '
     . ' var bChecked = isChecked(); '
@@ -162,29 +100,18 @@ $attrs2 = ['onchange' => 'javascript: '
     . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
     . _('Do you confirm the deletion ?') . "')) {"
     . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3 || "
-    . "this.form.elements['o2'].selectedIndex == 4 ||this.form.elements['o2'].selectedIndex == 5){"
+    . "else if (this.form.elements['o2'].selectedIndex == 3 || this.form.elements['o2'].selectedIndex == 4){"
     . " 	setO(this.form.elements['o2'].value); submit();} "
     . "this.form.elements['o2'].selectedIndex = 0"];
 $form->addElement(
     'select',
     'o2',
     null,
-    [null => _('More actions'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')],
+    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')],
     $attrs2
 );
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
 $o2 = $form->getElement('o2');
 $o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
-$tpl->assign('searchSC', $search);
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered service categories listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files

- **`ajaxServiceCategoriesListing.php`** — Standalone AJAX endpoint. Session validation, ACL read access (page 60209), sanitized search, prepared statements, JSON pagination.

- **`ajaxServiceCategoriesToggle.php`** — Secure toggle endpoint. CSRF validation + rotation, ACL write access (page 60209), audit logging.

### Modified files

- **`listServiceCategories.ihtml`** — Rewritten with `cl-*` classes: search, pagination, toggles, dup inputs.
- **`listServiceCategories.php`** — Simplified controller, removed SQL/rendering loop.

### Tests (9 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Toggle disables a service category
4. Toggle enables a service category
5. Pagination and rows-per-page
6. Bulk duplication
7. Bulk deletion
8. Click navigates to edit form
9. Session state persistence

## How to test

1. Navigate to Configuration > Services > Categories
2. Test search, pagination, toggle, duplicate, delete
3. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Implemented AJAX-driven service categories listing using shared CentreonListing framework

**⚡ Enhancements**
* Added secure AJAX toggle endpoint with CSRF rotation and audit logging

**🔧 Refactors**
* Rewrote template and simplified controller for modern AJAX-based UI


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98409596?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
