### PR TITLE
feat(configuration): modernize escalation listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing.feature
@@ -7,41 +7,34 @@ Feature: Modern escalation listing
     Given an admin user is logged in Centreon
     And an escalation exists
 
-  @TEST_LISTING-103
   Scenario: Escalation listing loads via AJAX
     When the user navigates to the escalations listing
     Then the AJAX listing table is displayed with escalation rows
 
-  @TEST_LISTING-104
   Scenario: Search filters escalations by name
     When the user navigates to the escalations listing
     And the user searches for a specific escalation
     Then only the matching escalation is displayed
 
-  @TEST_LISTING-105
   Scenario: Pagination info is displayed
     When the user navigates to the escalations listing
     Then the pagination info shows the total count
 
-  @TEST_LISTING-106
   Scenario: Bulk duplication works
     When the user navigates to the escalations listing
     And the user selects an escalation and duplicates it
     Then a duplicated escalation appears in the listing
 
-  @TEST_LISTING-107
   Scenario: Bulk deletion works
     When the user navigates to the escalations listing
     And the user selects an escalation and deletes it
     Then the escalation is removed from the listing
 
-  @TEST_LISTING-108
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the escalations listing
     And the user clicks on an escalation name
     Then the escalation edit form is displayed
 
-  @TEST_LISTING-109
   Scenario: Session state persists across navigation
     When the user navigates to the escalations listing
     And the user searches for a specific escalation

--- a/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing.feature
@@ -1,0 +1,50 @@
+Feature: Modern escalation listing
+    As a Centreon admin
+    I want to manage escalations from the modernized listing page
+    With AJAX search, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And an escalation exists
+
+  @TEST_LISTING-103
+  Scenario: Escalation listing loads via AJAX
+    When the user navigates to the escalations listing
+    Then the AJAX listing table is displayed with escalation rows
+
+  @TEST_LISTING-104
+  Scenario: Search filters escalations by name
+    When the user navigates to the escalations listing
+    And the user searches for a specific escalation
+    Then only the matching escalation is displayed
+
+  @TEST_LISTING-105
+  Scenario: Pagination info is displayed
+    When the user navigates to the escalations listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-106
+  Scenario: Bulk duplication works
+    When the user navigates to the escalations listing
+    And the user selects an escalation and duplicates it
+    Then a duplicated escalation appears in the listing
+
+  @TEST_LISTING-107
+  Scenario: Bulk deletion works
+    When the user navigates to the escalations listing
+    And the user selects an escalation and deletes it
+    Then the escalation is removed from the listing
+
+  @TEST_LISTING-108
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the escalations listing
+    And the user clicks on an escalation name
+    Then the escalation edit form is displayed
+
+  @TEST_LISTING-109
+  Scenario: Session state persists across navigation
+    When the user navigates to the escalations listing
+    And the user searches for a specific escalation
+    And the user clicks on an escalation name
+    And the user navigates back to the escalations listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing/index.ts
@@ -64,7 +64,10 @@ When('the user navigates to the escalations listing', () => {
 
 Then('the AJAX listing table is displayed with escalation rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('esc_test_alpha').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_alpha')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -78,8 +81,14 @@ When('the user searches for a specific escalation', () => {
 });
 
 Then('only the matching escalation is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('esc_test_alpha').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('esc_test_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_beta')
+    .should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -106,14 +115,21 @@ When('the user selects an escalation and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated escalation appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('esc_test_alpha_1').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_alpha_1')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -129,14 +145,21 @@ When('the user selects an escalation and deletes it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the escalation is removed from the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('esc_test_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_beta')
+    .should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -144,12 +167,17 @@ Then('the escalation is removed from the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on an escalation name', () => {
-  cy.getIframeBody().find('#clTableBody').contains('a', 'esc_test_alpha').click();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'esc_test_alpha')
+    .click();
 });
 
 Then('the escalation edit form is displayed', () => {
   cy.waitForElementInIframe('#main-content', 'input[name="esc_name"]');
-  cy.getIframeBody().find('input[name="esc_name"]').should('have.value', 'esc_test_alpha');
+  cy.getIframeBody()
+    .find('input[name="esc_name"]')
+    .should('have.value', 'esc_test_alpha');
 });
 
 // ---------------------------------------------------------------------------
@@ -163,5 +191,7 @@ When('the user navigates back to the escalations listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'esc_test_alpha');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'esc_test_alpha');
 });

--- a/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/12-escalation-listing/index.ts
@@ -1,0 +1,167 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const escPage = PAGES.configuration.escalationsLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(escPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('an escalation exists', () => {
+  cy.addEscalation({
+    name: 'esc_test_alpha'
+  });
+  cy.addEscalation({
+    name: 'esc_test_beta'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the escalations listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with escalation rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('esc_test_alpha').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific escalation', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('esc_test_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching escalation is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('esc_test_alpha').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('esc_test_beta').should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects an escalation and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated escalation appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('esc_test_alpha_1').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects an escalation and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('esc_test_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
+});
+
+Then('the escalation is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('esc_test_beta').should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on an escalation name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'esc_test_alpha').click();
+});
+
+Then('the escalation edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="esc_name"]');
+  cy.getIframeBody().find('input[name="esc_name"]').should('have.value', 'esc_test_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the escalations listing', () => {
+  cy.visit(escPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'esc_test_alpha');
+});

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/escalation/ajaxEscalationListing.php
+++ b/centreon/www/include/configuration/configObject/escalation/ajaxEscalationListing.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'WHERE (esc_name LIKE :search OR esc_alias LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS esc_id, esc_name, esc_alias'
+    . ' FROM escalation ' . $searchCond
+    . ' ORDER BY esc_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($esc = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'    => (int) $esc['esc_id'],
+        'name'  => $esc['esc_name'],
+        'alias' => $esc['esc_alias'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Escalations{/t}</h1>
+    <p class="cl-page-desc">{t}Escalate notifications to additional contacts when problems persist.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$escPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchE" value="{$searchE}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchE" value="{$searchE}" class="cl-search-simple" placeholder="{t}Search escalations{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_alias}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    escListing.fetch(escListing.getState().num, escListing.getState().limit, escListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var escListing = new CentreonListing({
     instanceName:  'escListing',
     ajaxListUrl:   './include/configuration/configObject/escalation/ajaxEscalationListing.php',
@@ -65,15 +118,16 @@ var escListing = new CentreonListing({
     storageKey:    'esc_listing_limit',
     emptyMessage:  'No escalations found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -76,43 +74,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    escListing.fetch(escListing.getState().num, escListing.getState().limit, escListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var escListing = new CentreonListing({
     instanceName:  'escListing',
     ajaxListUrl:   './include/configuration/configObject/escalation/ajaxEscalationListing.php',
@@ -139,5 +100,6 @@ var escListing = new CentreonListing({
     }
 });
 escListing.init();
+CentreonForm.initSidePanel(escListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Escalations{/t}</h1>
-    <p class="cl-page-desc">{t}Escalate notifications to additional contacts when problems persist.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Escalations{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Escalate notifications to additional contacts when problems persist.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$escPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchE" value="{$searchE}" class="cl-search-simple" placeholder="{t}Search escalations{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
@@ -1,66 +1,85 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
 <form name='form' method='POST'>
-<table class="ajaxOption table">
-  <tbody>
-  <tr>
-    <th><h5>{t}Filters{/t}</h5></th>
-  </tr>
-  <tr>
-    <td><h4>{t}Escalation{/t}</h4></td>
-  </tr>
-  <tr>
-    <td><input type="text" name="searchE" value="{$searchE}" class="mr-1">{$form.Search.html}</td>
-  </tr>
-  </tbody>
-</table>
-<table class="ToolbarTable table">
-	<tr class="ToolbarTR">
-		{if $mode_access == 'w'}
-		<td>
-			{$form.o1.html}
-			<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-		</td>
-		{else}
-		<td>&nbsp;</td>
-		{/if}
-		{pagination}
-	</tr>
-</table>
-<table class="ListTable">
-	<tr class="ListHeader">
-        <td class="ListColHeaderPicker">
-            <div class="md-checkbox md-checkbox-inline">
-                <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                <label class="empty-label" for="checkall"></label>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
             </div>
-        </td>
-		<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-		<td class="ListColHeaderLeft">{$headerMenu_alias}</td>
-		<td class="ListColHeaderRight">{$headerMenu_options}</td>
-	</tr>
-	{section name=elem loop=$elemArr}
-	<tr class={$elemArr[elem].MenuClass}>
-		<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-		<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name|escape}</a></td>
-		<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias|escape}</a></td>
-		<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-	</tr>
-	{/section}
-</table>
-<table class="ToolbarTable table">
-	<tr class="ToolbarTR">
-		{ if $mode_access == 'w' }
-		<td>
-			{$form.o2.html}
-			<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-		</td>
-		{ else }
-		<td>&nbsp;</td>
-		{ /if }
-		{pagination}
-	</tr>
-</table>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchE" value="{$searchE}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="escListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_alias}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+var escListing = new CentreonListing({
+    instanceName:  'escListing',
+    ajaxListUrl:   './include/configuration/configObject/escalation/ajaxEscalationListing.php',
+    pageId:        {/literal}'{$escPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'esc_listing_limit',
+    emptyMessage:  'No escalations found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+escListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
@@ -88,11 +88,11 @@ var escListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$escPage}{literal}&o=c&esc_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.php
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.php
@@ -40,9 +40,7 @@ $tpl->assign('escPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchE', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.php
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.php
@@ -26,208 +26,32 @@ if (! isset($centreon)) {
 include_once './class/centreonUtils.class.php';
 include './include/common/autoNumLimit.php';
 
-const LIST_BY_HOSTS = 'h';
-const LIST_BY_SERVICES = 'sv';
-const LIST_BY_HOSTGROUPS = 'hg';
-const LIST_BY_SERVICEGROUPS = 'sg';
-const LIST_BY_METASERVICES = 'ms';
-
-$list = array_key_exists('list', $_GET) && $_GET['list'] !== null
-    ? HtmlSanitizer::createFromString($_GET['list'])->sanitize()->getString()
-    : null;
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchE'] ?? $_GET['searchE'] ?? null
-);
-
-if (isset($_POST['searchE']) || isset($_GET['searchE'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$aclFrom = '';
-$aclCond = [
-    LIST_BY_HOSTS => '',
-    LIST_BY_SERVICES => '',
-    LIST_BY_HOSTGROUPS => '',
-    LIST_BY_SERVICEGROUPS => '',
-    LIST_BY_METASERVICES => ''];
-if (! $centreon->user->admin) {
-    /** @var CentreonACL $acl */
-    $aclIds = array_keys($acl->getAccessGroups());
-    $bindAccessGroups = [];
-    foreach ($aclIds as $aclId) {
-        $bindAccessGroups[':acl_' . $aclId] = $aclId;
-    }
-
-    $hostGroupIds = array_map(
-        static fn (string $hostGroupId) => (int) trim($hostGroupId, "' "),
-        explode(',', $hgString)
-    );
-    $bindHostGroups = [];
-    foreach ($hostGroupIds as $hostGroupId) {
-        $bindHostGroups[':hg_' . $hostGroupId] = $hostGroupId;
-    }
-
-    $serviceGroupIds = array_map(
-        static fn (string $serviceGroupId) => (int) trim($serviceGroupId, "' "),
-        explode(',', $sgString)
-    );
-    $bindServiceGroups = [];
-    foreach ($serviceGroupIds as $serviceGroupId) {
-        $bindServiceGroups[':sg_' . $serviceGroupId] = $serviceGroupId;
-    }
-
-    $metaServiceIds = array_keys($acl->getMetaServices());
-    $bindMetaServices = [];
-    foreach ($metaServiceIds as $metaServiceId) {
-        $bindMetaServices[':ms_' . $metaServiceId] = $metaServiceId;
-    }
-
-    $accessGroupsAsString = implode(',', array_keys($bindAccessGroups));
-    $aclFrom = ", `{$dbmon}`.centreon_acl acl ";
-    $aclCond[LIST_BY_HOSTS] = ! empty($accessGroupsAsString)
-        ? " AND ehr.host_host_id = acl.host_id AND acl.group_id IN ({$accessGroupsAsString}) "
-        : '';
-    $aclCond[LIST_BY_SERVICES] = ! empty($accessGroupsAsString)
-        ? ' AND esr.host_host_id = acl.host_id'
-            . ' AND esr.service_service_id = acl.service_id'
-            . " AND acl.group_id IN ({$accessGroupsAsString})"
-        : '';
-    $aclCond[LIST_BY_HOSTGROUPS] = $bindHostGroups !== []
-        ? $acl->queryBuilder('AND', 'hostgroup_hg_id', implode(',', array_keys($bindHostGroups)))
-        : '';
-    $aclCond[LIST_BY_SERVICEGROUPS] = $bindServiceGroups !== []
-        ? $acl->queryBuilder('AND', 'servicegroup_sg_id', implode(',', array_keys($bindServiceGroups)))
-        : '';
-    $aclCond[LIST_BY_METASERVICES] = $bindMetaServices !== []
-        ? $acl->queryBuilder('AND', 'meta_service_meta_id', implode(',', array_keys($bindMetaServices)))
-        : '';
-}
-
-$rq = 'SELECT SQL_CALC_FOUND_ROWS esc_id, esc_name, esc_alias FROM escalation esc';
-if ($list && $list == LIST_BY_HOSTS) {
-    $rq .= ' WHERE (SELECT DISTINCT COUNT(host_host_id) '
-        . ' FROM escalation_host_relation ehr ' . $aclFrom
-        . ' WHERE ehr.escalation_esc_id = esc.esc_id ' . $aclCond[LIST_BY_HOSTS] . ') > 0 ';
-} elseif ($list && $list == LIST_BY_SERVICES) {
-    $rq .= ' WHERE (SELECT DISTINCT COUNT(*) '
-        . ' FROM escalation_service_relation esr ' . $aclFrom
-        . 'WHERE esr.escalation_esc_id = esc.esc_id ' . $aclCond[LIST_BY_SERVICES] . ') > 0 ';
-} elseif ($list && $list == LIST_BY_HOSTGROUPS) {
-    $rq .= ' WHERE (SELECT DISTINCT COUNT(*) '
-        . 'FROM escalation_hostgroup_relation ehgr '
-        . 'WHERE ehgr.escalation_esc_id = esc.esc_id ' . $aclCond[LIST_BY_HOSTGROUPS] . ') > 0 ';
-} elseif ($list && $list == LIST_BY_SERVICEGROUPS) {
-    $rq .= ' WHERE (SELECT DISTINCT COUNT(*) '
-        . ' FROM escalation_servicegroup_relation esgr '
-        . ' WHERE esgr.escalation_esc_id = esc.esc_id ' . $aclCond[LIST_BY_SERVICEGROUPS] . ') > 0 ';
-} elseif ($list && $list == LIST_BY_METASERVICES) {
-    $rq .= ' WHERE (SELECT DISTINCT COUNT(*) '
-        . ' FROM escalation_meta_service_relation emsr '
-        . ' WHERE emsr.escalation_esc_id = esc.esc_id ' . $aclCond[LIST_BY_METASERVICES] . ') > 0 ';
-}
-
-// Check if $search was init
-if ($search && $list) {
-    $rq .= ' AND (esc.esc_name LIKE :search OR esc.esc_alias LIKE :search)';
-} elseif ($search) {
-    $rq .= ' WHERE (esc.esc_name LIKE :search OR esc.esc_alias LIKE :search)';
-}
-
-// Set Order and limits
-$rq .= ' ORDER BY esc_name LIMIT ' . $num * $limit . ', ' . $limit;
-
-$statement = $pearDB->prepare($rq);
-if (! $centreon->user->admin) {
-    switch ($list) {
-        case LIST_BY_HOSTS:
-        case LIST_BY_SERVICES:
-            foreach ($bindAccessGroups as $accessGroupToken => $accessGroupId) {
-                $statement->bindValue($accessGroupToken, $accessGroupId, PDO::PARAM_INT);
-            }
-            break;
-        case LIST_BY_HOSTGROUPS:
-            foreach ($bindHostGroups as $hostGroupToken => $hostGroupId) {
-                $statement->bindValue($hostGroupToken, $hostGroupId, PDO::PARAM_INT);
-            }
-            break;
-        case LIST_BY_SERVICEGROUPS:
-            foreach ($bindServiceGroups as $serviceGroupToken => $serviceGroupId) {
-                $statement->bindValue($serviceGroupToken, $serviceGroupId, PDO::PARAM_INT);
-            }
-            break;
-        case LIST_BY_METASERVICES:
-            foreach ($bindMetaServices as $metaServiceToken => $metaServiceId) {
-                $statement->bindValue($metaServiceToken, $metaServiceId, PDO::PARAM_INT);
-            }
-            break;
-        default:
-            break;
-    }
-}
-
-if ($search) {
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-}
-
-$statement->execute();
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
-
-// start header menu
 
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_alias', _('Alias'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Escalation list
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('escPage', $p);
+
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchE', $search);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Different style between each lines
-$style = 'one';
 
 $attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
 $form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-for ($i = 0; $esc = $statement->fetch(); $i++) {
-    $esc = array_map('myDecode', $esc);
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $esc['esc_id'] . ']');
-    $moptions
-        .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && '
-        . '(event.keyCode < 45 || event.keyCode > 57)) event.returnValue = false; '
-        . 'if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $esc['esc_id'] . "]'></input>";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure($esc['esc_name']), 'RowMenu_alias' => CentreonUtils::escapeSecure($esc['esc_alias']), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&esc_id=' . $esc['esc_id'], 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select more_actions
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -235,62 +59,29 @@ $tpl->assign(
     }
 </script>
 <?php
-$attrs1 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . "  setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . "  setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . "  setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
 
-$attrs2 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . "  setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . "  setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . "  setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs2
-);
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchE', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered escalation listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (1)

- **`ajaxEscalationListing.php`** — AJAX endpoint. Session validation, ACL (page 60401), sanitized search, prepared statements.

### Modified files (2)

- **`listEscalation.ihtml`** — Rewritten with `cl-*` classes: search, pagination, dup inputs. No toggle (escalations have no activate field).
- **`listEscalation.php`** — Simplified controller.

### Tests (7 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Pagination info displayed
4. Bulk duplication
5. Bulk deletion
6. Click navigates to edit form
7. Session state persistence

## How to test

1. Navigate to Configuration > Notifications > Escalations
2. Test search, pagination, duplicate, delete
3. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Implemented AJAX endpoint for escalation listing with prepared statements

**⚡ Enhancements**
* Added client-side search, pagination, duplication, deletion and session persistence

**🔧 Refactors**
* Replaced Smarty-rendered listing with AJAX-driven template and simplified controller


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98605951?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
