### PR TITLE
feat(configuration): modernize meta service and metrics listings

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing.feature
@@ -1,0 +1,64 @@
+Feature: Modern meta service listing
+    As a Centreon admin
+    I want to manage meta services and their metrics from modernized listing pages
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And a meta service exists
+
+  @TEST_LISTING-057
+  Scenario: Meta service listing loads via AJAX
+    When the user navigates to the meta services listing
+    Then the AJAX listing table is displayed with meta service rows
+
+  @TEST_LISTING-058
+  Scenario: Search filters meta services by name
+    When the user navigates to the meta services listing
+    And the user searches for a specific meta service
+    Then only the matching meta service is displayed
+
+  @TEST_LISTING-059
+  Scenario: Toggle disables a meta service
+    When the user navigates to the meta services listing
+    And the user clicks the toggle to disable a meta service
+    Then the meta service toggle switches to disabled
+    And the toggle response is successful
+
+  @TEST_LISTING-060
+  Scenario: Toggle enables a meta service
+    When the user navigates to the meta services listing
+    And the meta service is disabled
+    And the user clicks the toggle to enable the meta service
+    Then the meta service toggle switches to enabled
+
+  @TEST_LISTING-061
+  Scenario: Pagination and rows per page
+    When the user navigates to the meta services listing
+    Then the pagination info is displayed
+
+  @TEST_LISTING-062
+  Scenario: Bulk duplication works
+    When the user navigates to the meta services listing
+    And the user selects a meta service and duplicates it
+    Then a duplicated meta service appears in the listing
+
+  @TEST_LISTING-063
+  Scenario: Bulk deletion works
+    When the user navigates to the meta services listing
+    And the user selects a meta service and deletes it
+    Then the meta service is removed from the listing
+
+  @TEST_LISTING-064
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the meta services listing
+    And the user clicks on a meta service name
+    Then the meta service edit form is displayed
+
+  @TEST_LISTING-065
+  Scenario: Session state persists across navigation
+    When the user navigates to the meta services listing
+    And the user searches for a specific meta service
+    And the user clicks on a meta service name
+    And the user navigates back to the meta services listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing.feature
@@ -7,55 +7,46 @@ Feature: Modern meta service listing
     Given an admin user is logged in Centreon
     And a meta service exists
 
-  @TEST_LISTING-057
   Scenario: Meta service listing loads via AJAX
     When the user navigates to the meta services listing
     Then the AJAX listing table is displayed with meta service rows
 
-  @TEST_LISTING-058
   Scenario: Search filters meta services by name
     When the user navigates to the meta services listing
     And the user searches for a specific meta service
     Then only the matching meta service is displayed
 
-  @TEST_LISTING-059
   Scenario: Toggle disables a meta service
     When the user navigates to the meta services listing
     And the user clicks the toggle to disable a meta service
     Then the meta service toggle switches to disabled
     And the toggle response is successful
 
-  @TEST_LISTING-060
   Scenario: Toggle enables a meta service
     When the user navigates to the meta services listing
     And the meta service is disabled
     And the user clicks the toggle to enable the meta service
     Then the meta service toggle switches to enabled
 
-  @TEST_LISTING-061
   Scenario: Pagination and rows per page
     When the user navigates to the meta services listing
     Then the pagination info is displayed
 
-  @TEST_LISTING-062
   Scenario: Bulk duplication works
     When the user navigates to the meta services listing
     And the user selects a meta service and duplicates it
     Then a duplicated meta service appears in the listing
 
-  @TEST_LISTING-063
   Scenario: Bulk deletion works
     When the user navigates to the meta services listing
     And the user selects a meta service and deletes it
     Then the meta service is removed from the listing
 
-  @TEST_LISTING-064
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the meta services listing
     And the user clicks on a meta service name
     Then the meta service edit form is displayed
 
-  @TEST_LISTING-065
   Scenario: Session state persists across navigation
     When the user navigates to the meta services listing
     And the user searches for a specific meta service

--- a/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing/index.ts
@@ -47,12 +47,12 @@ Given('an admin user is logged in Centreon', () => {
 
 Given('a meta service exists', () => {
   cy.addMetaService({
-    name: 'meta_alpha',
-    maxCheckAttempts: '3'
+    maxCheckAttempts: '3',
+    name: 'meta_alpha'
   });
   cy.addMetaService({
-    name: 'meta_beta',
-    maxCheckAttempts: '3'
+    maxCheckAttempts: '3',
+    name: 'meta_beta'
   });
 });
 
@@ -65,9 +65,7 @@ When('the user navigates to the meta services listing', () => {
 });
 
 Then('the AJAX listing table is displayed with meta service rows', () => {
-  cy.getIframeBody()
-    .find('table.cl-listing-table')
-    .should('exist');
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
   cy.getIframeBody()
     .find('#clTableBody')
     .contains('meta_alpha')
@@ -79,13 +77,8 @@ Then('the AJAX listing table is displayed with meta service rows', () => {
 // ---------------------------------------------------------------------------
 
 When('the user searches for a specific meta service', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .clear()
-    .type('meta_alpha');
-  cy.getIframeBody()
-    .find('#clSearchBtn')
-    .click();
+  cy.getIframeBody().find('#clSearchInput').clear().type('meta_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
 
@@ -131,9 +124,7 @@ Then('the meta service toggle switches to disabled', () => {
 });
 
 Then('the toggle response is successful', () => {
-  cy.get('@toggleMeta')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@toggleMeta').its('response.statusCode').should('eq', 200);
   cy.get('@toggleMeta')
     .its('response.body')
     .should('have.property', 'success', true);
@@ -146,7 +137,8 @@ Then('the toggle response is successful', () => {
 When('the meta service is disabled', () => {
   cy.executeSqlQuery({
     database: 'centreon',
-    query: "UPDATE meta_service SET meta_activate = '0' WHERE meta_name = 'meta_alpha'"
+    query:
+      "UPDATE meta_service SET meta_activate = '0' WHERE meta_name = 'meta_alpha'"
   });
   visitAndWait();
 });
@@ -165,9 +157,7 @@ When('the user clicks the toggle to enable the meta service', () => {
     .should('not.be.checked')
     .click();
 
-  cy.wait('@toggleMetaOn')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.wait('@toggleMetaOn').its('response.statusCode').should('eq', 200);
 });
 
 Then('the meta service toggle switches to enabled', () => {
@@ -209,9 +199,7 @@ When('the user selects a meta service and duplicates it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Duplicate');
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated meta service appears in the listing', () => {
@@ -242,9 +230,7 @@ When('the user selects a meta service and deletes it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Delete');
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the meta service is removed from the listing', () => {
@@ -261,10 +247,7 @@ Then('the meta service is removed from the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a meta service name', () => {
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .contains('a', 'meta_alpha')
-    .click();
+  cy.getIframeBody().find('#clTableBody').contains('a', 'meta_alpha').click();
 });
 
 Then('the meta service edit form is displayed', () => {
@@ -285,7 +268,5 @@ When('the user navigates back to the meta services listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .should('have.value', 'meta_alpha');
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'meta_alpha');
 });

--- a/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/07-meta-service-listing/index.ts
@@ -1,0 +1,291 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const metaPage = PAGES.configuration.metaServicesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(metaPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('a meta service exists', () => {
+  cy.addMetaService({
+    name: 'meta_alpha',
+    maxCheckAttempts: '3'
+  });
+  cy.addMetaService({
+    name: 'meta_beta',
+    maxCheckAttempts: '3'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the meta services listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with meta service rows', () => {
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific meta service', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('meta_alpha');
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching meta service is displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a meta service', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxMetaServiceToggle.php'
+  }).as('toggleMeta');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleMeta');
+});
+
+Then('the meta service toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleMeta')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@toggleMeta')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the meta service is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE meta_service SET meta_activate = '0' WHERE meta_name = 'meta_alpha'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the meta service', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxMetaServiceToggle.php'
+  }).as('toggleMetaOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleMetaOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the meta service toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info is displayed', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a meta service and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated meta service appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_alpha_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects a meta service and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the meta service is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('meta_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a meta service name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'meta_alpha')
+    .click();
+});
+
+Then('the meta service edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="meta_name"]');
+  cy.getIframeBody()
+    .find('input[name="meta_name"]')
+    .should('have.value', 'meta_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the meta services listing', () => {
+  cy.visit(metaPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'meta_alpha');
+});

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/meta_service/ajaxMetaMetricListing.php
+++ b/centreon/www/include/configuration/configObject/meta_service/ajaxMetaMetricListing.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$metaId = filter_var($_GET['meta_id'] ?? null, FILTER_VALIDATE_INT);
+if (! $metaId) {
+    AjaxListingHelper::jsonError('Missing meta_id', 400);
+}
+
+$calcType = ['AVE' => 'Average', 'SOM' => 'Sum', 'MIN' => 'Min', 'MAX' => 'Max'];
+
+// Get meta service info
+$metaStmt = $pearDB->prepare('SELECT meta_name, calcul_type FROM meta_service WHERE meta_id = :meta_id');
+$metaStmt->bindValue(':meta_id', $metaId, PDO::PARAM_INT);
+$metaStmt->execute();
+$metaInfo = $metaStmt->fetch(PDO::FETCH_ASSOC);
+if (! $metaInfo) {
+    AjaxListingHelper::jsonError('Meta service not found', 404);
+}
+
+// ACL
+$aclFrom = '';
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $aclDbName = $acl->getNameDBAcl();
+    $aclFrom = ", `{$aclDbName}`.centreon_acl acl ";
+    $aclCond = ' AND acl.host_id = msr.host_id AND acl.group_id IN (' . $acl->getAccessGroupsString() . ') ';
+}
+
+// Get metric relations
+$statement = $pearDB->prepare(
+    "SELECT DISTINCT msr.msr_id, msr.metric_id, msr.activate
+    FROM meta_service_relation msr {$aclFrom}
+    WHERE msr.meta_id = :meta_id {$aclCond}
+    ORDER BY msr.host_id"
+);
+$statement->bindValue(':meta_id', $metaId, PDO::PARAM_INT);
+$statement->execute();
+
+$relations = [];
+$metricIds = [];
+while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $relations[$row['metric_id']][] = [
+        'msr_id' => (int) $row['msr_id'],
+        'activate' => (int) $row['activate'],
+    ];
+    $metricIds[] = (int) $row['metric_id'];
+}
+
+$rows = [];
+if (! empty($metricIds)) {
+    // Query centstorage for metric details
+    $pearDBO = new CentreonDB('centstorage');
+    $inList = implode(',', $metricIds);
+    $dbResult = $pearDBO->query(
+        "SELECT m.metric_id, m.metric_name, m.unit_name, i.host_name, i.service_description
+        FROM metrics m, index_data i
+        WHERE m.metric_id IN ({$inList})
+        AND m.index_id = i.id
+        ORDER BY i.host_name, i.service_description, m.metric_name"
+    );
+
+    while ($metric = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+        $svcDesc = str_replace(['#S#', '#BS#'], ['/', '\\'], $metric['service_description']);
+        foreach ($relations[$metric['metric_id']] as $rel) {
+            $rows[] = [
+                'id'       => $rel['msr_id'],
+                'host'     => $metric['host_name'],
+                'service'  => $svcDesc,
+                'metric'   => $metric['metric_name'] . ' (' . ($metric['unit_name'] ?? '') . ')',
+                'activate' => $rel['activate'],
+            ];
+        }
+    }
+}
+
+// Return meta info alongside rows
+$centreonToken = createCSRFToken();
+echo json_encode([
+    'rows'           => $rows,
+    'total'          => count($rows),
+    'num'            => 0,
+    'limit'          => count($rows),
+    'centreon_token' => $centreonToken,
+    'meta_name'      => $metaInfo['meta_name'],
+    'meta_calc_type' => $calcType[$metaInfo['calcul_type']] ?? $metaInfo['calcul_type'],
+]);
+
+exit;

--- a/centreon/www/include/configuration/configObject/meta_service/ajaxMetaMetricToggle.php
+++ b/centreon/www/include/configuration/configObject/meta_service/ajaxMetaMetricToggle.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60204);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT msr_id FROM meta_service_relation WHERE msr_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE meta_service_relation SET activate = :activate WHERE msr_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('meta_service_metric', $objId, (string) $objId, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configObject/meta_service/ajaxMetaServiceListing.php
+++ b/centreon/www/include/configuration/configObject/meta_service/ajaxMetaServiceListing.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $metaStr = $acl->getMetaServiceString();
+    if ($metaStr !== "''" && $metaStr !== '') {
+        $clause = $search !== '' ? 'AND' : 'WHERE';
+        $aclCond = $acl->queryBuilder($clause, 'meta_id', $metaStr);
+    } else {
+        $helper->jsonResponse([], 0, 0, $limit);
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'WHERE meta_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS meta_id, meta_name, calcul_type, warning, critical, meta_activate, meta_select_mode'
+    . ' FROM meta_service ' . $searchCond . $aclCond
+    . ' ORDER BY meta_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($ms = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'          => (int) $ms['meta_id'],
+        'name'        => $ms['meta_name'],
+        'calcul_type' => $ms['calcul_type'],
+        'warning'     => $ms['warning'],
+        'critical'    => $ms['critical'],
+        'activate'    => (int) $ms['meta_activate'],
+        'select_mode' => (int) $ms['meta_select_mode'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/meta_service/ajaxMetaServiceToggle.php
+++ b/centreon/www/include/configuration/configObject/meta_service/ajaxMetaServiceToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60204);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT meta_id FROM meta_service WHERE meta_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT meta_name FROM meta_service WHERE meta_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE meta_service SET meta_activate = :activate WHERE meta_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('meta_service', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -131,7 +131,10 @@ var msListing = new CentreonListing({
             var title = '{/literal}{t}Modify a Meta Service{/t}{literal} - ' + row.name;
             return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
-        { id:'calcul_type', align:'center' },
+        { id:'calcul_type', align:'center', render: function(row) {
+            var map = { 'AVE':'Average', 'SOM':'Sum', 'MIN':'Min', 'MAX':'Max' };
+            return map[row.calcul_type] || row.calcul_type || '';
+        }},
         { id:'warning', align:'center', render: function(row) { return row.warning || '-'; }},
         { id:'critical', align:'center', render: function(row) { return row.critical || '-'; }}
     ],

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -95,19 +95,19 @@ var msListing = new CentreonListing({
         { id:'name', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$msPage}{literal}&o=c&meta_id=' + row.id;
             var title = '{/literal}{t}Modify a Meta Service{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
-        { id:'calcul_type', align:'center', render: function(row) {
+        { id:'calcul_type', align:'center', render: function(row, l) {
             var map = { 'AVE':'Average', 'SOM':'Sum', 'MIN':'Min', 'MAX':'Max' };
-            return map[row.calcul_type] || row.calcul_type || '';
+            return map[row.calcul_type] || l.escape(row.calcul_type) || '';
         }},
-        { id:'warning', align:'center', render: function(row) { return row.warning || '-'; }},
-        { id:'critical', align:'center', render: function(row) { return row.critical || '-'; }}
+        { id:'warning', align:'center', render: function(row, l) { return l.escape(row.warning) || '-'; }},
+        { id:'critical', align:'center', render: function(row, l) { return l.escape(row.critical) || '-'; }}
     ],
     renderOptions: function(row, l) {
         var html = '';
         if (row.select_mode === 1) {
-            html += '<a href="#" title="Components" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" onclick="cfOpenPanel(\'main.get.php?p={/literal}{$msPage}{literal}&meta_id=' + row.id + '&o=ci\', \'' + l.escape(row.name || '') + ' - Components\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></a>';
+            html += '<a href="#" title="Components" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" onclick="cfOpenPanel(\'main.get.php?p={/literal}{$msPage}{literal}&meta_id=' + row.id + '&o=ci\', \'' + clEscapeAttr(row.name || '') + ' - Components\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></a>';
         }
         var checked = row.activate ? ' checked' : '';
         html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="msListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -80,42 +80,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    msListing.fetch(msListing.getState().num, msListing.getState().limit, msListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var msListing = new CentreonListing({
     instanceName:  'msListing',
@@ -154,5 +118,6 @@ var msListing = new CentreonListing({
     }
 });
 msListing.init();
+CentreonForm.initSidePanel(msListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -1,77 +1,96 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-      <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Name{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchMS" value="{$searchMS}" class="mr-1">{$form.Search.html}</td>
-      </tr>
-      </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class='ListHeader'>
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_type}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_levelw}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_levelc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_levelw}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_levelc}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchMS" value="{$searchMS}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="msListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th class="cl-col-center">{$headerMenu_type}</th>
+                    <th class="cl-col-center">{$headerMenu_levelw}</th>
+                    <th class="cl-col-center">{$headerMenu_levelc}</th>
+                    { if $mode_access == 'w' }
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    { /if }
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <input type='hidden' name='o' id='o' value='42'>
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>  
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
+<script type="text/javascript">
+var msListing = new CentreonListing({
+    instanceName:  'msListing',
+    ajaxListUrl:   './include/configuration/configObject/meta_service/ajaxMetaServiceListing.php',
+    ajaxToggleUrl: './include/configuration/configObject/meta_service/ajaxMetaServiceToggle.php',
+    pageId:        {/literal}'{$msPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'ms_listing_limit',
+    emptyMessage:  'No meta services found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$msPage}{literal}&o=c&meta_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'calcul_type', align:'center' },
+        { id:'warning', align:'center', render: function(row) { return row.warning || '-'; }},
+        { id:'critical', align:'center', render: function(row) { return row.critical || '-'; }}
+    ],
+    renderOptions: function(row, l) {
+        var html = '';
+        if (row.select_mode === 1) {
+            html += '<a href="main.php?p={/literal}{$msPage}{literal}&meta_id='+row.id+'&o=ci" title="Components"><img src="img/icons/redirect.png" class="ico-16" alt="Components"/></a>';
+        }
+        var checked = row.activate ? ' checked' : '';
+        html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="msListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+        return html;
+    }
+});
+msListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -141,7 +141,7 @@ var msListing = new CentreonListing({
     renderOptions: function(row, l) {
         var html = '';
         if (row.select_mode === 1) {
-            html += '<a href="main.php?p={/literal}{$msPage}{literal}&meta_id='+row.id+'&o=ci" title="Components"><img src="img/icons/redirect.png" class="ico-16" alt="Components"/></a>';
+            html += '<a href="main.php?p={/literal}{$msPage}{literal}&meta_id='+row.id+'&o=ci" title="Components" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></a>';
         }
         var checked = row.activate ? ' checked' : '';
         html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="msListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Meta services{/t}</h1>
-    <p class="cl-page-desc">{t}Build virtual services that aggregate metrics from other services.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Meta services{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Build virtual services that aggregate metrics from other services.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$msPage}&o=a', '{t}Add a Meta Service{/t}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchMS" value="{$searchMS}" class="cl-search-simple" placeholder="{t}Search meta services{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Meta services{/t}</h1>
+    <p class="cl-page-desc">{t}Build virtual services that aggregate metrics from other services.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$msPage}&o=a', '{t}Add a Meta Service{/t}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchMS" value="{$searchMS}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchMS" value="{$searchMS}" class="cl-search-simple" placeholder="{t}Search meta services{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -32,7 +45,7 @@
                     <th class="cl-col-center">{$headerMenu_levelw}</th>
                     <th class="cl-col-center">{$headerMenu_levelc}</th>
                     { if $mode_access == 'w' }
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     { /if }
                 </tr>
             </thead>
@@ -41,16 +54,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -58,8 +61,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    msListing.fetch(msListing.getState().num, msListing.getState().limit, msListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var msListing = new CentreonListing({
     instanceName:  'msListing',
     ajaxListUrl:   './include/configuration/configObject/meta_service/ajaxMetaServiceListing.php',
@@ -70,11 +123,13 @@ var msListing = new CentreonListing({
     storageKey:    'ms_listing_limit',
     emptyMessage:  'No meta services found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$msPage}{literal}&o=c&meta_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var editUrl = 'main.get.php?p={/literal}{$msPage}{literal}&o=c&meta_id=' + row.id;
+            var title = '{/literal}{t}Modify a Meta Service{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'calcul_type', align:'center' },
         { id:'warning', align:'center', render: function(row) { return row.warning || '-'; }},

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -141,7 +141,7 @@ var msListing = new CentreonListing({
     renderOptions: function(row, l) {
         var html = '';
         if (row.select_mode === 1) {
-            html += '<a href="main.php?p={/literal}{$msPage}{literal}&meta_id='+row.id+'&o=ci" title="Components" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></a>';
+            html += '<a href="#" title="Components" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" onclick="cfOpenPanel(\'main.get.php?p={/literal}{$msPage}{literal}&meta_id=' + row.id + '&o=ci\', \'' + l.escape(row.name || '') + ' - Components\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg></a>';
         }
         var checked = row.activate ? ' checked' : '';
         html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="msListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -47,9 +47,7 @@ $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchMS', $search);
 
 // Default limit from DB
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 // Form for bulk actions

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -27,34 +27,6 @@ include_once './class/centreonUtils.class.php';
 
 include './include/common/autoNumLimit.php';
 
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchMS'] ?? $_GET['searchMS'] ?? null
-);
-
-if (isset($_POST['searchMS']) || isset($_GET['searchMS'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-// Meta Service list
-$rq = 'SELECT SQL_CALC_FOUND_ROWS * FROM meta_service ';
-if ($search) {
-    $rq .= "WHERE meta_name LIKE '%" . $search . "%' "
-        . $acl->queryBuilder('AND', 'meta_id', $metaStr);
-} else {
-    $rq .= $acl->queryBuilder('WHERE', 'meta_id', $metaStr);
-}
-$rq .= ' ORDER BY meta_name LIMIT ' . $num * $limit . ', ' . $limit;
-
-$dbResult = $pearDB->query($rq);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
@@ -62,103 +34,32 @@ $tpl = SmartyBC::createSmartyTemplate($path);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_type', _('Calculation Type'));
 $tpl->assign('headerMenu_levelw', _('Warning Level'));
 $tpl->assign('headerMenu_levelc', _('Critical Level'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$calcType = ['AVE' => _('Average'), 'SOM' => _('Sum'), 'MIN' => _('Min'), 'MAX' => _('Max')];
+$tpl->assign('msPage', $p);
 
-// Meta Service list
-$conditionStr = '';
-$metaStrParams = [];
-// binding query params for non admin  acl rules
-$searchIsNull = $search === null || $search === '';
-// the metaStr are the metas linked to the user's ACL
-if ($acl->admin === '0' || $acl->admin === false) {
-    if ($metaStr === "''" || $metaStr === '') {
-        $queryParams = '0';
-    } else {
-        $metaStrList = explode(',', $metaStr);
-        foreach ($metaStrList as $index => $metaId) {
-            $metaStrParams[':meta_' . $index] = (int) str_replace("'", '', $metaId);
-        }
-        $queryParams = implode(',', array_keys($metaStrParams));
-    }
-    $conditionStr = ! $searchIsNull ? 'AND meta_id IN (' . $queryParams . ')' : 'WHERE meta_id IN (' . $queryParams . ')';
-}
-if (! $searchIsNull) {
-    $statement = $pearDB->prepare('SELECT * FROM meta_service '
-        . 'WHERE meta_name LIKE :search ' . $conditionStr
-        . ' ORDER BY meta_name LIMIT :offset, :limit');
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-} else {
-    $statement = $pearDB->prepare('SELECT * FROM meta_service ' . $conditionStr
-        . ' ORDER BY meta_name LIMIT :offset, :limit');
-}
-foreach ($metaStrParams as $key => $metaId) {
-    $statement->bindValue($key, $metaId, PDO::PARAM_INT);
-}
-$statement->bindValue(':offset', (int) $num * (int) $limit, PDO::PARAM_INT);
-$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
-$statement->execute();
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchMS', $search);
 
-$form = new HTML_QuickFormCustom('select_form', 'GET', '?p=' . $p);
+// Default limit from DB
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-// Different style between each lines
-$style = 'one';
+// Form for bulk actions
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
 $attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
 $form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-for ($i = 0; $ms = $statement->fetch(PDO::FETCH_ASSOC); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $ms['meta_id'] . ']');
-    if ($ms['meta_select_mode'] == 1) {
-        $moptions = "<a href='main.php?p=" . $p . '&meta_id=' . $ms['meta_id'] . '&o=ci&search='
-            . $search . "'><img src='img/icons/redirect.png' class='ico-16' border='0' alt='"
-            . _('View') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions = '';
-    }
-
-    if ($ms['meta_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&meta_id=' . $ms['meta_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&meta_id=' . $ms['meta_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;';
-
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $ms['meta_id'] . "]' />";
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure($ms['meta_name']), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&meta_id=' . $ms['meta_id'], 'RowMenu_type' => CentreonUtils::escapeSecure($calcType[$ms['calcul_type']]), 'RowMenu_levelw' => isset($ms['warning']) && $ms['warning'] ? $ms['warning'] : '-', 'RowMenu_levelc' => isset($ms['critical']) && $ms['critical'] ? $ms['critical'] : '-', 'RowMenu_status' => $ms['meta_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $ms['meta_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -166,7 +67,6 @@ $tpl->assign(
     }
 </script>
 <?php
-
 $attrs1 = ['onchange' => 'javascript: '
     . ' var bChecked = isChecked(); '
     . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
@@ -187,7 +87,8 @@ $form->addElement(
     [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
     $attrs1
 );
-$form->setDefaults(['o1' => null]);
+$o1 = $form->getElement('o1');
+$o1->setValue(null);
 
 $attrs2 = ['onchange' => 'javascript: '
     . ' var bChecked = isChecked(); '
@@ -209,18 +110,8 @@ $form->addElement(
     [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
     $attrs2
 );
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
 $o2 = $form->getElement('o2');
 $o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
-$tpl->assign('searchMS', $search);
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);

--- a/centreon/www/include/configuration/configObject/meta_service/listMetric.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetric.ihtml
@@ -1,70 +1,92 @@
-<table class="ListTable table">
-    <tr class="list_lvl_1">
-    <td class="ListColLvl1_name">
-        <h4>{$meta.meta} -  {$meta.name}&nbsp;({$meta.calc_type})</h4>
-    </td>
-    </tr>
-</table>
-<br />
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<form name='form'  method='POST'>
-<input type='hidden' name='o' id='o' value='42'>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+
+<div class="cl-meta-header" id="metricMetaHeader">{t}Loading...{/t}</div>
+
+<form name='form' method='POST'>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL1}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                &nbsp;&nbsp;&nbsp;
-                <a href="{$msg.addL1}" class="btc bt_success">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColLeft">{$headerMenu_host}</td>
-            <td class="ListColLeft">{$headerMenu_service}</td>
-            <td class="ListColCenter">{$headerMenu_metric}</td>
-            <td class="ListColCenter">{$headerMenu_status}</td>
-            <td class="ListColRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr1}
-        <tr class={$elemArr1[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr1[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr1[elem].RowMenu_link}">{$elemArr1[elem].RowMenu_host}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr1[elem].RowMenu_link}">{$elemArr1[elem].RowMenu_service}</a></td>
-            <td class="ListColCenter">{$elemArr1[elem].RowMenu_metric}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr1[elem].RowMenu_badge}">{$elemArr1[elem].RowMenu_status}</span></td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr1[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="metricListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_host}</th>
+                    <th>{$headerMenu_service}</th>
+                    <th class="cl-col-center">{$headerMenu_metric}</th>
+                    { if $mode_access == 'w' }
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    { /if }
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="5" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                &nbsp;&nbsp;&nbsp;
-                <a href="{$msg.addL1}" class="btc bt_success">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-        </tr>
-    </table>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>  
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
+<script type="text/javascript">
+var metricListing = new CentreonListing({
+    instanceName:  'metricListing',
+    ajaxListUrl:   './include/configuration/configObject/meta_service/ajaxMetaMetricListing.php',
+    ajaxToggleUrl: './include/configuration/configObject/meta_service/ajaxMetaMetricToggle.php',
+    pageId:        {/literal}'{$msPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  9999,
+    storageKey:    'mm_listing_limit',
+    emptyMessage:  'No metrics found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    extraParams:   { meta_id: {/literal}{$metaId}{literal} },
+    columns: [
+        { id:'host', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$msPage}{literal}&o=cs&msr_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.host)+'</a>';
+        }},
+        { id:'service' },
+        { id:'metric', align:'center' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="metricListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>';
+    },
+    onDataLoaded: function(data) {
+        if (data.meta_name) {
+            jQuery('#metricMetaHeader').text('Meta Service - ' + data.meta_name + ' (' + data.meta_calc_type + ')');
+        }
+    }
+});
+metricListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/meta_service/listMetric.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetric.ihtml
@@ -1,8 +1,8 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
-<div class="cl-meta-header" id="metricMetaHeader">{t}Loading...{/t}</div>
-
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Metrics{/t}</h1>
+    <p class="cl-page-desc" id="metricMetaHeader">{t}Loading...{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
@@ -29,7 +29,7 @@
                     <th>{$headerMenu_service}</th>
                     <th class="cl-col-center">{$headerMenu_metric}</th>
                     { if $mode_access == 'w' }
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     { /if }
                 </tr>
             </thead>
@@ -38,16 +38,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -57,6 +47,11 @@
 
 {literal}
 <script type="text/javascript">
+// Hide the breadcrumb when this listing is shown inside the side panel
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    var _bc = document.querySelector('.pathway');
+    if (_bc) { _bc.style.display = 'none'; }
+}
 var metricListing = new CentreonListing({
     instanceName:  'metricListing',
     ajaxListUrl:   './include/configuration/configObject/meta_service/ajaxMetaMetricListing.php',
@@ -83,7 +78,9 @@ var metricListing = new CentreonListing({
     },
     onDataLoaded: function(data) {
         if (data.meta_name) {
-            jQuery('#metricMetaHeader').text('Meta Service - ' + data.meta_name + ' (' + data.meta_calc_type + ')');
+            var map = { 'AVE':'Average', 'SOM':'Sum', 'MIN':'Min', 'MAX':'Max' };
+            var ct = map[data.meta_calc_type] || data.meta_calc_type || '';
+            jQuery('#metricMetaHeader').text('Meta service: ' + data.meta_name + (ct ? ' — ' + ct : ''));
         }
     }
 });

--- a/centreon/www/include/configuration/configObject/meta_service/listMetric.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetric.ihtml
@@ -1,8 +1,11 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Metrics{/t}</h1>
-    <p class="cl-page-desc" id="metricMetaHeader">{t}Loading...{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Metrics{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc" id="metricMetaHeader">{t}Loading...{/t}</p>
+    </div>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }

--- a/centreon/www/include/configuration/configObject/meta_service/listMetric.php
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -18,8 +19,6 @@
  *
  */
 
-$calcType = ['AVE' => _('Average'), 'SOM' => _('Sum'), 'MIN' => _('Min'), 'MAX' => _('Max')];
-
 if (! isset($oreon)) {
     exit();
 }
@@ -35,115 +34,33 @@ $tpl = SmartyBC::createSmartyTemplate($path);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-require_once './class/centreonDB.class.php';
-$pearDBO = new CentreonDB('centstorage');
-
-$DBRESULT = $pearDB->prepare('SELECT * FROM meta_service WHERE meta_id = :meta_id');
-$DBRESULT->bindValue(':meta_id', $meta_id, PDO::PARAM_INT);
-$DBRESULT->execute();
-
-$meta = $DBRESULT->fetchRow();
-$tpl->assign('meta', ['meta' => _('Meta Service'), 'name' => $meta['meta_name'], 'calc_type' => $calcType[$meta['calcul_type']]]);
-$DBRESULT->closeCursor();
-
-// start header menu
 $tpl->assign('headerMenu_host', _('Host'));
 $tpl->assign('headerMenu_service', _('Services'));
 $tpl->assign('headerMenu_metric', _('Metrics'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$aclFrom = '';
-$aclCond = '';
-if (! $oreon->user->admin) {
-    $aclFrom = ", `{$aclDbName}`.centreon_acl acl ";
-    $aclCond = ' AND acl.host_id = msr.host_id
-                 AND acl.group_id IN (' . $acl->getAccessGroupsString() . ') ';
-}
+$tpl->assign('msPage', $p);
+$tpl->assign('metaId', $meta_id);
 
-$statement = $pearDB->prepare(
-    "SELECT DISTINCT msr.*
-    FROM `meta_service_relation` msr {$aclFrom}
-    WHERE msr.meta_id = :meta_id
-    {$aclCond}
-    ORDER BY host_id"
-);
-$statement->bindValue(':meta_id', $meta_id, PDO::PARAM_INT);
-$statement->execute();
-
-$ar_relations = [];
-
+// Form for bulk actions
 $form = new HTML_QuickFormCustom('Form', 'POST', '?p=' . $p);
 
-// Construct request
-
-$metrics = [];
-
-while ($row = $statement->fetchRow()) {
-    $ar_relations[$row['metric_id']][] = ['activate' => $row['activate'], 'msr_id' => $row['msr_id']];
-    $metrics[] = $row['metric_id'];
-}
-$in_statement = implode(',', $metrics);
-
-if ($in_statement != '') {
-    $query = 'SELECT * FROM metrics m, index_data i '
-        . "WHERE m.metric_id IN ({$in_statement}) "
-        . 'AND m.index_id=i.id ORDER BY i.host_name, i.service_description, m.metric_name';
-    $DBRESULTO = $pearDBO->query($query);
-    // Different style between each lines
-    $style = 'one';
-    // Fill a tab with a mutlidimensionnal Array we put in $tpl
-    $elemArr1 = [];
-    $i = 0;
-    $centreonToken = createCSRFToken();
-
-    while ($metric = $DBRESULTO->fetchRow()) {
-        foreach ($ar_relations[$metric['metric_id']] as $relation) {
-            $moptions = '';
-            $selectedElements = $form->addElement('checkbox', 'select[' . $relation['msr_id'] . ']');
-            if ($relation['activate']) {
-                $moptions .= "<a href='main.php?p=" . $p . '&msr_id=' . $relation['msr_id']
-                    . '&o=us&meta_id=' . $meta_id . '&metric_id=' . $metric['metric_id']
-                    . '&centreon_token=' . $centreonToken
-                    . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' border='0' alt='"
-                    . _('Disabled') . "'></a>&nbsp;&nbsp;";
-            } else {
-                $moptions .= "<a href='main.php?p=" . $p . '&msr_id=' . $relation['msr_id']
-                    . '&o=ss&meta_id=' . $meta_id . '&metric_id=' . $metric['metric_id']
-                    . '&centreon_token=' . $centreonToken
-                    . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' border='0' alt='"
-                    . _('Enabled') . "'></a>&nbsp;&nbsp;";
-            }
-            $metric['service_description'] = str_replace('#S#', '/', $metric['service_description']);
-            $metric['service_description'] = str_replace('#BS#', '\\', $metric['service_description']);
-            $elemArr1[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_host' => htmlentities($metric['host_name'], ENT_QUOTES, 'UTF-8'), 'RowMenu_link' => 'main.php?p=' . $p . '&o=cs&msr_id=' . $relation['msr_id'], 'RowMenu_service' => htmlentities($metric['service_description'], ENT_QUOTES, 'UTF-8'), 'RowMenu_metric' => CentreonUtils::escapeSecure($metric['metric_name'] . ' (' . $metric['unit_name'] . ')'), 'RowMenu_status' => $relation['activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $relation['activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-            $style = $style != 'two' ? 'two' : 'one';
-            $i++;
-        }
-    }
-}
-if (isset($elemArr1)) {
-    $tpl->assign('elemArr1', $elemArr1);
-} else {
-    $tpl->assign('elemArr1', []);
-}
-
-// Different messages we put in the template
-$tpl->assign('msg', ['addL1' => 'main.php?p=' . $p . '&o=as&meta_id=' . $meta_id, 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]);
+$tpl->assign('msg', [
+    'addL1' => 'main.php?p=' . $p . '&o=as&meta_id=' . $meta_id,
+    'addT' => _('Add'),
+]);
 
 // Element we need when we reload the page
 $form->addElement('hidden', 'p');
 $form->addElement('hidden', 'meta_id');
-$tab = ['p' => $p, 'meta_id' => $meta_id];
-$form->setDefaults($tab);
+$form->setDefaults(['p' => $p, 'meta_id' => $meta_id]);
 
-// Toolbar select
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </SCRIPT>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
 $attrs1 = ['onchange' => 'javascript: '
     . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('" . _('Do you confirm the deletion ?') . "')) {"

--- a/centreon/www/include/configuration/configObject/meta_service/metric.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/metric.ihtml
@@ -1,36 +1,66 @@
 {$form.javascript}
-<div>
-    <form {$form.attributes}>
-            <table class="ListTable">
-                    <tr class="ListHeader">
-                    	<td class="FormHeader" colspan="2">{$form.header.title}</td>
-                    <tr>
-                    <tr class="list_one">
-                		<td>{$form.host_id.label}</td>
-                		<td>{$form.host_id.html}</td>
-                    </tr>
-	                <tr class="list_two">
-                        <td>{$form.metric_sel.label}</td>
-                        <td>{$form.metric_sel.html}</td>
-	                </tr>
-                    <tr class="list_one">
-                        <td>{$form.msr_comment.label}</td>
-                        <td>{$form.msr_comment.html}</td>
-                    </tr>
-                    <tr class="list_two">
-                        <td>{$form.activate.label}</td>
-                        <td>{$form.activate.html}</td>
-                    </tr>
-            </table>
-            <div id="validForm">
-                <p>
-                    {if isset($form.submitC)}
-                        {$form.submitC.html}
-                    {else}
-                        {$form.submitA.html}
-                    {/if}
-                    &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
+<link href="./include/common/form/form.css" rel="stylesheet" type="text/css" />
+
+<form {$form.attributes}>
+<div class="cf-form-wrapper">
+
+    <h1 class="cf-page-title">{$form.header.title}</h1>
+
+    <div class="cf-section" id="cf-sec-info">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.title}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.host_id.html}
+                    <label class="cf-label-float">{$form.host_id.label}</label>
+                </div>
+                <div class="cf-toggle-row" style="flex:0;white-space:nowrap;">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-activate-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.activate.label}</span>
+                    <span style="display:none;">{$form.activate.html}</span>
+                </div>
             </div>
-            {$form.hidden}
-    </form>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.metric_sel.html}
+                    <label class="cf-label-float">{$form.metric_sel.label}</label>
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.msr_comment.html}
+                    <label class="cf-label-float">{$form.msr_comment.label}</label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="cf-actions">
+        {if isset($backUrl)}
+            <button type="button" class="cf-btn-back" style="color:var(--c-text-secondary,#555);background-color:transparent;border:1px solid var(--c-stroke,#b0b7c3);" onclick="window.location.href='{$backUrl}';">&#8592;&nbsp;{t}Back to metrics{/t}</button>
+        {/if}
+        {$form.reset.html}
+        {if isset($form.submitC)}
+            {$form.submitC.html}
+        {else}
+            {$form.submitA.html}
+        {/if}
+    </div>
+
 </div>
+{$form.hidden}
+</form>
+
+{literal}
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    if (window.CentreonForm) {
+        CentreonForm.initFormPage();
+        CentreonForm.syncToggle('cf-activate-toggle', 'activate', '1', '0');
+    }
+});
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/meta_service/metric.php
+++ b/centreon/www/include/configuration/configObject/meta_service/metric.php
@@ -180,5 +180,9 @@ if ($valid) {
     $tpl->assign('form', $renderer->toArray());
     $tpl->assign('o', $o);
     $tpl->assign('valid', $valid);
+    // In edit mode (o=cs) the request carries msr_id, not meta_id; recover the
+    // meta service id from the loaded relation so Back returns to the right list.
+    $backMetaId = (int) ($meta_id ?: ($metric['meta_id'] ?? 0));
+    $tpl->assign('backUrl', 'main.get.php?p=' . $p . '&o=ci&meta_id=' . $backMetaId);
     $tpl->display('metric.ihtml');
 }


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered meta service listing and its metrics sub-listing with AJAX-driven tables using the shared `CentreonListing` framework.

## What changed

### New files (4)

- **`ajaxMetaServiceListing.php`** — AJAX endpoint for meta services. Session validation, ACL (page 60204), sanitized search, prepared statements.
- **`ajaxMetaServiceToggle.php`** — Toggle endpoint. CSRF rotation, ACL write access, audit logging.
- **`ajaxMetaMetricListing.php`** — AJAX endpoint for the metrics sub-listing within a meta service.
- **`ajaxMetaMetricToggle.php`** — Toggle endpoint for individual metric activation.

### Modified files (4)

- **`listMetaService.ihtml`** — Rewritten with `cl-*` classes, CentreonListing JS, search, pagination, toggles.
- **`listMetaService.php`** — Simplified controller.
- **`listMetric.ihtml`** — Rewritten metrics sub-listing.
- **`listMetric.php`** — Simplified controller.

### Tests (9 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Toggle disables a meta service
4. Toggle enables a meta service
5. Pagination info displayed
6. Bulk duplication
7. Bulk deletion
8. Click navigates to edit form
9. Session state persistence

## How to test

1. Navigate to Configuration > Services > Meta Services
2. Test search, pagination, toggle, duplicate, delete
3. Click a meta service → verify metrics sub-listing loads via AJAX
4. Test metric toggle on/off
5. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added AJAX endpoints for meta service and metric listings and toggles

**⚡ Enhancements**
* Added CSRF rotation, ACL write checks and audit logging for toggles
* Added Cypress tests covering listing, search, toggles, bulk actions

**🔧 Refactors**
* Rewrote Smarty templates to use CentreonListing AJAX-driven tables
* Simplified controllers and moved listing logic to AJAX helpers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98593934?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
