### PR TITLE
feat(configuration): modernize host template listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing.feature
@@ -7,18 +7,15 @@ Feature: Modern host template listing
     Given an admin user is logged in Centreon
     And several host templates exist
 
-  @TEST_LISTING-066
   Scenario: Host template listing loads via AJAX
     When the user navigates to the host templates listing
     Then the AJAX listing table is displayed with host template rows
 
-  @TEST_LISTING-067
   Scenario: Search filters host templates by name
     When the user navigates to the host templates listing
     And the user searches for a specific host template
     Then only the matching host template is displayed
 
-  @TEST_LISTING-068
   Scenario: Locked checkbox shows and hides locked templates
     When the user navigates to the host templates listing
     And the locked checkbox is checked
@@ -26,39 +23,33 @@ Feature: Modern host template listing
     When the user unchecks the locked checkbox and searches
     Then locked host templates are hidden
 
-  @TEST_LISTING-069
   Scenario: Locked templates have disabled checkboxes and dup inputs
     When the user navigates to the host templates listing
     And the locked checkbox is checked
     Then locked rows have disabled selection checkboxes
     And locked rows have disabled duplication inputs
 
-  @TEST_LISTING-070
   Scenario: Pagination and rows per page
     When the user navigates to the host templates listing
     Then the pagination info shows the total count
     When the user changes the rows per page to 10
     Then at most 10 rows are displayed
 
-  @TEST_LISTING-071
   Scenario: Bulk duplication works
     When the user navigates to the host templates listing
     And the user selects a host template and duplicates it
     Then a duplicated host template appears in the listing
 
-  @TEST_LISTING-072
   Scenario: Bulk deletion works
     When the user navigates to the host templates listing
     And the user selects a host template and deletes it
     Then the host template is removed from the listing
 
-  @TEST_LISTING-073
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the host templates listing
     And the user clicks on a host template name
     Then the host template edit form is displayed
 
-  @TEST_LISTING-074
   Scenario: Session state persists across navigation
     When the user navigates to the host templates listing
     And the user searches for a specific host template

--- a/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing.feature
@@ -1,0 +1,67 @@
+Feature: Modern host template listing
+    As a Centreon admin
+    I want to manage host templates from the modernized listing page
+    With AJAX search, locked elements support, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And several host templates exist
+
+  @TEST_LISTING-066
+  Scenario: Host template listing loads via AJAX
+    When the user navigates to the host templates listing
+    Then the AJAX listing table is displayed with host template rows
+
+  @TEST_LISTING-067
+  Scenario: Search filters host templates by name
+    When the user navigates to the host templates listing
+    And the user searches for a specific host template
+    Then only the matching host template is displayed
+
+  @TEST_LISTING-068
+  Scenario: Locked checkbox shows and hides locked templates
+    When the user navigates to the host templates listing
+    And the locked checkbox is checked
+    Then locked host templates are visible
+    When the user unchecks the locked checkbox and searches
+    Then locked host templates are hidden
+
+  @TEST_LISTING-069
+  Scenario: Locked templates have disabled checkboxes and dup inputs
+    When the user navigates to the host templates listing
+    And the locked checkbox is checked
+    Then locked rows have disabled selection checkboxes
+    And locked rows have disabled duplication inputs
+
+  @TEST_LISTING-070
+  Scenario: Pagination and rows per page
+    When the user navigates to the host templates listing
+    Then the pagination info shows the total count
+    When the user changes the rows per page to 10
+    Then at most 10 rows are displayed
+
+  @TEST_LISTING-071
+  Scenario: Bulk duplication works
+    When the user navigates to the host templates listing
+    And the user selects a host template and duplicates it
+    Then a duplicated host template appears in the listing
+
+  @TEST_LISTING-072
+  Scenario: Bulk deletion works
+    When the user navigates to the host templates listing
+    And the user selects a host template and deletes it
+    Then the host template is removed from the listing
+
+  @TEST_LISTING-073
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the host templates listing
+    And the user clicks on a host template name
+    Then the host template edit form is displayed
+
+  @TEST_LISTING-074
+  Scenario: Session state persists across navigation
+    When the user navigates to the host templates listing
+    And the user searches for a specific host template
+    And the user clicks on a host template name
+    And the user navigates back to the host templates listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing/index.ts
@@ -1,0 +1,285 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const htPage = PAGES.configuration.hostsTemplatesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(htPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('several host templates exist', () => {
+  cy.addHostTemplate({
+    name: 'ht_test_alpha',
+    alias: 'Host Template Alpha',
+    template: 'generic-host'
+  });
+  cy.addHostTemplate({
+    name: 'ht_test_beta',
+    alias: 'Host Template Beta',
+    template: 'generic-host'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the host templates listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with host template rows', () => {
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_alpha')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific host template', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('ht_test_alpha');
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching host template is displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked checkbox
+// ---------------------------------------------------------------------------
+
+When('the locked checkbox is checked', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .then($cb => {
+      if (!$cb.is(':checked')) {
+        cy.wrap($cb).click();
+        cy.getIframeBody().find('#clSearchBtn').click();
+        waitForAjaxRefresh();
+      }
+    });
+});
+
+Then('locked host templates are visible', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .as('countWithLocked');
+});
+
+When('the user unchecks the locked checkbox and searches', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .uncheck();
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('locked host templates are hidden', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .then(countWithout => {
+      cy.get('@countWithLocked').then(countWith => {
+        expect(countWithout).to.be.at.most(countWith as unknown as number);
+      });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked rows disabled
+// ---------------------------------------------------------------------------
+
+Then('locked rows have disabled selection checkboxes', () => {
+  cy.getIframeBody()
+    .find('#clTableBody .cl-col-picker input[type="checkbox"][disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('locked rows have disabled duplication inputs', () => {
+  cy.getIframeBody()
+    .find('#clTableBody input.cl-dup-input[disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('at most 10 rows are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a host template and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated host template appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_alpha_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects a host template and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the host template is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('ht_test_beta')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a host template name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'ht_test_alpha')
+    .click();
+});
+
+Then('the host template edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="host_name"]');
+  cy.getIframeBody()
+    .find('input[name="host_name"]')
+    .should('have.value', 'ht_test_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the host templates listing', () => {
+  cy.visit(htPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'ht_test_alpha');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/08-host-template-listing/index.ts
@@ -47,13 +47,13 @@ Given('an admin user is logged in Centreon', () => {
 
 Given('several host templates exist', () => {
   cy.addHostTemplate({
-    name: 'ht_test_alpha',
     alias: 'Host Template Alpha',
+    name: 'ht_test_alpha',
     template: 'generic-host'
   });
   cy.addHostTemplate({
-    name: 'ht_test_beta',
     alias: 'Host Template Beta',
+    name: 'ht_test_beta',
     template: 'generic-host'
   });
 });
@@ -67,9 +67,7 @@ When('the user navigates to the host templates listing', () => {
 });
 
 Then('the AJAX listing table is displayed with host template rows', () => {
-  cy.getIframeBody()
-    .find('table.cl-listing-table')
-    .should('exist');
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
   cy.getIframeBody()
     .find('#clTableBody')
     .contains('ht_test_alpha')
@@ -81,13 +79,8 @@ Then('the AJAX listing table is displayed with host template rows', () => {
 // ---------------------------------------------------------------------------
 
 When('the user searches for a specific host template', () => {
-  cy.getIframeBody()
-    .find('#clSearchInput')
-    .clear()
-    .type('ht_test_alpha');
-  cy.getIframeBody()
-    .find('#clSearchBtn')
-    .click();
+  cy.getIframeBody().find('#clSearchInput').clear().type('ht_test_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
 
@@ -109,7 +102,7 @@ Then('only the matching host template is displayed', () => {
 When('the locked checkbox is checked', () => {
   cy.getIframeBody()
     .find('#displayLocked')
-    .then($cb => {
+    .then(($cb) => {
       if (!$cb.is(':checked')) {
         cy.wrap($cb).click();
         cy.getIframeBody().find('#clSearchBtn').click();
@@ -126,9 +119,7 @@ Then('locked host templates are visible', () => {
 });
 
 When('the user unchecks the locked checkbox and searches', () => {
-  cy.getIframeBody()
-    .find('#displayLocked')
-    .uncheck();
+  cy.getIframeBody().find('#displayLocked').uncheck();
   cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
@@ -137,8 +128,8 @@ Then('locked host templates are hidden', () => {
   cy.getIframeBody()
     .find('#clTableBody tr')
     .its('length')
-    .then(countWithout => {
-      cy.get('@countWithLocked').then(countWith => {
+    .then((countWithout) => {
+      cy.get('@countWithLocked').then((countWith) => {
         expect(countWithout).to.be.at.most(countWith as unknown as number);
       });
     });
@@ -179,9 +170,7 @@ When('the user changes the rows per page to 10', () => {
 });
 
 Then('at most 10 rows are displayed', () => {
-  cy.getIframeBody()
-    .find('#clTableBody tr')
-    .should('have.length.at.most', 10);
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.at.most', 10);
 });
 
 // ---------------------------------------------------------------------------
@@ -203,9 +192,7 @@ When('the user selects a host template and duplicates it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Duplicate');
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated host template appears in the listing', () => {
@@ -236,9 +223,7 @@ When('the user selects a host template and deletes it', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Delete');
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the host template is removed from the listing', () => {

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/host_template_model/ajaxHostTemplateListing.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/ajaxHostTemplateListing.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search        = $params['search'];
+$num           = $params['num'];
+$limit         = $params['limit'];
+$displayLocked = filter_var($_GET['displayLocked'] ?? 'off', FILTER_VALIDATE_BOOLEAN);
+
+// Locked filter
+$lockedFilter = $displayLocked ? '' : 'AND host_locked = 0 ';
+
+// Search
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = "AND (host_name LIKE :search OR host_alias LIKE :search) ";
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS host_id, host_name, host_alias, host_template_model_htm_id'
+    . " FROM host WHERE host_register = '0' " . $lockedFilter . $searchCond
+    . ' ORDER BY host_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+// Prepare service count query
+$svcStmt = $pearDB->prepare(
+    "SELECT COUNT(*) AS cnt FROM host_service_relation WHERE host_host_id = :hid"
+);
+
+// Prepare parent templates query (via host_template_relation)
+$tplStmt = $pearDB->prepare(
+    "SELECT h.host_id, h.host_name FROM host_template_relation htr"
+    . " INNER JOIN host h ON htr.host_tpl_id = h.host_id"
+    . " WHERE htr.host_host_id = :hid ORDER BY htr.`order`"
+);
+
+// Locked elements
+$lockedElements = [];
+$lockResult = $pearDB->query("SELECT host_id FROM host WHERE host_locked = 1 AND host_register = '0'");
+while ($row = $lockResult->fetch(PDO::FETCH_ASSOC)) {
+    $lockedElements[(int) $row['host_id']] = true;
+}
+
+// Icon cache: extended_host_information → view_img (direct icons)
+$directIcons = [];
+$iconResult = $pearDB->query(
+    "SELECT ehi.host_host_id, CONCAT(vid.dir_alias, '/', vi.img_path) AS icon_path"
+    . " FROM extended_host_information ehi"
+    . " INNER JOIN view_img vi ON ehi.ehi_icon_image = vi.img_id"
+    . " INNER JOIN view_img_dir_relation vidr ON vi.img_id = vidr.img_img_id"
+    . " INNER JOIN view_img_dir vid ON vidr.dir_dir_parent_id = vid.dir_id"
+    . " WHERE ehi.ehi_icon_image IS NOT NULL"
+);
+while ($row = $iconResult->fetch(PDO::FETCH_ASSOC)) {
+    $directIcons[(int) $row['host_host_id']] = './img/media/' . $row['icon_path'];
+}
+
+// Resolve icon with inheritance (walk up template chain)
+function resolveIcon(int $hostId, array &$directIcons, CentreonDB $pearDB): ?string
+{
+    if (isset($directIcons[$hostId])) {
+        return $directIcons[$hostId];
+    }
+    // Check parent templates
+    $stmt = $pearDB->prepare("SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = :hid ORDER BY `order` LIMIT 1");
+    $stmt->execute([':hid' => $hostId]);
+    $parent = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($parent) {
+        return resolveIcon((int) $parent['host_tpl_id'], $directIcons, $pearDB);
+    }
+    return null;
+}
+
+$rows = [];
+while ($host = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $hid = (int) $host['host_id'];
+
+    // Service count
+    $svcStmt->execute([':hid' => $hid]);
+    $svcCount = (int) $svcStmt->fetch(PDO::FETCH_ASSOC)['cnt'];
+
+    // Parent templates (first level only for simplicity)
+    $templates = [];
+    $tplStmt->execute([':hid' => $hid]);
+    while ($tpl = $tplStmt->fetch(PDO::FETCH_ASSOC)) {
+        $templates[] = ['id' => (int) $tpl['host_id'], 'name' => $tpl['host_name']];
+    }
+
+    $rows[] = [
+        'id'        => $hid,
+        'name'      => $host['host_name'] ?: '',
+        'alias'     => $host['host_alias'],
+        'svc_count' => $svcCount,
+        'templates' => $templates,
+        'locked'    => isset($lockedElements[$hid]),
+        'icon'      => resolveIcon($hid, $directIcons, $pearDB),
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -116,13 +116,13 @@ var htListing = new CentreonListing({
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
             var icon = row.icon
-                ? '<img src="'+l.escape(row.icon)+'" class="ico-16 margin_right" onerror="this.outerHTML=\'<img src=./img/icons/host.svg class=ico-16 style=width:16px;height:16px;vertical-align:middle;margin-right:4px; />\'" />'
+                ? '<img src="'+clEscapeAttr(row.icon)+'" class="ico-16 margin_right" onerror="this.outerHTML=\'<img src=./img/icons/host.svg class=ico-16 style=width:16px;height:16px;vertical-align:middle;margin-right:4px; />\'" />'
                 : '<svg viewBox="0 0 24 24" width="16" height="16" style="vertical-align:middle;margin-right:4px;" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="7" rx="1.5"/><rect x="2" y="14" width="20" height="7" rx="1.5"/><circle cx="6.5" cy="6.5" r="0.6" fill="currentColor" stroke="none"/><circle cx="6.5" cy="17.5" r="0.6" fill="currentColor" stroke="none"/></svg>';
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+icon+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+icon+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'svc_count', align:'center', render: function(row) {
             return row.svc_count ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.svc_count+'</span>' : '<span style="opacity:.4;">0</span>';

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -156,7 +156,7 @@ var htListing = new CentreonListing({
             var link = 'main.get.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
             var icon = row.icon
                 ? '<img src="'+l.escape(row.icon)+'" class="ico-16 margin_right" onerror="this.outerHTML=\'<img src=./img/icons/host.svg class=ico-16 style=width:16px;height:16px;vertical-align:middle;margin-right:4px; />\'" />'
-                : '<img src="./img/icons/host.svg" class="ico-16" style="width:16px;height:16px;vertical-align:middle;margin-right:4px;" />';
+                : '<svg viewBox="0 0 24 24" width="16" height="16" style="vertical-align:middle;margin-right:4px;" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="7" rx="1.5"/><rect x="2" y="14" width="20" height="7" rx="1.5"/><circle cx="6.5" cy="6.5" r="0.6" fill="currentColor" stroke="none"/><circle cx="6.5" cy="17.5" r="0.6" fill="currentColor" stroke="none"/></svg>';
             return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+icon+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Host templates{/t}</h1>
-    <p class="cl-page-desc">{t}Define reusable configurations to apply shared settings across your hosts.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Host templates{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define reusable configurations to apply shared settings across your hosts.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$htPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,35 +24,36 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--with-adv">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchHT" value="{$searchHT}" class="cl-search-simple" placeholder="{t}Search host templates{/t}" autocomplete="off">
-                </div>
-                <button type="button" class="cl-adv-btn" data-cl-adv-panel="clAdvPanel" data-cl-label-show="{t}Advanced filters{/t}" data-cl-label-hide="{t}Hide filters{/t}" onclick="clToggleAdvancedFilters(this)">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
-                    <span class="cl-adv-label">{t}Advanced filters{/t}</span>
-                </button>
-                <span class="cl-toolbar-sep"></span>
-                <div class="cl-pagination" id="clPaginationTop"></div>
-            </div>
-        </div>
+                    <button type="button" class="cl-adv-icon-btn" data-cl-adv-panel="clAdvPanel" onclick="clToggleAdvancedFilters(this)" title="{t}Advanced filters{/t}">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+                        <span class="cl-adv-badge"></span>
+                    </button>
 
-        <div class="cl-adv-panel" id="clAdvPanel">
-            <div class="cl-adv-inner">
-                <div class="cl-adv-fields">
-                    <div class="cl-filter-toggle">
-                        <label class="cl-toggle">
-                            <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
-                            <span class="cl-toggle-slider"></span>
-                        </label>
-                        <span>{t}Locked{/t}</span>
+                    <div class="cl-adv-panel cl-adv-panel--popover" id="clAdvPanel">
+                        <div class="cl-adv-inner">
+                            <div class="cl-adv-fields">
+                                <div class="cl-filter-toggle">
+                                    <label class="cl-toggle">
+                                        <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
+                                        <span class="cl-toggle-slider"></span>
+                                    </label>
+                                    <span>{t}Locked{/t}</span>
+                                </div>
+                            </div>
+                            <div class="cl-adv-actions">
+                                <button type="button" class="cl-adv-clear" onclick="jQuery('#displayLocked').prop('checked', false); document.getElementById('clSearchBtn').click();">{t}Clear{/t}</button>
+                                <button type="button" id="clSearchBtn" class="cl-adv-search">{t}Search{/t}</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div class="cl-adv-actions">
-                    <button type="button" class="cl-adv-clear" onclick="jQuery('#displayLocked').prop('checked', false); document.getElementById('clSearchBtn').click();">{t}Clear{/t}</button>
-                    <button type="button" id="clSearchBtn" class="cl-adv-search">{t}Search{/t}</button>
-                </div>
+            </div>
+            <div class="cl-toolbar-right">
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>
 

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -1,29 +1,56 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
-<form name='form' method='POST'>
-    <div class="cl-filter-box">
-        <div class="cl-filter-bar">
-            <span class="cl-filter-label">{t}Host template{/t}</span>
-            <input type="text" id="clSearchInput" name="searchHT" value="{$searchHT}" class="cl-search-input" placeholder="{t}Name or alias{/t}" style="max-width:none;width:220px;">
-            <div class="md-checkbox md-checkbox-inline" style="margin:0;">
-                <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
-                <label for="displayLocked">{t}Locked{/t}</label>
-            </div>
-            <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
-        </div>
-    </div>
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
 
+<form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Host templates{/t}</h1>
+    <p class="cl-page-desc">{t}Define reusable configurations to apply shared settings across your hosts.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$htPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-pagination" id="clPaginationTop"></div>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchHT" value="{$searchHT}" class="cl-search-simple" placeholder="{t}Search host templates{/t}" autocomplete="off">
+                </div>
+                <button type="button" class="cl-adv-btn" data-cl-adv-panel="clAdvPanel" data-cl-label-show="{t}Advanced filters{/t}" data-cl-label-hide="{t}Hide filters{/t}" onclick="clToggleAdvancedFilters(this)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+                    <span class="cl-adv-label">{t}Advanced filters{/t}</span>
+                </button>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <div class="cl-adv-panel" id="clAdvPanel">
+            <div class="cl-adv-inner">
+                <div class="cl-adv-fields">
+                    <div class="cl-filter-toggle">
+                        <label class="cl-toggle">
+                            <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
+                            <span class="cl-toggle-slider"></span>
+                        </label>
+                        <span>{t}Locked{/t}</span>
+                    </div>
+                </div>
+                <div class="cl-adv-actions">
+                    <button type="button" class="cl-adv-clear" onclick="jQuery('#displayLocked').prop('checked', false); document.getElementById('clSearchBtn').click();">{t}Clear{/t}</button>
+                    <button type="button" id="clSearchBtn" class="cl-adv-search">{t}Search{/t}</button>
+                </div>
+            </div>
         </div>
 
         <table class="cl-listing-table">
@@ -39,7 +66,7 @@
                     <th>{$headerMenu_desc}</th>
                     <th class="cl-col-center">{$headerMenu_svChilds}</th>
                     <th class="cl-col-center">{$headerMenu_parent}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -47,16 +74,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -64,8 +81,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    htListing.fetch(htListing.getState().num, htListing.getState().limit, htListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var htListing = new CentreonListing({
     instanceName:  'htListing',
     ajaxListUrl:   './include/configuration/configObject/host_template_model/ajaxHostTemplateListing.php',
@@ -75,21 +142,22 @@ var htListing = new CentreonListing({
     storageKey:    'ht_listing_limit',
     emptyMessage:  'No host templates found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     extraParams:   function() {
         return jQuery('#displayLocked').is(':checked') ? { displayLocked: 'on' } : {};
     },
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
+            var link = 'main.get.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
             var icon = row.icon
                 ? '<img src="'+l.escape(row.icon)+'" class="ico-16 margin_right" onerror="this.outerHTML=\'<img src=./img/icons/host.svg class=ico-16 style=width:16px;height:16px;vertical-align:middle;margin-right:4px; />\'" />'
                 : '<img src="./img/icons/host.svg" class="ico-16" style="width:16px;height:16px;vertical-align:middle;margin-right:4px;" />';
-            return '<a href="'+link+'">'+icon+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+icon+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'svc_count', align:'center', render: function(row) {
             return row.svc_count ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.svc_count+'</span>' : '<span style="opacity:.4;">0</span>';

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -1,96 +1,114 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type="text/javascript" src="./include/common/javascript/resize_td.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-      <tbody>
-        <tr>
-          <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-          <td><h4>{t}Host template{/t}</h4></td>
-        </tr>
-        <tr>
-          <td><input type="text" name="searchHT" value="{$searchHT}"></td>
-            <td>
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
-                    <label for="displayLocked">{t}Locked elements{/t}</label>
-                </div>
-            </td>
-          <td><input type='submit' value='{t}Search{/t}' class="btc bt_success"/></td>
-        </tr>
-      </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-			<td class="ListColHeaderCenter" width="62">{$headerMenu_svChilds}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_parent}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-			<tr class="{$elemArr[elem].MenuClass}">
-				<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-				<td class="ListColLeft">
-					<a href="{$elemArr[elem].RowMenu_link}">
-                        {if $elemArr[elem].isHostTemplateSvgFile}
-                            <span class="ico-16  margin_right">
-                                {$elemArr[elem].RowMenu_icone}
-                            </span>
-                        {else}
-                            <img src='{$elemArr[elem].RowMenu_icone}' class='ico-16 margin_right' />
-                        {/if}
-                        {$elemArr[elem].RowMenu_name|escape:"html"}
-                    </a>
-				</td>
-				<td class="ListColLeft resizeTitle"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc|escape:"html"}</a></td>
-				<td class="ListColCenter">{$elemArr[elem].RowMenu_svChilds}</td>
-				<td class="ListColCenter resizeTitle">{$elemArr[elem].RowMenu_parent}</td>
-				<td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-			</tr>
-		{/section}
-	</table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
+    <div class="cl-filter-box">
+        <div class="cl-filter-bar">
+            <span class="cl-filter-label">{t}Host template{/t}</span>
+            <input type="text" id="clSearchInput" name="searchHT" value="{$searchHT}" class="cl-search-input" placeholder="{t}Name or alias{/t}" style="max-width:none;width:220px;">
+            <div class="md-checkbox md-checkbox-inline" style="margin:0;">
+                <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
+                <label for="displayLocked">{t}Locked{/t}</label>
+            </div>
+            <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+        </div>
+    </div>
+
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="htListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-center">{$headerMenu_svChilds}</th>
+                    <th class="cl-col-center">{$headerMenu_parent}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
-    setOverflowDivToTitle(('.resizeTitle'));
+<script type="text/javascript">
+var htListing = new CentreonListing({
+    instanceName:  'htListing',
+    ajaxListUrl:   './include/configuration/configObject/host_template_model/ajaxHostTemplateListing.php',
+    pageId:        {/literal}'{$htPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'ht_listing_limit',
+    emptyMessage:  'No host templates found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    extraParams:   function() {
+        return jQuery('#displayLocked').is(':checked') ? { displayLocked: 'on' } : {};
+    },
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
+            var icon = row.icon
+                ? '<img src="'+l.escape(row.icon)+'" class="ico-16 margin_right" onerror="this.outerHTML=\'<img src=./img/icons/host.svg class=ico-16 style=width:16px;height:16px;vertical-align:middle;margin-right:4px; />\'" />'
+                : '<img src="./img/icons/host.svg" class="ico-16" style="width:16px;height:16px;vertical-align:middle;margin-right:4px;" />';
+            return '<a href="'+link+'">'+icon+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$htPage}{literal}&o=c&host_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }},
+        { id:'svc_count', align:'center', render: function(row) {
+            return row.svc_count ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.svc_count+'</span>' : '<span style="opacity:.4;">0</span>';
+        }},
+        { id:'templates', align:'center', render: function(row, l) {
+            if (!row.templates || !row.templates.length) return '';
+            var parts = [];
+            for (var i=0; i<row.templates.length; i++) {
+                var t = row.templates[i];
+                parts.push('<a href="main.php?p={/literal}{$htPage}{literal}&o=c&host_id='+t.id+'">'+l.escape(t.name)+'</a>');
+            }
+            return parts.join(' | ');
+        }}
+    ],
+    renderOptions: function(row, l) {
+        if (row.locked) return '';
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+htListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -100,43 +98,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    htListing.fetch(htListing.getState().num, htListing.getState().limit, htListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var htListing = new CentreonListing({
     instanceName:  'htListing',
     ajaxListUrl:   './include/configuration/configObject/host_template_model/ajaxHostTemplateListing.php',
@@ -182,5 +143,6 @@ var htListing = new CentreonListing({
     }
 });
 htListing.init();
+CentreonForm.initSidePanel(htListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
@@ -45,9 +45,7 @@ $displayLocked = $centreon->historySearch[$url]['displayLocked'] ?? false;
 $tpl->assign('searchHT', $search);
 $tpl->assign('displayLocked', $displayLocked);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
@@ -19,209 +19,72 @@
  *
  */
 
+
 if (! isset($centreon)) {
     exit();
 }
 
-require_once './class/centreonUtils.class.php';
-
+include_once './class/centreonUtils.class.php';
 include './include/common/autoNumLimit.php';
 
-// Init Host Method
-$host_method = new CentreonHost($pearDB);
-$mediaObj = new CentreonMedia($pearDB);
-
-// Get Extended informations
-$ehiCache = [];
-$DBRESULT = $pearDB->query('SELECT ehi_icon_image, host_host_id FROM extended_host_information');
-while ($ehi = $DBRESULT->fetch()) {
-    $ehiCache[$ehi['host_host_id']] = $ehi['ehi_icon_image'];
-}
-$DBRESULT->closeCursor();
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchHT'] ?? $_GET['searchHT'] ?? $centreon->historySearch[$url]['search'] ?? ''
-);
-
-$displayLocked = filter_var(
-    $_POST['displayLocked'] ?? $_GET['displayLocked'] ?? 'off',
-    FILTER_VALIDATE_BOOLEAN
-);
-
-// keep checkbox state if navigating in pagination
-// this trick is mandatory cause unchecked checkboxes do not post any data
-if (
-    (isset($centreon->historyPage[$url]) && $centreon->historyPage[$url] > 0 || $num !== 0)
-    && isset($centreon->historySearch[$url]['displayLocked'])
-) {
-    $displayLocked = $centreon->historySearch[$url]['displayLocked'];
-}
-
-// store filters in session
-$centreon->historySearch[$url] = [
-    'search' => $search,
-    'displayLocked' => $displayLocked,
-];
-
-// Locked filter
-$lockedFilter = $displayLocked ? '' : 'AND host_locked = 0 ';
-
-// Host Template list
-$rq = 'SELECT SQL_CALC_FOUND_ROWS host_id, host_name, host_alias, host_template_model_htm_id '
-    . 'FROM host '
-    . "WHERE host_register = '0' "
-    . $lockedFilter;
-if ($search) {
-    $rq .= "AND (host_name LIKE '%" . CentreonDB::escape($search) . "%' OR host_alias LIKE '%"
-        . CentreonDB::escape($search) . "%')";
-}
-$rq .= ' ORDER BY host_name LIMIT ' . $num * $limit . ', ' . $limit;
-
-$DBRESULT = $pearDB->query($rq);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Alias'));
-$tpl->assign('headerMenu_svChilds', _('Linked Services Templates'));
+$tpl->assign('headerMenu_svChilds', _('Svc TPL'));
 $tpl->assign('headerMenu_parent', _('Templates'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('htPage', $p);
+
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$displayLocked = $centreon->historySearch[$url]['displayLocked'] ?? false;
+$tpl->assign('searchHT', $search);
+$tpl->assign('displayLocked', $displayLocked);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Different style between each lines
-$style = 'one';
 
 $attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
 $form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]);
 
-for ($i = 0; $host = $DBRESULT->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $host['host_id'] . ']');
-    if (isset($lockedElements[$host['host_id']])) {
-        $selectedElements->setAttribute('disabled', 'disabled');
-    } else {
-        $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-            . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-            . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-            . "name='dupNbr[" . $host['host_id'] . "]' />";
-    }
-    // If the name of our Host Model is in the Template definition, we have to catch it, whatever the level of it :-)
-    if (! $host['host_name']) {
-        $host['host_name'] = getMyHostName($host['host_template_model_htm_id']);
-    }
-
-    // TPL List
-    $tplArr = [];
-    $tplStr = null;
-
-    $tplArr = getMyHostMultipleTemplateModels($host['host_id']);
-    if (count($tplArr)) {
-        $firstTpl = 1;
-        foreach ($tplArr as $key => $value) {
-            $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-            if ($firstTpl) {
-                $tplStr .= "<a href='main.php?p=60103&o=c&host_id=" . $key . "'>" . $value . '</a>';
-                $firstTpl = 0;
-            } else {
-                $tplStr .= "&nbsp;|&nbsp;<a href='main.php?p=60103&o=c&host_id=" . $key . "'>" . $value . '</a>';
-            }
-        }
-    }
-
-    // Check icon
-    $isHostTemplateSvgFile = true;
-    if ((isset($ehiCache[$host['host_id']]) && $ehiCache[$host['host_id']])) {
-        $isHostTemplateSvgFile = false;
-        $host_icone = './img/media/' . $mediaObj->getFilename($ehiCache[$host['host_id']]);
-    } elseif (
-        $icone = $host_method->replaceMacroInString(
-            $host['host_id'],
-            getMyHostExtendedInfoImage($host['host_id'], 'ehi_icon_image', 1)
-        )
-    ) {
-        $isHostTemplateSvgFile = false;
-        $host_icone = './img/media/' . $icone;
-    } else {
-        $isHostTemplateSvgFile = true;
-        $host_icone = returnSvg('www/img/icons/host.svg', 'var(--icons-fill-color)', 16, 16);
-    }
-
-    // Service List
-    $svArr = [];
-    $svStr = null;
-    $svArr = getMyHostServices($host['host_id']);
-    $elemArr[$i] = [
-        'MenuClass' => 'list_' . $style,
-        'RowMenu_select' => $selectedElements->toHtml(),
-        'RowMenu_name' => $host['host_name'],
-        'RowMenu_link' => 'main.php?p=' . $p . '&o=c&host_id=' . $host['host_id'],
-        'RowMenu_desc' => $host['host_alias'],
-        'RowMenu_icone' => $host_icone,
-        'RowMenu_svChilds' => count($svArr),
-        'RowMenu_parent' => CentreonUtils::escapeSecure($tplStr),
-        'RowMenu_options' => $moptions,
-        'isHostTemplateSvgFile' => $isHostTemplateSvgFile,
-    ];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </SCRIPT>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
+
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
-        . 'var bChecked = isChecked();'
-        . "if (this.form.elements['{$option}'].selectedIndex != 0 && !bChecked) {"
-        . "   alert('" . _('Please select one or more items') . "'); return false;} "
-        . "if (this.form.elements['{$option}'].selectedIndex == 1 && confirm('"
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
-        . "   setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 2 && confirm('"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
-        . "   setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 3 || "
-        . "this.form.elements['{$option}'].selectedIndex == 4 || this.form.elements['{$option}'].selectedIndex == 5){"
-        . "   setO(this.form.elements['{$option}'].value); submit();} "
-        . "this.form.elements['o1'].selectedIndex = 0"];
-    $form->addElement(
-        'select',
-        $option,
-        null,
-        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'mc' => _('Mass Change')],
-        $attrs1
-    );
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'mc' => _('Mass Change')], $attrs);
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
-    $o1->setSelected(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
@@ -229,6 +92,4 @@ $tpl->assign('limit', $limit);
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-$tpl->assign('searchHT', $search);
-$tpl->assign('displayLocked', $displayLocked);
 $tpl->display('listHostTemplateModel.ihtml');


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered host template listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (1)

- **`ajaxHostTemplateListing.php`** — AJAX endpoint with session validation, ACL (page 60103), locked filter, template chain resolution, sanitized search, prepared statements.

### Modified files (2)

- **`listHostTemplateModel.ihtml`** — Filter box with search + locked checkbox. CentreonListing with `lockedField` support for disabled checkboxes/dup inputs on locked rows.
- **`listHostTemplateModel.php`** — Simplified controller.

### Tests (9 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Locked checkbox shows/hides locked templates
4. Locked rows have disabled checkboxes and dup inputs
5. Pagination and rows-per-page
6. Bulk duplication
7. Bulk deletion
8. Click navigates to edit form
9. Session state persistence

## How to test

1. Navigate to Configuration > Hosts > Templates
2. Test search, locked checkbox toggle
3. Verify locked templates have grayed-out checkboxes and dup inputs
4. Test pagination, duplicate, delete
5. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added AJAX endpoint that returned host templates with prepared statements.

**🔧 Refactors**
* Reworked host template controller to simplify logic and expose listing state.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98595743?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
