### PR TITLE
feat(configuration): modernize time period listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing.feature
@@ -7,41 +7,34 @@ Feature: Modern time period listing
     Given an admin user is logged in Centreon
     And several time periods exist
 
-  @TEST_LISTING-096
   Scenario: Time period listing loads via AJAX
     When the user navigates to the time periods listing
     Then the AJAX listing table is displayed with time period rows
 
-  @TEST_LISTING-097
   Scenario: Search filters time periods by name
     When the user navigates to the time periods listing
     And the user searches for a specific time period
     Then only the matching time period is displayed
 
-  @TEST_LISTING-098
   Scenario: Pagination and rows per page
     When the user navigates to the time periods listing
     Then the pagination info shows the total count
 
-  @TEST_LISTING-099
   Scenario: Bulk duplication works
     When the user navigates to the time periods listing
     And the user selects a time period and duplicates it
     Then a duplicated time period appears in the listing
 
-  @TEST_LISTING-100
   Scenario: Bulk deletion works
     When the user navigates to the time periods listing
     And the user selects a time period and deletes it
     Then the time period is removed from the listing
 
-  @TEST_LISTING-101
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the time periods listing
     And the user clicks on a time period name
     Then the time period edit form is displayed
 
-  @TEST_LISTING-102
   Scenario: Session state persists across navigation
     When the user navigates to the time periods listing
     And the user searches for a specific time period

--- a/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing.feature
@@ -1,0 +1,50 @@
+Feature: Modern time period listing
+    As a Centreon admin
+    I want to manage time periods from the modernized listing page
+    With AJAX search, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And several time periods exist
+
+  @TEST_LISTING-096
+  Scenario: Time period listing loads via AJAX
+    When the user navigates to the time periods listing
+    Then the AJAX listing table is displayed with time period rows
+
+  @TEST_LISTING-097
+  Scenario: Search filters time periods by name
+    When the user navigates to the time periods listing
+    And the user searches for a specific time period
+    Then only the matching time period is displayed
+
+  @TEST_LISTING-098
+  Scenario: Pagination and rows per page
+    When the user navigates to the time periods listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-099
+  Scenario: Bulk duplication works
+    When the user navigates to the time periods listing
+    And the user selects a time period and duplicates it
+    Then a duplicated time period appears in the listing
+
+  @TEST_LISTING-100
+  Scenario: Bulk deletion works
+    When the user navigates to the time periods listing
+    And the user selects a time period and deletes it
+    Then the time period is removed from the listing
+
+  @TEST_LISTING-101
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the time periods listing
+    And the user clicks on a time period name
+    Then the time period edit form is displayed
+
+  @TEST_LISTING-102
+  Scenario: Session state persists across navigation
+    When the user navigates to the time periods listing
+    And the user searches for a specific time period
+    And the user clicks on a time period name
+    And the user navigates back to the time periods listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing/index.ts
@@ -48,12 +48,12 @@ Given('an admin user is logged in Centreon', () => {
 Given('several time periods exist', () => {
   // Default install includes 24x7 and nonworkhours
   cy.addTimePeriod({
-    name: 'tp_test_alpha',
-    alias: 'Test TP Alpha'
+    alias: 'Test TP Alpha',
+    name: 'tp_test_alpha'
   });
   cy.addTimePeriod({
-    name: 'tp_test_beta',
-    alias: 'Test TP Beta'
+    alias: 'Test TP Beta',
+    name: 'tp_test_beta'
   });
 });
 
@@ -67,7 +67,10 @@ When('the user navigates to the time periods listing', () => {
 
 Then('the AJAX listing table is displayed with time period rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('tp_test_alpha').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_alpha')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -81,8 +84,14 @@ When('the user searches for a specific time period', () => {
 });
 
 Then('only the matching time period is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('tp_test_alpha').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('tp_test_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_beta')
+    .should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -109,14 +118,21 @@ When('the user selects a time period and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated time period appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('tp_test_alpha_1').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_alpha_1')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -132,14 +148,21 @@ When('the user selects a time period and deletes it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the time period is removed from the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('tp_test_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_beta')
+    .should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -147,12 +170,17 @@ Then('the time period is removed from the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a time period name', () => {
-  cy.getIframeBody().find('#clTableBody').contains('a', 'tp_test_alpha').click();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'tp_test_alpha')
+    .click();
 });
 
 Then('the time period edit form is displayed', () => {
   cy.waitForElementInIframe('#main-content', 'input[name="tp_name"]');
-  cy.getIframeBody().find('input[name="tp_name"]').should('have.value', 'tp_test_alpha');
+  cy.getIframeBody()
+    .find('input[name="tp_name"]')
+    .should('have.value', 'tp_test_alpha');
 });
 
 // ---------------------------------------------------------------------------
@@ -166,5 +194,7 @@ When('the user navigates back to the time periods listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'tp_test_alpha');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'tp_test_alpha');
 });

--- a/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/11-timeperiod-listing/index.ts
@@ -1,0 +1,170 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const tpPage = PAGES.configuration.timePeriodsLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(tpPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('several time periods exist', () => {
+  // Default install includes 24x7 and nonworkhours
+  cy.addTimePeriod({
+    name: 'tp_test_alpha',
+    alias: 'Test TP Alpha'
+  });
+  cy.addTimePeriod({
+    name: 'tp_test_beta',
+    alias: 'Test TP Beta'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the time periods listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with time period rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('tp_test_alpha').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific time period', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('tp_test_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching time period is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('tp_test_alpha').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('tp_test_beta').should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a time period and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated time period appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('tp_test_alpha_1').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects a time period and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('tp_test_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
+});
+
+Then('the time period is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('tp_test_beta').should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a time period name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'tp_test_alpha').click();
+});
+
+Then('the time period edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="tp_name"]');
+  cy.getIframeBody().find('input[name="tp_name"]').should('have.value', 'tp_test_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the time periods listing', () => {
+  cy.visit(tpPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'tp_test_alpha');
+});

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/timeperiod/ajaxTimeperiodListing.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/ajaxTimeperiodListing.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'WHERE tp_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS tp_id, tp_name, tp_alias'
+    . ' FROM timeperiod ' . $searchCond
+    . ' ORDER BY tp_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($tp = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'    => (int) $tp['tp_id'],
+        'name'  => $tp['tp_name'],
+        'alias' => $tp['tp_alias'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
@@ -7,10 +7,13 @@ CentreonForm.detectSidePanelClose();
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Time periods{/t}</h1>
-    <p class="cl-page-desc">{t}Define time ranges used to schedule checks and notifications.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Time periods{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define time ranges used to schedule checks and notifications.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$tpPage}&o=a', '{t}Add a Time Period{/t}'); return false;">{$msg.addT}</a>
@@ -20,12 +23,13 @@ CentreonForm.detectSidePanelClose();
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchTP" value="{$searchTP}" class="cl-search-simple" placeholder="{t}Search time periods{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
@@ -97,8 +97,9 @@ var tpListing = new CentreonListing({
             return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
-    renderOptions: function(row) {
-        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    renderOptions: function(row, l) {
+        var view = '<a href="#" title="Graphical view" class="cl-icon-action" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);" onclick="cfOpenPanel(\'main.get.php?p={/literal}{$tpPage}{literal}&o=s&tp_id=' + row.id + '\', \'' + l.escape((row.name || '') + ' - Graphical view') + '\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg></a>';
+        return view + '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
     }
 });
 tpListing.init();

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
@@ -1,75 +1,89 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Timeperiod{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchTP" value="{$searchTP}" class="mr-1">{$form.Search.html}</td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft">
-                <span><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></span>
-                <span style='float: right;'><a href='{$elemArr[elem].resultingLink}'><img
-                        src='./img/icones/16x16/table_view.gif'></a></span>
-            </td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-            <td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchTP" value="{$searchTP}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-    </table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="tpListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    { if $mode_access == 'w' }
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    { /if }
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
 
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
-    <input type='hidden' name='o' id='o' value='42'>
-
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+var tpListing = new CentreonListing({
+    instanceName:  'tpListing',
+    ajaxListUrl:   './include/configuration/configObject/timeperiod/ajaxTimeperiodListing.php',
+    pageId:        {/literal}'{$tpPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'tp_listing_limit',
+    emptyMessage:  'No time periods found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var editLink = 'main.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
+            var viewLink = 'main.php?p={/literal}{$tpPage}{literal}&o=s&tp_id=' + row.id;
+            return '<a href="'+editLink+'">'+l.escape(row.name)+'</a>' +
+                '<span style="float:right"><a href="'+viewLink+'"><img src="./img/icones/16x16/table_view.gif" title="View"></a></span>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+tpListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
@@ -93,16 +93,16 @@ var tpListing = new CentreonListing({
         { id:'name', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
             var title = '{/literal}{t}Modify Time Period{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var editUrl = 'main.get.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
             var title = '{/literal}{t}Modify Time Period{/t}{literal} - ' + row.name;
-            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {
-        var view = '<a href="#" title="Graphical view" class="cl-icon-action" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);" onclick="cfOpenPanel(\'main.get.php?p={/literal}{$tpPage}{literal}&o=s&tp_id=' + row.id + '\', \'' + l.escape((row.name || '') + ' - Graphical view') + '\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg></a>';
+        var view = '<a href="#" title="Graphical view" class="cl-icon-action" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);" onclick="cfOpenPanel(\'main.get.php?p={/literal}{$tpPage}{literal}&o=s&tp_id=' + row.id + '\', \'' + clEscapeAttr((row.name || '') + ' - Graphical view') + '\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg></a>';
         return view + '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
     }
 });

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
@@ -1,21 +1,33 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+<link href="./include/common/form/form.css" rel="stylesheet" type="text/css" />
+{literal}
+<script type="text/javascript">
+CentreonForm.detectSidePanelClose();
+</script>
+{/literal}
 
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Time periods{/t}</h1>
+    <p class="cl-page-desc">{t}Define time ranges used to schedule checks and notifications.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$tpPage}&o=a', '{t}Add a Time Period{/t}'); return false;">{$msg.addT}</a>
+
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchTP" value="{$searchTP}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchTP" value="{$searchTP}" class="cl-search-simple" placeholder="{t}Search time periods{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -30,7 +42,7 @@
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
                     { if $mode_access == 'w' }
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     { /if }
                 </tr>
             </thead>
@@ -39,16 +51,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -56,8 +58,22 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+
 var tpListing = new CentreonListing({
     instanceName:  'tpListing',
     ajaxListUrl:   './include/configuration/configObject/timeperiod/ajaxTimeperiodListing.php',
@@ -67,17 +83,18 @@ var tpListing = new CentreonListing({
     storageKey:    'tp_listing_limit',
     emptyMessage:  'No time periods found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var editLink = 'main.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
-            var viewLink = 'main.php?p={/literal}{$tpPage}{literal}&o=s&tp_id=' + row.id;
-            return '<a href="'+editLink+'">'+l.escape(row.name)+'</a>' +
-                '<span style="float:right"><a href="'+viewLink+'"><img src="./img/icones/16x16/table_view.gif" title="View"></a></span>';
+            var editUrl = 'main.get.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
+            var title = '{/literal}{t}Modify Time Period{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var editUrl = 'main.get.php?p={/literal}{$tpPage}{literal}&o=c&tp_id=' + row.id;
+            var title = '{/literal}{t}Modify Time Period{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {
@@ -85,5 +102,6 @@ var tpListing = new CentreonListing({
     }
 });
 tpListing.init();
+CentreonForm.initSidePanel(tpListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -24,31 +25,6 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchTP'] ?? $_GET['searchTP'] ?? null
-);
-if (isset($_POST['searchTP']) || isset($_GET['searchTP'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$SearchTool = '';
-if ($search) {
-    $SearchTool .= " WHERE tp_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%'";
-}
-
-// Timeperiod list
-$query = "SELECT SQL_CALC_FOUND_ROWS tp_id, tp_name, tp_alias FROM timeperiod {$SearchTool} "
-    . 'ORDER BY tp_name LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($query);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
@@ -56,42 +32,33 @@ $tpl = SmartyBC::createSmartyTemplate($path);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('tpPage', $p);
 
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchTP', $search);
+
+// Default limit from DB
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+// Form for bulk actions
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-// Different style between each lines
-$style = 'one';
 
 $attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
 $form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-
-for ($i = 0; $timeperiod = $dbResult->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $timeperiod['tp_id'] . ']');
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $timeperiod['tp_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $timeperiod['tp_name'], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&tp_id=' . $timeperiod['tp_id'], 'RowMenu_desc' => $timeperiod['tp_alias'], 'RowMenu_options' => $moptions, 'resultingLink' => 'main.php?p=' . $p . '&o=s&tp_id=' . $timeperiod['tp_id']];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
 $tpl->assign(
     'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
+    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]
 );
 
-// Toolbar select
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -101,7 +68,7 @@ $tpl->assign(
 <?php
 
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
+    $attrs = ['onchange' => 'javascript: '
         . ' var bChecked = isChecked(); '
         . "if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
         . " alert('" . _('Please select one or more items') . "'); return false;} "
@@ -119,16 +86,15 @@ foreach (['o1', 'o2'] as $option) {
         $option,
         null,
         [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-        $attrs1
+        $attrs
     );
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
-    $o1->setSelected(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchTP', $search);
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
@@ -43,9 +43,7 @@ $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchTP', $search);
 
 // Default limit from DB
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 // Form for bulk actions

--- a/centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.css
+++ b/centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.css
@@ -1,73 +1,60 @@
-td.unset,td.included,td.excluded,td.warning {
-	border: 0px;
-	padding: 0px;
-	margin: 0px;
-	height: 12px;
-	background-image: -webkit-gradient(linear, 0% 0, 100% 0, from(rgba(255, 255, 255, .55)
-		), to(rgba(255, 255, 255, .5) ), color-stop(.5, rgba(255, 255, 255, 0)
-		), color-stop(.8, rgba(255, 255, 255, 0) ) );
-	background-image: -moz-linear-gradient(top, rgba(255, 255, 255, .55),
-		rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0) 80%,
-		rgba(255, 255, 255, .5) );
-	background-image: gradient(linear, 0% 0, 100% 0, from(rgba(255, 255, 255, .55)
-		), to(rgba(255, 255, 255, .5) ), color-stop(.5, rgba(255, 255, 255, 0)
-		), color-stop(.8, rgba(255, 255, 255, 0) ) );
-	-webkit-transition: background .2s ease-in-out;
-	-moz-transition: background .2s ease-in-out;
-	transition: background .2s ease-in-out;
-	/* color */
-	color: hsl(0, 0%, 40%) !important;
-	-webkit-box-shadow: inset rgba(255, 254, 255, 0.6) 0 0.3em .3em, inset
-		rgba(0, 0, 0, 0.15) 0 -0.1em .3em, /* inner shadow */ 
-                                                 hsl(0, 0%, 60%) 0 .1em
-		3px, hsl(0, 0%, 45%) 0 .3em 1px, /* color border */ 
-                                                 rgba(0, 0, 0, 0.2) 0
-		.5em 5px; /* drop shadow */
-	-moz-box-shadow: inset rgba(255, 254, 255, 0.6) 0 0.3em .3em, inset
-		rgba(0, 0, 0, 0.15) 0 -0.1em .3em, /* inner shadow */ 
-                                                 hsl(0, 0%, 60%) 0 .1em
-		3px, hsl(0, 0%, 45%) 0 .3em 1px, /* color border */ 
-                                                 rgba(0, 0, 0, 0.2) 0
-		.5em 5px; /* drop shadow */
-	box-shadow: inset rgba(255, 254, 255, 0.6) 0 0.3em .3em, inset
-		rgba(0, 0, 0, 0.15) 0 -0.1em .3em, /* inner shadow */ 
-                                                 hsl(0, 0%, 60%) 0 .1em
-		3px, hsl(0, 0%, 45%) 0 .3em 1px, /* color border */ 
-                                                 rgba(0, 0, 0, 0.2) 0
-		.5em 5px; /* drop shadow */
+/* ==========================================================================
+   Time period — graphical view (modernized)
+   ========================================================================== */
+.tp-wrap { padding: 16px 18px; }
+
+.tp-title {
+    display: flex; align-items: center; gap: 8px;
+    font-size: 16px; font-weight: 600;
+    color: var(--c-text-primary, #255891);
+    margin: 0 0 14px;
+}
+.tp-title svg { color: var(--c-primary-main, #2E68AA); }
+
+.tp-switch { margin-bottom: 18px; }
+.tp-switch select {
+    height: 36px; min-width: 240px;
+    border: 1px solid var(--c-stroke, #d0d5dd); border-radius: 6px;
+    padding: 0 10px; background: #fff; font-size: 14px;
 }
 
-.unset {
-	color: #BBB;
-	background-color: #BBB;
+.tp-section-title {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 13px; font-weight: 600;
+    color: var(--c-text-primary, #255891);
+    margin: 20px 0 8px; padding-bottom: 4px;
+    border-bottom: 1px solid var(--c-divider, #e8e8e8);
 }
+.tp-section-title svg { color: var(--c-primary-main, #2E68AA); }
 
-.included {
-	color: #0B0;
-	background-color: #0B0;
-}
+.tp-meta { display: flex; gap: 40px; margin: 6px 0 4px; }
+.tp-meta span { display: block; font-size: 12px; color: var(--c-text-secondary, #6b7280); }
+.tp-meta b { font-size: 14px; color: var(--list-color, #333); }
 
-.excluded {
-	color: #B00;
-	background-color: #B00;
-}
+/* Timeline */
+.tp-timeline { display: flex; gap: 28px; align-items: flex-start; flex-wrap: wrap; }
+.tp-grid td { vertical-align: middle; }
+.tp-axis span { display: inline-block; font-size: 11px; color: var(--c-text-secondary, #6b7280); }
+.tp-day-label { font-size: 13px; padding: 3px 14px 3px 0; white-space: nowrap; color: var(--list-color, #333); }
 
-.warning {
-	color: #DD4;
-	background-color: #DD4;
+td.unset, td.included, td.excluded, td.warning {
+    border: 0; padding: 0; margin: 0; height: 14px; border-radius: 2px;
 }
+.unset    { background-color: #e3e7ec; }
+.included { background-color: var(--color-success, #88B922); }
+.excluded { background-color: #FF4A4A; }
+.warning  { background-color: #FFA600; }
+
+/* Legend */
+.tp-legend { display: flex; flex-direction: column; gap: 10px; padding-top: 4px; }
+.tp-legend-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--list-color, #333); }
+.tp-swatch { width: 28px; height: 14px; border-radius: 3px; display: inline-block; flex: 0 0 auto; }
+.tp-legend-hint { font-size: 12px; color: var(--c-text-secondary, #6b7280); font-style: italic; margin-top: 4px; }
+
+.tp-empty { text-align: center; padding: 28px; color: var(--c-text-secondary, #6b7280); }
 
 .toolTip {
-	border: 1px solid #999999;
-	background-color: #dddddd;
-	position: absolute;
-	padding: 1px 5px 1px 5px;
-}
-
-.buttonSet {
-	font-family: arial, sans-serif;
-	color: #336699;
-	background-color: #ffffff;
-	float: left;
-	border: 1px solid #999999;
+    border: 0; background: rgba(30, 41, 59, .95); color: #fff;
+    position: absolute; padding: 3px 8px; border-radius: 4px;
+    font-size: 12px; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,.2);
 }

--- a/centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.ihtml
@@ -1,116 +1,92 @@
-<link href="{$path}renderTimeperiod.css" rel="stylesheet" type="text/css">
- {$form.javascript}
+<link href="{$path}renderTimeperiod.css?v=1" rel="stylesheet" type="text/css">
+<link href="./include/common/listing/listing.css" rel="stylesheet" type="text/css">
+{$form.javascript}
 <form {$form.attributes}>
-<div id='tab1' class='tab'>
-	<table class="ListTable">
-		<tr class="ListHeader">
-			<td class="FormHeader">
-				<img src='./img/icones/16x16/calendar.gif'>&nbsp;&nbsp;{$form.header.title}
-			</td>
-			<td class="FormHeader" style='text-align: right;'>
-				{$form.tp_id.html}
-			</td>
-		</tr>
-		{if !$tpId}
-		<tr>
-			<td class='FormRowField' colspan='2'><center><b>{$labels.no_tp_selected}</b></center></td>
-		</tr>
-		{else}
-		<tr class="list_lvl_1">
-			<td class="ListColLvl1_name" colspan="2">
-				<img src='./img/icones/16x16/note.gif'>&nbsp;&nbsp;{$form.header.information}
-			</td>
-		</tr>
-		<tr class="list_one">
-			<td class="FormRowField">{$form.tp_name.label}</td>
-			<td class="FormRowValue">{$tp->getName()}</td>
-		</tr>
-		<tr class="list_two">
-			<td class="FormRowField">{$form.tp_alias.label}</td>
-			<td class="FormRowValue">{$tp->getAlias()}</td>
-		</tr>
-		<tr class="list_lvl_1">
-			<td class="ListColLvl1_name" colspan="2">
-				<img src='./img/icones/16x16/calendar.gif'>&nbsp;&nbsp;{$form.header.notification}
-			</td>
-		</tr>
-		<tr class="list_one">
-			<td class="FormRowField" colspan="2">
-				<table>
-					<tr>
-						<td class="FormRowField">
-							<table>
-								<tr class="list_one">
-									<td class="FormRowField">Day</td>
-                                    <td class="FormRowField" style="border:0px; width:360px;">
-                                    	<span style="border:0px; display:inline-block; width:50px;">0</span>
-                                        <span style="border:0px; display:inline-block; width:58px;">4</span>
-										<span style="border:0px; display:inline-block; width:58px;">8</span>
-                                        <span style="border:0px; display:inline-block; width:55px;">12</span>
-                                        <span style="border:0px; display:inline-block; width:55px;">16</span>
-                                        <span style="border:0px; display:inline-block; width:54px;">20</span>
-                                        <span style="border:0px; display:inline-block; width:auto;">24</span>
-									</td>
-								</tr>
-                    			{foreach from=$tp->getTimeline() key=day item=dtl}
-								<tr class="list_one">
-									<td class="FormRowField">{$form.$day.label}</td>
-                        			<td class="FormRowValue">
-	                            		<table>
-		                                	<tr style="border:0px;">
-												{foreach name=times from=$dtl item=time}
-												<td class="{$time.style}" style="border:0px; width:{$time.size}px;" onmouseover="showTip(event,'{$time.From}')" onmouseout="hideTip()"></td>
-		                                        {/foreach}
-											</tr>
-										</table>
-									</td>
-								</tr>
-								{/foreach}
-							</table>
-						</td>
-						<td class="FormRowField" style="vertical-align:middle;">
-							<br/>
-							<table>
-								<tr class="list_one"><td class="unset" style="width:50px;"> </td><td>{$labels.unset_timerange}</td></tr>
-								<tr style="height:6px;"><td colspan=2> </td></tr>
-								<tr class="list_one"><td class="included" style="width:50px;"> </td><td>{$labels.included_timerange}</td></tr>
-								<tr style="height:6px;"><td colspan=2> </td></tr>
-								<tr class="list_one"><td class="excluded" style="width:50px;"> </td><td>{$labels.excluded_timerange}</td></tr>
-								<tr style="height:6px;"><td colspan=2> </td></tr>
-								<tr class="list_one"><td class="warning" style="width:50px;"> </td><td>{$labels.timerange_overlaps}</td></tr>
-								<tr style="height:6px;"><td colspan=2> </td></tr>
-								<tr class="list_one"><td colspan=2>{$labels.hover_for_info}</td></tr>
-							</table>
-						</td>
-					</tr>
-				</table>
-			</td>
-		</tr>
-		<tr class="list_lvl_1">
-			<td class="ListColLvl1_name" colspan="2">
-				<img src='./img/icones/16x16/date-time_preferences.gif'>&nbsp;&nbsp;{$form.header.exception}
-			</td>
-		</tr>
-		<tr class="list_two">
-			<td class='FormRowField' colspan="2">
-				<table id="exceptionTable" class="ListTableSmall" style='text-align:left; padding-top:0px'>
-					<tr>
-						<th class="ListColLeft">TimePeriod</th>
-						<th class="ListColLeft">Day</th>
-						<th class="ListColLeft">TimeRange</th>
-					</tr>
-					{foreach from=$tp->getExceptionList() item=exception}
-					<tr class="FormRowField">
-						<td class="ListColLeft">{$exception.fromTpName}</td>
-						<td class="ListColLeft">{$exception.day}</td>
-						<td class="ListColLeft">{$exception.range}</td>
-					</tr>
-					{/foreach}
-				</table>
-			</td>
-		</tr>
-		{/if}
-	</table>
+<div class="tp-wrap">
+
+    <div class="tp-title">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+        {$form.header.title}
+    </div>
+
+    <div class="tp-switch">
+        {$form.tp_id.html}
+    </div>
+
+    {if !$tpId}
+        <div class="tp-empty">{$labels.no_tp_selected}</div>
+    {else}
+
+    <div class="tp-section-title">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        {$form.header.information}
+    </div>
+    <div class="tp-meta">
+        <div><span>{$form.tp_name.label}</span><b>{$tp->getName()|escape}</b></div>
+        <div><span>{$form.tp_alias.label}</span><b>{$tp->getAlias()|escape}</b></div>
+    </div>
+
+    <div class="tp-section-title">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+        {$form.header.notification}
+    </div>
+    <div class="tp-timeline">
+        <table class="tp-grid">
+            <tr>
+                <td class="tp-day-label">&nbsp;</td>
+                <td class="tp-axis" style="width:360px;">
+                    <span style="width:50px;">0</span><span style="width:58px;">4</span><span style="width:58px;">8</span><span style="width:55px;">12</span><span style="width:55px;">16</span><span style="width:54px;">20</span><span style="width:auto;">24</span>
+                </td>
+            </tr>
+            {foreach from=$tp->getTimeline() key=day item=dtl}
+            <tr>
+                <td class="tp-day-label">{$form.$day.label}</td>
+                <td>
+                    <table style="width:360px;"><tr style="border:0px;">
+                        {foreach name=times from=$dtl item=time}
+                        <td class="{$time.style}" style="border:0px; width:{$time.size}px;" onmouseover="showTip(event,'{$time.From}')" onmouseout="hideTip()"></td>
+                        {/foreach}
+                    </tr></table>
+                </td>
+            </tr>
+            {/foreach}
+        </table>
+
+        <div class="tp-legend">
+            <div class="tp-legend-item"><span class="tp-swatch unset"></span>{$labels.unset_timerange}</div>
+            <div class="tp-legend-item"><span class="tp-swatch included"></span>{$labels.included_timerange}</div>
+            <div class="tp-legend-item"><span class="tp-swatch excluded"></span>{$labels.excluded_timerange}</div>
+            <div class="tp-legend-item"><span class="tp-swatch warning"></span>{$labels.timerange_overlaps}</div>
+            <div class="tp-legend-hint">{$labels.hover_for_info}</div>
+        </div>
+    </div>
+
+    <div class="tp-section-title">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        {$form.header.exception}
+    </div>
+    <table id="exceptionTable" class="cl-listing-table">
+        <thead>
+            <tr>
+                <th>{t}Time period{/t}</th>
+                <th>{t}Day{/t}</th>
+                <th>{t}Time range{/t}</th>
+            </tr>
+        </thead>
+        <tbody>
+        {foreach from=$tp->getExceptionList() item=exception}
+            <tr>
+                <td>{$exception.fromTpName|escape}</td>
+                <td>{$exception.day|escape}</td>
+                <td>{$exception.range|escape}</td>
+            </tr>
+        {foreachelse}
+            <tr><td colspan="3" class="tp-empty">-</td></tr>
+        {/foreach}
+        </tbody>
+    </table>
+
+    {/if}
 </div>
 {$form.hidden}
 </form>

--- a/centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
@@ -21,9 +21,13 @@ if (! isset($centreon)) {
     exit();
 }
 
-$tpG = $_GET['tp_id'] ?? null;
-$tpP = $_POST['tp_id'] ?? null;
-$tp_id = $tpG ?: $tpP;
+// tp_id is concatenated into SQL downstream (CentreonTimePeriodRenderer):
+// force it to a strict integer to prevent SQL injection via the request.
+$rawTpId = $_GET['tp_id'] ?? $_POST['tp_id'] ?? null;
+$tp_id = filter_var($rawTpId, FILTER_VALIDATE_INT);
+if ($tp_id === false || $tp_id <= 0) {
+    $tp_id = null;
+}
 $path = './include/configuration/configObject/timeperiod/';
 require_once $path . 'DB-Func.php';
 require_once './include/common/common-Func.php';


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered time period listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (1)

- **`ajaxTimeperiodListing.php`** — AJAX endpoint. Session validation, ACL (page 60304), sanitized search, prepared statements.

### Modified files (2)

- **`listTimeperiod.ihtml`** — Rewritten with `cl-*` classes: search, pagination, dup inputs. No toggle (time periods have no activate field).
- **`listTimeperiod.php`** — Simplified controller.

### Tests (7 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Pagination info displayed
4. Bulk duplication
5. Bulk deletion
6. Click navigates to edit form
7. Session state persistence

## How to test

1. Navigate to Configuration > Users > Time Periods
2. Test search, pagination, duplicate, delete
3. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Introduced AJAX endpoint to list time periods with pagination.

**🔧 Refactors**
* Rewrote time period controller to use modern template variables.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98605258?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
