### PR TITLE
feat(configuration): modernize all dependency listings with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing.feature
@@ -1,0 +1,60 @@
+Feature: Modern dependency listings (host, hostgroup, service, servicegroup, metaservice)
+    As a Centreon admin
+    I want to manage all dependency types from modernized listing pages
+    With AJAX search, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-121
+  Scenario: Host dependency listing loads via AJAX
+    Given a host dependency exists
+    When the user navigates to the host dependencies listing
+    Then the AJAX listing table is displayed with dependency rows
+
+  @TEST_LISTING-122
+  Scenario: Search filters host dependencies
+    Given a host dependency exists
+    When the user navigates to the host dependencies listing
+    And the user searches for a specific dependency
+    Then only the matching dependency is displayed
+
+  @TEST_LISTING-123
+  Scenario: Host dependency bulk duplication
+    Given a host dependency exists
+    When the user navigates to the host dependencies listing
+    And the user selects a dependency and duplicates it
+    Then a duplicated dependency appears in the listing
+
+  @TEST_LISTING-124
+  Scenario: Hostgroup dependency listing loads via AJAX
+    Given a hostgroup dependency exists
+    When the user navigates to the hostgroup dependencies listing
+    Then the AJAX listing table is displayed with dependency rows
+
+  @TEST_LISTING-125
+  Scenario: Service dependency listing loads via AJAX
+    Given a service dependency exists
+    When the user navigates to the service dependencies listing
+    Then the AJAX listing table is displayed with dependency rows
+
+  @TEST_LISTING-126
+  Scenario: Servicegroup dependency listing loads via AJAX
+    Given a servicegroup dependency exists
+    When the user navigates to the servicegroup dependencies listing
+    Then the AJAX listing table is displayed with dependency rows
+
+  @TEST_LISTING-127
+  Scenario: Metaservice dependency listing loads via AJAX
+    Given a metaservice dependency exists
+    When the user navigates to the metaservice dependencies listing
+    Then the AJAX listing table is displayed with dependency rows
+
+  @TEST_LISTING-128
+  Scenario: Session state persists on host dependency listing
+    Given a host dependency exists
+    When the user navigates to the host dependencies listing
+    And the user searches for a specific dependency
+    And the user clicks on a dependency name
+    And the user navigates back to the host dependencies listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing.feature
@@ -6,51 +6,43 @@ Feature: Modern dependency listings (host, hostgroup, service, servicegroup, met
   Background:
     Given an admin user is logged in Centreon
 
-  @TEST_LISTING-121
   Scenario: Host dependency listing loads via AJAX
     Given a host dependency exists
     When the user navigates to the host dependencies listing
     Then the AJAX listing table is displayed with dependency rows
 
-  @TEST_LISTING-122
   Scenario: Search filters host dependencies
     Given a host dependency exists
     When the user navigates to the host dependencies listing
     And the user searches for a specific dependency
     Then only the matching dependency is displayed
 
-  @TEST_LISTING-123
   Scenario: Host dependency bulk duplication
     Given a host dependency exists
     When the user navigates to the host dependencies listing
     And the user selects a dependency and duplicates it
     Then a duplicated dependency appears in the listing
 
-  @TEST_LISTING-124
   Scenario: Hostgroup dependency listing loads via AJAX
     Given a hostgroup dependency exists
     When the user navigates to the hostgroup dependencies listing
     Then the AJAX listing table is displayed with dependency rows
 
-  @TEST_LISTING-125
   Scenario: Service dependency listing loads via AJAX
     Given a service dependency exists
     When the user navigates to the service dependencies listing
     Then the AJAX listing table is displayed with dependency rows
 
-  @TEST_LISTING-126
   Scenario: Servicegroup dependency listing loads via AJAX
     Given a servicegroup dependency exists
     When the user navigates to the servicegroup dependencies listing
     Then the AJAX listing table is displayed with dependency rows
 
-  @TEST_LISTING-127
   Scenario: Metaservice dependency listing loads via AJAX
     Given a metaservice dependency exists
     When the user navigates to the metaservice dependencies listing
     Then the AJAX listing table is displayed with dependency rows
 
-  @TEST_LISTING-128
   Scenario: Session state persists on host dependency listing
     Given a host dependency exists
     When the user navigates to the host dependencies listing

--- a/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing/index.ts
@@ -1,0 +1,182 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const hostDepPage = PAGES.configuration.hostsDependenciesLegacy;
+const hgDepPage = PAGES.configuration.hostGroupsDependenciesLegacy;
+const svcDepPage = PAGES.configuration.servicesDependenciesLegacy;
+const sgDepPage = PAGES.configuration.serviceGroupsDependenciesLegacy;
+const msDepPage = PAGES.configuration.metaServicesDependenciesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(page: string): void {
+  cy.visit(page);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('a host dependency exists', () => {
+  cy.addHostDependency({
+    name: 'dep_host_alpha',
+    description: 'Test host dependency'
+  });
+  cy.addHostDependency({
+    name: 'dep_host_beta',
+    description: 'Test host dependency 2'
+  });
+});
+
+Given('a hostgroup dependency exists', () => {
+  cy.addHostGroupDependency({
+    name: 'dep_hg_alpha',
+    description: 'Test HG dependency'
+  });
+});
+
+Given('a service dependency exists', () => {
+  cy.addServiceDependency({
+    name: 'dep_svc_alpha',
+    description: 'Test service dependency'
+  });
+});
+
+Given('a servicegroup dependency exists', () => {
+  cy.addServiceGroupDependency({
+    name: 'dep_sg_alpha',
+    description: 'Test SG dependency'
+  });
+});
+
+Given('a metaservice dependency exists', () => {
+  cy.addMetaServiceDependency({
+    name: 'dep_ms_alpha',
+    description: 'Test meta dependency'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Host dependency
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the host dependencies listing', () => {
+  visitAndWait(hostDepPage);
+});
+
+Then('the AJAX listing table is displayed with dependency rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+When('the user searches for a specific dependency', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('dep_host_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching dependency is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('dep_host_alpha').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('dep_host_beta').should('not.exist');
+});
+
+When('the user selects a dependency and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('dep_host_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated dependency appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('dep_host_alpha_1').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Hostgroup dependency
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the hostgroup dependencies listing', () => {
+  visitAndWait(hgDepPage);
+});
+
+// ---------------------------------------------------------------------------
+// Service dependency
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service dependencies listing', () => {
+  visitAndWait(svcDepPage);
+});
+
+// ---------------------------------------------------------------------------
+// Servicegroup dependency
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the servicegroup dependencies listing', () => {
+  visitAndWait(sgDepPage);
+});
+
+// ---------------------------------------------------------------------------
+// Metaservice dependency
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the metaservice dependencies listing', () => {
+  visitAndWait(msDepPage);
+});
+
+// ---------------------------------------------------------------------------
+// Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a dependency name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'dep_host_alpha').click();
+});
+
+When('the user navigates back to the host dependencies listing', () => {
+  cy.visit(hostDepPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'dep_host_alpha');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/14-dependencies-listing/index.ts
@@ -51,40 +51,40 @@ Given('an admin user is logged in Centreon', () => {
 
 Given('a host dependency exists', () => {
   cy.addHostDependency({
-    name: 'dep_host_alpha',
-    description: 'Test host dependency'
+    description: 'Test host dependency',
+    name: 'dep_host_alpha'
   });
   cy.addHostDependency({
-    name: 'dep_host_beta',
-    description: 'Test host dependency 2'
+    description: 'Test host dependency 2',
+    name: 'dep_host_beta'
   });
 });
 
 Given('a hostgroup dependency exists', () => {
   cy.addHostGroupDependency({
-    name: 'dep_hg_alpha',
-    description: 'Test HG dependency'
+    description: 'Test HG dependency',
+    name: 'dep_hg_alpha'
   });
 });
 
 Given('a service dependency exists', () => {
   cy.addServiceDependency({
-    name: 'dep_svc_alpha',
-    description: 'Test service dependency'
+    description: 'Test service dependency',
+    name: 'dep_svc_alpha'
   });
 });
 
 Given('a servicegroup dependency exists', () => {
   cy.addServiceGroupDependency({
-    name: 'dep_sg_alpha',
-    description: 'Test SG dependency'
+    description: 'Test SG dependency',
+    name: 'dep_sg_alpha'
   });
 });
 
 Given('a metaservice dependency exists', () => {
   cy.addMetaServiceDependency({
-    name: 'dep_ms_alpha',
-    description: 'Test meta dependency'
+    description: 'Test meta dependency',
+    name: 'dep_ms_alpha'
   });
 });
 
@@ -98,7 +98,9 @@ When('the user navigates to the host dependencies listing', () => {
 
 Then('the AJAX listing table is displayed with dependency rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 When('the user searches for a specific dependency', () => {
@@ -108,8 +110,14 @@ When('the user searches for a specific dependency', () => {
 });
 
 Then('only the matching dependency is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('dep_host_alpha').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('dep_host_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('dep_host_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('dep_host_beta')
+    .should('not.exist');
 });
 
 When('the user selects a dependency and duplicates it', () => {
@@ -121,14 +129,21 @@ When('the user selects a dependency and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated dependency appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('dep_host_alpha_1').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('dep_host_alpha_1')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -168,7 +183,10 @@ When('the user navigates to the metaservice dependencies listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a dependency name', () => {
-  cy.getIframeBody().find('#clTableBody').contains('a', 'dep_host_alpha').click();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'dep_host_alpha')
+    .click();
 });
 
 When('the user navigates back to the host dependencies listing', () => {
@@ -178,5 +196,7 @@ When('the user navigates back to the host dependencies listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'dep_host_alpha');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'dep_host_alpha');
 });

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/host_dependency/ajaxHostDepListing.php
+++ b/centreon/www/include/configuration/configObject/host_dependency/ajaxHostDepListing.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (d.dep_name LIKE :search OR d.dep_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS d.dep_id, d.dep_name, d.dep_description'
+    . ' FROM dependency d'
+    . ' INNER JOIN dependency_hostParent_relation rel ON rel.dependency_dep_id = d.dep_id'
+    . ' WHERE 1=1 ' . $searchCond
+    . ' GROUP BY d.dep_id ORDER BY d.dep_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($dep = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'   => (int) $dep['dep_id'],
+        'name' => $dep['dep_name'],
+        'desc' => $dep['dep_description'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Host dependencies{/t}</h1>
-    <p class="cl-page-desc">{t}Suppress host notifications based on the state of other hosts.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Host dependencies{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Suppress host notifications based on the state of other hosts.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depHDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchHD" value="{$searchHD}" class="cl-search-simple" placeholder="{t}Search host dependencies{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -89,11 +89,11 @@ var hdListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Host dependencies{/t}</h1>
+    <p class="cl-page-desc">{t}Suppress host notifications based on the state of other hosts.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depHDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchHD" value="{$searchHD}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchHD" value="{$searchHD}" class="cl-search-simple" placeholder="{t}Search host dependencies{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    hdListing.fetch(hdListing.getState().num, hdListing.getState().limit, hdListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var hdListing = new CentreonListing({
     instanceName:  'hdListing',
     ajaxListUrl:   './include/configuration/configObject/host_dependency/ajaxHostDepListing.php',
@@ -65,15 +118,16 @@ var hdListing = new CentreonListing({
     storageKey:    'host_dependency_listing_limit',
     emptyMessage:  'No dependencies found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -1,74 +1,85 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Host dependency{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchHD" value="{$searchHD}" class="mr-1">{$form.Search.html}</td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchHD" value="{$searchHD}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_description}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_description}</a></td>
-			<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	
-	</table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="hdListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
 
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
 
-{$form.hidden}
+{literal}
+<script type="text/javascript">
+var hdListing = new CentreonListing({
+    instanceName:  'hdListing',
+    ajaxListUrl:   './include/configuration/configObject/host_dependency/ajaxHostDepListing.php',
+    pageId:        {/literal}'{$depHDPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'host_dependency_listing_limit',
+    emptyMessage:  'No dependencies found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depHDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+hdListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -76,42 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    hdListing.fetch(hdListing.getState().num, hdListing.getState().limit, hdListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var hdListing = new CentreonListing({
     instanceName:  'hdListing',
@@ -139,5 +103,6 @@ var hdListing = new CentreonListing({
     }
 });
 hdListing.init();
+CentreonForm.initSidePanel(hdListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
@@ -40,9 +40,7 @@ $tpl->assign('depHDPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchHD', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
@@ -1,6 +1,8 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,15 +16,8 @@
  * limitations under the License.
  *
  * For more information : contact@centreon.com
+ *
  */
-
-declare(strict_types=1);
-
-use Adaptation\Database\Connection\Collection\QueryParameters;
-use Adaptation\Database\Connection\Exception\ConnectionException;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
-use Core\Common\Domain\Exception\CollectionException;
-use Core\Common\Domain\Exception\ValueObjectException;
 
 if (! isset($centreon)) {
     exit();
@@ -31,223 +26,57 @@ if (! isset($centreon)) {
 include_once './class/centreonUtils.class.php';
 include './include/common/autoNumLimit.php';
 
-// Preserve and sanitize search term
-$rawSearch = $_POST['searchHD'] ?? $_GET['searchHD'] ?? null;
-
-if ($rawSearch !== null) {
-    // saving filters values
-    $search = HtmlSanitizer::createFromString((string) $rawSearch)
-        ->removeTags()
-        ->sanitize()
-        ->getString();
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-// Fetch dependencies from DB with pagination
-try {
-    $db = $pearDB;
-    $qb = $db->createQueryBuilder();
-
-    $qb->select('dep.dep_id', 'dep.dep_name', 'dep.dep_description')
-        ->distinct()
-        ->from('dependency', 'dep')
-        ->innerJoin('dep', 'dependency_hostParent_relation', 'dhpr', 'dhpr.dependency_dep_id = dep.dep_id');
-
-    if (! $centreon->user->admin) {
-        $qb->innerJoin(
-            'dep',
-            "{$dbmon}.centreon_acl",
-            'acl',
-            'dhpr.host_host_id = acl.host_id'
-        )
-            ->andWhere("acl.group_id IN ({$acl->getAccessGroupsString()})");
-    }
-
-    $params = null;
-    // Search filter
-    if ($search !== null && $search !== '') {
-        $qb->andWhere(
-            $qb->expr()->or(
-                $qb->expr()->like('dep.dep_name', ':search'),
-                $qb->expr()->like('dep.dep_description', ':search')
-            )
-        );
-        $params = QueryParameters::create([QueryParameter::string('search', "%{$search}%")]);
-
-    }
-
-    // Ordering and pagination
-    $qb->orderBy('dep.dep_name')
-        ->addOrderBy('dep.dep_description')
-        ->limit($limit)
-        ->offset($num * $limit);
-
-    $sql = $qb->getQuery();
-    $dependencies = $db->fetchAllAssociative($sql, $params);
-
-    // Count total for pagination
-    $countQueryBuilder = $db->createQueryBuilder()
-        ->select('COUNT(DISTINCT dep.dep_id) AS total')
-        ->from('dependency', 'dep')
-        ->innerJoin('dep', 'dependency_hostParent_relation', 'dhpr', 'dhpr.dependency_dep_id = dep.dep_id');
-
-    if (! $centreon->user->admin) {
-        $countQueryBuilder->innerJoin(
-            'dep',
-            "{$dbmon}.centreon_acl",
-            'acl',
-            'dhpr.host_host_id = acl.host_id'
-        )
-            ->andWhere("acl.group_id IN ({$acl->getAccessGroupsString()})");
-    }
-    if ($search !== null && $search !== '') {
-        $countQueryBuilder->andWhere(
-            $countQueryBuilder->expr()->or(
-                $countQueryBuilder->expr()->like('dep.dep_name', ':search'),
-                $countQueryBuilder->expr()->like('dep.dep_description', ':search')
-            )
-        );
-    }
-
-    $countSql = $countQueryBuilder->getQuery();
-    $countResult = $pearDB->fetchAssociative($countSql, $params);
-    $rows = (int) ($countResult['total'] ?? 0);
-} catch (ValueObjectException|CollectionException|ConnectionException $exception) {
-    CentreonLog::create()->error(
-        CentreonLog::TYPE_SQL,
-        'Error while fetching host dependencies',
-        ['search' => $search],
-        $exception
-    );
-    $msg = new CentreonMsg();
-    $msg->setImage('./img/icons/warning.png');
-    $msg->setTextStyle('bold');
-    $msg->setText(_('Error while retrieving host dependencies'));
-    $dependencies = [];
-    $rows = 0;
-}
-
-// Pagination setup
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
-$lvlAccess = ($centreon->user->access->page($p) === 1) ? 'w' : 'r';
-$tpl->assign('mode_access', $lvlAccess);
+
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_description', _('Description'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Build search form & results
-$searchKey = tidySearchKey($search, $advanced_search);
-$form = new HTML_QuickFormCustom('select_form', 'POST', "?p={$p}");
-$form->addElement(
-    'submit',
-    'Search',
-    _('Search'),
-    [
-        'class' => 'btc bt_success',
-        'onClick' => "window.history.replaceState('', '', '?p={$p}');",
-    ]
-);
+$tpl->assign('depHDPage', $p);
 
-$elemArr = [];
-$style = 'one';
-foreach ($dependencies as $dep) {
-    $depId = (int) $dep['dep_id'];
-    $checkbox = $form->addElement('checkbox', "select[{$depId}]");
-    $dupInput = sprintf(
-        '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" style="margin-bottom:0;" name="dupNbr[%d]"/>',
-        $depId
-    );
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchHD', $search);
 
-    $elemArr[] = [
-        'MenuClass' => "list_{$style}",
-        'RowMenu_select' => $checkbox->toHtml(),
-        'RowMenu_name' => CentreonUtils::escapeSecure(myDecode((string) $dep['dep_name'])),
-        'RowMenu_description' => CentreonUtils::escapeSecure(myDecode((string) $dep['dep_description'])),
-        'RowMenu_link' => "main.php?p={$p}&o=c&dep_id={$depId}",
-        'RowMenu_options' => $dupInput,
-    ];
-    $style = ($style === 'one') ? 'two' : 'one';
-}
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-$tpl->assign('elemArr', $elemArr);
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-// Different messages we put in the template
-$tpl->assign('msg', [
-    'addL' => "main.php?p={$p}&o=a",
-    'addT' => _('Add'),
-    'delConfirm' => _('Do you confirm the deletion ?'),
-]);
-
-// Toolbar select
 ?>
 <script type="text/javascript">
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
+    function setO(_i) { document.forms['form'].elements['o'].value = _i; }
 </script>
 <?php
-$attrs1 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
 
-$attrs2 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs2
-);
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchHD', $searchKey);
-
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/ajaxHgDepListing.php
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/ajaxHgDepListing.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (d.dep_name LIKE :search OR d.dep_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS d.dep_id, d.dep_name, d.dep_description'
+    . ' FROM dependency d'
+    . ' INNER JOIN dependency_hostgroupParent_relation rel ON rel.dependency_dep_id = d.dep_id'
+    . ' WHERE 1=1 ' . $searchCond
+    . ' GROUP BY d.dep_id ORDER BY d.dep_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($dep = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'   => (int) $dep['dep_id'],
+        'name' => $dep['dep_name'],
+        'desc' => $dep['dep_description'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Host group dependencies{/t}</h1>
-    <p class="cl-page-desc">{t}Suppress notifications based on the state of other host groups.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Host group dependencies{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Suppress notifications based on the state of other host groups.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depHGDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchHGD" value="{$searchHGD}" class="cl-search-simple" placeholder="{t}Search host group dependencies{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -76,42 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    hgdListing.fetch(hgdListing.getState().num, hgdListing.getState().limit, hgdListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var hgdListing = new CentreonListing({
     instanceName:  'hgdListing',
@@ -139,5 +103,6 @@ var hgdListing = new CentreonListing({
     }
 });
 hgdListing.init();
+CentreonForm.initSidePanel(hgdListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Host group dependencies{/t}</h1>
+    <p class="cl-page-desc">{t}Suppress notifications based on the state of other host groups.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depHGDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchHGD" value="{$searchHGD}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchHGD" value="{$searchHGD}" class="cl-search-simple" placeholder="{t}Search host group dependencies{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    hgdListing.fetch(hgdListing.getState().num, hgdListing.getState().limit, hgdListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var hgdListing = new CentreonListing({
     instanceName:  'hgdListing',
     ajaxListUrl:   './include/configuration/configObject/hostgroup_dependency/ajaxHgDepListing.php',
@@ -65,15 +118,16 @@ var hgdListing = new CentreonListing({
     storageKey:    'hostgroup_dep_listing_limit',
     emptyMessage:  'No dependencies found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -89,11 +89,11 @@ var hgdListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -1,70 +1,85 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Hostgroup dependency{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchHGD" value="{$searchHGD}" class="mr-1">{$form.Search.html}</td>
-      </tr>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchHGD" value="{$searchHGD}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_description}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_description}</a></td>
-			<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	
-	</table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="hgdListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
 
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+var hgdListing = new CentreonListing({
+    instanceName:  'hgdListing',
+    ajaxListUrl:   './include/configuration/configObject/hostgroup_dependency/ajaxHgDepListing.php',
+    pageId:        {/literal}'{$depHGDPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'hostgroup_dep_listing_limit',
+    emptyMessage:  'No dependencies found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depHGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+hgdListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -18,218 +19,64 @@
  *
  */
 
-use Adaptation\Database\Connection\Collection\QueryParameters;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
-
 if (! isset($centreon)) {
     exit();
 }
 
 include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-$list = $_GET['list'] ?? null;
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchHGD'] ?? $_GET['searchHGD'] ?? null
-);
-
-if (isset($_POST['searchHGD']) || isset($_GET['searchHGD'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-// List dependencies
-$qb = $pearDB->createQueryBuilder()
-    ->select('dep.dep_id', 'dep.dep_name', 'dep.dep_description')
-    ->from('dependency', 'dep');
-
-$subQueryParent = $pearDB->createQueryBuilder()
-    ->select('COUNT(DISTINCT dhgpr_parent.dependency_dep_id)')
-    ->from('dependency_hostgroupParent_relation', 'dhgpr_parent')
-    ->where('dhgpr_parent.dependency_dep_id = dep.dep_id');
-
-$subQueryChild = $pearDB->createQueryBuilder()
-    ->select('COUNT(DISTINCT dhgpr_child.dependency_dep_id)')
-    ->from('dependency_hostgroupChild_relation', 'dhgpr_child')
-    ->where('dhgpr_child.dependency_dep_id = dep.dep_id');
-
-if (! $oreon->user->admin) {
-    $subQueryParent->andWhere("dhgpr_parent.hostgroup_hg_id IN ({$hgstring})");
-    $subQueryChild->andWhere("dhgpr_child.hostgroup_hg_id IN ({$hgstring})");
-}
-
-$qb->where('(' . $subQueryParent->getQuery() . ') > 0')
-    ->orWhere('(' . $subQueryChild->getQuery() . ') > 0');
-
-$params = null;
-if ($search) {
-    $qb->andWhere(
-        $qb->expr()->or(
-            $qb->expr()->like('dep.dep_name', ':search'),
-            $qb->expr()->like('dep.dep_description', ':search')
-        )
-    );
-
-    $params = QueryParameters::create([
-        QueryParameter::string('search', '%' . $search . '%'),
-    ]);
-}
-
-$qb->orderBy('dep.dep_name')
-    ->addOrderBy('dep.dep_description')
-    ->offset($num * $limit)
-    ->limit($limit);
-
-$result = $pearDB->fetchAllAssociative($qb->getQuery(), $params ?? null);
-
-// get rows count with same filters as the select query
-$countQb = $pearDB->createQueryBuilder()
-    ->select('COUNT(DISTINCT dep.dep_id)')
-    ->from('dependency', 'dep');
-
-$countSubQueryParent = $pearDB->createQueryBuilder()
-    ->select('COUNT(DISTINCT dhgpr_parent.dependency_dep_id)')
-    ->from('dependency_hostgroupParent_relation', 'dhgpr_parent')
-    ->where('dhgpr_parent.dependency_dep_id = dep.dep_id');
-
-$countSubQueryChild = $pearDB->createQueryBuilder()
-    ->select('COUNT(DISTINCT dhgpr_child.dependency_dep_id)')
-    ->from('dependency_hostgroupChild_relation', 'dhgpr_child')
-    ->where('dhgpr_child.dependency_dep_id = dep.dep_id');
-
-if (! $oreon->user->admin) {
-    $countSubQueryParent->andWhere("dhgpr_parent.hostgroup_hg_id IN ({$hgstring})");
-    $countSubQueryChild->andWhere("dhgpr_child.hostgroup_hg_id IN ({$hgstring})");
-}
-
-$countQb->where('(' . $countSubQueryParent->getQuery() . ') > 0')
-    ->orWhere('(' . $countSubQueryChild->getQuery() . ') > 0');
-
-if ($search) {
-    $countQb->andWhere(
-        $countQb->expr()->or(
-            $countQb->expr()->like('dep.dep_name', ':search'),
-            $countQb->expr()->like('dep.dep_description', ':search')
-        )
-    );
-}
-
-$rows = $pearDB->fetchOne($countQb->getQuery(), $params ?? null);
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_description', _('Alias'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('depHGDPage', $p);
 
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-foreach ($result as $i => $dep) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $dep['dep_id'] . ']');
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57))'
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $dep['dep_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure($dep['dep_name']), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&dep_id=' . $dep['dep_id'], 'RowMenu_description' => CentreonUtils::escapeSecure($dep['dep_description']), 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar
-?>
-<script type="text/javascript">
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-</script>
-<?php
-$attrs1 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
-
-$attrs2 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs2
-);
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
+$search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchHGD', $search);
 
-// Apply a template definition
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
+
+?>
+<script type="text/javascript">
+    function setO(_i) { document.forms['form'].elements['o'].value = _i; }
+</script>
+<?php
+
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
+
+$tpl->assign('limit', $limit);
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
@@ -40,9 +40,7 @@ $tpl->assign('depHGDPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchHGD', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/ajaxMsDepListing.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/ajaxMsDepListing.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (d.dep_name LIKE :search OR d.dep_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS d.dep_id, d.dep_name, d.dep_description'
+    . ' FROM dependency d'
+    . ' INNER JOIN dependency_metaserviceParent_relation rel ON rel.dependency_dep_id = d.dep_id'
+    . ' WHERE 1=1 ' . $searchCond
+    . ' GROUP BY d.dep_id ORDER BY d.dep_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($dep = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'   => (int) $dep['dep_id'],
+        'name' => $dep['dep_name'],
+        'desc' => $dep['dep_description'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Meta service dependencies{/t}</h1>
-    <p class="cl-page-desc">{t}Suppress notifications based on the state of other meta services.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Meta service dependencies{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Suppress notifications based on the state of other meta services.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depMSDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchMSD" value="{$searchMSD}" class="cl-search-simple" placeholder="{t}Search meta service dependencies{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -1,72 +1,85 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Meta-service dependency{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchMSD" value="{$searchMSD}" class="mr-1">{$form.Search.html}</td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchMSD" value="{$searchMSD}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_description}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_description}</a></td>
-			<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	
-	</table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="msdListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
 
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+var msdListing = new CentreonListing({
+    instanceName:  'msdListing',
+    ajaxListUrl:   './include/configuration/configObject/metaservice_dependency/ajaxMsDepListing.php',
+    pageId:        {/literal}'{$depMSDPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'metaservice_dependency_listing_limit',
+    emptyMessage:  'No dependencies found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+msdListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -76,42 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    msdListing.fetch(msdListing.getState().num, msdListing.getState().limit, msdListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var msdListing = new CentreonListing({
     instanceName:  'msdListing',
@@ -139,5 +103,6 @@ var msdListing = new CentreonListing({
     }
 });
 msdListing.init();
+CentreonForm.initSidePanel(msdListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Meta service dependencies{/t}</h1>
+    <p class="cl-page-desc">{t}Suppress notifications based on the state of other meta services.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depMSDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchMSD" value="{$searchMSD}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchMSD" value="{$searchMSD}" class="cl-search-simple" placeholder="{t}Search meta service dependencies{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    msdListing.fetch(msdListing.getState().num, msdListing.getState().limit, msdListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var msdListing = new CentreonListing({
     instanceName:  'msdListing',
     ajaxListUrl:   './include/configuration/configObject/metaservice_dependency/ajaxMsDepListing.php',
@@ -65,15 +118,16 @@ var msdListing = new CentreonListing({
     storageKey:    'metaservice_dependency_listing_limit',
     emptyMessage:  'No dependencies found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -89,11 +89,11 @@ var msdListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depMSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
@@ -40,9 +40,7 @@ $tpl->assign('depMSDPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchMSD', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -23,152 +24,59 @@ if (! isset($centreon)) {
 }
 
 include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-$list = $_GET['list'] ?? null;
-
-$aclCond = '';
-if (! $centreon->user->admin) {
-    $aclCond = " AND meta_service_meta_id IN ({$metastr}) ";
-}
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchMSD'] ?? $_GET['searchMSD'] ?? null
-);
-
-if (isset($_POST['searchMSD']) || isset($_GET['searchMSD'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-// Dependency list
-$rq = 'SELECT SQL_CALC_FOUND_ROWS dep_id, dep_name, dep_description FROM dependency dep';
-$rq .= " WHERE ((SELECT DISTINCT COUNT(*) 
-                    FROM dependency_metaserviceParent_relation dmspr 
-                    WHERE dmspr.dependency_dep_id = dep.dep_id {$aclCond}) > 0 
-             OR    (SELECT DISTINCT COUNT(*) 
-                    FROM dependency_metaserviceChild_relation dmspr 
-                    WHERE dmspr.dependency_dep_id = dep.dep_id {$aclCond}) > 0)";
-
-if ($search) {
-    $rq .= " AND (dep_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8')
-        . "%' OR dep_description LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%')";
-}
-$rq .= ' ORDER BY dep_name, dep_description LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($rq);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_description', _('Description'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('depMSDPage', $p);
 
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-for ($i = 0; $dep = $dbResult->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $dep['dep_id'] . ']');
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" . $dep['dep_id'] . "]' />";
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure($dep['dep_name']), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&dep_id=' . $dep['dep_id'], 'RowMenu_description' => CentreonUtils::escapeSecure($dep['dep_description']), 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-include './include/common/checkPagination.php';
-
-// Toolbar select more_actions
-?>
-<script type="text/javascript">
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-</script>
-<?php
-$attrs1 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-
-$attrs = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o2' => null]);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-
-$tpl->assign('limit', $limit);
+$search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchMSD', $search);
 
-// Apply a template definition
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
+
+?>
+<script type="text/javascript">
+    function setO(_i) { document.forms['form'].elements['o'].value = _i; }
+</script>
+<?php
+
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
+
+$tpl->assign('limit', $limit);
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/configuration/configObject/service_dependency/ajaxSvcDepListing.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/ajaxSvcDepListing.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (d.dep_name LIKE :search OR d.dep_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS d.dep_id, d.dep_name, d.dep_description'
+    . ' FROM dependency d'
+    . ' INNER JOIN dependency_serviceParent_relation rel ON rel.dependency_dep_id = d.dep_id'
+    . ' WHERE 1=1 ' . $searchCond
+    . ' GROUP BY d.dep_id ORDER BY d.dep_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($dep = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'   => (int) $dep['dep_id'],
+        'name' => $dep['dep_name'],
+        'desc' => $dep['dep_description'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -1,71 +1,85 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Service dependency{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchSD" value="{$searchSD}" class="mr-1">{$form.Search.html}</td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_description}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_description}</a>
-            </td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchSD" value="{$searchSD}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="svcdListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
-    <input type='hidden' name='o' id='o' value='42'>
-
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+var svcdListing = new CentreonListing({
+    instanceName:  'svcdListing',
+    ajaxListUrl:   './include/configuration/configObject/service_dependency/ajaxSvcDepListing.php',
+    pageId:        {/literal}'{$depSDPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'service_dep_listing_limit',
+    emptyMessage:  'No dependencies found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+svcdListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -89,11 +89,11 @@ var svcdListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Service dependencies{/t}</h1>
+    <p class="cl-page-desc">{t}Suppress service notifications based on the state of other services.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depSDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchSD" value="{$searchSD}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchSD" value="{$searchSD}" class="cl-search-simple" placeholder="{t}Search service dependencies{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    svcdListing.fetch(svcdListing.getState().num, svcdListing.getState().limit, svcdListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var svcdListing = new CentreonListing({
     instanceName:  'svcdListing',
     ajaxListUrl:   './include/configuration/configObject/service_dependency/ajaxSvcDepListing.php',
@@ -65,15 +118,16 @@ var svcdListing = new CentreonListing({
     storageKey:    'service_dep_listing_limit',
     emptyMessage:  'No dependencies found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$depSDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -76,42 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    svcdListing.fetch(svcdListing.getState().num, svcdListing.getState().limit, svcdListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var svcdListing = new CentreonListing({
     instanceName:  'svcdListing',
@@ -139,5 +103,6 @@ var svcdListing = new CentreonListing({
     }
 });
 svcdListing.init();
+CentreonForm.initSidePanel(svcdListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Service dependencies{/t}</h1>
-    <p class="cl-page-desc">{t}Suppress service notifications based on the state of other services.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Service dependencies{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Suppress service notifications based on the state of other services.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depSDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchSD" value="{$searchSD}" class="cl-search-simple" placeholder="{t}Search service dependencies{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
@@ -40,9 +40,7 @@ $tpl->assign('depSDPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchSD', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -18,160 +19,64 @@
  *
  */
 
-if (! isset($oreon)) {
+if (! isset($centreon)) {
     exit();
 }
 
 include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-$list = $_GET['list'] ?? null;
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchSD'] ?? $_GET['searchSD'] ?? null
-);
-
-if (isset($_POST['searchSD']) || isset($_GET['searchSD'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$aclFrom = '';
-$aclCond = '';
-if (! $oreon->user->admin) {
-    $aclFrom = ", `{$dbmon}`.centreon_acl acl ";
-    $aclCond = ' AND dspr.host_host_id = acl.host_id 
-                 AND acl.service_id = dspr.service_service_id 
-                 AND acl.group_id IN (' . $acl->getAccessGroupsString() . ') ';
-}
-
-$rq = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT dep_id, dep_name, dep_description '
-    . 'FROM dependency dep, dependency_serviceParent_relation dspr ' . $aclFrom . ' '
-    . 'WHERE dspr.dependency_dep_id = dep.dep_id ' . $aclCond . ' '
-    . "AND dspr.host_host_id NOT IN (SELECT host_id FROM host WHERE host_register = '2') ";
-
-if ($search) {
-    $rq .= " AND (dep_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8')
-        . "%' OR dep_description LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%')";
-}
-$rq .= ' ORDER BY dep_name, dep_description LIMIT ' . $num * $limit . ', ' . $limit;
-
-$DBRESULT = $pearDB->query($rq);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_description', _('Description'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('depSDPage', $p);
 
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-for ($i = 0; $dep = $DBRESULT->fetchRow(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $dep['dep_id'] . ']');
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $dep['dep_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure(myDecode($dep['dep_name'])), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&dep_id=' . $dep['dep_id'], 'RowMenu_description' => CentreonUtils::escapeSecure(myDecode($dep['dep_description'])), 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
-?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </script>
-<?php
-$attrs1 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
-
-$attrs2 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs2
-);
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
+$search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchSD', $search);
 
-// Apply a template definition
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
+
+?>
+<script type="text/javascript">
+    function setO(_i) { document.forms['form'].elements['o'].value = _i; }
+</script>
+<?php
+
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
+
+$tpl->assign('limit', $limit);
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/ajaxSgDepListing.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/ajaxSgDepListing.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (d.dep_name LIKE :search OR d.dep_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS d.dep_id, d.dep_name, d.dep_description'
+    . ' FROM dependency d'
+    . ' INNER JOIN dependency_servicegroupParent_relation rel ON rel.dependency_dep_id = d.dep_id'
+    . ' WHERE 1=1 ' . $searchCond
+    . ' GROUP BY d.dep_id ORDER BY d.dep_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($dep = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'   => (int) $dep['dep_id'],
+        'name' => $dep['dep_name'],
+        'desc' => $dep['dep_description'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Service group dependencies{/t}</h1>
+    <p class="cl-page-desc">{t}Suppress notifications based on the state of other service groups.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depSGDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchSGD" value="{$searchSGD}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchSGD" value="{$searchSGD}" class="cl-search-simple" placeholder="{t}Search service group dependencies{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    sgdListing.fetch(sgdListing.getState().num, sgdListing.getState().limit, sgdListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var sgdListing = new CentreonListing({
     instanceName:  'sgdListing',
     ajaxListUrl:   './include/configuration/configObject/servicegroup_dependency/ajaxSgDepListing.php',
@@ -65,15 +118,16 @@ var sgdListing = new CentreonListing({
     storageKey:    'servicegroup_dependency_listing_limit',
     emptyMessage:  'No dependencies found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Service group dependencies{/t}</h1>
-    <p class="cl-page-desc">{t}Suppress notifications based on the state of other service groups.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Service group dependencies{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Suppress notifications based on the state of other service groups.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$depSGDPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchSGD" value="{$searchSGD}" class="cl-search-simple" placeholder="{t}Search service group dependencies{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -1,71 +1,85 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Servicegroup dependency{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchSGD" value="{$searchSGD}" class="mr-1">{$form.Search.html}</td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_description}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_description}</a>
-            </td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchSGD" value="{$searchSGD}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="sgdListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
-    <input type='hidden' name='o' id='o' value='42'>
-
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+var sgdListing = new CentreonListing({
+    instanceName:  'sgdListing',
+    ajaxListUrl:   './include/configuration/configObject/servicegroup_dependency/ajaxSgDepListing.php',
+    pageId:        {/literal}'{$depSGDPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'servicegroup_dependency_listing_limit',
+    emptyMessage:  'No dependencies found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+sgdListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -76,42 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    sgdListing.fetch(sgdListing.getState().num, sgdListing.getState().limit, sgdListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var sgdListing = new CentreonListing({
     instanceName:  'sgdListing',
@@ -139,5 +103,6 @@ var sgdListing = new CentreonListing({
     }
 });
 sgdListing.init();
+CentreonForm.initSidePanel(sgdListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -89,11 +89,11 @@ var sgdListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$depSGDPage}{literal}&o=c&dep_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row) {

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
@@ -40,9 +40,7 @@ $tpl->assign('depSGDPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchSGD', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -23,152 +24,59 @@ if (! isset($centreon)) {
 }
 
 include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-$list = $_GET['list'] ?? null;
-
-$aclCond = '';
-if (! $centreon->user->admin) {
-    $aclCond = " AND servicegroup_sg_id IN ({$sgstring}) ";
-}
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchSGD'] ?? $_GET['searchSGD'] ?? null
-);
-if (isset($_POST['searchSGD']) || isset($_GET['searchSGD'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-// Dependencies list
-$rq = 'SELECT SQL_CALC_FOUND_ROWS dep_id, dep_name, dep_description FROM dependency dep';
-$rq .= ' WHERE ((SELECT DISTINCT COUNT(*)
-                    FROM dependency_servicegroupParent_relation dsgpr
-                    WHERE dsgpr.dependency_dep_id = dep.dep_id ' . $aclCond . ') > 0
-             OR    (SELECT DISTINCT COUNT(*)
-                    FROM dependency_servicegroupChild_relation dsgpr
-                    WHERE dsgpr.dependency_dep_id = dep.dep_id ' . $aclCond . ') > 0)';
-// Search Case
-if ($search) {
-    $rq .= " AND (dep_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8')
-        . "%' OR dep_description LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%')";
-}
-$rq .= ' ORDER BY dep_name, dep_description LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($rq);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-//  start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_description', _('Description'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('depSGDPage', $p);
 
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-for ($i = 0; $dep = $dbResult->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $dep['dep_id'] . ']');
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" . $dep['dep_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure(htmlentities($dep['dep_name'])), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&dep_id=' . $dep['dep_id'], 'RowMenu_description' => CentreonUtils::escapeSecure(htmlentities($dep['dep_description'])), 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
-?>
-<script type="text/javascript">
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-</script>
-<?php
-$attrs1 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
-
-$attrs2 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs2
-);
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
+$search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchSGD', $search);
 
-// Apply a template definition
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
+
+?>
+<script type="text/javascript">
+    function setO(_i) { document.forms['form'].elements['o'].value = _i; }
+</script>
+<?php
+
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . "     setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
+
+$tpl->assign('limit', $limit);
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());


### PR DESCRIPTION
## Summary

Replaces the 5 legacy Smarty-rendered dependency listings with AJAX-driven tables using the shared `CentreonListing` framework.

## What changed

### 5 pages migrated (15 files)

| Page | AJAX endpoint | ACL page |
|------|--------------|----------|
| Host dependencies | `ajaxHostDepListing.php` | 60407 |
| Hostgroup dependencies | `ajaxHgDepListing.php` | 60408 |
| Service dependencies | `ajaxSvcDepListing.php` | 60409 |
| Servicegroup dependencies | `ajaxSgDepListing.php` | 60410 |
| Metaservice dependencies | `ajaxMsDepListing.php` | 60411 |

Each page: new AJAX endpoint + rewritten ihtml + simplified PHP controller.
No toggles (dependencies have no activate field).

### Tests (8 scenarios)

- Host dep: AJAX load, search, duplicate, session persistence
- Hostgroup / Service / Servicegroup / Metaservice dep: AJAX load verification

## How to test

1. Navigate to Configuration > Notifications > each dependency type
2. Test search, pagination, duplicate, delete
3. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 5 | ✅ Resolved Issues: 2 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added AJAX endpoints for five dependency listing pages and responses

**⚡ Enhancements**
* Added Cypress test scenarios covering AJAX load, search, duplicate, pagination

**🔧 Refactors**
* Rewrote legacy Smarty dependency listings to use CentreonListing AJAX framework

**📚 Documentation**
* Added and standardized license headers and comments across updated files


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98610361?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
