### PR TITLE
feat(configuration): modernize pollers sub menus listing and forms

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
@@ -1,0 +1,53 @@
+Feature: Modern pollers listing
+    As a Centreon admin
+    I want to manage pollers from the modernized listing page
+    With AJAX search, toggle, LED status indicators, export button and pagination
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  Scenario: Pollers listing loads via AJAX
+    When the user navigates to the pollers listing
+    Then the AJAX listing table is displayed with poller rows
+    And the Central poller is visible
+
+  Scenario: Search filters pollers by name
+    When the user navigates to the pollers listing
+    And the user searches for a specific poller
+    Then only the matching poller is displayed
+
+  Scenario: Toggle disables a poller
+    When the user navigates to the pollers listing
+    And the user clicks the toggle to disable a poller
+    Then the poller toggle switches to disabled
+    And the toggle response is successful
+
+  Scenario: Toggle enables a poller
+    When the user navigates to the pollers listing
+    And the poller is disabled
+    And the user clicks the toggle to enable the poller
+    Then the poller toggle switches to enabled
+
+  Scenario: LED status indicators are displayed
+    When the user navigates to the pollers listing
+    Then each poller row has running and configuration status indicators
+
+  Scenario: Tooltips show poller details
+    When the user navigates to the pollers listing
+    Then poller rows have tooltips with PID, uptime and version info
+
+  Scenario: Pagination and rows per page
+    When the user navigates to the pollers listing
+    Then the pagination info shows the total count
+
+  Scenario: Clicking a poller name navigates to the edit form
+    When the user navigates to the pollers listing
+    And the user clicks on the Central poller name
+    Then the poller edit form is displayed
+
+  Scenario: Session state persists across navigation
+    When the user navigates to the pollers listing
+    And the user searches for a specific poller
+    And the user clicks on the Central poller name
+    And the user navigates back to the pollers listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
@@ -1,0 +1,62 @@
+Feature: Modern pollers listing
+    As a Centreon admin
+    I want to manage pollers from the modernized listing page
+    With AJAX search, toggle, LED status indicators, export button and pagination
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-129
+  Scenario: Pollers listing loads via AJAX
+    When the user navigates to the pollers listing
+    Then the AJAX listing table is displayed with poller rows
+    And the Central poller is visible
+
+  @TEST_LISTING-130
+  Scenario: Search filters pollers by name
+    When the user navigates to the pollers listing
+    And the user searches for a specific poller
+    Then only the matching poller is displayed
+
+  @TEST_LISTING-131
+  Scenario: Toggle disables a poller
+    When the user navigates to the pollers listing
+    And the user clicks the toggle to disable a poller
+    Then the poller toggle switches to disabled
+    And the toggle response is successful
+
+  @TEST_LISTING-132
+  Scenario: Toggle enables a poller
+    When the user navigates to the pollers listing
+    And the poller is disabled
+    And the user clicks the toggle to enable the poller
+    Then the poller toggle switches to enabled
+
+  @TEST_LISTING-133
+  Scenario: LED status indicators are displayed
+    When the user navigates to the pollers listing
+    Then each poller row has running and configuration status indicators
+
+  @TEST_LISTING-134
+  Scenario: Tooltips show poller details
+    When the user navigates to the pollers listing
+    Then poller rows have tooltips with PID, uptime and version info
+
+  @TEST_LISTING-135
+  Scenario: Pagination and rows per page
+    When the user navigates to the pollers listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-136
+  Scenario: Clicking a poller name navigates to the edit form
+    When the user navigates to the pollers listing
+    And the user clicks on the Central poller name
+    Then the poller edit form is displayed
+
+  @TEST_LISTING-137
+  Scenario: Session state persists across navigation
+    When the user navigates to the pollers listing
+    And the user searches for a specific poller
+    And the user clicks on the Central poller name
+    And the user navigates back to the pollers listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
@@ -1,0 +1,221 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const pollersPage = PAGES.configuration.pollersLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(pollersPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the pollers listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with poller rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+Then('the Central poller is visible', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific poller', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('Central');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching poller is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a poller', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServerToggle.php'
+  }).as('togglePoller');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@togglePoller');
+});
+
+Then('the poller toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@togglePoller')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@togglePoller')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the poller is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE nagios_server SET ns_activate = '0' WHERE name = 'Central'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the poller', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServerToggle.php'
+  }).as('togglePollerOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@togglePollerOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the poller toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: LED status indicators
+// ---------------------------------------------------------------------------
+
+Then('each poller row has running and configuration status indicators', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-mon-badge')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Tooltips
+// ---------------------------------------------------------------------------
+
+Then('poller rows have tooltips with PID, uptime and version info', () => {
+  cy.getIframeBody()
+    .find('#clTableBody [data-cl-tooltip]')
+    .first()
+    .invoke('attr', 'data-cl-tooltip')
+    .should('not.be.empty');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on the Central poller name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'Central').click();
+});
+
+Then('the poller edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="name"]');
+  cy.getIframeBody().find('input[name="name"]').should('have.value', 'Central');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the pollers listing', () => {
+  cy.visit(pollersPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'Central');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
@@ -1,0 +1,217 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const pollersPage = PAGES.configuration.pollersLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(pollersPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the pollers listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with poller rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('the Central poller is visible', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific poller', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('Central');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching poller is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a poller', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServerToggle.php'
+  }).as('togglePoller');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@togglePoller');
+});
+
+Then('the poller toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@togglePoller').its('response.statusCode').should('eq', 200);
+  cy.get('@togglePoller')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the poller is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE nagios_server SET ns_activate = '0' WHERE name = 'Central'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the poller', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServerToggle.php'
+  }).as('togglePollerOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@togglePollerOn').its('response.statusCode').should('eq', 200);
+});
+
+Then('the poller toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: LED status indicators
+// ---------------------------------------------------------------------------
+
+Then('each poller row has running and configuration status indicators', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-mon-badge')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Tooltips
+// ---------------------------------------------------------------------------
+
+Then('poller rows have tooltips with PID, uptime and version info', () => {
+  cy.getIframeBody()
+    .find('#clTableBody [data-cl-tooltip]')
+    .first()
+    .invoke('attr', 'data-cl-tooltip')
+    .should('not.be.empty');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on the Central poller name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'Central').click();
+});
+
+Then('the poller edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="name"]');
+  cy.getIframeBody().find('input[name="name"]').should('have.value', 'Central');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the pollers listing', () => {
+  cy.visit(pollersPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'Central');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing.feature
@@ -1,0 +1,50 @@
+Feature: Modern engine configuration listing
+    As a Centreon admin
+    I want to manage engine configurations from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  Scenario: Engine config listing loads via AJAX
+    When the user navigates to the engine config listing
+    Then the AJAX listing table is displayed with engine config rows
+    And the Central engine config is visible
+
+  Scenario: Search filters engine configs by name
+    When the user navigates to the engine config listing
+    And the user searches for a specific engine config
+    Then only the matching engine config is displayed
+
+  Scenario: Toggle disables an engine config
+    When the user navigates to the engine config listing
+    And the user clicks the toggle to disable an engine config
+    Then the engine config toggle switches to disabled
+    And the toggle response is successful
+
+  Scenario: Toggle enables an engine config
+    When the user navigates to the engine config listing
+    And the engine config is disabled
+    And the user clicks the toggle to enable the engine config
+    Then the engine config toggle switches to enabled
+
+  Scenario: Pagination info is displayed
+    When the user navigates to the engine config listing
+    Then the pagination info shows the total count
+
+  Scenario: Bulk duplication works
+    When the user navigates to the engine config listing
+    And the user selects an engine config and duplicates it
+    Then a duplicated engine config appears in the listing
+
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the engine config listing
+    And the user clicks on an engine config name
+    Then the engine config edit form is displayed
+
+  Scenario: Session state persists across navigation
+    When the user navigates to the engine config listing
+    And the user searches for a specific engine config
+    And the user clicks on an engine config name
+    And the user navigates back to the engine config listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing/index.ts
@@ -1,0 +1,237 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+// Engine config page is p=60903
+const enginePage = '/centreon/main.php?p=60903';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(enginePage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the engine config listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with engine config rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('the Central engine config is visible', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific engine config', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('Centreon Engine');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching engine config is displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable an engine config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxNagiosToggle.php'
+  }).as('toggleEngine');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleEngine');
+});
+
+Then('the engine config toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleEngine').its('response.statusCode').should('eq', 200);
+  cy.get('@toggleEngine')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the engine config is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query:
+      "UPDATE cfg_nagios SET nagios_activate = '0' WHERE nagios_name LIKE '%Centreon Engine%'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the engine config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxNagiosToggle.php'
+  }).as('toggleEngineOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleEngineOn').its('response.statusCode').should('eq', 200);
+});
+
+Then('the engine config toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects an engine config and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated engine config appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on an engine config name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'Centreon Engine')
+    .click();
+});
+
+Then('the engine config edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="nagios_name"]');
+  cy.getIframeBody()
+    .find('input[name="nagios_name"]')
+    .should('contain.value', 'Centreon Engine');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the engine config listing', () => {
+  cy.visit(enginePage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'Centreon Engine');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing.feature
@@ -1,0 +1,49 @@
+Feature: Modern broker configuration listing
+    As a Centreon admin
+    I want to manage broker configurations from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  Scenario: Broker config listing loads via AJAX
+    When the user navigates to the broker config listing
+    Then the AJAX listing table is displayed with broker config rows
+
+  Scenario: Search filters broker configs by name
+    When the user navigates to the broker config listing
+    And the user searches for a specific broker config
+    Then only the matching broker config is displayed
+
+  Scenario: Toggle disables a broker config
+    When the user navigates to the broker config listing
+    And the user clicks the toggle to disable a broker config
+    Then the broker config toggle switches to disabled
+    And the toggle response is successful
+
+  Scenario: Toggle enables a broker config
+    When the user navigates to the broker config listing
+    And the broker config is disabled
+    And the user clicks the toggle to enable the broker config
+    Then the broker config toggle switches to enabled
+
+  Scenario: Pagination info is displayed
+    When the user navigates to the broker config listing
+    Then the pagination info shows the total count
+
+  Scenario: Bulk duplication works
+    When the user navigates to the broker config listing
+    And the user selects a broker config and duplicates it
+    Then a duplicated broker config appears in the listing
+
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the broker config listing
+    And the user clicks on a broker config name
+    Then the broker config edit form is displayed
+
+  Scenario: Session state persists across navigation
+    When the user navigates to the broker config listing
+    And the user searches for a specific broker config
+    And the user clicks on a broker config name
+    And the user navigates back to the broker config listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing/index.ts
@@ -1,0 +1,224 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+// Broker config page is p=60909
+const brokerPage = '/centreon/main.php?p=60909';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(brokerPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the broker config listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with broker config rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific broker config', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('central-broker');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching broker config is displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('central-broker')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a broker config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxBrokerToggle.php'
+  }).as('toggleBroker');
+
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-toggle input[type="checkbox"]')
+    .then(($toggle) => {
+      if ($toggle.is(':checked')) {
+        cy.wrap($toggle).click();
+      }
+    });
+
+  cy.wait('@toggleBroker');
+});
+
+Then('the broker config toggle switches to disabled', () => {
+  cy.get('@toggleBroker').its('response.statusCode').should('eq', 200);
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleBroker')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the broker config is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query:
+      "UPDATE cfg_centreonbroker SET config_activate = '0' WHERE config_name LIKE '%central-broker%'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the broker config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxBrokerToggle.php'
+  }).as('toggleBrokerOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('central-broker')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleBrokerOn').its('response.statusCode').should('eq', 200);
+});
+
+Then('the broker config toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('central-broker')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a broker config and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated broker config appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  // Duplicated config gets _1 suffix
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 3);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a broker config name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'central-broker')
+    .click();
+});
+
+Then('the broker config edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="name"]');
+  cy.getIframeBody()
+    .find('input[name="name"]')
+    .should('contain.value', 'central-broker');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the broker config listing', () => {
+  cy.visit(brokerPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'central-broker');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/18-resources-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/18-resources-listing.feature
@@ -1,0 +1,50 @@
+Feature: Modern resources ($USERn$ macros) listing
+    As a Centreon admin
+    I want to manage engine resources from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  Scenario: Resources listing loads via AJAX
+    When the user navigates to the resources listing
+    Then the AJAX listing table is displayed with resource rows
+    And the USER1 resource is visible
+
+  Scenario: Search filters resources by name
+    When the user navigates to the resources listing
+    And the user searches for a specific resource
+    Then only the matching resource is displayed
+
+  Scenario: Toggle disables a resource
+    When the user navigates to the resources listing
+    And the user clicks the toggle to disable a resource
+    Then the resource toggle switches to disabled
+    And the toggle response is successful
+
+  Scenario: Toggle enables a resource
+    When the user navigates to the resources listing
+    And the resource is disabled
+    And the user clicks the toggle to enable the resource
+    Then the resource toggle switches to enabled
+
+  Scenario: Pagination info is displayed
+    When the user navigates to the resources listing
+    Then the pagination info shows the total count
+
+  Scenario: Bulk duplication works
+    When the user navigates to the resources listing
+    And the user selects a resource and duplicates it
+    Then a duplicated resource appears in the listing
+
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the resources listing
+    And the user clicks on a resource name
+    Then the resource edit form is displayed
+
+  Scenario: Session state persists across navigation
+    When the user navigates to the resources listing
+    And the user searches for a specific resource
+    And the user clicks on a resource name
+    And the user navigates back to the resources listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/18-resources-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/18-resources-listing/index.ts
@@ -1,0 +1,226 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+// Resources page is p=60904
+const resourcesPage = '/centreon/main.php?p=60904';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(resourcesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the resources listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with resource rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('the USER1 resource is visible', () => {
+  cy.getIframeBody().find('#clTableBody').contains('$USER1$').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific resource', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('$USER1$');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching resource is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('$USER1$').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a resource', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxResourceToggle.php'
+  }).as('toggleRes');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleRes');
+});
+
+Then('the resource toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleRes').its('response.statusCode').should('eq', 200);
+  cy.get('@toggleRes')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the resource is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query:
+      "UPDATE cfg_resource SET resource_activate = '0' WHERE resource_name = '$USER1$'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the resource', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxResourceToggle.php'
+  }).as('toggleResOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleResOn').its('response.statusCode').should('eq', 200);
+});
+
+Then('the resource toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a resource and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated resource appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  // Duplicated resource should appear
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a resource name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', '$USER1$').click();
+});
+
+Then('the resource edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="resource_name"]');
+  cy.getIframeBody()
+    .find('input[name="resource_name"]')
+    .should('have.value', '$USER1$');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the resources listing', () => {
+  cy.visit(resourcesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', '$USER1$');
+});

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerListing.php
+++ b/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerListing.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Server name cache
+$servers = [];
+$dbResult = $pearDB->query('SELECT id, name FROM nagios_server ORDER BY name');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $servers[(int) $row['id']] = $row['name'];
+}
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    $pollerIds = [];
+    foreach ($pollerResult as $p) {
+        $pollerIds[] = (int) $p['id'];
+    }
+    if (! empty($pollerIds)) {
+        $aclCond = 'AND ns_nagios_server IN (' . implode(',', $pollerIds) . ') ';
+    } else {
+        $helper->jsonResponse([], 0, 0, $limit);
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND config_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate'
+    . ' FROM cfg_centreonbroker WHERE 1=1 ' . $searchCond . $aclCond
+    . ' ORDER BY config_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+// Count inputs/outputs per config
+$countStmt = $pearDB->prepare(
+    "SELECT COUNT(DISTINCT config_group_id) AS cnt FROM cfg_centreonbroker_info WHERE config_id = :id AND config_group = :grp"
+);
+
+$rows = [];
+while ($cfg = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $configId = (int) $cfg['config_id'];
+
+    $countStmt->execute([':id' => $configId, ':grp' => 'input']);
+    $inputs = (int) $countStmt->fetch(PDO::FETCH_ASSOC)['cnt'];
+
+    $countStmt->execute([':id' => $configId, ':grp' => 'output']);
+    $outputs = (int) $countStmt->fetch(PDO::FETCH_ASSOC)['cnt'];
+
+    $rows[] = [
+        'id'        => $configId,
+        'name'      => $cfg['config_name'],
+        'requester' => $servers[(int) $cfg['ns_nagios_server']] ?? '',
+        'inputs'    => $inputs,
+        'outputs'   => $outputs,
+        'activate'  => (int) $cfg['config_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerToggle.php
+++ b/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerToggle.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60909);
+
+// Verify exists and capture its poller for the ACL check below
+$checkStmt = $pearDB->prepare('SELECT ns_nagios_server FROM cfg_centreonbroker WHERE config_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+$brokerCfg = $checkStmt->fetch(PDO::FETCH_ASSOC);
+if (! $brokerCfg) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Resource-level ACL: page-level write access is not enough - a user could
+// otherwise toggle any broker configuration by id (IDOR). The configuration's
+// poller must be one the user is allowed to manage (same scope as the listing).
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerIds = [];
+    foreach ($acl->getPollerAclConf(['fields' => ['id']]) as $poller) {
+        $pollerIds[] = (int) $poller['id'];
+    }
+    if (! in_array((int) $brokerCfg['ns_nagios_server'], $pollerIds, true)) {
+        AjaxListingHelper::jsonError('Access denied', 403);
+    }
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT config_name FROM cfg_centreonbroker WHERE config_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE cfg_centreonbroker SET config_activate = :activate WHERE config_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('broker_cfg', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.ihtml
@@ -91,13 +91,18 @@
 			<tbody id="{$tab.id}_0">
 				<tr class="list_lvl_1">
                   <td class="ListColLvl1_name" colspan="2">
-                    <h4>{$tab.name}</h4>
+                    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;">
+                        <h4 style="margin:0;">{$tab.name}</h4>
+                        <div style="display:flex;align-items:center;gap:8px;">
+                            <select id="block_{$tab.id}"
+                            onchange='checkTypeValidity("block_{$tab.id}")'>{foreach from=$tab.blocks item=block}
+                            <option value="{$block.id}">{$block.name}</option>
+                            {/foreach}</select>
+                            <a id="add_{$tab.id}" onClick="addInfo('{$tab.id}')" class='btc bt_success'>{$tab.link}</a>
+                        </div>
+                    </div>
                   </td>
                 </tr>
-				<tr class="list_one"><td class="FormRowValue" colspan="2"><select id="block_{$tab.id}"
-				onchange='checkTypeValidity("block_{$tab.id}")'>{foreach from=$tab.blocks item=block}
-				<option value="{$block.id}">{$block.name}</option>
-				{/foreach}</select>&nbsp;<a id="add_{$tab.id}" onClick="addInfo('{$tab.id}')" class='btc bt_success'>{$tab.link}</a></td></tr>
 			</tbody>
 			{foreach from=$tab.forms item=formBlock name=formForeach}
 				{assign var="posAbs" value=$smarty.foreach.formForeach.index}

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -1,77 +1,113 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
+{literal}
+<script type="text/javascript">
+CentreonForm.detectSidePanelClose();
+</script>
+{/literal}
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Centreon Broker{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchCB" value="{$searchCB}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Broker configuration{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Configure how monitoring data is collected and forwarded.{/t}</p>
+    </div>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$brokerPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchCB" value="{$searchCB}" class="cl-search-simple" placeholder="{t}Search broker configurations{/t}" autocomplete="off">
                 </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_inputs}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_outputs}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_inputs}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_outputs}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            { if $mode_access == 'w' }
-            <td>
-                {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            { else }
-            <td>&nbsp;</td>
-            { /if }
-            {pagination}
-        </tr>
-    </table>
+            </div>
+            <div class="cl-toolbar-right">
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="brokerListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_requester}</th>
+                    <th class="cl-col-center">{$headerMenu_inputs}</th>
+                    <th class="cl-col-center">{$headerMenu_outputs}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
+<script type="text/javascript">
+var brokerListing = new CentreonListing({
+    instanceName:  'brokerListing',
+    ajaxListUrl:   './include/configuration/configCentreonBroker/ajaxBrokerListing.php',
+    ajaxToggleUrl: './include/configuration/configCentreonBroker/ajaxBrokerToggle.php',
+    pageId:        {/literal}'{$brokerPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'broker_listing_limit',
+    emptyMessage:  'No broker configurations found',
+    autoRefresh:   30000,
+    liveSearch:    true,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.get.php?p={/literal}{$brokerPage}{literal}&o=c&id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'requester' },
+        { id:'inputs', align:'center', render: function(row) {
+            return row.inputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.inputs+'</span>' : '<span style="opacity:.4;">0</span>';
+        }},
+        { id:'outputs', align:'center', render: function(row) {
+            return row.outputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.outputs+'</span>' : '<span style="opacity:.4;">0</span>';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="brokerListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+brokerListing.init();
+CentreonForm.initSidePanel(brokerListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
@@ -23,147 +23,34 @@ if (! isset($centreon)) {
     exit();
 }
 
-include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-// nagios servers comes from DB
-$nagios_servers = [];
-$dbResult = $pearDB->query('SELECT * FROM nagios_server ORDER BY name');
-while ($nagios_server = $dbResult->fetch()) {
-    $nagios_servers[$nagios_server['id']] = $nagios_server['name'];
-}
-$dbResult->closeCursor();
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_desc', _('Requester'));
-$tpl->assign('headerMenu_outputs', _('Outputs'));
+$tpl->assign('headerMenu_requester', _('Requester'));
 $tpl->assign('headerMenu_inputs', _('Inputs'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_outputs', _('Outputs'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Centreon Broker config list
+$tpl->assign('brokerPage', $p);
 
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchCB'] ?? $_GET['searchCB'] ?? null,
-);
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchCB', $search);
 
-if (isset($_POST['searchCB']) || isset($_GET['searchCB'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$aclCond = '';
-if (! $centreon->user->admin && count($allowedBrokerConf)) {
-    $aclCond = $search !== '' ? ' AND ' : ' WHERE ';
-    $aclCond .= 'config_id IN (' . implode(',', array_keys($allowedBrokerConf)) . ') ';
-}
-
-if ($search !== '') {
-    $cfgBrokerStmt = $pearDB->prepare(
-        'SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate '
-        . 'FROM cfg_centreonbroker '
-        . 'WHERE config_name LIKE :search' . $aclCond
-        . ' ORDER BY config_name '
-        . 'LIMIT :scoop, :limit'
-    );
-    $cfgBrokerStmt->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-} else {
-    $cfgBrokerStmt = $pearDB->prepare(
-        'SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate '
-        . 'FROM cfg_centreonbroker ' . $aclCond
-        . ' ORDER BY config_name '
-        . 'LIMIT :scoop, :limit'
-    );
-}
-
-$cfgBrokerStmt->bindValue(':scoop', (int) $num * (int) $limit, PDO::PARAM_INT);
-$cfgBrokerStmt->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
-$cfgBrokerStmt->execute();
-
-// Get results numbers
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-$statementBrokerInfo = $pearDB->prepare(
-    'SELECT COUNT(DISTINCT(config_group_id)) as num '
-    . 'FROM cfg_centreonbroker_info '
-    . 'WHERE config_group = :config_group '
-    . 'AND config_id = :config_id'
-);
-
-for ($i = 0; $config = $cfgBrokerStmt->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $config['config_id'] . ']');
-
-    if ($config['config_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&id=' . $config['config_id'] . '&o=u&limit=' . $limit . '&num='
-            . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14' border='0' alt='"
-            . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&id=' . $config['config_id'] . '&o=s&limit=' . $limit . '&num='
-            . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14' border='0' alt='"
-            . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 '
-        . '&& (event.keyCode < 45 || event.keyCode > 57)) event.returnValue = false; '
-        . 'if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;"'
-        . "  maxlength=\"3\" size=\"3\" value='1' "
-        . "style=\"margin-bottom:0px;\" name='dupNbr[" . $config['config_id'] . "]'></input>";
-
-    // Number of output
-    $statementBrokerInfo->bindValue(':config_id', (int) $config['config_id'], PDO::PARAM_INT);
-    $statementBrokerInfo->bindValue(':config_group', 'output', PDO::PARAM_STR);
-    $statementBrokerInfo->execute();
-    $row = $statementBrokerInfo->fetch(PDO::FETCH_ASSOC);
-    $outputNumber = $row['num'];
-
-    // Number of input
-    $statementBrokerInfo->bindValue(':config_group', 'input', PDO::PARAM_STR);
-    $statementBrokerInfo->execute();
-    $row = $statementBrokerInfo->fetch(PDO::FETCH_ASSOC);
-    $inputNumber = $row['num'];
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => htmlentities($config['config_name'], ENT_QUOTES, 'UTF-8'), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&id=' . $config['config_id'], 'RowMenu_desc' => CentreonUtils::escapeSecure(
-        substr(
-            $nagios_servers[$config['ns_nagios_server']],
-            0,
-            40
-        )
-    ), 'RowMenu_inputs' => $inputNumber, 'RowMenu_outputs' => $outputNumber, 'RowMenu_status' => $config['config_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $config['config_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'addWizard' => _('Add with wizard'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -171,58 +58,29 @@ $tpl->assign(
     }
 </script>
 <?php
-$attrs = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o1' => null]);
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
 
-$attrs = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o2' => null]);
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchCB', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/configuration/configCentreonBroker/style.css
+++ b/centreon/www/include/configuration/configCentreonBroker/style.css
@@ -40,3 +40,161 @@ span.v_required_star {
     font-size: 12px;
     font-weight: bold;
 }
+
+/* ==========================================================================
+   Visual-only alignment with the CentreonForm look used across the rest of
+   the app (form.css). Structure and JS are untouched — this stylesheet is
+   only ever loaded on this page, so selectors below are broader than usual
+   without risk of leaking onto other legacy pages sharing the same class
+   names (e.g. .list_lvl_1, .btc.bt_success).
+   ========================================================================== */
+
+/* Tab bar, restyled to resemble .cf-tab-nav */
+#mainnav {
+    display: flex;
+    float: none;
+    gap: 0;
+    border-bottom: 2px solid var(--color-divider, #e3e3e3);
+    margin-bottom: 16px;
+}
+
+#mainnav li {
+    float: none;
+    margin: 0;
+}
+
+#mainnav li.a,
+#mainnav li.b {
+    border-bottom: none;
+    background: none !important;
+    margin: 0;
+}
+
+#mainnav li a {
+    display: inline-block;
+    padding: 10px 20px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--body-color, #666);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+#mainnav li a:hover {
+    color: var(--list-color, #333);
+}
+
+/* .a marks whichever <li> is the active tab (toggled by the existing
+   montre()/changeTab() JS, untouched here) — give it the same active
+   indicator as .cf-tab-nav a.active. */
+#mainnav li.a a {
+    color: var(--color-primary-light, #2E68AA);
+    border-bottom-color: var(--color-primary-light, #2E68AA);
+    font-weight: 600;
+}
+
+.headerTabContainer {
+    margin-bottom: 16px;
+}
+
+/* Section / block header rows — same light-grey used by .cf-section-header
+   elsewhere, not var(--body-background) (too close to white to read as a
+   distinct header band). This same rule covers both the per-tab header
+   ("Centreon-Broker Input") and every per-block header ("Input 1 - IPv4",
+   from blockConfig.ihtml) since they share this class. */
+.formTable .list_lvl_1 .ListColLvl1_name,
+.collapse-wrapper .list_lvl_1 .ListColLvl1_name {
+    background: #ddd;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 14px;
+}
+
+.formTable .list_lvl_1 h4 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--list-color, #333);
+}
+
+/* Field rows */
+.formTable {
+    max-width: 700px;
+}
+
+.formTable .FormRowField {
+    width: 170px;
+    font-size: 13px;
+    color: var(--list-color, #555);
+}
+
+.formTable .FormRowValue {
+    max-width: 400px;
+}
+
+.formTable input[type="text"],
+.formTable input[type="password"],
+.formTable select {
+    max-width: 400px;
+    border-radius: 6px;
+    box-sizing: border-box;
+}
+
+/* Drop the busy row-separator lines between ordinary field rows — plain
+   .cf-field rows elsewhere rely on spacing alone, no visible divider. */
+.formTable .list_one td,
+.formTable .list_two td {
+    border-bottom: none;
+}
+
+/* Add / delete affordances */
+#validForm .oreonbutton a.btc,
+#validFormTop .oreonbutton a.btc {
+    border-radius: 6px;
+}
+
+/* Save/Reset: the form already renders these buttons twice (#validFormTop
+   right under the tab bar, #validForm again at the very end) as a legacy
+   convenience so they're reachable without scrolling. Keep only the
+   bottom copy, pinned like every other modernized form's .cf-actions,
+   instead of showing both. No markup change: #Form (the actual <form>
+   QuickForm renders, see formCentreonBroker.php) is turned into the same
+   flex-column + min-height:100vh trick .cf-form-wrapper uses elsewhere,
+   so the sticky bottom bar has something to stick to even on a short tab. */
+#validFormTop {
+    display: none;
+}
+
+form#Form {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#validForm {
+    margin-top: auto;
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    padding: 16px 0;
+    background: var(--body-background, #fff);
+    border-top: 1px solid var(--color-divider, #e3e3e3);
+}
+
+/* Breadcrumb ("fil d'ariane") above the tab bar — shared component
+   (www/include/core/pathway/pathway.php), not specific to this page, but
+   this stylesheet only ever loads here so hiding it is scoped to Broker. */
+.pathway {
+    display: none;
+}
+
+.ListColLvl1_name a img.ico-14 {
+    opacity: 0.6;
+    transition: opacity 0.15s;
+}
+
+.ListColLvl1_name a:hover img.ico-14 {
+    opacity: 1;
+}

--- a/centreon/www/include/configuration/configGenerate/formGenerateFiles.ihtml
+++ b/centreon/www/include/configuration/configGenerate/formGenerateFiles.ihtml
@@ -1,103 +1,51 @@
 {$form.javascript}
+
 <form {$form.attributes}>
-    <input type="hidden" id="centreon_token" name="centreon_token" value="{$csrfToken}" />
-    <input type="hidden" name="level" value="1">
-    <table class="formTable table">
-        <tr class="ListHeader">
-          <td class="FormHeader" colspan="2">
-            <h3>| {t}Configuration Files Export{/t}</h3>
-          </td>
-        </tr>
-        <tr class="list_lvl_1">
-          <td class="ListColLvl1_name" colspan="2">
-            <h4>{t}Polling instances{/t}</h4>
-          </td>
-        </tr>
-        <tr class="list_one">
-            <td class="FormRowField"><img class="helpTooltip" name="host">&nbsp;{$form.nhost.label}</td>
-          <td class="FormRowValue">
-              <i id="noSelectedPoller" style="color:red;margin-left:20px;" hidden>{$noPollerSelectedLabel}</i>
-              {$form.nhost.html}
-          </td>
-        </tr>
-        <tr class="list_lvl_1">
-          <td class="ListColLvl1_name" colspan="2"><h4>{t}Actions{/t}</h4></td>
-        </tr>
-        <tr class="list_two"><td class="FormRowField" colspan="2"><img class="helpTooltip" name="gen">&nbsp;{$form.gen.html}&nbsp;{$form.gen.label}</td></tr>
-        <tr class="list_one"><td class="FormRowField" colspan="2"><img class="helpTooltip" name="debug">&nbsp;{$form.debug.html}&nbsp;{$form.debug.label}</td></tr>
-        <tr class="list_two"><td class="FormRowValue" colspan="2"><img class="helpTooltip" name="move">&nbsp;{$form.move.html}&nbsp;{$form.move.label}</td></tr>
-        <tr class="list_one"><td class="FormRowValue"><img class="helpTooltip" name="restart">&nbsp;{$form.restart.html}&nbsp;{$form.restart.label}</td>
-        <td class="FormRowValue">{$form.restart_mode.label}&nbsp;{$form.restart_mode.html}</td></tr>
-        <tr class="list_two"><td class="FormRowValue" colspan="2"><img class="helpTooltip" name="postcmd">&nbsp;{$form.postcmd.html}&nbsp;{$form.postcmd.label}</td></tr>
-	</table>
-	<div align="center" id="validForm"><p class="oreonbutton">{$form.submit.html}</p></div>
-	<div id='console' style='visibility: hidden;'>
-		<table class="formTable table">
-			<tr class="ListHeader">
-				<td class="FormHeader" colspan="2">
-                  <h3>| {$consoleLabel}</h3>
-                </td>
-			</tr>
-			<tr class="list_one">
-				<td class="FormRowField">
-					{$progressLabel} (<label id='progressPct'></label>)
-				</td>
-				<td class="FormRowValue">
-					<div id="progress_bar"></div>
-				</td>
-			</tr>
-			<tr class="list_two">
-				<td class="FormRowField consoleSteps">
-					<div id="consoleContent"></div>
-				</td>
-				<td class="FormRowValue">
-					<div id="consoleDetails"></div>
-				</td>
-			</tr>
-			<tbody id="error_log">
-			</tbody>
-		</table>
-	</div>
-	{if isset($msg_debug) || isset($msg_copy) || isset($msg_restart) }
-	<div>
-		<ul id="mainnav">
-		{assign var='cpt' value=0}
-		{foreach from=$host_list key=key item=item}
-			{if isset($msg_restart[$key]) || isset($msg_copy[$key]) || isset($msg_debug[$key])}
-			{assign var='cpt' value=$cpt+1}
-			<li class="a" id='c{$cpt}'><a href="#generate"  onclick="javascript:montre('{$cpt}');">{$host_list[$key]}</a></li>
-			{/if}
-		{/foreach}
-		</ul>
-	</div>
-	<a name="generate">
-	{assign var='cpt' value=0}
-	{foreach from=$tab_server key=key item=item}
-	{assign var='cpt' value=$cpt+1}
-	<div id='tab{$cpt}' class='tab'>
-	 	<table class="ListTable">
-		 	<tr class="ListHeader">
-		 		<td class="FormHeader"><img src='./img/icones/16x16/component_green.gif'>&nbsp;&nbsp;{$form.header.status}</td>
-		 	</tr>
-		 	{if isset($msg_debug[$key])}
-		 	<tr class="list_two_fixe">
-		 		<td class="ListColLvl1_name">{$msg_debug[$key]}</td>
-		 	</tr>
-		 	{/if}
-		 	{if isset($msg_copy[$key])}
-		 	<tr class="list_one_fixe">
-		 		<td class="ListColLvl1_name">{$msg_copy[$key]}</td>
-		 	</tr>
-			{/if}
-		 	{if isset($msg_restart[$key])}
-		 	<tr class="list_two_fixe">
-		 		<td class="ListColLvl1_name">{$msg_restart[$key]}</td>
-		 	</tr>
-		 	{/if}
-		 </table>
-	</div>
-	 	{/foreach}
-	{/if}
-	{$form.hidden}
+<input type="hidden" id="centreon_token" name="centreon_token" value="{$csrfToken}" />
+
+<div class="cf-form-wrapper gen-wrap">
+    <h1 class="cf-page-title" style="margin-bottom:22px;">{t}Deploy configuration{/t}</h1>
+
+    <div class="gen-top">
+        <div class="cf-field">
+            {$form.nhost.html}
+            <label class="cf-label-float">{$form.nhost.label}</label>
+        </div>
+        <button type="button" id="applyBtn" class="gen-apply" onclick="genApply();">
+            {t}Apply configuration{/t}
+        </button>
+    </div>
+    <p id="noSelectedPoller" class="gen-nopoller" hidden>{$noPollerSelectedLabel}</p>
+    <p id="noSelectedAction" class="gen-nopoller" hidden>{t}Please select at least one action (Generate &amp; Test, Move or Restart/Reload).{/t}</p>
+
+    <!-- Advanced (right under the poller field) -->
+    <details class="gen-adv">
+        <summary>{t}Advanced{/t}</summary>
+        <div class="gen-adv-body">
+            <div class="gen-adv-row">{$form.gen.html} <span>{$form.gen.label}</span></div>
+            <div class="gen-adv-row">{$form.move.html} <span>{$form.move.label}</span></div>
+            <div class="gen-adv-row">{$form.restart.html} <span>{$form.restart.label}</span> &nbsp;&mdash;&nbsp; {$form.restart_mode.label} {$form.restart_mode.html}</div>
+        </div>
+    </details>
+
+    <!-- Stepper -->
+    <div class="gen-stepper">
+        <div class="gen-step" id="stp-generate"><span class="dot">1</span><span>{t}Generate & Test{/t}</span></div>
+        <div class="gen-connector"></div>
+        <div class="gen-step" id="stp-restart"><span class="dot">2</span><span>{t}Move & Restart{/t}</span></div>
+        <div class="gen-connector"></div>
+        <div class="gen-step" id="stp-postcmd"><span class="dot">3</span><span>{t}Post-command{/t}</span></div>
+    </div>
+
+    <div class="gen-progress"><span id="genBar"></span></div>
+    <div class="gen-pct"><span id="genPct">0%</span></div>
+
+    <!-- One tab + console panel per poller -->
+    <div id="console" style="display:none;">
+        <div class="gen-tabs" id="genTabs"></div>
+        <div id="genPanels"></div>
+    </div>
+</div>
+
+{$form.hidden}
 </form>
-{$helptext}

--- a/centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+++ b/centreon/www/include/configuration/configGenerate/formGenerateFiles.php
@@ -48,10 +48,9 @@ foreach ($tab_nagios_server as $key => $name) {
 $form = new HTML_QuickFormCustom('Form', 'post', '?p=' . $p);
 
 $form->addElement('checkbox', 'debug', _('Run monitoring engine debug (-v)'), null, ['id' => 'ndebug']);
-$form->addElement('checkbox', 'gen', _('Generate Configuration Files'), null, ['id' => 'ngen']);
+$form->addElement('checkbox', 'gen', _('Generate & Test configuration'), null, ['id' => 'ngen']);
 $form->addElement('checkbox', 'move', _('Move Export Files'), null, ['id' => 'nmove']);
 $form->addElement('checkbox', 'restart', _('Restart Monitoring Engine'), null, ['id' => 'nrestart']);
-$form->addElement('checkbox', 'postcmd', _('Post generation command'), null, ['id' => 'npostcmd']);
 $form->addElement(
     'select',
     'restart_mode',
@@ -59,7 +58,7 @@ $form->addElement(
     [2 => _('Restart'), 1 => _('Reload')],
     ['id' => 'nrestart_mode', 'style' => 'width: 220px;']
 );
-$form->setDefaults(['debug' => '1', 'gen' => '1', 'restart_mode' => '1']);
+$form->setDefaults(['debug' => '1', 'gen' => '1', 'move' => '1', 'restart' => '1', 'restart_mode' => '1']);
 
 // Add multiselect for pollers
 $route = './include/common/webServices/rest/internal.php?object=centreon_configuration_poller&action=list';
@@ -75,33 +74,8 @@ $tpl = SmartyBC::createSmartyTemplate($path);
 $csrfToken = createCSRFToken();
 
 $tpl->assign('csrfToken', $csrfToken);
-
-$sub = $form->addElement(
-    'button',
-    'submit',
-    _('Export'),
-    ['id' => 'exportBtn', 'onClick' => 'generationProcess();', 'class' => 'btc bt_success']
-);
-$msg = null;
-$stdout = null;
-
 $tpl->assign('noPollerSelectedLabel', _('Compulsory Poller'));
-$tpl->assign('consoleLabel', _('Console'));
-$tpl->assign('progressLabel', _('Progress'));
-$tpl->assign(
-    'helpattr',
-    'TITLE, "' . _('Help') . '", CLOSEBTN, true, FIX, [this, 0, 5], BGCOLOR, "#ffff99", BORDERCOLOR, '
-    . '"orange", TITLEFONTCOLOR, "black", TITLEBGCOLOR, "orange", CLOSEBTNCOLORS, ["","black", "white", "red"], '
-    . 'WIDTH, -300, SHADOW, true, TEXTALIGN, "justify"'
-);
 
-include_once 'help.php';
-
-$helptext = '';
-foreach ($help as $key => $text) {
-    $helptext .= '<span style="display:none" id="help:' . $key . '">' . $text . '</span>' . "\n";
-}
-$tpl->assign('helptext', $helptext);
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font>');
@@ -114,424 +88,270 @@ $tpl->display('formGenerateFiles.ihtml');
 
 ?>
 <script type='text/javascript'>
-    var initPollers = '<?php echo json_encode($selectedPollers); ?>';
-    var selectedPoller;
-    var debugOption;
-    var generateOption;
-    var moveOption;
-    var restartOption;
-    var restartMode;
-    var exportBtn;
-    var steps = new Array();
-    var stepProgress;
-    var curProgress;
-    var postcmdOption;
-
-    var tooltip = new CentreonToolTip();
-    var svg = "<?php displaySvg('www/img/icons/question.svg', 'var(--help-tool-tip-icon-fill-color)', 18, 18); ?>"
-    tooltip.setSource(svg);
-    var session_id = "<?php echo session_id(); ?>";
-    tooltip.render();
-    var msgTab = new Array();
-
-    msgTab['start'] = "<?php echo addslashes(_('Preparing environment')); ?>";
-    msgTab['gen'] = "<?php echo addslashes(_('Generating files')); ?>";
-    msgTab['debug'] = "<?php echo addslashes(_('Running debug mode')); ?>";
-    msgTab['move'] = "<?php echo addslashes(_('Moving files')); ?>";
-    msgTab['restart'] = "<?php echo addslashes(_('Restarting engine')); ?>";
-    msgTab['abort'] = "<?php echo addslashes(_('Aborted.')); ?>";
-    msgTab['noPoller'] = "<?php echo addslashes(_('No poller selected')); ?>";
-    msgTab['postcmd'] = "<?php echo addslashes(_('Executing command')); ?>";
+    var genInitPollers = <?php echo json_encode($selectedPollers); ?>;
+    var genBase = './include/configuration/configGenerate/xml/';
+    var genMsg = {
+        move:     "<?php echo addslashes(_('Move files')); ?>",
+        restart:  "<?php echo addslashes(_('Restart engine')); ?>",
+        generate: "<?php echo addslashes(_('Generate & test')); ?>",
+        postcmd:  "<?php echo addslashes(_('Post-command')); ?>",
+        done:     "<?php echo addslashes(_('Configuration applied')); ?>",
+        aborted:  "<?php echo addslashes(_('Finished with errors')); ?>",
+        skippedPrev: "<?php echo addslashes(_('skipped (a previous step failed)')); ?>",
+        noPostcmd:"<?php echo addslashes(_('Post-command — skipped (none configured)')); ?>"
+    };
 
     jQuery(function () {
-
-        $('#progress_bar').progressbar({
-            value: 0
-        }).removeClass('ui-corner-all');
-
-        var pollers = JSON.parse(initPollers);
-        for (var i = 0; i < pollers.length; i++) {
+        for (var i = 0; i < genInitPollers.length; i++) {
             jQuery('#nhost').append(
-                '<option value="' + pollers[i].id + '" selected>' + pollers[i].text + '</option>'
+                '<option value="' + genInitPollers[i].id + '" selected>' + genInitPollers[i].text + '</option>'
             );
         }
         jQuery('#nhost').trigger('change');
+
+        // Turn the Advanced checkboxes into iPhone-style toggles
+        document.querySelectorAll('.gen-adv-body input[type=checkbox]').forEach(function (input) {
+            var wrapper = input.closest('.md-checkbox') || input;
+            var toggle = document.createElement('label');
+            toggle.className = 'cl-toggle';
+            toggle.appendChild(input);
+            var slider = document.createElement('span');
+            slider.className = 'cl-toggle-slider';
+            toggle.appendChild(slider);
+            wrapper.parentNode.replaceChild(toggle, wrapper);
+        });
     });
 
-    /**
-     * Next step
-     *
-     * @returns void
-     */
-    function nextStep() {
-        var func = window[steps.shift()];
-        if (typeof(func) === 'function') {
-            func();
+    function genLog(pid, html) {
+        var c = document.getElementById('gen-log-' + pid);
+        if (!c) return;
+        c.innerHTML += html;
+        c.scrollTop = c.scrollHeight;
+    }
+
+    function genProgress(done, total) {
+        var pct = total > 0 ? Math.round((done / total) * 100) : 100;
+        document.getElementById('genBar').style.width = pct + '%';
+        document.getElementById('genPct').textContent = pct + '%';
+    }
+
+    function genStep(id, state) {
+        var el = document.getElementById('stp-' + id);
+        if (!el) return;
+        el.classList.remove('active', 'done', 'err', 'skipped');
+        if (state) el.classList.add(state);
+    }
+
+    // Restore every step + connector (before recomputing which ones will run)
+    function genResetStepper() {
+        ['generate', 'restart', 'postcmd'].forEach(function (s) {
+            var e = document.getElementById('stp-' + s);
+            if (e) { e.style.display = ''; }
+        });
+        var conns = document.querySelectorAll('.gen-stepper .gen-connector');
+        for (var i = 0; i < conns.length; i++) { conns[i].style.display = ''; }
+    }
+
+    // Hide a step whose option is unchecked, along with one adjacent connector
+    function genHideStep(id) {
+        var el = document.getElementById('stp-' + id);
+        if (!el) { return; }
+        el.style.display = 'none';
+        var next = el.nextElementSibling;
+        if (next && next.classList.contains('gen-connector')) {
+            next.style.display = 'none';
         } else {
-            // no more step
-            exportBtn.disabled = false;
+            var prev = el.previousElementSibling;
+            if (prev && prev.classList.contains('gen-connector')) { prev.style.display = 'none'; }
         }
     }
 
-    /**
-     * Display error if no poller is selected
-     *
-     * @returns boolean
-     */
-    function checkSelectedPoller() {
-        var countSelectedPoller = jQuery('#nhost').next('span').find('.select2-selection__choice').length;
-        if (countSelectedPoller > 0) {
-            jQuery('#noSelectedPoller').hide();
-            jQuery('#noSelectedPoller').next('br').remove();
-            return true;
-        } else {
-            jQuery('#noSelectedPoller').show();
-            if (!jQuery('#noSelectedPoller').next('br').length) {
-                jQuery('#noSelectedPoller').after('<br>');
-            }
-            return false;
-        }
+    function genTabState(pid, state) {
+        var el = document.getElementById('gen-tab-' + pid);
+        if (!el) return;
+        el.classList.remove('run', 'ok', 'err');
+        if (state) el.classList.add(state);
     }
 
-    /**
-     * Generation process
-     *
-     * @return void
-     */
-    function generationProcess() {
-        if (!checkSelectedPoller()) {
-            return null;
-        }
-        curProgress = 0;
-        stepProgress = 0;
-        updateProgress();
-        cleanErrorPhp();
-        document.getElementById('console').style.visibility = 'visible';
-        $('#consoleContent').html(msgTab['start'] + "... ");
-        $('#consoleDetails').html("");
-        initEnvironment();
-        if (selectedPoller !== "-1") {
-            nextStep();
-        }
+    function genTabSwitch(pid) {
+        jQuery('.gen-tab').removeClass('active');
+        jQuery('#genPanels .gen-console').hide();
+        jQuery('#gen-tab-' + pid).addClass('active');
+        jQuery('#gen-log-' + pid).show();
     }
 
-    /**
-     * Initializes generation options
-     */
-    function initEnvironment() {
-        selectedPoller = jQuery('#nhost').val().join(',');
-        debugOption = document.getElementById('ndebug').checked;
-        generateOption = document.getElementById('ngen').checked;
-        if (generateOption) {
-            steps.push("generateFiles");
-        }
-        moveOption = document.getElementById('nmove').checked;
-        if (moveOption) {
-            steps.push("moveFiles");
-        }
-        restartOption = document.getElementById('nrestart').checked;
-        if (restartOption) {
-            steps.push("restartPollers");
-        }
-        restartMode = document.getElementById('nrestart_mode').value;
-        postcmdOption = 0;
-        if (document.getElementById('npostcmd')) {
-            postcmdOption = document.getElementById('npostcmd').checked;
-        }
-        if (postcmdOption) {
-            steps.push("executeCommand");
-        }
-        stepProgress = 100 / steps.length;
-        curProgress = 0;
-        exportBtn = document.getElementById('exportBtn');
-        exportBtn.disabled = true;
-        if (selectedPoller == "-1") {
-            $('#consoleContent').append("<b><font color='red'>NOK</font></b> (" + msgTab['noPoller'] + ")<br/>");
-            abortProgress();
-            return null;
-        }
-        $('#consoleContent').append("<b><font color='green'>OK</font></b><br/>");
-    }
-
-    /**
-     * Generate files
-     */
-    function generateFiles() {
-        if (debugOption && !generateOption) {
-            $('#consoleContent').append(msgTab['debug'] + '... ');
-        } else {
-            $('#consoleContent').append(msgTab['gen'] + "... ");
-        }
-        jQuery.ajax({
-            url: './include/configuration/configGenerate/xml/generateFiles.php',
-            type: 'POST',
-            dataType: "xml",
-            data: {
-                poller: selectedPoller,
-                debug: debugOption,
-                generate: generateOption
-            },
-            success: function (data) {
-                data = $(data);
-                displayStatusMessage(data);
-                displayDetails(data);
-                displayPhpErrorMsg('generate', data);
-                if (isError(data) == "1") {
-                    abortProgress();
-                    return null;
-                }
-                updateProgress();
-                nextStep();
-            }
+    function genXhr(file, data) {
+        return new Promise(function (resolve) {
+            jQuery.ajax({
+                url: genBase + file, type: 'POST', dataType: 'xml', data: data,
+                success: function (xml) {
+                    var d = jQuery(xml);
+                    resolve({
+                        error: (d.find('statuscode').first().text() || '0') === '1',
+                        status: d.find('status').first().text(),
+                        err: d.find('error').first().text(),
+                        debug: d.find('debug').first().text()
+                    });
+                },
+                error: function () { resolve({ error: true, status: '', err: 'request failed', debug: '' }); }
+            });
         });
     }
 
-    /**
-     * Move files
-     */
-    function moveFiles() {
-        $('#consoleContent').append(msgTab['move'] + "... ");
-        jQuery.ajax({
-            url: './include/configuration/configGenerate/xml/moveFiles.php',
-            type: 'POST',
-            dataType: "xml",
-            data: {
-                poller: selectedPoller
-            },
-            success: function (data) {
-                data = $(data);
-                displayStatusMessage(data);
-                displayDetails(data);
-                displayPhpErrorMsg('move', data);
-                if (isError(data) == "1") {
-                    abortProgress();
-                    return null;
-                }
-                updateProgress();
-                nextStep();
-            }
+    function genPost(pid, token) {
+        return new Promise(function (resolve) {
+            jQuery.ajax({
+                url: genBase + 'postcommand.php', type: 'POST', dataType: 'xml',
+                data: { poller: pid, centreon_token: token },
+                success: function (xml) {
+                    var d = jQuery(xml);
+                    var st = d.find('status').first().text();
+                    resolve({ error: /NOK/i.test(st), status: st.replace(/<[^>]+>/g, '').trim(), err: '', debug: '' });
+                },
+                error: function () { resolve({ error: true, status: '', err: 'request failed', debug: '' }); }
+            });
         });
     }
 
-    /**
-     * Restart Pollers
-     */
-    function restartPollers() {
-        $('#consoleContent').append(msgTab['restart'] + "... ");
-        jQuery.ajax({
-            url: './include/configuration/configGenerate/xml/restartPollers.php',
-            type: 'POST',
-            dataType: "xml",
-            data: {
-                poller: selectedPoller,
-                mode: restartMode
-            },
-            success: function (data) {
-                data = $(data);
-                displayStatusMessage(data);
-                displayDetails(data);
-                displayPhpErrorMsg('restart', data);
-                if (isError(data) == "1") {
-                    abortProgress();
-                    return null;
-                }
-                updateProgress();
-                nextStep();
-            }
-        });
-    }
-
-    /**
-     * Execute commands
-     */
-    function executeCommand() {
-        $('#consoleContent').append(msgTab['postcmd'] + "... ");
-        jQuery.ajax({
-            url: './include/configuration/configGenerate/xml/postcommand.php',
-            type: 'POST',
-            dataType: "xml",
-            data: {
-                poller: selectedPoller,
-                centreon_token: jQuery("#Form").find('input[name="centreon_token"]').val(),
-            },
-            success: function (data) {
-                data = $(data);
-                displayPostExecutionCommand(data);
-                if (isError(data) == "1") {
-                    abortProgress();
-                    return null;
-                }
-                updateProgress();
-                nextStep();
-            }
-        });
-    }
-
-    /**
-     * Display status message
-     */
-    function displayStatusMessage(responseXML) {
-        var status = responseXML.find("status");
-        var error = responseXML.find("error");
-        var str;
-
-        str = status.text();
-        if (error.length) {
-            str += " (" + error.text() + ")";
-        }
-        str += "<br/>";
-        $('#consoleContent').append(str);
-    }
-
-    /**
-     * Display details
-     */
-    function displayDetails(responseXML) {
-        var debug = responseXML.find("debug");
-        var str;
-
-        str = "";
-        if (debug.length) {
-            str = debug.text();
-        }
-        str += "<br/>";
-        $('#consoleDetails').append(str);
-    }
-
-    /**
-     * Display post command result and output
-     */
-    function displayPostExecutionCommand(responseXML) {
-        var xml = responseXML.find("result");
-        var xmlStatus = responseXML.find("status");
-        var str;
-        str = "";
-        if (xml.length) {
-            str += xml.text();
-        }
-        str += "<br/>";
-        $('#consoleDetails').append(str);
-        $('#consoleContent').append(xmlStatus.text());
-    }
-
-    /**
-     * Returns 1 if is error
-     * Returns 0 otherwise
-     */
-    function isError(responseXML) {
-        var statuscode = responseXML.find("statuscode");
-        if (statuscode.length) {
-            return statuscode.text();
-        }
-        return 0;
-    }
-
-    /**
-     * Action (generate, move, restart)
-     */
-    var errorClass = 'list_two';
-
-    function displayPhpErrorMsg(action, responseXML) {
-        var errors = responseXML.find('errorPhp');
-        var titleError;
-        if (errorClass == 'list_one') {
-            errorClass = 'list_two';
-        } else {
-            errorClass = 'list_one';
-        }
-        if (errors.length == 0) {
+    async function genApply() {
+        var pollers = jQuery('#nhost').val() || [];
+        if (!pollers.length) {
+            document.getElementById('noSelectedPoller').hidden = false;
             return;
         }
-        switch (action) {
-            case 'generate':
-                titleError = '<b>Errors/warnings in generate</b>';
-                break;
-            case 'move':
-                titleError = '<b>Errors/warnings in move files</b>';
-                break;
-            case 'restart':
-                titleError = '<b>Errors/warnings in restart</b>';
-                break;
+        document.getElementById('noSelectedPoller').hidden = true;
+
+        var meta = {};
+        jQuery('#nhost option:selected').each(function () { meta[this.value] = this.text; });
+
+        // "Generate & Test" is a single option: generation always runs with the
+        // engine test (-v). Each action is independent, so the user can also
+        // only push the configuration (move) or only restart/reload the engine.
+        var genOpt = jQuery('#ngen').is(':checked');
+        var debugOpt = genOpt;
+        var moveOpt = jQuery('#nmove').is(':checked');
+        var restartOpt = jQuery('#nrestart').is(':checked');
+        var mode = jQuery('#nrestart_mode').val();
+        var token = jQuery('#centreon_token').val();
+
+        // At least one action must be selected.
+        if (!genOpt && !moveOpt && !restartOpt) {
+            document.getElementById('noSelectedAction').hidden = false;
+            return;
+        }
+        document.getElementById('noSelectedAction').hidden = true;
+
+        var btn = document.getElementById('applyBtn');
+        btn.disabled = true;
+        ['generate', 'restart', 'postcmd'].forEach(function (s) { genStep(s, null); });
+        // Only display the steps that will actually run (hide unchecked options)
+        genResetStepper();
+        if (!(genOpt || debugOpt)) { genHideStep('generate'); }
+        if (!(moveOpt || restartOpt)) { genHideStep('restart'); }
+        var bar = document.getElementById('genBar');
+        bar.style.background = 'var(--color-success, #88B922)';
+        bar.style.width = '0%';
+        document.getElementById('genPct').textContent = '0%';
+        document.getElementById('console').style.display = 'block';
+
+        // Build tabs (only if >1 poller) + one console panel per poller
+        var showTabs = pollers.length > 1;
+        var tabsHtml = '', panelsHtml = '';
+        pollers.forEach(function (p, idx) {
+            if (showTabs) {
+                tabsHtml += '<div class="gen-tab' + (idx === 0 ? ' active' : '') + '" id="gen-tab-' + p + '" onclick="genTabSwitch(\'' + p + '\')">'
+                    + '<span class="st"></span>' + meta[p] + '</div>';
+            }
+            panelsHtml += '<div class="gen-console' + (showTabs ? ' attached' : '') + '" id="gen-log-' + p + '"'
+                + (idx === 0 ? '' : ' style="display:none"') + '></div>';
+        });
+        document.getElementById('genTabs').innerHTML = tabsHtml;
+        document.getElementById('genPanels').innerHTML = panelsHtml;
+
+        // Which pollers have a post-command?
+        var postPollers = [];
+        try {
+            var map = await jQuery.post(genBase + 'hasPostCommand.php', { poller: pollers.join(','), centreon_token: token });
+            if (typeof map === 'string') { map = JSON.parse(map); }
+            postPollers = pollers.filter(function (p) { return map && map[p]; });
+        } catch (e) { postPollers = []; }
+
+        // Visual groups -> substeps
+        var groups = [];
+        if (genOpt || debugOpt) {
+            groups.push({ visual: 'generate', sub: [{ label: genMsg.generate, file: 'generateFiles.php', extra: { debug: debugOpt, generate: genOpt } }], pollers: pollers });
+        }
+        var mvrt = [];
+        if (moveOpt) mvrt.push({ label: genMsg.move, file: 'moveFiles.php', extra: {} });
+        if (restartOpt) mvrt.push({ label: genMsg.restart, file: 'restartPollers.php', extra: { mode: mode } });
+        if (mvrt.length) groups.push({ visual: 'restart', sub: mvrt, pollers: pollers });
+        if (postPollers.length) {
+            groups.push({ visual: 'postcmd', sub: [{ label: genMsg.postcmd, post: true }], pollers: postPollers });
         }
 
-        var bodyErrors = document.getElementById('error_log');
-        var trEl = document.createElement('tr');
-        trEl.setAttribute('class', errorClass);
-        bodyErrors.appendChild(trEl);
-        var tdEl1 = document.createElement('td');
-        tdEl1.setAttribute('class', 'FormRowField');
-        tdEl1.innerHTML = titleError;
-        trEl.appendChild(tdEl1);
-        var tdEl2 = document.createElement('td');
-        tdEl2.setAttribute('class', 'FormRowValue');
-        tdEl2.innerHTML = '<span style="position: relative; float: left; margin-right: 5px;">' +
-        '<a href="javascript:toggleErrorPhp(\'' + action + '\');" id="expend_' + action + '">[ + ]</a></span>';
-        trEl.appendChild(tdEl2);
-        var divErrors = document.createElement('div');
-        divErrors.setAttribute('id', 'errors_' + action);
-        divErrors.setAttribute('style', 'position: relative; float: left;');
-        divErrors.style.visibility = 'hidden';
-        tdEl2.appendChild(divErrors);
-        for (var i = 0; i < errors.length; i++) {
-            divErrors.innerHTML += errors.get(i).firstChild.data + "<br/>";
-        }
-    }
+        var total = 0;
+        groups.forEach(function (g) { total += g.sub.length * g.pollers.length; });
+        var done = 0;
+        var failed = {};
+        var anyError = false;
 
-    function toggleErrorPhp(action) {
-        var linkEl = document.getElementById('expend_' + action);
-        var divErrors = document.getElementById('errors_' + action);
-        if (linkEl.innerHTML == '[ + ]') {
-            linkEl.innerHTML = '[ - ]';
-            divErrors.style.visibility = 'visible';
-        } else {
-            linkEl.innerHTML = '[ + ]';
-            divErrors.style.visibility = 'hidden';
+        for (var gi = 0; gi < groups.length; gi++) {
+            var g = groups[gi];
+            genStep(g.visual, 'active');
+            var groupRan = 0, groupFail = 0;
+            for (var si = 0; si < g.sub.length; si++) {
+                var sub = g.sub[si];
+                for (var pi = 0; pi < g.pollers.length; pi++) {
+                    var pid = g.pollers[pi];
+                    // A previous step failed for this poller: skip without counting
+                    // it as done, so the bar stops at the level actually reached.
+                    if (failed[pid]) { continue; }
+                    groupRan++;
+                    genTabState(pid, 'run');
+                    genLog(pid, '<b>' + sub.label + '</b>&#8230; ');
+                    var res = sub.post
+                        ? await genPost(pid, token)
+                        : await genXhr(sub.file, Object.assign({ poller: pid }, sub.extra || {}));
+                    if (res.error) {
+                        failed[pid] = true; anyError = true; groupFail++;
+                        genTabState(pid, 'err');
+                        genLog(pid, '<span class="err">&#10007; ' + (res.err || res.status || 'failed') + '</span>\n');
+                        if (res.debug) { genLog(pid, '<span class="muted">' + res.debug + '</span>\n'); }
+                    } else {
+                        genTabState(pid, 'ok');
+                        // Post-command result is meaningful: show it in green, not muted grey
+                        var stCls = sub.post ? 'ok' : 'muted';
+                        genLog(pid, '<span class="ok">&#10003;</span>' + (res.status ? ' <span class="' + stCls + '">' + res.status + '</span>' : '') + '\n');
+                    }
+                    done++; genProgress(done, total);
+                }
+            }
+            genStep(g.visual, groupFail > 0 ? 'err' : (groupRan === 0 ? 'skipped' : 'done'));
         }
-    }
 
-    function cleanErrorPhp() {
-        var bodyErrors = document.getElementById('error_log');
-        while (bodyErrors.hasChildNodes()) {
-            bodyErrors.removeChild(bodyErrors.firstChild);
+        // Post-command step skipped (no poller has one configured)
+        if (!postPollers.length) {
+            genStep('postcmd', 'skipped');
+            pollers.forEach(function (p) {
+                if (!failed[p]) { genLog(p, '<span class="muted">' + genMsg.noPostcmd + '</span>\n'); }
+            });
         }
-    }
 
-    /**
-     * Updates progress
-     */
-    function updateProgress() {
-        var pct = 0;
-        if (typeof(curProgress) != 'undefined' && typeof(stepProgress) != 'undefined') {
-            pct = curProgress + stepProgress;
-            curProgress += stepProgress;
-        }
-        if (pct > 100) {
-            pct = 100;
-        }
-        $('#progress_bar').progressbar('value', pct);
-        $('#progressPct').html(Math.round(pct) + "%");
-    }
+        // Final line + bar colour
+        genProgress(done, total);
+        if (anyError) { bar.style.background = '#FF4A4A'; }
+        pollers.forEach(function (p) {
+            genLog(p, failed[p]
+                ? '\n<span class="err"><b>' + genMsg.aborted + '</b></span>\n'
+                : '\n<span class="ok"><b>' + genMsg.done + '</b></span>\n');
+        });
 
-    /**
-     * Toggle debug
-     */
-    function toggleDebug(pollerId) {
-        if (pollerId) {
-            if ($('#debug_' + pollerId).is(':visible')) {
-                $('#togglerp_' + pollerId).show();
-                $('#togglerm_' + pollerId).hide();
-                $('#debug_' + pollerId).hide();
-            } else {
-                $('#togglerp_' + pollerId).hide();
-                $('#togglerm_' + pollerId).show();
-                $('#debug_' + pollerId).show();
+        // Focus the first failed poller, if any
+        if (showTabs) {
+            for (var k = 0; k < pollers.length; k++) {
+                if (failed[pollers[k]]) { genTabSwitch(pollers[k]); break; }
             }
         }
-    }
-
-    function abortProgress() {
-        $('#consoleContent').append(msgTab['abort']);
-        exportBtn.disabled = false;
-        steps = new Array();
+        btn.disabled = false;
     }
 </script>

--- a/centreon/www/include/configuration/configGenerate/xml/hasPostCommand.php
+++ b/centreon/www/include/configuration/configGenerate/xml/hasPostCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * Lightweight endpoint used by the modern "Export configuration" page.
+ * Given a list of poller ids, it returns for each whether a post-generation
+ * command is configured, so the UI can show/skip the "Post-command" step.
+ * Response: {"<pollerId>": true|false, ...}
+ */
+
+use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
+use Core\Contact\Domain\AdminResolver;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+
+if (! isset($_POST['poller'])) {
+    exit();
+}
+
+require_once realpath(__DIR__ . '/../../../../../config/centreon.config.php');
+require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonInstance.class.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonSession.class.php';
+require_once _CENTREON_PATH_ . '/www/include/common/common-Func.php';
+require_once _CENTREON_PATH_ . 'bootstrap.php';
+
+$db = new CentreonDB();
+$kernel = App\Kernel::createForWeb();
+CentreonSession::start(1);
+
+$readAccessGroupRepository = $kernel->getContainer()->get(ReadAccessGroupRepositoryInterface::class);
+$isCloudPlatform = $kernel->getContainer()->getParameter('env(IS_CLOUD_PLATFORM)');
+$adminResolver = new AdminResolver($readAccessGroupRepository, $isCloudPlatform);
+$readContactRepository = $kernel->getContainer()->get(ContactRepositoryInterface::class);
+$contact = $readContactRepository->findBySession(session_id());
+
+// Check Session
+if (
+    ! CentreonSession::checkSession(session_id(), $db)
+    || $contact === null
+    || (! $adminResolver->isAdmin($contact) && ! $contact->hasRole('ROLE_GENERATE_CONFIGURATION'))
+) {
+    header('Content-Type: application/json');
+    echo json_encode([]);
+
+    exit();
+}
+
+$pollers = array_filter(array_map('intval', explode(',', $_POST['poller'])));
+$instanceObj = new CentreonInstance($db);
+
+$result = [];
+foreach ($pollers as $pollerId) {
+    $result[$pollerId] = count($instanceObj->getCommandData($pollerId)) > 0;
+}
+
+header('Content-Type: application/json');
+header('Cache-Control: no-cache, must-revalidate');
+echo json_encode($result);

--- a/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -103,6 +103,16 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
     }
 
     $centreon = $_SESSION['centreon'];
+
+    // Reloading / restarting the monitoring engine requires the "Generate
+    // configuration files" action ACL, exactly like the export page. Without
+    // this check a user with page access but no generate_cfg right could
+    // trigger an engine reload/restart from the poller listing.
+    if (! $centreon->user->admin && $centreon->user->access->checkAction('generate_cfg') === 0) {
+        echo 'Access denied';
+
+        exit();
+    }
 }
 
 if (! isset($_POST['poller']) || ! isset($_POST['mode'])) {

--- a/centreon/www/include/configuration/configNagios/ajaxNagiosListing.php
+++ b/centreon/www/include/configuration/configNagios/ajaxNagiosListing.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Server name cache
+$servers = [];
+$dbResult = $pearDB->query('SELECT id, name FROM nagios_server ORDER BY name');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $servers[(int) $row['id']] = $row['name'];
+}
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    $pollerIds = [];
+    foreach ($pollerResult as $p) {
+        $pollerIds[] = (int) $p['id'];
+    }
+    if (! empty($pollerIds)) {
+        // Get nagios_ids for allowed pollers
+        $inList = implode(',', $pollerIds);
+        $nagiosIds = [];
+        $stmt = $pearDB->query("SELECT nagios_id FROM cfg_nagios WHERE nagios_server_id IN ({$inList})");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $nagiosIds[] = (int) $row['nagios_id'];
+        }
+        if (! empty($nagiosIds)) {
+            $aclCond = 'AND nagios_id IN (' . implode(',', $nagiosIds) . ') ';
+        } else {
+            $helper->jsonResponse([], 0, 0, $limit);
+        }
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND nagios_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS nagios_id, nagios_name, nagios_comment, nagios_activate, nagios_server_id'
+    . ' FROM cfg_nagios WHERE 1=1 ' . $searchCond . $aclCond
+    . ' ORDER BY nagios_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($cfg = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $desc = $cfg['nagios_comment'] ?? '';
+    if (mb_strlen($desc) > 40) {
+        $desc = mb_substr($desc, 0, 40) . '...';
+    }
+    $rows[] = [
+        'id'       => (int) $cfg['nagios_id'],
+        'name'     => $cfg['nagios_name'],
+        'desc'     => $desc,
+        'instance' => $servers[(int) $cfg['nagios_server_id']] ?? '',
+        'activate' => (int) $cfg['nagios_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configNagios/ajaxNagiosToggle.php
+++ b/centreon/www/include/configuration/configNagios/ajaxNagiosToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60903);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT nagios_id FROM cfg_nagios WHERE nagios_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT nagios_name FROM cfg_nagios WHERE nagios_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE cfg_nagios SET nagios_activate = :activate WHERE nagios_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('engine_cfg', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configNagios/formNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/formNagios.ihtml
@@ -1,1044 +1,809 @@
 {$form.javascript}
+
 <form {$form.attributes}>
-	<div class="headerTabContainer">
-		<ul id="mainnav">
-			<li class="a" id='c1'><a href="#" onclick="javascript:montre('1');">{$sort1}</a></li>
-			<li class="b" id='c2'><a href="#" onclick="javascript:montre('2');">{$sort2}</a></li>
-			<li class="b" id='c3'><a href="#" onclick="javascript:montre('3');">{$sort3}</a></li>
-			<li class="b" id='c4'><a href="#" onclick="javascript:montre('4');">{$sort4}</a></li>
-			<li class="b" id='c5'><a href="#" onclick="javascript:montre('5');">{$sort5}</a></li>
-			<li class="b" id='c6'><a href="#" onclick="javascript:montre('6');">{$sort6}</a></li>
-		</ul>
-    <div id="validFormTop">
-    {if $o == "a" || $o == "c"}
-        <p class="oreonbutton">
+<div class="cf-form-wrapper">
+
+    <h1 class="cf-page-title">{$form.header.title}</h1>
+
+    <div class="cf-tab-nav">
+        <a href="#cf-sec-1" class="active" onclick="cfScrollTo('cf-sec-1', this); return false;">{$sort1}</a>
+        <a href="#cf-sec-2" onclick="cfScrollTo('cf-sec-2', this); return false;">{$sort2}</a>
+        <a href="#cf-sec-3" onclick="cfScrollTo('cf-sec-3', this); return false;">{$sort3}</a>
+        <a href="#cf-sec-4" onclick="cfScrollTo('cf-sec-4', this); return false;">{$sort4}</a>
+        <a href="#cf-sec-5" onclick="cfScrollTo('cf-sec-5', this); return false;">{$sort5}</a>
+        <a href="#cf-sec-6" onclick="cfScrollTo('cf-sec-6', this); return false;">{$sort6}</a>
+        <a href="#cf-sec-7" onclick="cfScrollTo('cf-sec-7', this); return false;">{t}Comment{/t}</a>
+    </div>
+
+    <div class="cf-section" id="cf-sec-1">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$sort1}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+			<div class="cf-row-inline">
+                <div class="cf-field" style="max-width:280px;">
+                    {$form.nagios_name.html}
+                    <label class="cf-label-float">{$form.nagios_name.label}</label>
+                    <img class="helpTooltip" name="nagios_name">
+                </div>
+                <div class="cf-field">
+                    {$form.nagios_server_id.html}
+                    <label class="cf-label-float">{$form.nagios_server_id.label}</label>
+                    <img class="helpTooltip" name="nagios_server_id">
+                </div>
+                <div class="cf-toggle-row">
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-nagios_activate-toggle" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span>{$form.nagios_activate.label}</span>
+                    <span style="display:none;">{$form.nagios_activate.html}</span>
+                </div>
+            </div>
+			<div class="cf-row">
+                <div class="cf-field">
+                    {$form.use_timezone.html}
+                    <label class="cf-label-float">{$form.use_timezone.label}</label>
+                    <img class="helpTooltip" name="use_timezone">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$Folders}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.cfg_dir.html}
+                    <label class="cf-label-float">{$form.cfg_dir.label}</label>
+                    <img class="helpTooltip" name="cfg_dir">
+                </div>
+                <div class="cf-field">
+                    {$form.cfg_file.html}
+                    <label class="cf-label-float">{$form.cfg_file.label}</label>
+                    <img class="helpTooltip" name="cfg_file">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$Files}</div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.status_file.html}
+                    <label class="cf-label-float">{$form.status_file.label}</label>
+                    <img class="helpTooltip" name="status_file">
+                </div>
+                <div class="cf-field">
+                    {$form.status_update_interval.html}&nbsp;&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.status_update_interval.label}</label>
+                    <img class="helpTooltip" name="status_update_interval">
+                </div>
+            </div>
+			<div class="cf-row">
+                <div class="cf-field" style="max-width:50%;">
+                    {$form.log_file.html}
+                    <label class="cf-label-float">{$form.log_file.label}</label>
+                    <img class="helpTooltip" name="log_file">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$ExternalCommandes}</div>
+            <div class="cf-row">
+                <div class="cf-toggle-row">
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-check_external_commands-toggle" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span>{$form.check_external_commands.label}</span>
+                    <span style="display:none;">{$form.check_external_commands.html}</span>
+                    <img class="helpTooltip" name="check_external_commands">
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.command_file.html}
+                    <label class="cf-label-float">{$form.command_file.label}</label>
+                    <img class="helpTooltip" name="command_file">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.command_check_interval.html}
+                    <label class="cf-label-float">{$form.command_check_interval.label}</label>
+                    <img class="helpTooltip" name="command_check_interval">
+                </div>
+                <div class="cf-field">
+                    {$form.external_command_buffer_slots.html}
+                    <label class="cf-label-float">{$form.external_command_buffer_slots.label}</label>
+                    <img class="helpTooltip" name="external_command_buffer_slots">
+                </div>
+            </div>
+
+      {if $o == "a" || $o == "c"}
+          <div class="cf-row"><small>{if isset($form.required)}
+              {$form.required._note}
+          {/if}</small></div>
+      {/if}
+        </div>
+    </div>
+    <div class="cf-section" id="cf-sec-2">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$sort2}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection">{$HostCheckOptions}</div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_predictive_host_dependency_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_predictive_host_dependency_checks.label}</span>
+                    <span style="display:none;">{$form.enable_predictive_host_dependency_checks.html}</span>
+                    <img class="helpTooltip" name="enable_predictive_host_dependency_checks">
+                </div>
+            </div>
+            <div class="cf-subsection">{$ServiceCheckOptions}</div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-check_for_orphaned_services-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.check_for_orphaned_services.label}</span>
+                    <span style="display:none;">{$form.check_for_orphaned_services.html}</span>
+                    <img class="helpTooltip" name="check_for_orphaned_services">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-check_for_orphaned_hosts-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.check_for_orphaned_hosts.label}</span>
+                    <span style="display:none;">{$form.check_for_orphaned_hosts.html}</span>
+                    <img class="helpTooltip" name="check_for_orphaned_hosts">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-soft_state_dependencies-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.soft_state_dependencies.label}</span>
+                    <span style="display:none;">{$form.soft_state_dependencies.html}</span>
+                    <img class="helpTooltip" name="soft_state_dependencies">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_predictive_service_dependency_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_predictive_service_dependency_checks.label}</span>
+                    <span style="display:none;">{$form.enable_predictive_service_dependency_checks.html}</span>
+                    <img class="helpTooltip" name="enable_predictive_service_dependency_checks">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-host_down_disable_service_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.host_down_disable_service_checks.label}</span>
+                    <span style="display:none;">{$form.host_down_disable_service_checks.html}</span>
+                    <img class="helpTooltip" name="host_down_disable_service_checks">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$EventHandler}</div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.global_host_event_handler.html}
+                    <label class="cf-label-float">{$form.global_host_event_handler.label}</label>
+                    <img class="helpTooltip" name="global_host_event_handler">
+                </div>
+                <div class="cf-field">
+                    {$form.global_service_event_handler.html}
+                    <label class="cf-label-float">{$form.global_service_event_handler.label}</label>
+                    <img class="helpTooltip" name="global_service_event_handler">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$Freshness}</div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-check_service_freshness-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.check_service_freshness.label}</span>
+                    <span style="display:none;">{$form.check_service_freshness.html}</span>
+                    <img class="helpTooltip" name="check_service_freshness">
+                </div>
+                <div class="cf-field" style="flex:0 0 300px;max-width:300px;">
+                    {$form.service_freshness_check_interval.html}&nbsp;&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.service_freshness_check_interval.label}</label>
+                    <img class="helpTooltip" name="service_freshness_check_interval">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-check_host_freshness-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.check_host_freshness.label}</span>
+                    <span style="display:none;">{$form.check_host_freshness.html}</span>
+                    <img class="helpTooltip" name="check_host_freshness">
+                </div>
+                <div class="cf-field" style="flex:0 0 300px;max-width:300px;">
+                    {$form.host_freshness_check_interval.html}&nbsp;&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.host_freshness_check_interval.label}</label>
+                    <img class="helpTooltip" name="host_freshness_check_interval">
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field" style="max-width:50%;">
+                    {$form.additional_freshness_latency.html}&nbsp;&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.additional_freshness_latency.label}</label>
+                    <img class="helpTooltip" name="additional_freshness_latency">
+                </div>
+            </div>
+
+		 	<div class="cf-subsection">{$FlappingOptions}</div>
+			<div class="cf-row">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_flap_detection-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_flap_detection.label}</span>
+                    <span style="display:none;">{$form.enable_flap_detection.html}</span>
+                    <img class="helpTooltip" name="enable_flap_detection">
+                </div>
+            </div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.low_service_flap_threshold.html}&nbsp;&nbsp;%
+                    <label class="cf-label-float">{$form.low_service_flap_threshold.label}</label>
+                    <img class="helpTooltip" name="low_service_flap_threshold">
+                </div>
+                <div class="cf-field">
+                    {$form.high_service_flap_threshold.html}&nbsp;&nbsp;%
+                    <label class="cf-label-float">{$form.high_service_flap_threshold.label}</label>
+                    <img class="helpTooltip" name="high_service_flap_threshold">
+                </div>
+            </div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.low_host_flap_threshold.html}&nbsp;&nbsp;%
+                    <label class="cf-label-float">{$form.low_host_flap_threshold.label}</label>
+                    <img class="helpTooltip" name="low_host_flap_threshold">
+                </div>
+                <div class="cf-field">
+                    {$form.high_host_flap_threshold.html}&nbsp;&nbsp;%
+                    <label class="cf-label-float">{$form.high_host_flap_threshold.label}</label>
+                    <img class="helpTooltip" name="high_host_flap_threshold">
+                </div>
+            </div>
+
+      <div class="cf-subsection">{$MiscOptions}</div>
+			<div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_notifications-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_notifications.label}</span>
+                    <span style="display:none;">{$form.enable_notifications.html}</span>
+                    <img class="helpTooltip" name="enable_notifications">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-execute_service_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.execute_service_checks.label}</span>
+                    <span style="display:none;">{$form.execute_service_checks.html}</span>
+                    <img class="helpTooltip" name="execute_service_checks">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-accept_passive_service_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.accept_passive_service_checks.label}</span>
+                    <span style="display:none;">{$form.accept_passive_service_checks.html}</span>
+                    <img class="helpTooltip" name="accept_passive_service_checks">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_event_handlers-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_event_handlers.label}</span>
+                    <span style="display:none;">{$form.enable_event_handlers.html}</span>
+                    <img class="helpTooltip" name="enable_event_handlers">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-execute_host_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.execute_host_checks.label}</span>
+                    <span style="display:none;">{$form.execute_host_checks.html}</span>
+                    <img class="helpTooltip" name="execute_host_checks">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-accept_passive_host_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.accept_passive_host_checks.label}</span>
+                    <span style="display:none;">{$form.accept_passive_host_checks.html}</span>
+                    <img class="helpTooltip" name="accept_passive_host_checks">
+                </div>
+            </div>
+
+            {if $o == "a" || $o == "c"}
+          <div class="cf-row"><small>{if isset($form.required)}
+              {$form.required._note}
+          {/if}</small></div>
+      {/if}
+        </div>
+    </div>
+    <div class="cf-section" id="cf-sec-3">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$sort3}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection">{$LoggingOptions}</div>
+      <div class="cf-row">
+                <div class="cf-toggle-row">
+                    <span>{$form.logger_version.label}</span>
+                    {$form.logger_version.html}
+                    <img class="helpTooltip" name="logger_version">
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v1_option">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-use_syslog-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.use_syslog.label}</span>
+                    <span style="display:none;">{$form.use_syslog.html}</span>
+                    <img class="helpTooltip" name="use_syslog">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_notifications-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_notifications.label}</span>
+                    <span style="display:none;">{$form.log_notifications.html}</span>
+                    <img class="helpTooltip" name="log_notifications">
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v1_option">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_service_retries-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_service_retries.label}</span>
+                    <span style="display:none;">{$form.log_service_retries.html}</span>
+                    <img class="helpTooltip" name="log_service_retries">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_host_retries-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_host_retries.label}</span>
+                    <span style="display:none;">{$form.log_host_retries.html}</span>
+                    <img class="helpTooltip" name="log_host_retries">
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v1_option">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_event_handlers-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_event_handlers.label}</span>
+                    <span style="display:none;">{$form.log_event_handlers.html}</span>
+                    <img class="helpTooltip" name="log_event_handlers">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_external_commands-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_external_commands.label}</span>
+                    <span style="display:none;">{$form.log_external_commands.html}</span>
+                    <img class="helpTooltip" name="log_external_commands">
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v1_option">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_passive_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_passive_checks.label}</span>
+                    <span style="display:none;">{$form.log_passive_checks.html}</span>
+                    <img class="helpTooltip" name="log_passive_checks">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-log_pid-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.log_pid.label}</span>
+                    <span style="display:none;">{$form.log_pid.html}</span>
+                    <img class="helpTooltip" name="log_pid">
+                </div>
+            </div>
+            <div class="cf-subsection logger_v1_option">{$DebugConfiguration}</div>
+            <div class="cf-row logger_v1_option">
+                <div class="cf-field">
+                    {$form.debug_file.html}
+                    <label class="cf-label-float">{$form.debug_file.label}</label>
+                    <img class="helpTooltip" name="debug_file">
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v1_option">
+                <div class="cf-field">
+                    {$form.debug_verbosity.html}
+                    <label class="cf-label-float">{$form.debug_verbosity.label}</label>
+                    <img class="helpTooltip" name="debug_verbosity">
+                </div>
+                <div class="cf-field">
+                    {$form.max_debug_file_size.html}&nbsp;{$Bytes}
+                    <label class="cf-label-float">{$form.max_debug_file_size.label}</label>
+                    <img class="helpTooltip" name="max_debug_file_size">
+                </div>
+            </div>
+            <div class="cf-row logger_v1_option">
+                <div class="cf-field cf-field-clone">
+                    <div class="cf-clone-title">{$form.nagios_debug_level.label} <img class="helpTooltip" name="nagios_debug_level"></div>
+                    {$form.nagios_debug_level.html}
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v2_option">
+                <div class="cf-field">
+                    {$form.log_v2_logger.html}
+                    <label class="cf-label-float">{$form.log_v2_logger.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_checks.html}
+                    <label class="cf-label-float">{$form.log_level_checks.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_commands.html}
+                    <label class="cf-label-float">{$form.log_level_commands.label}</label>
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v2_option">
+                <div class="cf-field">
+                    {$form.log_level_comments.html}
+                    <label class="cf-label-float">{$form.log_level_comments.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_config.html}
+                    <label class="cf-label-float">{$form.log_level_config.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_downtimes.html}
+                    <label class="cf-label-float">{$form.log_level_downtimes.label}</label>
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v2_option">
+                <div class="cf-field">
+                    {$form.log_level_eventbroker.html}
+                    <label class="cf-label-float">{$form.log_level_eventbroker.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_events.html}
+                    <label class="cf-label-float">{$form.log_level_events.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_external_command.html}
+                    <label class="cf-label-float">{$form.log_level_external_command.label}</label>
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v2_option">
+                <div class="cf-field">
+                    {$form.log_level_functions.html}
+                    <label class="cf-label-float">{$form.log_level_functions.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_macros.html}
+                    <label class="cf-label-float">{$form.log_level_macros.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_notifications.html}
+                    <label class="cf-label-float">{$form.log_level_notifications.label}</label>
+                </div>
+            </div>
+            <div class="cf-row-inline logger_v2_option">
+                <div class="cf-field">
+                    {$form.log_level_process.html}
+                    <label class="cf-label-float">{$form.log_level_process.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_runtime.html}
+                    <label class="cf-label-float">{$form.log_level_runtime.label}</label>
+                </div>
+                <div class="cf-field">
+                    {$form.log_level_otl.html}
+                    <label class="cf-label-float">{$form.log_level_otl.label}</label>
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$Timouts}</div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.service_check_timeout.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.service_check_timeout.label}</label>
+                    <img class="helpTooltip" name="service_check_timeout">
+                </div>
+                <div class="cf-field">
+                    {$form.host_check_timeout.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.host_check_timeout.label}</label>
+                    <img class="helpTooltip" name="host_check_timeout">
+                </div>
+            </div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.event_handler_timeout.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.event_handler_timeout.label}</label>
+                    <img class="helpTooltip" name="event_handler_timeout">
+                </div>
+                <div class="cf-field">
+                    {$form.notification_timeout.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.notification_timeout.label}</label>
+                    <img class="helpTooltip" name="notification_timeout">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$StatesRetention}</div>
+			<div class="cf-row">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-retain_state_information-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.retain_state_information.label}</span>
+                    <span style="display:none;">{$form.retain_state_information.html}</span>
+                    <img class="helpTooltip" name="retain_state_information">
+                </div>
+            </div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.state_retention_file.html}
+                    <label class="cf-label-float">{$form.state_retention_file.label}</label>
+                    <img class="helpTooltip" name="state_retention_file">
+                </div>
+                <div class="cf-field">
+                    {$form.retention_update_interval.html}&nbsp;{$Minutes}
+                    <label class="cf-label-float">{$form.retention_update_interval.label}</label>
+                    <img class="helpTooltip" name="retention_update_interval">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-use_retained_program_state-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.use_retained_program_state.label}</span>
+                    <span style="display:none;">{$form.use_retained_program_state.html}</span>
+                    <img class="helpTooltip" name="use_retained_program_state">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-use_retained_scheduling_info-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.use_retained_scheduling_info.label}</span>
+                    <span style="display:none;">{$form.use_retained_scheduling_info.html}</span>
+                    <img class="helpTooltip" name="use_retained_scheduling_info">
+                </div>
+            </div>
+
+            {if $o == "a" || $o == "c"}
+          <div class="cf-row"><small>{if isset($form.required)}
+              {$form.required._note}
+          {/if}</small></div>
+      {/if}
+        </div>
+    </div>
+    <div class="cf-section" id="cf-sec-4">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$sort4}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection">{$BrokerModule}</div>
+			<div class="cf-row">
+                <div class="cf-field cf-field-clone" id="multipleBroker">
+                    <div class="cf-clone-title">{$form.multiple_broker_module.label}</div>
+                    {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="broker" cloneSet=$cloneSet}
+                    <small class="cf-clone-hint">{$form.bkTextMultiple.label}</small>
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.event_broker_options.html}
+                    <label class="cf-label-float">{$form.event_broker_options.label}</label>
+                    <img class="helpTooltip" name="event_broker_options">
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.broker_module_cfg_file.html}
+                    <label class="cf-label-float">{$form.broker_module_cfg_file.label}</label>
+                </div>
+            </div>
+            <div class="cf-subsection">{$MacrosMgmt}</div>
+			<div class="cf-row">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_macros_filter-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_macros_filter.label}</span>
+                    <span style="display:none;">{$form.enable_macros_filter.html}</span>
+                    <img class="helpTooltip" name="enable_macros_filter">
+                </div>
+            </div>
+			<div class="cf-row">
+                <div class="cf-field cf-field-clone">
+                    <div class="cf-clone-title">{$form.macros_filter.label} <img class="helpTooltip" name="macros_filter"></div>
+                    {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="macros_filter" cloneSet=$cloneSetMacrosFilter}
+					{$form.macros_filter.error}
+                </div>
+            </div>
+      {if $o == "a" || $o == "c"}
+          <div class="cf-row"><small>{if isset($form.required)}
+              {$form.required._note}
+          {/if}</small></div>
+      {/if}
+        </div>
+    </div>
+    <div class="cf-section" id="cf-sec-5">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$sort5}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection">{$TimeUnit}</div>
+			<div class="cf-row">
+                <div class="cf-field" style="max-width:33%;">
+                    {$form.sleep_time.html}&nbsp;{$Minutes}
+                    <label class="cf-label-float">{$form.sleep_time.label}</label>
+                    <img class="helpTooltip" name="sleep_time">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$HostCheckSchedulingOptions}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.host_inter_check_delay_method.html}
+                    <label class="cf-label-float">{$form.host_inter_check_delay_method.label}</label>
+                    <img class="helpTooltip" name="host_inter_check_delay_method">
+                </div>
+                <div class="cf-field">
+                    {$form.max_host_check_spread.html}&nbsp;{$Minutes}
+                    <label class="cf-label-float">{$form.max_host_check_spread.label}</label>
+                    <img class="helpTooltip" name="max_host_check_spread">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$ServiceCheckSchedulingOptions}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.service_inter_check_delay_method.html}
+                    <label class="cf-label-float">{$form.service_inter_check_delay_method.label}</label>
+                    <img class="helpTooltip" name="service_inter_check_delay_method">
+                </div>
+                <div class="cf-field">
+                    {$form.max_service_check_spread.html}&nbsp;{$Minutes}
+                    <label class="cf-label-float">{$form.max_service_check_spread.label}</label>
+                    <img class="helpTooltip" name="max_service_check_spread">
+                </div>
+                <div class="cf-field">
+                    {$form.service_interleave_factor.html}
+                    <label class="cf-label-float">{$form.service_interleave_factor.label}</label>
+                    <img class="helpTooltip" name="service_interleave_factor">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.max_concurrent_checks.html}
+                    <label class="cf-label-float">{$form.max_concurrent_checks.label}</label>
+                    <img class="helpTooltip" name="max_concurrent_checks">
+                </div>
+                <div class="cf-field" style="flex:2;">
+                    {$form.check_result_reaper_frequency.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.check_result_reaper_frequency.label}</label>
+                    <img class="helpTooltip" name="check_result_reaper_frequency">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$CachedCheck}</div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.cached_host_check_horizon.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.cached_host_check_horizon.label}</label>
+                    <img class="helpTooltip" name="cached_host_check_horizon">
+                </div>
+                <div class="cf-field">
+                    {$form.cached_service_check_horizon.html}&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.cached_service_check_horizon.label}</label>
+                    <img class="helpTooltip" name="cached_service_check_horizon">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$AutoRescheduling}</div>
+			<div class="cf-row">
+                <div class="cf-toggle-row" data-cf-enables="#cf-auto-resched-fields">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-auto_reschedule_checks-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.auto_reschedule_checks.label}</span>
+                    <span style="display:none;">{$form.auto_reschedule_checks.html}</span>
+                    <img class="helpTooltip" name="auto_reschedule_checks">
+                </div>
+            </div>
+			<div class="cf-row-inline" id="cf-auto-resched-fields">
+                <div class="cf-field">
+                    {$form.auto_rescheduling_interval.html}&nbsp;&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.auto_rescheduling_interval.label}</label>
+                    <img class="helpTooltip" name="auto_rescheduling_interval">
+                </div>
+                <div class="cf-field">
+                    {$form.auto_rescheduling_window.html}&nbsp;&nbsp;{$Seconds}
+                    <label class="cf-label-float">{$form.auto_rescheduling_window.label}</label>
+                    <img class="helpTooltip" name="auto_rescheduling_window">
+                </div>
+            </div>
+
+			<div class="cf-subsection">{$Optimization}</div>
+			<div class="cf-row">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-enable_environment_macros-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.enable_environment_macros.label}</span>
+                    <span style="display:none;">{$form.enable_environment_macros.html}</span>
+                    <img class="helpTooltip" name="enable_environment_macros">
+                </div>
+            </div>
+      {if $o == "a" || $o == "c"}
+          <div class="cf-row"><small>{if isset($form.required)}
+              {$form.required._note}
+          {/if}</small></div>
+      {/if}
+        </div>
+    </div>
+    <div class="cf-section" id="cf-sec-6">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$sort6}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection">{$Advanced}</div>
+			<div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.date_format.html}
+                    <label class="cf-label-float">{$form.date_format.label}</label>
+                    <img class="helpTooltip" name="date_format">
+                </div>
+                <div class="cf-field">
+                    {$form.instance_heartbeat_interval.html}
+                    <label class="cf-label-float">{$form.instance_heartbeat_interval.label}</label>
+                    <img class="helpTooltip" name="instance_heartbeat_interval">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.illegal_object_name_chars.html}
+                    <label class="cf-label-float">{$form.illegal_object_name_chars.label}</label>
+                    <img class="helpTooltip" name="illegal_object_name_chars">
+                </div>
+                <div class="cf-field">
+                    {$form.illegal_macro_output_chars.html}
+                    <label class="cf-label-float">{$form.illegal_macro_output_chars.label}</label>
+                    <img class="helpTooltip" name="illegal_macro_output_chars">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-use_regexp_matching-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.use_regexp_matching.label}</span>
+                    <span style="display:none;">{$form.use_regexp_matching.html}</span>
+                    <img class="helpTooltip" name="use_regexp_matching">
+                </div>
+                <div class="cf-toggle-row cf-toggle-row--grow">
+                    <label class="cl-toggle"><input type="checkbox" id="cf-use_true_regexp_matching-toggle"><span class="cl-toggle-slider"></span></label>
+                    <span>{$form.use_true_regexp_matching.label}</span>
+                    <span style="display:none;">{$form.use_true_regexp_matching.html}</span>
+                    <img class="helpTooltip" name="use_true_regexp_matching">
+                </div>
+            </div>
+            <div class="cf-subsection">{$AdminInfo}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.admin_email.html}
+                    <label class="cf-label-float">{$form.admin_email.label}</label>
+                    <img class="helpTooltip" name="admin_email">
+                </div>
+                <div class="cf-field">
+                    {$form.admin_pager.html}
+                    <label class="cf-label-float">{$form.admin_pager.label}</label>
+                    <img class="helpTooltip" name="admin_pager">
+                </div>
+            </div>
+      {if $o == "a" || $o == "c"}
+          <div class="cf-row"><small>{if isset($form.required)}
+              {$form.required._note}
+          {/if}</small></div>
+      {/if}
+        </div>
+    </div>
+    <div class="cf-section" id="cf-sec-7">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {t}Comment{/t}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.nagios_comment.html}
+                    <label class="cf-label-float">{$form.nagios_comment.label}</label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="cf-actions">
+        {if $o == "a" || $o == "c"}
+            {$form.reset.html}
             {if isset($form.submitC)}
                 {$form.submitC.html}
             {else}
                 {$form.submitA.html}
             {/if}
-            &nbsp;&nbsp;&nbsp;{$form.reset.html}
-        </p>
-    {else if $o == "w"}
-        <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-    {/if}
+        {else if $o == "w"}
+            {if isset($form.change)}{$form.change.html}{/if}
+        {/if}
     </div>
-	</div>
-	<div id='tab1' class='tab'>
-		<table class="formTable table">
-		 	<tr class="ListHeader">
-        <td class="FormHeader" colspan="2">
-          <h3>| {$form.header.title}</h3>
-        </td>
-      </tr>
-		 	<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$form.header.information}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_name" />&nbsp;{$form.nagios_name.label}</td><td class="FormRowValue">{$form.nagios_name.html}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagios_activate" />&nbsp;{$form.nagios_activate.label}</td><td class="FormRowValue">{$form.nagios_activate.html}</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_server_id" />&nbsp;{$form.nagios_server_id.label}</td><td class="FormRowValue">{$form.nagios_server_id.html}</td></tr>
-			<tr class="list_two">
-				<td class="FormRowField"><img class="helpTooltip" name="use_timezone"> {$form.use_timezone.label}</td>
-				<td class="FormRowValue">{$form.use_timezone.html}</td>
-			</tr>
 
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$Folders}</h4>
-        </td>
-      </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                <div class="formRowLabel">
-                    <div>
-                        <img class="helpTooltip" name="cfg_dir"/>
-                    </div>
-                    <div>
-                        <p class="fieldLabel">
-                           {$form.cfg_dir.label}
-                        </p>
+</div>
 
-                    </div>
-                </div></td>
-                <td class="FormRowValue">{$form.cfg_dir.html}</td>
-            </tr>
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="cfg_file" />&nbsp;{$form.cfg_file.label}</td><td class="FormRowValue">{$form.cfg_file.html}</td></tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$Files}</h4>
-        </td>
-      </tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="status_file" />&nbsp;{$form.status_file.label}</td><td class="FormRowValue">{$form.status_file.html}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="status_update_interval" />&nbsp;{$form.status_update_interval.label}</td><td class="FormRowValue">{$form.status_update_interval.html}&nbsp;&nbsp;{$Seconds}</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="log_file" />&nbsp;{$form.log_file.label}</td><td class="FormRowValue">{$form.log_file.html}</td></tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$ExternalCommandes}</h4>
-        </td>
-      </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="check_external_commands"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                              {$form.check_external_commands.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.check_external_commands.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="command_check_interval"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.command_check_interval.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.command_check_interval.html}</td>
-            </tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="command_file" />&nbsp;{$form.command_file.label}</td><td class="FormRowValue">{$form.command_file.html}</td></tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip"
-                                 name="external_command_buffer_slots"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.external_command_buffer_slots.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.external_command_buffer_slots.html}</td>
-            </tr>
-
-            <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$form.header.information}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField">&nbsp;{$form.nagios_comment.label}</td><td class="FormRowValue">{$form.nagios_comment.html}</td></tr>
-      {if $o == "a" || $o == "c"}
-          <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-          {if isset($form.required)}
-              {$form.required._note}
-          {/if}
-          </td></tr>
-      {/if}
-		</table>
-	</div>
-	<div id='tab2' class='tab'>
-		<table class="formTable table">
-		 	<tr class="ListHeader">
-        <td class="FormHeader" colspan="2">
-          <h3>| {$form.header.title}</h3>
-        </td>
-      </tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$HostCheckOptions}</h4>
-        </td>
-      </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="enable_predictive_host_dependency_checks"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.enable_predictive_host_dependency_checks.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.enable_predictive_host_dependency_checks.html}</td>
-            </tr>
-            <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$ServiceCheckOptions}</h4>
-        </td>
-      </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="check_for_orphaned_services"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.check_for_orphaned_services.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.check_for_orphaned_services.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="check_for_orphaned_hosts"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.check_for_orphaned_hosts.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.check_for_orphaned_hosts.html}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="soft_state_dependencies"/>
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.soft_state_dependencies.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.soft_state_dependencies.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="enable_predictive_service_dependency_checks"/>
-
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.enable_predictive_service_dependency_checks.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.enable_predictive_service_dependency_checks.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="host_down_disable_service_checks"/>
-
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.host_down_disable_service_checks.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.host_down_disable_service_checks.html}</td>
-            </tr>
-
-            <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$EventHandler}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="global_host_event_handler" />&nbsp;{$form.global_host_event_handler.label}</td><td class="FormRowValue">{$form.global_host_event_handler.html}</td></tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="global_service_event_handler">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.global_service_event_handler.label}
-                            </p>
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.global_service_event_handler.html}</td>
-            </tr>
-
-            <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$Freshness}</h4>
-        </td>
-      </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="check_service_freshness">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.check_service_freshness.label}
-                            </p>
-
-                        </div>
-                    </div> </td>
-                <td class="FormRowValue">{$form.check_service_freshness.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="service_freshness_check_interval">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.service_freshness_check_interval.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.service_freshness_check_interval.html}&nbsp;&nbsp;{$Seconds}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="check_host_freshness">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.check_host_freshness.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.check_host_freshness.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="host_freshness_check_interval">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.host_freshness_check_interval.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.host_freshness_check_interval.html}&nbsp;&nbsp;{$Seconds}</td>
-            </tr>
-
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="additional_freshness_latency">&nbsp;{$form.additional_freshness_latency.label}</td><td class="FormRowValue">{$form.additional_freshness_latency.html}&nbsp;&nbsp;{$Seconds}</td></tr>
-
-		 	<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$FlappingOptions}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="enable_flap_detection">&nbsp;{$form.enable_flap_detection.label}</td><td class="FormRowValue">{$form.enable_flap_detection.html}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="low_service_flap_threshold">&nbsp;{$form.low_service_flap_threshold.label}</td><td class="FormRowValue">{$form.low_service_flap_threshold.html}&nbsp;&nbsp;%</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="high_service_flap_threshold">&nbsp;{$form.high_service_flap_threshold.label}</td><td class="FormRowValue">{$form.high_service_flap_threshold.html}&nbsp;&nbsp;%</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="low_host_flap_threshold">&nbsp;{$form.low_host_flap_threshold.label}</td><td class="FormRowValue">{$form.low_host_flap_threshold.html}&nbsp;&nbsp;%</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="high_host_flap_threshold">&nbsp;{$form.high_host_flap_threshold.label}</td><td class="FormRowValue">{$form.high_host_flap_threshold.html}&nbsp;&nbsp;%</td></tr>
-
-      <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$MiscOptions}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="enable_notifications">&nbsp;{$form.enable_notifications.label}</td><td class="FormRowValue">{$form.enable_notifications.html}</td></tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="execute_service_checks">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.execute_service_checks.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.execute_service_checks.html}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="accept_passive_service_checks">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.accept_passive_service_checks.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.accept_passive_service_checks.html}</td>
-            </tr>
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="enable_event_handlers">&nbsp;{$form.enable_event_handlers.label}</td><td class="FormRowValue">{$form.enable_event_handlers.html}</td></tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="execute_host_checks">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.execute_host_checks.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.execute_host_checks.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="accept_passive_host_checks">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.accept_passive_host_checks.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.accept_passive_host_checks.html}</td>
-            </tr>
-
-            {if $o == "a" || $o == "c"}
-          <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-          {if isset($form.required)}
-              {$form.required._note}
-          {/if}
-          </td></tr>
-      {/if}
-		</table>
-	</div>
-	<div id='tab3' class='tab'>
-		<table class="formTable table">
-		 	<tr class="ListHeader">
-        <td class="FormHeader" colspan="2">
-          <h3>| {$form.header.title}</h3>
-        </td>
-      </tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$LoggingOptions}</h4>
-        </td>
-      </tr>
-      <tr class="list_one">
-        <td class="FormRowField"><img class="helpTooltip" name="logger_version">&nbsp;{$form.logger_version.label}</td>
-        <td class="FormRowValue">{$form.logger_version.html}</td>
-      </tr>
-      <tr class="list_one logger_v1_option"><td class="FormRowField"><img class="helpTooltip" name="use_syslog">&nbsp;{$form.use_syslog.label}</td><td class="FormRowValue">{$form.use_syslog.html}</td></tr>
-      <tr class="list_two logger_v1_option"><td class="FormRowField"><img class="helpTooltip" name="log_notifications">&nbsp;{$form.log_notifications.label}</td><td class="FormRowValue">{$form.log_notifications.html}</td></tr>
-            <tr class="list_one logger_v1_option">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip"
-                                 name="log_service_retries">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.log_service_retries.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.log_service_retries.html}</td>
-            </tr>
-            <tr class="list_two logger_v1_option"><td class="FormRowField"><img class="helpTooltip" name="log_host_retries">&nbsp;{$form.log_host_retries.label}</td><td class="FormRowValue">{$form.log_host_retries.html}</td></tr>
-            <tr class="list_one logger_v1_option">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="log_event_handlers">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.log_event_handlers.label}
-                            </p>
-
-                        </div>
-                    </div>
-                    </td>
-                <td class="FormRowValue">{$form.log_event_handlers.html}</td>
-            </tr>
-            <tr class="list_one logger_v1_option">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="log_external_commands">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.log_external_commands.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.log_external_commands.html}</td>
-            </tr>
-            <tr class="list_two logger_v1_option">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="log_passive_checks">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-
-                                {$form.log_passive_checks.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.log_passive_checks.html}</td>
-            </tr>
-            <tr class="list_one logger_v1_option">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="log_pid">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.log_pid.label}
-                            </p>
-
-                        </div>
-                    </div>
-
-                </td>
-                <td class="FormRowValue">{$form.log_pid.html}</td>
-            </tr>
-
-            <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$DebugConfiguration}</h4>
-        </td>
-      </tr>
-      <!-- LOGGER V1 OPTIONS -->
-      <tr class="list_one logger_v1_option">
-        <td class="FormRowField"><img class="helpTooltip" name="debug_file">&nbsp;{$form.debug_file.label}</td>
-        <td class="FormRowValue">{$form.debug_file.html}</td>
-      </tr>
-      <tr class="list_two logger_v1_option">
-        <td class="FormRowField"><img class="helpTooltip" name="nagios_debug_level">&nbsp;{$form.nagios_debug_level.label}
-        </td>
-        <td class="FormRowValue">{$form.nagios_debug_level.html}</td>
-      </tr>
-      <tr class="list_one logger_v1_option">
-        <td class="FormRowField"><img class="helpTooltip" name="debug_verbosity">&nbsp;{$form.debug_verbosity.label}</td>
-        <td class="FormRowValue">{$form.debug_verbosity.html}</td>
-      </tr>
-      <tr class="list_two logger_v1_option">
-        <td class="FormRowField"><img class="helpTooltip" name="max_debug_file_size">&nbsp;{$form.max_debug_file_size.label}
-        </td>
-        <td class="FormRowValue">{$form.max_debug_file_size.html}&nbsp;{$Bytes}</td>
-      </tr>
-      <!-- LOGGER V2 OPTIONS -->
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_v2_logger.label}</td>
-        <td class="FormRowValue">{$form.log_v2_logger.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_checks.label}</td>
-        <td class="FormRowValue">{$form.log_level_checks.html}</td>
-      </tr>
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_level_commands.label}</td>
-        <td class="FormRowValue">{$form.log_level_commands.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_comments.label}</td>
-        <td class="FormRowValue">{$form.log_level_comments.html}</td>
-      </tr>
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_level_config.label}</td>
-        <td class="FormRowValue">{$form.log_level_config.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_downtimes.label}</td>
-        <td class="FormRowValue">{$form.log_level_downtimes.html}</td>
-      </tr>
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_level_eventbroker.label}</td>
-        <td class="FormRowValue">{$form.log_level_eventbroker.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_events.label}</td>
-        <td class="FormRowValue">{$form.log_level_events.html}</td>
-      </tr>
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_level_external_command.label}</td>
-        <td class="FormRowValue">{$form.log_level_external_command.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_functions.label}</td>
-        <td class="FormRowValue">{$form.log_level_functions.html}</td>
-      </tr>
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_level_macros.label}</td>
-        <td class="FormRowValue">{$form.log_level_macros.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_notifications.label}</td>
-        <td class="FormRowValue">{$form.log_level_notifications.html}</td>
-      </tr>
-      <tr class="list_one logger_v2_option">
-        <td class="FormRowField">{$form.log_level_process.label}</td>
-        <td class="FormRowValue">{$form.log_level_process.html}</td>
-      </tr>
-      <tr class="list_two logger_v2_option">
-        <td class="FormRowField">{$form.log_level_runtime.label}</td>
-        <td class="FormRowValue">{$form.log_level_runtime.html}</td>
-      </tr>
-        <tr class="list_one logger_v2_option">
-            <td class="FormRowField">{$form.log_level_otl.label}</td>
-            <td class="FormRowValue">{$form.log_level_otl.html}</td>
-        </tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$Timouts}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="service_check_timeout">&nbsp;{$form.service_check_timeout.label}</td><td class="FormRowValue">{$form.service_check_timeout.html}&nbsp;{$Seconds}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="host_check_timeout">&nbsp;{$form.host_check_timeout.label}</td><td class="FormRowValue">{$form.host_check_timeout.html}&nbsp;{$Seconds}</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="event_handler_timeout">&nbsp;{$form.event_handler_timeout.label}</td><td class="FormRowValue">{$form.event_handler_timeout.html}&nbsp;{$Seconds}</td></tr>
-      <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="notification_timeout">&nbsp;{$form.notification_timeout.label}</td><td class="FormRowValue">{$form.notification_timeout.html}&nbsp;{$Seconds}</td></tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$StatesRetention}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="retain_state_information">&nbsp;{$form.retain_state_information.label}</td><td class="FormRowValue">{$form.retain_state_information.html}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="state_retention_file">&nbsp;{$form.state_retention_file.label}</td><td class="FormRowValue">{$form.state_retention_file.html}</td></tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="retention_update_interval">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.retention_update_interval.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.retention_update_interval.html}&nbsp;{$Minutes}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="use_retained_program_state">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.use_retained_program_state.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.use_retained_program_state.html}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="use_retained_scheduling_info">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.use_retained_scheduling_info.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.use_retained_scheduling_info.html}</td>
-            </tr>
-
-            {if $o == "a" || $o == "c"}
-          <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-          {if isset($form.required)}
-              {$form.required._note}
-          {/if}
-          </td></tr>
-      {/if}
-		</table>
-	</div>
-	<div id='tab4' class='tab'>
-		 <table class="formTable table">
-		 	<tr class="ListHeader">
-                <td class="FormHeader" colspan="2">
-                <h3>| {$form.header.title}</h3>
-                </td>
-            </tr>
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                <h4>{$BrokerModule}</h4>
-                </td>
-            </tr>
-			<tr class="list_one">
-				<td class="FormRowField">
-				<div style="text-decoration: underline;">{$form.multiple_broker_module.label}</div>
-				{$form.bkTextMultiple.label}
-				</td>
-				<td class="FormRowValue" id="multipleBroker">
-                {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="broker" cloneSet=$cloneSet}
-				</td>
-			</tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <img class="helpTooltip" name="event_broker_options">
-                    &nbsp;{$form.event_broker_options.label}
-                </td>
-                <td class="FormRowValue flex-row-wrap">
-                    {$form.event_broker_options.html}
-                </td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    {$form.broker_module_cfg_file.label}
-                </td>
-                <td class="FormRowValue">
-                    {$form.broker_module_cfg_file.html}
-                </td>
-            </tr>
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                <h4>{$MacrosMgmt}</h4>
-                </td>
-            </tr>
-			<tr class="list_one">
-				<td class="FormRowField"><img class="helpTooltip" name="enable_macros_filter">&nbsp;{$form.enable_macros_filter.label}</td>
-				<td class="FormRowValue">{$form.enable_macros_filter.html}</td>
-			</tr>
-			<tr class="list_two">
-				<td class="FormRowField">
-					<img class="helpTooltip" name="macros_filter">&nbsp;{$form.macros_filter.label}
-				</td>
-				<td class="FormRowValue">
-					{include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="macros_filter" cloneSet=$cloneSetMacrosFilter}
-					{$form.macros_filter.error}
-				</td>
-			</tr>
-      {if $o == "a" || $o == "c"}
-          <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-          {if isset($form.required)}
-              {$form.required._note}
-          {/if}
-          </td></tr>
-      {/if}
-		</table>
-	</div>
-	<div id='tab5' class='tab'>
-		<table class="formTable table">
-		 	<tr class="ListHeader">
-        <td class="FormHeader" colspan="2">
-          <h3>| {$form.header.title}</h3>
-        </td>
-      </tr>
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$TimeUnit}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="sleep_time">&nbsp;{$form.sleep_time.label}</td><td class="FormRowValue">{$form.sleep_time.html}&nbsp;{$Minutes}</td></tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$HostCheckSchedulingOptions}</h4>
-        </td>
-      </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip"
-                                 name="host_inter_check_delay_method">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.host_inter_check_delay_method.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.host_inter_check_delay_method.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip"
-                                 name="max_host_check_spread">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.max_host_check_spread.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.max_host_check_spread.html}&nbsp;{$Minutes}</td>
-            </tr>
-
-            <tr class="list_lvl_1">
-          <td class="ListColLvl1_name" colspan="2">
-            <h4>{$ServiceCheckSchedulingOptions}</h4>
-          </td>
-      </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="service_inter_check_delay_method">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.service_inter_check_delay_method.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.service_inter_check_delay_method.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="max_service_check_spread">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.max_service_check_spread.label}
-                            </p>
-
-                        </div>
-                    </div>
-                </td>
-                <td class="FormRowValue">{$form.max_service_check_spread.html}&nbsp;{$Minutes}</td>
-            </tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="service_interleave_factor">&nbsp;{$form.service_interleave_factor.label}</td><td class="FormRowValue">{$form.service_interleave_factor.html}</td></tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="max_concurrent_checks">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.max_concurrent_checks.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.max_concurrent_checks.html}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="check_result_reaper_frequency">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.check_result_reaper_frequency.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.check_result_reaper_frequency.html}&nbsp;{$Seconds}</td>
-            </tr>
-
-            <tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$CachedCheck}</h4>
-        </td>
-      </tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="cached_host_check_horizon">&nbsp;{$form.cached_host_check_horizon.label}</td><td class="FormRowValue">{$form.cached_host_check_horizon.html}&nbsp;{$Seconds}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="cached_service_check_horizon">&nbsp;{$form.cached_service_check_horizon.label}</td><td class="FormRowValue">{$form.cached_service_check_horizon.html}&nbsp;{$Seconds}</td></tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$AutoRescheduling}</h4>
-        </td>
-      </tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="auto_reschedule_checks">&nbsp;{$form.auto_reschedule_checks.label}</td><td class="FormRowValue">{$form.auto_reschedule_checks.html}</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="auto_rescheduling_interval">&nbsp;{$form.auto_rescheduling_interval.label}</td><td class="FormRowValue">{$form.auto_rescheduling_interval.html}&nbsp;&nbsp;{$Seconds}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="auto_rescheduling_window">&nbsp;{$form.auto_rescheduling_window.label}</td><td class="FormRowValue">{$form.auto_rescheduling_window.html}&nbsp;&nbsp;{$Seconds}</td></tr>
-
-			<tr class="list_lvl_1">
-        <td class="ListColLvl1_name" colspan="2">
-          <h4>{$Optimization}</h4>
-        </td>
-      </tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="enable_environment_macros">&nbsp;{$form.enable_environment_macros.label}</td><td class="FormRowValue">{$form.enable_environment_macros.html}</td></tr>
-      {if $o == "a" || $o == "c"}
-          <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-          {if isset($form.required)}
-              {$form.required._note}
-          {/if}
-          </td></tr>
-      {/if}
-		</table>
-	</div>
-	<div id='tab6' class='tab'>
-		<table class="formTable table">
-		 	<tr class="ListHeader">
-        <td class="FormHeader" colspan="2">
-          <h3>| {$form.header.title}</h3>
-        </td>
-      </tr>
-			<tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2"><h4>{$Advanced}</h4></td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="date_format">&nbsp;{$form.date_format.label}</td><td class="FormRowValue">{$form.date_format.html}</td></tr>
-			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="instance_heartbeat_interval">&nbsp;{$form.instance_heartbeat_interval.label}</td><td class="FormRowValue">{$form.instance_heartbeat_interval.html}</td></tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="illegal_object_name_chars">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.illegal_object_name_chars.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.illegal_object_name_chars.html}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="illegal_macro_output_chars">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.illegal_macro_output_chars.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.illegal_macro_output_chars.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="use_regexp_matching">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.use_regexp_matching.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.use_regexp_matching.html}</td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="use_true_regexp_matching">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.use_true_regexp_matching.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                <td class="FormRowValue">{$form.use_true_regexp_matching.html}</td>
-            </tr>
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2"><h4>{$AdminInfo}</h4></td>
-            </tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="admin_email">&nbsp;{$form.admin_email.label}</td><td class="FormRowValue">{$form.admin_email.html}</td></tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="admin_pager">&nbsp;{$form.admin_pager.label}</td><td class="FormRowValue">{$form.admin_pager.html}</td></tr>
-      {if $o == "a" || $o == "c"}
-          <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-          {if isset($form.required)}
-              {$form.required._note}
-          {/if}
-          </td></tr>
-      {/if}
-		</table>
-	</div>
-	<div id="validForm">
-	{if $o == "a" || $o == "c"}
-		<p class="oreonbutton">
-			{if isset($form.submitC)}
-				{$form.submitC.html}
-			{else}
-				{$form.submitA.html}
-			{/if}
-			&nbsp;&nbsp;&nbsp;{$form.reset.html}
-		</p>
-	{else if $o == "w"}
-		<p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-	{/if}
-	</div>
-	{$form.hidden}
+{$form.hidden}
 </form>
 {$helptext}
 {literal}
@@ -1086,5 +851,70 @@ jQuery(document).ready(function() {
     jQuery(window).on('load', updateLoggerOptions);
 });
 
+
+document.addEventListener('DOMContentLoaded', function() {
+    if (window.CentreonForm) {
+        CentreonForm.initFormPage();
+        CentreonForm.syncToggle('cf-nagios_activate-toggle', 'nagios_activate', '1', '0');
+        CentreonForm.syncToggle('cf-check_external_commands-toggle', 'check_external_commands', '1', '0');
+        CentreonForm.syncToggle('cf-enable_predictive_host_dependency_checks-toggle', 'enable_predictive_host_dependency_checks', '1', '0');
+        CentreonForm.syncToggle('cf-check_for_orphaned_services-toggle', 'check_for_orphaned_services', '1', '0');
+        CentreonForm.syncToggle('cf-check_for_orphaned_hosts-toggle', 'check_for_orphaned_hosts', '1', '0');
+        CentreonForm.syncToggle('cf-soft_state_dependencies-toggle', 'soft_state_dependencies', '1', '0');
+        CentreonForm.syncToggle('cf-enable_predictive_service_dependency_checks-toggle', 'enable_predictive_service_dependency_checks', '1', '0');
+        CentreonForm.syncToggle('cf-host_down_disable_service_checks-toggle', 'host_down_disable_service_checks', '1', '0');
+        CentreonForm.syncToggle('cf-check_service_freshness-toggle', 'check_service_freshness', '1', '0');
+        CentreonForm.syncToggle('cf-check_host_freshness-toggle', 'check_host_freshness', '1', '0');
+        CentreonForm.syncToggle('cf-enable_flap_detection-toggle', 'enable_flap_detection', '1', '0');
+        CentreonForm.syncToggle('cf-enable_notifications-toggle', 'enable_notifications', '1', '0');
+        CentreonForm.syncToggle('cf-execute_service_checks-toggle', 'execute_service_checks', '1', '0');
+        CentreonForm.syncToggle('cf-accept_passive_service_checks-toggle', 'accept_passive_service_checks', '1', '0');
+        CentreonForm.syncToggle('cf-enable_event_handlers-toggle', 'enable_event_handlers', '1', '0');
+        CentreonForm.syncToggle('cf-execute_host_checks-toggle', 'execute_host_checks', '1', '0');
+        CentreonForm.syncToggle('cf-accept_passive_host_checks-toggle', 'accept_passive_host_checks', '1', '0');
+        CentreonForm.syncToggle('cf-use_syslog-toggle', 'use_syslog', '1', '0');
+        CentreonForm.syncToggle('cf-log_notifications-toggle', 'log_notifications', '1', '0');
+        CentreonForm.syncToggle('cf-log_service_retries-toggle', 'log_service_retries', '1', '0');
+        CentreonForm.syncToggle('cf-log_host_retries-toggle', 'log_host_retries', '1', '0');
+        CentreonForm.syncToggle('cf-log_event_handlers-toggle', 'log_event_handlers', '1', '0');
+        CentreonForm.syncToggle('cf-log_external_commands-toggle', 'log_external_commands', '1', '0');
+        CentreonForm.syncToggle('cf-log_passive_checks-toggle', 'log_passive_checks', '1', '0');
+        CentreonForm.syncToggle('cf-log_pid-toggle', 'log_pid', '1', '0');
+        CentreonForm.syncToggle('cf-retain_state_information-toggle', 'retain_state_information', '1', '0');
+        CentreonForm.syncToggle('cf-use_retained_program_state-toggle', 'use_retained_program_state', '1', '0');
+        CentreonForm.syncToggle('cf-use_retained_scheduling_info-toggle', 'use_retained_scheduling_info', '1', '0');
+        CentreonForm.syncToggle('cf-enable_macros_filter-toggle', 'enable_macros_filter', '1', '0');
+        CentreonForm.syncToggle('cf-auto_reschedule_checks-toggle', 'auto_reschedule_checks', '1', '0');
+        CentreonForm.syncToggle('cf-enable_environment_macros-toggle', 'enable_environment_macros', '1', '0');
+        CentreonForm.syncToggle('cf-use_regexp_matching-toggle', 'use_regexp_matching', '1', '0');
+        CentreonForm.syncToggle('cf-use_true_regexp_matching-toggle', 'use_true_regexp_matching', '1', '0');
+        var _ar = document.getElementById('cf-auto_reschedule_checks-toggle');
+        if (_ar) { _ar.dispatchEvent(new Event('change')); }
+    }
+
+    // Exclusive "all / none" behaviour for chip-style checkbox groups.
+    // The design-system chips only support a single exclusive option, but these
+    // groups have two mutually-exclusive entries: [-1] (everything) and [0] (nothing).
+    // Checking one of them clears every other option; checking a specific option
+    // clears everything/nothing. Chip clicks dispatch a 'change' on the underlying
+    // checkbox, so we drive the logic (and the chip 'active' state) from there.
+    function cfExclusiveCheckboxGroup(className) {
+        var boxes = Array.prototype.slice.call(document.querySelectorAll('.' + className));
+        if (!boxes.length) { return; }
+        function isAllNone(b) { return /\[(0|-1)\]$/.test(b.name || ''); }
+        function syncChip(b) { if (b.chipEl) { b.chipEl.classList.toggle('active', b.checked); } }
+        boxes.forEach(function (b) {
+            b.addEventListener('change', function () {
+                if (!b.checked) { return; }
+                boxes.forEach(function (o) {
+                    if (o === b) { return; }
+                    if (isAllNone(b) || isAllNone(o)) { o.checked = false; syncChip(o); }
+                });
+            });
+        });
+    }
+    cfExclusiveCheckboxGroup('event-broker-options');
+    cfExclusiveCheckboxGroup('debug-level');
+});
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -1,79 +1,110 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-{if isset($msg_interval)}<center><span class='msg'>{$msg_interval}</span></center>{/if}
-<form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Monitoring engine config{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchN" value="{$searchN}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_instance}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-			<td class="ListColLeft">{$elemArr[elem].RowMenu_instance}</td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	</table>
 
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
+{literal}
+<script type="text/javascript">
+CentreonForm.detectSidePanelClose();
+</script>
+{/literal}
+
+<form name='form' method='POST'>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Engine configuration{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Configure the monitoring engine settings applied to your pollers.{/t}</p>
+    </div>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar cl-actions-bar--centered">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$nagiosPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchN" value="{$searchN}" class="cl-search-simple" placeholder="{t}Search engine configurations{/t}" autocomplete="off">
+                </div>
+            </div>
+            <div class="cl-toolbar-right">
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="nagiosListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th>{$headerMenu_instance}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="5" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
-<script type='text/javascript'>
-	setDisabledRowStyle();
+<script type="text/javascript">
+var nagiosListing = new CentreonListing({
+    instanceName:  'nagiosListing',
+    ajaxListUrl:   './include/configuration/configNagios/ajaxNagiosListing.php',
+    ajaxToggleUrl: './include/configuration/configNagios/ajaxNagiosToggle.php',
+    pageId:        {/literal}'{$nagiosPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'nagios_listing_limit',
+    emptyMessage:  'No monitoring engine configurations found',
+    autoRefresh:   30000,
+    liveSearch:    true,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.get.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.get.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+        }},
+        { id:'instance' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="nagiosListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+nagiosListing.init();
+CentreonForm.initSidePanel(nagiosListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configNagios/listNagios.php
+++ b/centreon/www/include/configuration/configNagios/listNagios.php
@@ -25,54 +25,6 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$search = $_POST['searchN'] ?? $_GET['searchN'] ?? null;
-
-if (! is_null($search)) {
-    $search = HtmlSanitizer::createFromString($search)->sanitize()->getString();
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$SearchTool = '';
-$searchBind = null;
-if (! is_null($search)) {
-    $SearchTool .= ' WHERE nagios_name LIKE :search ';
-    $searchBind = '%' . $search . '%';
-}
-
-$aclCond = '';
-if (! $centreon->user->admin && count($allowedMainConf)) {
-    $aclCond = isset($search) && $search ? ' AND ' : ' WHERE ';
-    $aclCond .= 'nagios_id IN (' . implode(',', array_keys($allowedMainConf)) . ') ';
-}
-
-// nagios servers comes from DB
-$nagios_servers = [null => ''];
-$dbResult = $pearDB->query('SELECT * FROM nagios_server ORDER BY name');
-while ($nagios_server = $dbResult->fetch()) {
-    $nagios_servers[$nagios_server['id']] = HtmlSanitizer::createFromString($nagios_server['name'])->sanitize()->getString();
-}
-$dbResult->closeCursor();
-
-$dbResult = $pearDB->prepare(
-    'SELECT SQL_CALC_FOUND_ROWS nagios_id, nagios_name, nagios_comment, nagios_activate, nagios_server_id '
-    . 'FROM cfg_nagios ' . $SearchTool . $aclCond . ' ORDER BY nagios_name LIMIT :offset, :limit'
-);
-if (! is_null($searchBind)) {
-    $dbResult->bindValue(':search', $searchBind, PDO::PARAM_STR);
-}
-$dbResult->bindValue(':offset', (int) ($num * $limit), PDO::PARAM_INT);
-$dbResult->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
-$dbResult->execute();
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 
@@ -80,52 +32,28 @@ $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_instance', _('Satellites'));
 $tpl->assign('headerMenu_desc', _('Description'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_instance', _('Poller'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Nagios list
+$tpl->assign('nagiosPage', $p);
+
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchN', $search);
+
+// Default limit
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+// Form for bulk actions
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-for ($i = 0; $nagios = $dbResult->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $nagios['nagios_id'] . ']');
-    if ($nagios['nagios_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&nagios_id=' . $nagios['nagios_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14' border='0' "
-            . "alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&nagios_id=' . $nagios['nagios_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' "
-            . "class='ico-14' border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $nagios['nagios_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $nagios['nagios_name'], 'RowMenu_instance' => $nagios_servers[$nagios['nagios_server_id']], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&nagios_id=' . $nagios['nagios_id'], 'RowMenu_desc' => substr($nagios['nagios_comment'], 0, 40), 'RowMenu_status' => $nagios['nagios_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $nagios['nagios_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
 ?>
 <script type="text/javascript">
@@ -137,15 +65,16 @@ $tpl->assign(
 
 foreach (['o1', 'o2'] as $option) {
     $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
         . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
         . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3) {"
-        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . ''];
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
     $form->addElement(
         'select',
         $option,
@@ -154,12 +83,12 @@ foreach (['o1', 'o2'] as $option) {
         $attrs
     );
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchN', $search);
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);

--- a/centreon/www/include/configuration/configResources/ajaxResourceListing.php
+++ b/centreon/www/include/configuration/configResources/ajaxResourceListing.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Server name cache
+$servers = [];
+$dbResult = $pearDB->query('SELECT id, name FROM nagios_server ORDER BY name');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $servers[(int) $row['id']] = $row['name'];
+}
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    $pollerIds = [];
+    foreach ($pollerResult as $p) {
+        $pollerIds[] = (int) $p['id'];
+    }
+    if (! empty($pollerIds)) {
+        $inList = implode(',', $pollerIds);
+        $resIds = [];
+        $stmt = $pearDB->query("SELECT DISTINCT resource_id FROM cfg_resource_instance_relations WHERE instance_id IN ({$inList})");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $resIds[] = (int) $row['resource_id'];
+        }
+        if (! empty($resIds)) {
+            $aclCond = 'AND resource_id IN (' . implode(',', $resIds) . ') ';
+        } else {
+            $helper->jsonResponse([], 0, 0, $limit);
+        }
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND resource_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS resource_id, resource_name, resource_line, resource_comment, resource_activate, is_password'
+    . ' FROM cfg_resource WHERE 1=1 ' . $searchCond . $aclCond
+    . ' ORDER BY resource_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+// Linked pollers per resource
+$pollerStmt = $pearDB->prepare(
+    'SELECT instance_id FROM cfg_resource_instance_relations WHERE resource_id = :rid'
+);
+
+$rows = [];
+while ($res = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rid = (int) $res['resource_id'];
+
+    // Get linked poller names
+    $pollerStmt->execute([':rid' => $rid]);
+    $pollerNames = [];
+    while ($rel = $pollerStmt->fetch(PDO::FETCH_ASSOC)) {
+        $sid = (int) $rel['instance_id'];
+        if (isset($servers[$sid])) {
+            $pollerNames[] = $servers[$sid];
+        }
+    }
+
+    // Mask password values
+    $value = $res['is_password'] ? '**********' : $res['resource_line'];
+
+    $comment = $res['resource_comment'] ?? '';
+    if (mb_strlen($comment) > 40) {
+        $comment = mb_substr($comment, 0, 40) . '...';
+    }
+
+    $rows[] = [
+        'id'       => $rid,
+        'name'     => $res['resource_name'],
+        'value'    => $value,
+        'pollers'  => implode(', ', $pollerNames),
+        'comment'  => $comment,
+        'activate' => (int) $res['resource_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configResources/ajaxResourceToggle.php
+++ b/centreon/www/include/configuration/configResources/ajaxResourceToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60904);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT resource_id FROM cfg_resource WHERE resource_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT resource_name FROM cfg_resource WHERE resource_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE cfg_resource SET resource_activate = :activate WHERE resource_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('resource', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configResources/formResources.ihtml
+++ b/centreon/www/include/configuration/configResources/formResources.ihtml
@@ -1,81 +1,85 @@
 {$form.javascript}
+
 <form {$form.attributes}>
-	<div id="validFormTop">
-    {if $o == "a" || $o == "c"}
-        <p class="oreonbutton">
-        {if isset($form.submitC)}
-            {$form.submitC.html}
-        {else}
-            {$form.submitA.html}
-        {/if}
-        &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-	{else if $o == "w"}
-		<p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-	{/if}
-	</div>
-	 <div id='tab1' class='tab'>
-	 	<table class="formTable table">
-	 		<tr class="ListHeader">
-	 			<td class="FormHeader" colspan="2">
-                  <h3>| {$form.header.title}</h3>
-                </td>
-	 		</tr>
-		 	<tr class="list_lvl_1">
-		 		<td class="ListColLvl1_name" colspan="2">
-                  <h4>{$form.header.information}</h4>
-                </td>
-		 	</tr>
-			<tr class="list_one">
-				<td class="FormRowField">{$form.resource_name.label}</td>
-				<td class="FormRowValue">{$form.resource_name.html}</td>
-			</tr>
-			<tr class="list_two">
-				<td class="FormRowField">{$form.resource_line.label}</td>
-				<td class="FormRowValue">
-					<span>{$form.resource_line.html}</span>
-					<span>{$form.is_password.label}</span>
-					<span>{$form.is_password.html}</span>
-				</td>
-			</tr>
-			<tr class="list_one">
-				<td class="FormRowField">{$form.instance_id.label}</td>
-				<td class="FormRowValue">{$form.instance_id.html}</td>
-			</tr>
-			<tr class="list_lvl_1">
-				<td class="ListColLvl1_name" colspan="2">
-                  <h4>{$form.header.information}</h4>
-                </td>
-			</tr>
-			<tr class="list_one">
-				<td class="FormRowField">{$form.resource_activate.label}</td>
-				<td class="FormRowValue">{$form.resource_activate.html}</td>
-			</tr>
-			<tr class="list_two">
-				<td class="FormRowField">{$form.resource_comment.label}</td>
-				<td class="FormRowValue">{$form.resource_comment.html}</td>
-			</tr>
-		{if $o == "a" || $o == "c"}
-			<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
+<div class="cf-form-wrapper">
+
+    <h1 class="cf-page-title">{$form.header.title}</h1>
+
+    <!-- Section: General Information -->
+    <div class="cf-section" id="cf-sec-info">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.information}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.resource_name.html}
+                    <label class="cf-label-float">{$form.resource_name.label}</label>
+                </div>
+                <div class="cf-toggle-row">
+                    <span>{$form.resource_activate.label}</span>
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-resource-activate-toggle" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span style="display:none;">{$form.resource_activate.html}</span>
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field" style="flex:2;">
+                    {$form.resource_line.html}
+                    <label class="cf-label-float">{$form.resource_line.label}</label>
+                </div>
+                <div class="cf-toggle-row">
+                    <span>{$form.is_password.label}</span>
+                    <span>{$form.is_password.html}</span>
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.instance_id.html}
+                    <label class="cf-label-float">{$form.instance_id.label}</label>
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.resource_comment.html}
+                    <label class="cf-label-float">{$form.resource_comment.label}</label>
+                </div>
+            </div>
+            {if $o == "a" || $o == "c"}
                 {if isset($form.required)}
-                    {$form.required._note}
+                <div class="cf-row"><small>{$form.required._note}</small></div>
                 {/if}
-            </td></tr>
-		{/if}
-	</table>
-	</div>
-	<div id="validForm">
-	{if $o == "a" || $o == "c"}
-		<p class="oreonbutton">
-			{if isset($form.submitC)}
-				{$form.submitC.html}
-			{else}
-				{$form.submitA.html}
-			{/if}
-			&nbsp;&nbsp;&nbsp;{$form.reset.html}
-		</p>
-	{else if $o == "w"}
-		<p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-	{/if}
-	</div>
-	{$form.hidden}
+            {/if}
+        </div>
+    </div>
+
+    <!-- Action buttons -->
+    <div class="cf-actions">
+        {if $o == "a" || $o == "c"}
+            {$form.reset.html}
+            {if isset($form.submitC)}
+                {$form.submitC.html}
+            {else}
+                {$form.submitA.html}
+            {/if}
+        {else if $o == "w"}
+            {if isset($form.change)}{$form.change.html}{/if}
+        {/if}
+    </div>
+
+</div>
+
+{$form.hidden}
 </form>
+
+{literal}
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    CentreonForm.initFormPage();
+    CentreonForm.syncToggle('cf-resource-activate-toggle', 'resource_activate', '1', '0');
+});
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configResources/formResources.php
+++ b/centreon/www/include/configuration/configResources/formResources.php
@@ -17,9 +17,9 @@
  * For more information : contact@centreon.com
  *
  */
+
 if (! $centreon->user->admin
     && isset($resourceId)
-    && $resourceId !== false
     && count($allowedResourceConf)
     && ! isset($allowedResourceConf[$resourceId])
 ) {
@@ -71,11 +71,11 @@ require_once _CENTREON_PATH_ . 'www/class/centreonInstance.class.php';
  */
 $form = new HTML_QuickFormCustom('Form', 'post', '?p=' . $p);
 if ($o == MACRO_ADD) {
-    $form->addElement('header', 'title', _('Add a global macro'));
+    $form->addElement('header', 'title', _('Add a Resource'));
 } elseif ($o == MACRO_MODIFY) {
-    $form->addElement('header', 'title', _('Modify a global macro'));
+    $form->addElement('header', 'title', _('Modify a Resource'));
 } elseif ($o == MACRO_WATCH) {
-    $form->addElement('header', 'title', _('View global macro'));
+    $form->addElement('header', 'title', _('View Resource'));
 }
 
 $isPassword = isset($rs['is_password']) && $rs['is_password'];
@@ -84,8 +84,8 @@ $isPassword = isset($rs['is_password']) && $rs['is_password'];
  * Resources CFG basic information
  */
 $form->addElement('header', 'information', _('General Information'));
-$form->addElement('text', 'resource_name', _('Name'), $attrsText);
-$form->addElement($isPassword ? 'password' : 'text', 'resource_line', _('Value'), $attrsText);
+$form->addElement('text', 'resource_name', _('Resource Name'), $attrsText);
+$form->addElement($isPassword ? 'password' : 'text', 'resource_line', _('MACRO Expression'), $attrsText);
 $form->addElement(
     'checkbox',
     'is_password',
@@ -140,8 +140,6 @@ function myReplace()
 
 $form->applyFilter('__ALL__', 'myTrim');
 $form->applyFilter('resource_name', 'myReplace');
-$form->registerRule('validateName', 'callback', 'validateName');
-$form->addRule('resource_name', _("Name must start and end with a '$'"), 'validateName');
 $form->addRule('resource_name', _('Compulsory Name'), 'required');
 $form->addRule('resource_line', _('Compulsory Alias'), 'required');
 $form->addRule('instance_id', _('Compulsory Instance'), 'required');

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -1,80 +1,113 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
+{literal}
+<script type="text/javascript">
+CentreonForm.detectSidePanelClose();
+</script>
+{/literal}
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Resource{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchR" value="{$searchR}"></td>
-        <td><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Resources{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define resource macros ($USER$) reused across your configuration.{/t}</p>
+    </div>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar cl-actions-bar--centered">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$resPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchR" value="{$searchR}" class="cl-search-simple" placeholder="{t}Search resources{/t}" autocomplete="off">
                 </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_values}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_associated_poller}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_comment}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_values}</a></td>
-			<td class="ListColCenter">{$elemArr[elem].RowMenu_associated_poller}</td>
-			<td class="ListColLeft">{$elemArr[elem].RowMenu_comment}</td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	</table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+            </div>
+            <div class="cl-toolbar-right">
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="resListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_value}</th>
+                    <th class="cl-col-center">{$headerMenu_pollers}</th>
+                    <th>{$headerMenu_comment}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
-
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
-<script type='text/javascript'>
-	setDisabledRowStyle();
+<script type="text/javascript">
+
+var resListing = new CentreonListing({
+    instanceName:  'resListing',
+    ajaxListUrl:   './include/configuration/configResources/ajaxResourceListing.php',
+    ajaxToggleUrl: './include/configuration/configResources/ajaxResourceToggle.php',
+    pageId:        {/literal}'{$resPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'res_listing_limit',
+    emptyMessage:  'No resources found',
+    autoRefresh:   30000,
+    liveSearch:    true,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.get.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'value', render: function(row, l) {
+            var link = 'main.get.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.value)+'</a>';
+        }},
+        { id:'pollers', align:'center' },
+        { id:'comment' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="resListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+resListing.init();
+CentreonForm.initSidePanel(resListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configResources/listResources.php
+++ b/centreon/www/include/configuration/configResources/listResources.php
@@ -23,141 +23,34 @@ if (! isset($centreon)) {
     exit();
 }
 
-include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-const PASSWORD_REPLACEMENT_VALUE_LISTING = '**********';
-
-// Search engine
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchR'] ?? $_GET['searchR'] ?? null
-);
-
-if (isset($_POST['searchR']) || isset($_GET['searchR'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$SearchTool = '';
-if ($search) {
-    $SearchTool .= " WHERE resource_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%'";
-}
-
-$aclCond = '';
-if (! $oreon->user->admin && count($allowedResourceConf)) {
-    $aclCond = isset($search) && $search ? ' AND ' : ' WHERE ';
-    $aclCond .= 'resource_id IN (' . implode(',', array_keys($allowedResourceConf)) . ') ';
-}
-
-// resources list
-$dbResult = $pearDB->query(
-    'SELECT SQL_CALC_FOUND_ROWS * FROM cfg_resource ' . $SearchTool . $aclCond
-    . ' ORDER BY resource_name LIMIT ' . $num * $limit . ', ' . $limit
-);
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_values', _('Values'));
-$tpl->assign('headerMenu_comment', _('Description'));
-$tpl->assign('headerMenu_associated_poller', _('Associated pollers'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_value', _('Value'));
+$tpl->assign('headerMenu_pollers', _('Linked pollers'));
+$tpl->assign('headerMenu_comment', _('Comment'));
 $tpl->assign('headerMenu_options', _('Options'));
+
+$tpl->assign('resPage', $p);
+
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchR', $search);
+
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-for ($i = 0; $resource = $dbResult->fetch(); $i++) {
-    preg_match('$USER([0-9]*)$', $resource['resource_name'], $tabResources);
-    $selectedElements = $form->addElement('checkbox', 'select[' . $resource['resource_id'] . ']');
-    $moptions = '';
-    if ($resource['resource_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&resource_id=' . $resource['resource_id'] . '&o=u&limit='
-            . $limit . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' "
-            . "class='ico-14 margin_right' border='0' alt='" . _('Disabled') . "'></a>";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&resource_id=' . $resource['resource_id'] . '&o=s&limit='
-            . $limit . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' "
-            . "class='ico-14 margin_right' border='0' alt='" . _('Enabled') . "'></a>";
-    }
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;" '
-        . "maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $resource['resource_id'] . "]' />";
-    $elemArr[$i] = ['order' => $tabResources[1] ?? null, 'MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure(
-        $resource['resource_name'],
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&resource_id=' . $resource['resource_id'], 'RowMenu_values' => CentreonUtils::escapeSecure(
-        $resource['is_password'] ? PASSWORD_REPLACEMENT_VALUE_LISTING : substr($resource['resource_line'], 0, 40),
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_comment' => CentreonUtils::escapeSecure(
-        substr(
-            html_entity_decode(
-                $resource['resource_comment'],
-                ENT_QUOTES,
-                'UTF-8'
-            ),
-            0,
-            40
-        ),
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_associated_poller' => getLinkedPollerList($resource['resource_id']), 'RowMenu_status' => $resource['resource_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $resource['resource_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-
-$flag = 1;
-while ($flag) {
-    $flag = 0;
-    foreach ($elemArr as $key => $value) {
-        $key1 = $key + 1;
-        if (isset($elemArr[$key + 1]) && $value['order'] > $elemArr[$key + 1]['order']) {
-            $swmapTab = $elemArr[$key + 1];
-            $elemArr[$key + 1] = $elemArr[$key];
-            $elemArr[$key] = $swmapTab;
-            $flag = 1;
-        } elseif (! isset($elemArr[$key + 1]) && isset($elemArr[$key - 1]['order'])) {
-            if ($value['order'] < $elemArr[$key - 1]['order']) {
-                $swmapTab = $elemArr[$key - 1];
-                $elemArr[$key - 1] = $elemArr[$key];
-                $elemArr[$key] = $swmapTab;
-                $flag = 1;
-            }
-        }
-    }
-}
-
-$tpl->assign('elemArr', $elemArr);
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -165,34 +58,29 @@ $tpl->assign(
     }
 </script>
 <?php
+
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
         . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
         . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3) {"
-        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . ''];
-    $form->addElement(
-        'select',
-        $option,
-        null,
-        [null => _('More actions'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-        $attrs1
-    );
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
-    $o1->setSelected(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchR', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/configuration/configServers/ajaxServerListing.php
+++ b/centreon/www/include/configuration/configServers/ajaxServerListing.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// RTM database
+$pearDBO = new CentreonDB('centstorage');
+
+// Get RTM info (instances)
+$nagiosInfo = [];
+$dbResult = $pearDBO->query(
+    'SELECT start_time AS program_start_time, running AS is_currently_running, pid AS process_id, '
+    . 'instance_id, name AS instance_name, last_alive FROM instances WHERE deleted = 0'
+);
+while ($info = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $nagiosInfo[$info['instance_id']] = $info;
+}
+
+// Get engine version
+$dbResult = $pearDBO->query(
+    'SELECT DISTINCT instance_id, version AS program_version, engine AS program_name '
+    . 'FROM instances WHERE deleted = 0'
+);
+while ($info = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    if (isset($nagiosInfo[$info['instance_id']])) {
+        $nagiosInfo[$info['instance_id']]['version'] = $info['program_name'] . ' ' . $info['program_version'];
+    }
+}
+
+// Remote server IPs
+$remotesServerIPs = $pearDB->query('SELECT ip FROM remote_servers')->fetchAll(PDO::FETCH_COLUMN);
+
+// Last restart times
+$restartTimes = [];
+$dbResult = $pearDB->query('SELECT id, last_restart FROM nagios_server');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $restartTimes[(int) $row['id']] = $row['last_restart'];
+}
+
+// Main query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = "AND name LIKE :search ";
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+// ACL
+$acl = $helper->getAcl();
+$pollerIds = [];
+if ($acl) {
+    $serverResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    foreach ($serverResult as $srv) {
+        $pollerIds[] = (int) $srv['id'];
+    }
+}
+$aclCond = '';
+if (! empty($pollerIds)) {
+    $aclCond = 'WHERE id IN (' . implode(',', $pollerIds) . ') ';
+} else {
+    $aclCond = 'WHERE 1=1 ';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, '
+    . 'updated, gorgone_communication_type'
+    . ' FROM nagios_server ' . $aclCond . $searchCond
+    . ' ORDER BY name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($srv = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $id = (int) $srv['id'];
+    $isRunning = isset($nagiosInfo[$id]['is_currently_running']) && $nagiosInfo[$id]['is_currently_running'] == 1;
+
+    // Server type
+    $serverType = $srv['localhost'] ? 'Central' : 'Poller';
+    if (in_array($srv['ns_ip_address'], $remotesServerIPs)) {
+        $serverType = 'Remote Server';
+    }
+
+    // Conf changed
+    $confChanged = 'N/A';
+    if ($srv['ns_activate'] && isset($restartTimes[$id])) {
+        $confChanged = $srv['updated'] ? 'Yes' : 'No';
+    }
+
+    // Uptime
+    $uptime = '-';
+    if ($isRunning && isset($nagiosInfo[$id]['program_start_time'])) {
+        $now = new DateTime();
+        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$id]['program_start_time']);
+        $interval = date_diff($now, $startDate);
+        $days = (int) $interval->format('%a');
+        if ($days >= 2) {
+            $uptime = $interval->format('%a days');
+        } elseif ($days == 1) {
+            $uptime = $interval->format('%a day %h hours');
+        } elseif ((int) $interval->format('%h') >= 1) {
+            $uptime = $interval->format('%hh %imin');
+        } else {
+            $uptime = $interval->format('%imin %ss');
+        }
+    }
+
+    // Last update + stale flag
+    $lastAlive = $nagiosInfo[$id]['last_alive'] ?? null;
+    $lastUpdateStale = $lastAlive && (time() - $lastAlive > 600);
+
+    // Cfg ID for edit config link
+    $cfgStmt = $pearDB->prepare(
+        "SELECT nagios_id FROM cfg_nagios WHERE nagios_server_id = :id AND nagios_activate = '1'"
+    );
+    $cfgStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $cfgStmt->execute();
+    $cfgRow = $cfgStmt->fetch(PDO::FETCH_ASSOC);
+    $cfgId = $cfgRow ? (int) $cfgRow['nagios_id'] : null;
+
+    $rows[] = [
+        'id'              => $id,
+        'name'            => $srv['name'],
+        'ip_address'      => $srv['ns_ip_address'],
+        'type'            => $serverType,
+        'is_running'      => $isRunning,
+        'conf_changed'    => $confChanged,
+        'conf_changed_flag' => (int) $srv['updated'],
+        'pid'             => $isRunning ? ($nagiosInfo[$id]['process_id'] ?? '-') : '-',
+        'uptime'          => $uptime,
+        'version'         => $nagiosInfo[$id]['version'] ?? 'N/A',
+        'last_alive'      => $lastAlive ? (int) $lastAlive : null,
+        'last_alive_stale' => $lastUpdateStale,
+        'is_default'      => (int) $srv['is_default'],
+        'activate'        => (int) $srv['ns_activate'],
+        'cfg_id'          => $cfgId,
+        'gorgone_comm'    => (int) $srv['gorgone_communication_type'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configServers/ajaxServerToggle.php
+++ b/centreon/www/include/configuration/configServers/ajaxServerToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60901);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT id FROM nagios_server WHERE id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT name FROM nagios_server WHERE id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE nagios_server SET ns_activate = :activate WHERE id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('poller', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configServers/formServers.ihtml
+++ b/centreon/www/include/configuration/configServers/formServers.ihtml
@@ -1,147 +1,303 @@
 {$form.javascript}
+
 <form {$form.attributes}>
-    <div id="validFormTop">
-    {if $o == "a" || $o == "c"}
-        <p class="oreonbutton">
-            {if isset($form.submitC)}
-                {$form.submitC.html}
-            {else}
-                {$form.submitA.html}
-            {/if}
-            &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-    {else if $o == "w" && !$isRemote}
-        <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-    {/if}
-    </div>
-    <div id='tab1' class='tab'>
-    <table class="formTable table">
-        <tr class="ListHeader">
-            <td class="FormHeader" colspan="2">
-                <h3>| {$form.header.title}</h3>
-            </td>
-        </tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.Server_Informations}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="name"> {$form.name.label}</td><td class="FormRowValue">{$form.name.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_ip_address"> {$form.ns_ip_address.label}</td><td class="FormRowValue">{$form.ns_ip_address.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="localhost"> {$form.localhost.label}</td><td class="FormRowValue">{$form.localhost.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="is_default"> {$form.is_default.label}</td><td class="FormRowValue">{$form.is_default.html}</td></tr>
-        {if isset($form.remote_id)}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="remote_id"> {$form.remote_id.label}</td><td class="FormRowValue">{$form.remote_id.html}</td></tr>
-        <tr class="list_two">
-            <td class="FormRowField"><img class="helpTooltip" name="remote_additional_id"> {$form.remote_additional_id.label}</td>
-            <td class="FormRowValue">{$form.remote_additional_id.html}</td>
-        </tr>
-        {/if}
-        {if isset($form.ssh_port)}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ssh_port"> {$form.ssh_port.label}</td><td class="FormRowValue">{$form.ssh_port.html}</td></tr>
-        {/if}
-        {if isset($form.header.Remote_Configuration)}
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.Remote_Configuration}</h4>
-            </td>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_method">{$form.http_method.label}</td><td class="FormRowValue">{$form.http_method.html}</td></tr>
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="http_port">{$form.http_port.label}</td><td class="FormRowValue">{$form.http_port.html}</td></tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_check_certificate">{$form.no_check_certificate.label}</td><td class="FormRowValue">{$form.no_check_certificate.html}</td></tr>
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="no_proxy">{$form.no_proxy.label}</td><td class="FormRowValue">{$form.no_proxy.html}</td></tr>
-        </tr>
-        {/if}
-        <!-- specific gorgone fields for remote or poller -->
-        <tbody id="gorgoneData">
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.gorgone_Informations}</h4></td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField"><img class="helpTooltip" name="gorgone_communication_type"> {$form.gorgone_communication_type.label}</td>
-                <td class="FormRowValue">{$form.gorgone_communication_type.html}</td>
-            </tr>
-            <tr class="list_two">
-                <td class="FormRowField"><img class="helpTooltip" name="gorgone_port"> {$form.gorgone_port.label}</td>
-                <td class="FormRowValue">{$form.gorgone_port.html}</td>
-            </tr>
+<div class="cf-form-wrapper">
 
+    <h1 class="cf-page-title">{$form.header.title}</h1>
+
+    <div class="cf-tab-nav">
+        <a href="#cf-sec-server" class="active" onclick="cfScrollTo('cf-sec-server', this); return false;">{t}Server{/t}</a>
+        <a href="#cf-sec-gorgone" onclick="cfScrollTo('cf-sec-gorgone', this); return false;">{t}Gorgone{/t}</a>
+        <a href="#cf-sec-engine" onclick="cfScrollTo('cf-sec-engine', this); return false;">{t}Engine{/t}</a>
+        <a href="#cf-sec-broker" onclick="cfScrollTo('cf-sec-broker', this); return false;">{t}Broker{/t}</a>
+        <a href="#cf-sec-misc" onclick="cfScrollTo('cf-sec-misc', this); return false;">{t}Misc{/t}</a>
+    </div>
+
+    <!-- Section: Server Information -->
+    <div class="cf-section" id="cf-sec-server">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.Server_Informations}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.name.html}
+                    <label class="cf-label-float">{$form.name.label}</label>
+                    <img class="helpTooltip" name="name">
+                </div>
+                <div class="cf-field">
+                    {$form.ns_ip_address.html}
+                    <label class="cf-label-float">{$form.ns_ip_address.label}</label>
+                    <img class="helpTooltip" name="ns_ip_address">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row">
+                    <span>{$form.localhost.label}</span>
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-toggle-localhost" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span style="display:none;">{$form.localhost.html}</span>
+                    <img class="helpTooltip" name="localhost">
+                </div>
+                <div class="cf-toggle-row">
+                    <span>{$form.is_default.label}</span>
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-toggle-is-default" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span style="display:none;">{$form.is_default.html}</span>
+                    <img class="helpTooltip" name="is_default">
+                </div>
+                <div class="cf-toggle-row">
+                    <span>{$form.ns_activate.label}</span>
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-toggle-ns-activate" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span style="display:none;">{$form.ns_activate.html}</span>
+                    <img class="helpTooltip" name="ns_activate">
+                </div>
+            </div>
+            {if isset($form.remote_id)}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.remote_id.html}
+                    <label class="cf-label-float">{$form.remote_id.label}</label>
+                    <img class="helpTooltip" name="remote_id">
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.remote_additional_id.html}
+                    <label class="cf-label-float">{$form.remote_additional_id.label}</label>
+                    <img class="helpTooltip" name="remote_additional_id">
+                </div>
+            </div>
+            {/if}
+            {if isset($form.ssh_port)}
+            <div class="cf-row-inline">
+                <div class="cf-field" style="max-width:200px;">
+                    {$form.ssh_port.html}
+                    <label class="cf-label-float">{$form.ssh_port.label}</label>
+                    <img class="helpTooltip" name="ssh_port">
+                </div>
+            </div>
+            {/if}
+        </div>
+    </div>
+
+    <!-- Section: Remote Configuration (conditional) -->
+    {if isset($form.header.Remote_Configuration)}
+    <div class="cf-section" id="cf-sec-remote">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.Remote_Configuration}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field" style="max-width:200px;">
+                    {$form.http_method.html}
+                    <label class="cf-label-float">{$form.http_method.label}</label>
+                    <img class="helpTooltip" name="http_method">
+                </div>
+                <div class="cf-field" style="max-width:200px;">
+                    {$form.http_port.html}
+                    <label class="cf-label-float">{$form.http_port.label}</label>
+                    <img class="helpTooltip" name="http_port">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row">
+                    <span>{$form.no_check_certificate.label}</span>
+                    {$form.no_check_certificate.html}
+                    <img class="helpTooltip" name="no_check_certificate">
+                </div>
+                <div class="cf-toggle-row">
+                    <span>{$form.no_proxy.label}</span>
+                    {$form.no_proxy.html}
+                    <img class="helpTooltip" name="no_proxy">
+                </div>
+            </div>
+        </div>
+    </div>
+    {/if}
+
+    <!-- Section: Gorgone Information -->
+    <div class="cf-section" id="cf-sec-gorgone">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.gorgone_Informations}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-toggle-row">
+                    <span>{$form.gorgone_communication_type.label}</span>
+                    {$form.gorgone_communication_type.html}
+                    <img class="helpTooltip" name="gorgone_communication_type">
+                </div>
+                <div class="cf-field" style="max-width:200px;">
+                    {$form.gorgone_port.html}
+                    <label class="cf-label-float">{$form.gorgone_port.label}</label>
+                    <img class="helpTooltip" name="gorgone_port">
+                </div>
+            </div>
             {if isset($form.remote_server_use_as_proxy)}
-            <tr class="list_one">
-                <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
-                <td class="FormRowValue">{$form.remote_server_use_as_proxy.html}</td>
-            </tr>
+            <div class="cf-row">
+                <div class="cf-toggle-row">
+                    <span>{$form.remote_server_use_as_proxy.label}</span>
+                    {$form.remote_server_use_as_proxy.html}
+                    <img class="helpTooltip" name="remote_server_use_as_proxy">
+                </div>
+            </div>
             {/if}
-        </tbody>
-
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.Nagios_Informations}</h4></td>
-        </tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_start_command"> {$form.engine_start_command.label}</td><td class="FormRowValue">{$form.engine_start_command.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_stop_command"> {$form.engine_stop_command.label}</td><td class="FormRowValue">{$form.engine_stop_command.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_restart_command"> {$form.engine_restart_command.label}</td><td class="FormRowValue">{$form.engine_restart_command.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_reload_command"> {$form.engine_reload_command.label}</td><td class="FormRowValue">{$form.engine_reload_command.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagios_bin"> {$form.nagios_bin.label}</td><td class="FormRowValue">{$form.nagios_bin.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagiostats_bin"> {$form.nagiostats_bin.label}</td><td class="FormRowValue">{$form.nagiostats_bin.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagios_perfdata"> {$form.nagios_perfdata.label}</td><td class="FormRowValue">{$form.nagios_perfdata.html}</td></tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.CentreonBroker}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="broker_reload_command"> {$form.broker_reload_command.label}</td><td class="FormRowValue">{$form.broker_reload_command.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_cfg_path"> {$form.centreonbroker_cfg_path.label}</td><td class="FormRowValue">{$form.centreonbroker_cfg_path.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_module_path"> {$form.centreonbroker_module_path.label}</td><td class="FormRowValue">{$form.centreonbroker_module_path.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_logs_path"> {$form.centreonbroker_logs_path.label}</td><td class="FormRowValue">{$form.centreonbroker_logs_path.html}</td></tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.CentreonConnector}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreonconnector_path"> {$form.centreonconnector_path.label}</td><td class="FormRowValue">{$form.centreonconnector_path.html}</td></tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.Centreontrapd}</h4>
-            </td>
-        </tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreontrapd_init_script"> {$form.init_script_centreontrapd.label}</td><td class="FormRowValue">{$form.init_script_centreontrapd.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="snmp_trapd_path_conf"> {$form.snmp_trapd_path_conf.label}</td><td class="FormRowValue">{$form.snmp_trapd_path_conf.html}</td></tr>
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                    <h4>{$form.header.Misc}</h4>
-                </td>
-            </tr>
-        <tr class="list_two">
-            <td class="FormRowField">
-                <img class="helpTooltip" name="pollercmd"> {t}Post-Restart command{/t}
-            </td>
-            <td class="FormRowValue">
-                {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="pollercmd" cloneSet=$cloneSetCmd}
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ns_activate"> {$form.ns_activate.label}</td><td class="FormRowValue">{$form.ns_activate.html}</td></tr>
-        {if $o == "a" || $o == "c"}
-            <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-            {if isset($form.required_note)}
-                {$form.required_note}
-            {/if}
-            </td></tr>
-        {/if}
-    </table>
+        </div>
     </div>
-    <div id="validForm">
-    {if $o == "a" || $o == "c"}
-        <p class="oreonbutton">
+
+    <!-- Section: Monitoring Engine -->
+    <div class="cf-section" id="cf-sec-engine">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.Nagios_Informations}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.engine_start_command.html}
+                    <label class="cf-label-float">{$form.engine_start_command.label}</label>
+                    <img class="helpTooltip" name="engine_start_command">
+                </div>
+                <div class="cf-field">
+                    {$form.engine_stop_command.html}
+                    <label class="cf-label-float">{$form.engine_stop_command.label}</label>
+                    <img class="helpTooltip" name="engine_stop_command">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.engine_restart_command.html}
+                    <label class="cf-label-float">{$form.engine_restart_command.label}</label>
+                    <img class="helpTooltip" name="engine_restart_command">
+                </div>
+                <div class="cf-field">
+                    {$form.engine_reload_command.html}
+                    <label class="cf-label-float">{$form.engine_reload_command.label}</label>
+                    <img class="helpTooltip" name="engine_reload_command">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.nagios_bin.html}
+                    <label class="cf-label-float">{$form.nagios_bin.label}</label>
+                    <img class="helpTooltip" name="nagios_bin">
+                </div>
+                <div class="cf-field">
+                    {$form.nagiostats_bin.html}
+                    <label class="cf-label-float">{$form.nagiostats_bin.label}</label>
+                    <img class="helpTooltip" name="nagiostats_bin">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.nagios_perfdata.html}
+                    <label class="cf-label-float">{$form.nagios_perfdata.label}</label>
+                    <img class="helpTooltip" name="nagios_perfdata">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Section: Centreon Broker -->
+    <div class="cf-section" id="cf-sec-broker">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.CentreonBroker}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.broker_reload_command.html}
+                    <label class="cf-label-float">{$form.broker_reload_command.label}</label>
+                    <img class="helpTooltip" name="broker_reload_command">
+                </div>
+                <div class="cf-field">
+                    {$form.centreonbroker_cfg_path.html}
+                    <label class="cf-label-float">{$form.centreonbroker_cfg_path.label}</label>
+                    <img class="helpTooltip" name="centreonbroker_cfg_path">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.centreonbroker_module_path.html}
+                    <label class="cf-label-float">{$form.centreonbroker_module_path.label}</label>
+                    <img class="helpTooltip" name="centreonbroker_module_path">
+                </div>
+                <div class="cf-field">
+                    {$form.centreonbroker_logs_path.html}
+                    <label class="cf-label-float">{$form.centreonbroker_logs_path.label}</label>
+                    <img class="helpTooltip" name="centreonbroker_logs_path">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Section: Connector + Traps + Misc (collapsed by default) -->
+    <div class="cf-section collapsed" id="cf-sec-misc">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.Misc}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.centreonconnector_path.html}
+                    <label class="cf-label-float">{$form.centreonconnector_path.label}</label>
+                    <img class="helpTooltip" name="centreonconnector_path">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.init_script_centreontrapd.html}
+                    <label class="cf-label-float">{$form.init_script_centreontrapd.label}</label>
+                    <img class="helpTooltip" name="centreontrapd_init_script">
+                </div>
+                <div class="cf-field">
+                    {$form.snmp_trapd_path_conf.html}
+                    <label class="cf-label-float">{$form.snmp_trapd_path_conf.label}</label>
+                    <img class="helpTooltip" name="snmp_trapd_path_conf">
+                </div>
+            </div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    <label style="position:static;font-size:13px;color:var(--list-color,#555);margin-bottom:6px;display:block;">{t}Post-Restart command{/t}</label>
+                    {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="pollercmd" cloneSet=$cloneSetCmd}
+                    <img class="helpTooltip" name="pollercmd">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Action buttons -->
+    <div class="cf-actions">
+        {if $o == "a" || $o == "c"}
+            {$form.reset.html}
             {if isset($form.submitC)}
                 {$form.submitC.html}
             {else}
                 {$form.submitA.html}
             {/if}
-            &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-    {else if $o == "w" && !$isRemote}
-        <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-    {/if}
+        {else if $o == "w" && !$isRemote}
+            {if isset($form.change)}{$form.change.html}{/if}
+        {/if}
     </div>
-    {$form.hidden}
+
+</div>
+
+{$form.hidden}
 </form>
+
 <script type="text/javascript">
     var engines = {literal}{{/literal}
     {foreach name=engines from=$engines key=ename item=engine}
@@ -154,3 +310,14 @@
     {literal}}{/literal}
 </script>
 {$helptext}
+
+{literal}
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    CentreonForm.initFormPage();
+    CentreonForm.syncToggle('cf-toggle-localhost', 'localhost', '1', '0');
+    CentreonForm.syncToggle('cf-toggle-is-default', 'is_default', '1', '0');
+    CentreonForm.syncToggle('cf-toggle-ns-activate', 'ns_activate', '1', '0');
+});
+</script>
+{/literal}

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -1,195 +1,228 @@
-{literal}
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type='text/javascript'>
-    function applyConfiguration() {
-        var pollers = [];
-        jQuery('form tr').not('.row_disabled').find('input[id^="poller_"]:checked').each(function() {
-            pollers.push(this.id.substr(7));
-        });
-        var href = "main.php?p=60902&poller=" + pollers.join(',');
-        jQuery('#exportConfigurationLink').attr('href', href);
-    }
-
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-
-    function hasPollersSelected(){
-        var nbSelectedPollers = jQuery('form tr').find('input[id^="poller_"]:checked').length;
-        var buttons = jQuery('form').find('button[name="delete_action"],button[name="duplicate_action"]');
-
-        if (nbSelectedPollers > 0) {
-            buttons.each(function() {
-                $(this).prop("disabled",false);
-            });
-        } else {
-            buttons.each(function() {
-                $(this).prop("disabled",true);
-            });
-        }
-    }
-    hasPollersSelected();
-
-    jQuery(document).ready(function() {
-        jQuery('#exportConfigurationLink').on('click', function(event) {
-            event.preventDefault(); 
-            applyConfiguration();
-        });
-    })
-
+{literal}
+<script type="text/javascript">
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Poller{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchP" value="{$searchP}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Pollers{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Configure the monitoring pollers that run your checks.{/t}</p>
+    </div>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar cl-actions-bar--centered">
+            <div class="cl-actions-left">
                 {if !$isRemote}
                     {if $can_create_edit == 1}
-                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class} " isreact="true" target="_top">
-                            {$wizardAddBtn.icon} {$wizardAddBtn.text}
-                        </a>
-                        <a href="{$addBtn.link}" class="{$addBtn.class}">
-                            {$addBtn.icon} {$addBtn.text}
-                        </a>
+                        <div class="cl-add-dropdown" id="clAddDropdown">
+                            <a href="#" class="cl-btn-add" onclick="this.closest('.cl-add-dropdown').classList.toggle('cl-open'); return false;">{t}Add{/t}</a>
+                            <div class="cl-add-dropdown-menu">
+                                <a href="{$wizardAddBtn.link}" isreact="true" target="_top">{$wizardAddBtn.icon} {t}Wizard{/t}</a>
+                                <a href="#" onclick="cfOpenPanel('main.get.php?p={$pollerPage}&o=a', '{t}Add a Poller{/t}'); return false;">{$addBtn.icon} {t}Advanced{/t}</a>
+                            </div>
+                        </div>
                     {/if}
+                    {$form.o1.html}
                     {if $can_generate == 1}
-                            <a id="exportConfigurationLink" href="{$exportBtn.link}" class="{$exportBtn.class}">
+                        <a id="exportConfigurationLink" href="#" class="btc bt_success" style="padding:8px 16px;font-size:14px;border-radius:4px;line-height:1.4;white-space:nowrap;opacity:0.5;pointer-events:none;">
                             {$exportBtn.icon} {$exportBtn.text}
                         </a>
                     {/if}
-                    {if $can_create_edit == 1}
-                        <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
-                            {$duplicateBtn.icon} {$duplicateBtn.text}
-                        </button>
-                    {/if}
-                    {if $can_delete == 1}
-                        <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
-                            {$deleteBtn.icon} {$deleteBtn.text}
-                        </button>
-                    {/if}
                 {/if}
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-            {if !$isRemote}
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall"
-                        onclick="checkUncheckAll(this); hasPollersSelected();"/>
-                    <label class="empty-label" for="checkall"></label>
+            </div>
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchP" value="{$searchP}" class="cl-search-simple" placeholder="{t}Search pollers{/t}" autocomplete="off">
                 </div>
-            {/if}
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_ip_address}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_type}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_is_running}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_hasChanged}<font color='red' style='padding-left:3px;'>*</font></td>
-            <td class="ListColHeaderCenter">{$headerMenu_pid}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_uptime}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_lastUpdateTime}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_version}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_default}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderCenter">{t}Actions{/t}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{if !$isRemote}{$elemArr[elem].RowMenu_select} {/if}</td>
-            <td class="ListColLeft">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_name}{if $can_create_edit == 1}</a>{/if}</td>
-            <td class="ListColCenter">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $can_create_edit == 1}</a>{/if}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
-            <td class="ListColCenter">
-              <span class="badge {if $elemArr[elem].RowMenu_is_runningFlag}service_ok{else}service_critical{/if}">
-                {$elemArr[elem].RowMenu_is_running}
-              </span>
-            </td>
-            <td class="ListColCenter">
-                <span class="badge {if $elemArr[elem].RowMenu_hasChangedFlag == 0}service_ok{else}service_critical{/if}">
-                    {$elemArr[elem].RowMenu_hasChanged}
-                </span>
-            </td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_pid}</td>
-            <!-- using a class to format the timestamp -->
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_uptime}</td>
-            <td class="ListColCenter isTimestamp"{if $elemArr[elem].RowMenu_statusVal == 1} style='background-color:#{if $elemArr[elem].RowMenu_lastUpdateTimeFlag}F7D507;{/if}'{/if}>{$elemArr[elem].RowMenu_lastUpdateTime}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_version}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_is_default}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColCenter">
-                {if $can_create_edit == 1 && $elemArr[elem].RowMenu_cfg_id != "" && !$isRemote}
-                <!-- Link for edit poller monitoring engine configuration -->
-                <a href="./main.php?p=60903&o=c&nagios_id={$elemArr[elem].RowMenu_cfg_id}">
-                    <img src="./img/icons/edit_conf.png" class="ico-16" title="Edit monitoring engine configuration">
-                </a>
-                {/if}
+            </div>
+            <div class="cl-toolbar-right">
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
 
-                {if ($elemArr[elem].RowMenu_gorgone_protocol == 1 && $elemArr[elem].RowMenu_statusVal == 1)
-                || $elemArr[elem].RowMenu_type == 'Central'}
-                <!-- Link for edit poller monitoring engine configuration -->
-                <span  {literal}onclick="displayPopup('{/literal}{$elemArr[elem].RowMenu_server_id}{literal}'){/literal}" >
-                    <img src="./img/icons/show_template.png" class="ico-16" style="cursor: pointer" title="Gorgone configuration">
-                </span>
-                {/if}
-            </td>
-            <td class="ListColRight">{if $can_create_edit == 1 && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            {pagination}
-        </tr>
-        <tr>
-            <td colspan='3' style='text-align:right;vertical-align:bottom; height: 50px;'><font color='red'>*</font>&nbsp;{$notice}</td>
-        </tr>
-    </table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        {if !$isRemote}
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="pollerListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                        {/if}
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th class="cl-col-center">{$headerMenu_ip_address}</th>
+                    <th class="cl-col-center">{$headerMenu_type}</th>
+                    <th class="cl-col-center">{$headerMenu_is_running}</th>
+                    <th class="cl-col-center"><span style="border-bottom:1px dotted #fff;cursor:help;" title="{$notice}">{$headerMenu_hasChanged}</span></th>
+                    <th class="cl-col-center">{$headerMenu_lastUpdateTime}</th>
+                    <th class="cl-col-center">{$headerMenu_default}</th>
+                    {if !$isRemote && $can_create_edit == 1}
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                    {/if}
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="10" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
-<script type='text/javascript'>
-    function displayPopup(id) {
-        let popin = jQuery(
-            '<div id="config-popin">' +
-                '<div id="loading">' +
-                    '<img src="./img/misc/ajax-loader.gif" />' +
-                '</div>' +
-            '</div>'
-        );
-        let url = './include/configuration/configServers/popup/popup.php?id=' + id;
-        popin.centreonPopin({
-            url: url,
-            open: true,
-            ajaxType: 'GET',
-            ajaxDataType: 'html'
-        });
-    };
+<script type="text/javascript">
 
-    setDisabledRowStyle();
-    //formatting the tags containing a class isTimestamp
-    formatDateMoment();
-
-    jQuery(document).ready(function () {
-        hasPollersSelected();
+function displayPopup(id) {
+    var popin = jQuery(
+        '<div id="config-popin"><div id="loading"><img src="./img/misc/ajax-loader.gif" /></div></div>'
+    );
+    popin.centreonPopin({
+        url: './include/configuration/configServers/popup/popup.php?id=' + id,
+        open: true,
+        ajaxType: 'GET',
+        ajaxDataType: 'html'
     });
+}
+
+function applyConfiguration() {
+    var pollers = [];
+    jQuery('#clTableBody .cl-col-picker input[type=checkbox]:checked').each(function() {
+        var name = jQuery(this).attr('name');
+        var match = name && name.match(/select\[(\d+)\]/);
+        if (match) pollers.push(match[1]);
+    });
+    var href = 'main.php?p=60902&poller=' + pollers.join(',');
+    jQuery('#exportConfigurationLink').attr('href', href);
+}
+
+jQuery(document).ready(function() {
+    jQuery('#exportConfigurationLink').on('click', function(e) {
+        applyConfiguration();
+        var href = jQuery(this).attr('href');
+        if (!href || href === '#' || href === 'DYNAMIC_LINK') {
+            e.preventDefault();
+            return;
+        }
+    });
+});
+
+var canCreateEdit = {/literal}{$can_create_edit}{literal};
+var isRemoteSrv = {/literal}{if $isRemote}true{else}false{/if}{literal};
+var pollerPage = '{/literal}{$pollerPage}{literal}';
+
+var pollerListing = new CentreonListing({
+    instanceName:  'pollerListing',
+    ajaxListUrl:   './include/configuration/configServers/ajaxServerListing.php',
+    ajaxToggleUrl: './include/configuration/configServers/ajaxServerToggle.php',
+    pageId:        pollerPage,
+    writeAccess:   canCreateEdit === 1 && !isRemoteSrv,
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'poller_listing_limit',
+    emptyMessage:  'No pollers found',
+    autoRefresh:   15000,
+    liveSearch:    true,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var mode = isRemoteSrv ? 'w' : 'c';
+            var editUrl = 'main.get.php?p=' + pollerPage + '&o=' + mode + '&server_id=' + row.id;
+            var title = (mode === 'c' ? '{/literal}{t}Modify Poller{/t}{literal}' : '{/literal}{t}View Poller{/t}{literal}') + ' - ' + row.name;
+            if (canCreateEdit) {
+                return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
+            }
+            return l.escape(row.name);
+        }},
+        { id:'ip_address', align:'center', render: function(row, l) {
+            if (canCreateEdit) {
+                var mode = isRemoteSrv ? 'w' : 'c';
+                var editUrl = 'main.get.php?p=' + pollerPage + '&o=' + mode + '&server_id=' + row.id;
+                var title = (mode === 'c' ? '{/literal}{t}Modify Poller{/t}{literal}' : '{/literal}{t}View Poller{/t}{literal}') + ' - ' + row.name;
+                return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+clEscapeAttr(title)+'\'); return false;">'+l.escape(row.ip_address)+'</a>';
+            }
+            return l.escape(row.ip_address);
+        }},
+        { id:'type', align:'center' },
+        { id:'is_running', align:'center', render: function(row, l) {
+            var color = row.is_running ? 'var(--color-success,#88B922)' : 'var(--color-danger,#FF4A4A)';
+            var tipContent = '<b>PID:</b> '+l.escape(row.pid)+'<br><b>Uptime:</b> '+l.escape(row.uptime)+'<br><b>Version:</b> '+l.escape(row.version);
+            return '<span data-cl-tooltip="'+tipContent.replace(/"/g,'&quot;')+'" style="display:inline-block;width:14px;height:14px;border-radius:50%;background:'+color+';box-shadow:0 0 5px '+color+';cursor:help;"></span>';
+        }},
+        { id:'conf_changed', align:'center', render: function(row) {
+            if (row.conf_changed === 'N/A') return '<span style="opacity:.4;">&#8212;</span>';
+            if (row.conf_changed_flag === 0) {
+                return '<span class="cl-tag cl-tag--success" title="Configuration up to date">Up to date</span>';
+            }
+            return '<span class="cl-tag cl-tag--warning" data-cl-tooltip="<b>Configuration changed</b><br>An export and restart is required to apply changes." style="cursor:help;">Changed</span>';
+        }},
+        { id:'last_alive', align:'center', render: function(row) {
+            if (!row.last_alive) return '-';
+            var d = new Date(row.last_alive * 1000);
+            var str = d.toLocaleString();
+            return row.last_alive_stale ? '<span class="cl-stale">'+str+'</span>' : str;
+        }},
+        { id:'is_default', align:'center', render: function(row) { return row.is_default ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : ''; }}
+    ],
+    renderOptions: function(row, l) {
+        var html = '';
+        // Edit engine config — opens in the side panel (save closes it and refreshes)
+        if (row.cfg_id && canCreateEdit && !isRemoteSrv) {
+            html += '<a href="#" title="Edit monitoring engine configuration" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" onclick="cfOpenPanel(\'main.get.php?p=60903&o=c&nagios_id='+row.cfg_id+'\', \'Engine configuration\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></a>';
+        }
+        // Gorgone popup
+        if ((row.gorgone_comm === 1 && row.activate) || row.type === 'Central') {
+            html += '<span onclick="displayPopup('+row.id+')" style="cursor:pointer;margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" title="Gorgone configuration"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><rect x="2" y="2" width="20" height="8" rx="2"/><rect x="2" y="14" width="20" height="8" rx="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg></span>';
+        }
+        // Toggle
+        var checked = row.activate ? ' checked' : '';
+        html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="pollerListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>';
+        // Dup input
+        html += '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+        return html;
+    }
+});
+pollerListing.init();
+CentreonForm.initSidePanel(pollerListing);
+
+// Enable/disable Export button based on poller selection
+function updateExportBtn() {
+    var btn = document.getElementById('exportConfigurationLink');
+    if (!btn) return;
+    var checked = jQuery('#clTableBody .cl-col-picker input[type=checkbox]:checked').length;
+    btn.style.opacity = checked > 0 ? '1' : '0.5';
+    btn.style.pointerEvents = checked > 0 ? 'auto' : 'none';
+}
+jQuery(document).on('change', '#clTableBody input[type=checkbox], #checkall', function() {
+    updateExportBtn();
+});
+
+// Close Add dropdown on click outside
+document.addEventListener('click', function(e) {
+    var dd = document.getElementById('clAddDropdown');
+    if (dd && !dd.contains(e.target)) {
+        dd.classList.remove('cl-open');
+    }
+});
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -1,195 +1,224 @@
-{literal}
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type='text/javascript'>
-    function applyConfiguration() {
-        var pollers = [];
-        jQuery('form tr').not('.row_disabled').find('input[id^="poller_"]:checked').each(function() {
-            pollers.push(this.id.substr(7));
-        });
-        var href = "main.php?p=60902&poller=" + pollers.join(',');
-        jQuery('#exportConfigurationLink').attr('href', href);
-    }
 
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-
-    function hasPollersSelected(){
-        var nbSelectedPollers = jQuery('form tr').find('input[id^="poller_"]:checked').length;
-        var buttons = jQuery('form').find('button[name="delete_action"],button[name="duplicate_action"]');
-
-        if (nbSelectedPollers > 0) {
-            buttons.each(function() {
-                $(this).prop("disabled",false);
-            });
-        } else {
-            buttons.each(function() {
-                $(this).prop("disabled",true);
-            });
-        }
-    }
-    hasPollersSelected();
-
-    jQuery(document).ready(function() {
-        jQuery('#exportConfigurationLink').on('click', function(event) {
-            event.preventDefault(); 
-            applyConfiguration();
-        });
-    })
-
-</script>
-{/literal}
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Poller{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchP" value="{$searchP}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            <div class="cl-actions-left">
                 {if !$isRemote}
                     {if $can_create_edit == 1}
-                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class} " isreact="true" target="_top">
-                            {$wizardAddBtn.icon} {$wizardAddBtn.text}
-                        </a>
-                        <a href="{$addBtn.link}" class="{$addBtn.class}">
-                            {$addBtn.icon} {$addBtn.text}
-                        </a>
+                        <div class="cl-add-dropdown" id="clAddDropdown" style="position:relative;display:inline-block;">
+                            <a href="#" class="cl-btn-add" onclick="var m=document.getElementById('clAddMenu');m.style.display=m.style.display==='block'?'none':'block';return false;">{t}Add{/t}</a>
+                            <div id="clAddMenu" style="display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #ccc;border-radius:4px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:1000;min-width:160px;margin-top:4px;overflow:hidden;">
+                                <a href="{$wizardAddBtn.link}" isreact="true" target="_top" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$wizardAddBtn.icon} {t}Wizard{/t}</a>
+                                <a href="{$addBtn.link}" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$addBtn.icon} {t}Advanced{/t}</a>
+                            </div>
+                        </div>
                     {/if}
+                    {$form.o1.html}
                     {if $can_generate == 1}
-                            <a id="exportConfigurationLink" href="{$exportBtn.link}" class="{$exportBtn.class}">
+                        <a id="exportConfigurationLink" href="#" class="btc bt_success" style="padding:8px 16px;font-size:14px;border-radius:4px;line-height:1.4;white-space:nowrap;opacity:0.5;pointer-events:none;">
                             {$exportBtn.icon} {$exportBtn.text}
                         </a>
                     {/if}
-                    {if $can_create_edit == 1}
-                        <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
-                            {$duplicateBtn.icon} {$duplicateBtn.text}
-                        </button>
-                    {/if}
-                    {if $can_delete == 1}
-                        <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
-                            {$deleteBtn.icon} {$deleteBtn.text}
-                        </button>
-                    {/if}
                 {/if}
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-            {if !$isRemote}
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall"
-                        onclick="checkUncheckAll(this); hasPollersSelected();"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            {/if}
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_ip_address}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_type}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_is_running}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_hasChanged}<font color='red' style='padding-left:3px;'>*</font></td>
-            <td class="ListColHeaderCenter">{$headerMenu_pid}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_uptime}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_lastUpdateTime}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_version}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_default}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderCenter">{t}Actions{/t}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{if !$isRemote}{$elemArr[elem].RowMenu_select} {/if}</td>
-            <td class="ListColLeft">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_name}{if $can_create_edit == 1}</a>{/if}</td>
-            <td class="ListColCenter">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $can_create_edit == 1}</a>{/if}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
-            <td class="ListColCenter">
-              <span class="badge {if $elemArr[elem].RowMenu_is_runningFlag}service_ok{else}service_critical{/if}">
-                {$elemArr[elem].RowMenu_is_running}
-              </span>
-            </td>
-            <td class="ListColCenter">
-                <span class="badge {if $elemArr[elem].RowMenu_hasChangedFlag == 0}service_ok{else}service_critical{/if}">
-                    {$elemArr[elem].RowMenu_hasChanged}
-                </span>
-            </td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_pid}</td>
-            <!-- using a class to format the timestamp -->
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_uptime}</td>
-            <td class="ListColCenter isTimestamp"{if $elemArr[elem].RowMenu_statusVal == 1} style='background-color:#{if $elemArr[elem].RowMenu_lastUpdateTimeFlag}F7D507;{/if}'{/if}>{$elemArr[elem].RowMenu_lastUpdateTime}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_version}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_is_default}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColCenter">
-                {if $can_create_edit == 1 && $elemArr[elem].RowMenu_cfg_id != "" && !$isRemote}
-                <!-- Link for edit poller monitoring engine configuration -->
-                <a href="./main.php?p=60903&o=c&nagios_id={$elemArr[elem].RowMenu_cfg_id}">
-                    <img src="./img/icons/edit_conf.png" class="ico-16" title="Edit monitoring engine configuration">
-                </a>
-                {/if}
+            </div>
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchP" value="{$searchP}" placeholder="{t}Search poller{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-                {if ($elemArr[elem].RowMenu_gorgone_protocol == 1 && $elemArr[elem].RowMenu_statusVal == 1)
-                || $elemArr[elem].RowMenu_type == 'Central'}
-                <!-- Link for edit poller monitoring engine configuration -->
-                <span  {literal}onclick="displayPopup('{/literal}{$elemArr[elem].RowMenu_server_id}{literal}'){/literal}" >
-                    <img src="./img/icons/show_template.png" class="ico-16" style="cursor: pointer" title="Gorgone configuration">
-                </span>
-                {/if}
-            </td>
-            <td class="ListColRight">{if $can_create_edit == 1 && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            {pagination}
-        </tr>
-        <tr>
-            <td colspan='3' style='text-align:right;vertical-align:bottom; height: 50px;'><font color='red'>*</font>&nbsp;{$notice}</td>
-        </tr>
-    </table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        {if !$isRemote}
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="pollerListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                        {/if}
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th class="cl-col-center">{$headerMenu_ip_address}</th>
+                    <th class="cl-col-center">{$headerMenu_type}</th>
+                    <th class="cl-col-center">{$headerMenu_is_running}</th>
+                    <th class="cl-col-center"><span style="border-bottom:1px dotted #fff;cursor:help;" title="{$notice}">{$headerMenu_hasChanged}</span></th>
+                    <th class="cl-col-center">{$headerMenu_lastUpdateTime}</th>
+                    <th class="cl-col-center">{$headerMenu_default}</th>
+                    {if !$isRemote && $can_create_edit == 1}
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    {/if}
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="10" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            <div class="cl-actions-left"></div>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    function displayPopup(id) {
-        let popin = jQuery(
-            '<div id="config-popin">' +
-                '<div id="loading">' +
-                    '<img src="./img/misc/ajax-loader.gif" />' +
-                '</div>' +
-            '</div>'
-        );
-        let url = './include/configuration/configServers/popup/popup.php?id=' + id;
-        popin.centreonPopin({
-            url: url,
-            open: true,
-            ajaxType: 'GET',
-            ajaxDataType: 'html'
-        });
-    };
-
-    setDisabledRowStyle();
-    //formatting the tags containing a class isTimestamp
-    formatDateMoment();
-
-    jQuery(document).ready(function () {
-        hasPollersSelected();
+<script type="text/javascript">
+function displayPopup(id) {
+    var popin = jQuery(
+        '<div id="config-popin"><div id="loading"><img src="./img/misc/ajax-loader.gif" /></div></div>'
+    );
+    popin.centreonPopin({
+        url: './include/configuration/configServers/popup/popup.php?id=' + id,
+        open: true,
+        ajaxType: 'GET',
+        ajaxDataType: 'html'
     });
+}
+
+function applyConfiguration() {
+    var pollers = [];
+    jQuery('#clTableBody .cl-col-picker input[type=checkbox]:checked').each(function() {
+        var name = jQuery(this).attr('name');
+        var match = name && name.match(/select\[(\d+)\]/);
+        if (match) pollers.push(match[1]);
+    });
+    var href = 'main.php?p=60902&poller=' + pollers.join(',');
+    jQuery('#exportConfigurationLink').attr('href', href);
+}
+
+jQuery(document).ready(function() {
+    jQuery('#exportConfigurationLink').on('click', function(e) {
+        applyConfiguration();
+        var href = jQuery(this).attr('href');
+        if (!href || href === '#' || href === 'DYNAMIC_LINK') {
+            e.preventDefault();
+            return;
+        }
+    });
+});
+
+var canCreateEdit = {/literal}{$can_create_edit}{literal};
+var isRemoteSrv = {/literal}{if $isRemote}true{else}false{/if}{literal};
+var pollerPage = '{/literal}{$pollerPage}{literal}';
+
+var pollerListing = new CentreonListing({
+    instanceName:  'pollerListing',
+    ajaxListUrl:   './include/configuration/configServers/ajaxServerListing.php',
+    ajaxToggleUrl: './include/configuration/configServers/ajaxServerToggle.php',
+    pageId:        pollerPage,
+    writeAccess:   canCreateEdit === 1 && !isRemoteSrv,
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'poller_listing_limit',
+    emptyMessage:  'No pollers found',
+    autoRefresh:   15000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p=' + pollerPage + '&o=' + (isRemoteSrv ? 'w' : 'c') + '&server_id=' + row.id;
+            var html = canCreateEdit ? '<a href="'+link+'">'+l.escape(row.name)+'</a>' : l.escape(row.name);
+            // Info tooltip (PID, Uptime, Version)
+            return html;
+        }},
+        { id:'ip_address', align:'center', render: function(row, l) {
+            if (canCreateEdit) {
+                var link = 'main.php?p=' + pollerPage + '&o=' + (isRemoteSrv ? 'w' : 'c') + '&server_id=' + row.id;
+                return '<a href="'+link+'">'+l.escape(row.ip_address)+'</a>';
+            }
+            return l.escape(row.ip_address);
+        }},
+        { id:'type', align:'center' },
+        { id:'is_running', align:'center', render: function(row, l) {
+            var color = row.is_running ? 'var(--color-success,#88B922)' : 'var(--color-danger,#FF4A4A)';
+            var tipContent = '<b>PID:</b> '+l.escape(row.pid)+'<br><b>Uptime:</b> '+l.escape(row.uptime)+'<br><b>Version:</b> '+l.escape(row.version);
+            return '<span data-cl-tooltip="'+tipContent.replace(/"/g,'&quot;')+'" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';cursor:help;"></span>';
+        }},
+        { id:'conf_changed', align:'center', render: function(row) {
+            if (row.conf_changed === 'N/A') return '<span style="opacity:.4;">&#8212;</span>';
+            var color = row.conf_changed_flag === 0 ? 'var(--color-success,#88B922)' : 'var(--color-warning,#FD9B27)';
+            if (row.conf_changed_flag === 0) {
+                return '<span title="Up to date" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';"></span>';
+            }
+            return '<span data-cl-tooltip="<b>Configuration changed</b><br>An export and restart is required to apply changes." style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';cursor:help;"></span>';
+        }},
+        { id:'last_alive', align:'center', render: function(row) {
+            if (!row.last_alive) return '-';
+            var d = new Date(row.last_alive * 1000);
+            var str = d.toLocaleString();
+            return row.last_alive_stale ? '<span class="cl-stale">'+str+'</span>' : str;
+        }},
+        { id:'is_default', align:'center', render: function(row) { return row.is_default ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : ''; }}
+    ],
+    renderOptions: function(row, l) {
+        var html = '';
+        // Edit engine config
+        if (row.cfg_id && canCreateEdit && !isRemoteSrv) {
+            html += '<a href="./main.php?p=60903&o=c&nagios_id='+row.cfg_id+'" title="Edit monitoring engine configuration"><img src="./img/icons/edit_conf.png" class="ico-16"/></a>';
+        }
+        // Gorgone popup
+        if ((row.gorgone_comm === 1 && row.activate) || row.type === 'Central') {
+            html += '<span onclick="displayPopup('+row.id+')" style="cursor:pointer" title="Gorgone configuration"><img src="./img/icons/show_template.png" class="ico-16"/></span>';
+        }
+        // Toggle
+        var checked = row.activate ? ' checked' : '';
+        html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="pollerListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>';
+        // Dup input
+        html += '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+        return html;
+    }
+});
+pollerListing.init();
+
+// Enable/disable Export button based on poller selection
+function updateExportBtn() {
+    var btn = document.getElementById('exportConfigurationLink');
+    if (!btn) return;
+    var checked = jQuery('#clTableBody .cl-col-picker input[type=checkbox]:checked').length;
+    btn.style.opacity = checked > 0 ? '1' : '0.5';
+    btn.style.pointerEvents = checked > 0 ? 'auto' : 'none';
+}
+jQuery(document).on('change', '#clTableBody input[type=checkbox], #checkall', function() {
+    updateExportBtn();
+});
+
+// Close Add dropdown on click outside
+document.addEventListener('click', function(e) {
+    var dd = document.getElementById('clAddDropdown');
+    var menu = document.getElementById('clAddMenu');
+    if (dd && menu && !dd.contains(e.target)) {
+        menu.style.display = 'none';
+    }
+});
+
+// Instant tooltip for info icons
+(function() {
+    var tip = null;
+    jQuery(document).on('mouseenter', '[data-cl-tooltip]', function() {
+        var content = jQuery(this).attr('data-cl-tooltip');
+        if (!content) return;
+        if (tip) tip.remove();
+        tip = jQuery('<div></div>').html(content).css({
+            position:'fixed', zIndex:99999,
+            background:'#222', color:'#eee',
+            border:'1px solid #555', borderRadius:'6px',
+            padding:'8px 12px', fontSize:'12px',
+            whiteSpace:'nowrap', boxShadow:'0 2px 8px rgba(0,0,0,.3)',
+            pointerEvents:'none'
+        });
+        jQuery('body').append(tip);
+        var r = this.getBoundingClientRect();
+        var t = r.top - tip.outerHeight() - 6;
+        if (t < 0) t = r.bottom + 6;
+        tip.css({ top:t+'px', left:(r.left + r.width/2 - tip.outerWidth()/2)+'px' });
+    }).on('mouseleave', '[data-cl-tooltip]', function() {
+        if (tip) { tip.remove(); tip = null; }
+    });
+})();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -25,256 +25,42 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-// Init GMT class
-$centreonGMT = new CentreonGMT();
-$centreonGMT->getMyGMTFromSession(session_id());
+// Smarty template initialization
+$tpl = SmartyBC::createSmartyTemplate($path);
 
-$search = $_POST['searchP'] ?? $_GET['searchP'] ?? null;
+// Access level and permissions
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
 
-if (! is_null($search)) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$LCASearch = '';
-$searchBind = null;
-if (! is_null($search)) {
-    $search = HtmlSanitizer::createFromString($search)->sanitize()->getString();
-    $LCASearch .= ' name LIKE :search';
-    $searchBind = '%' . $search . '%';
-}
-
-// Get Authorized Actions
 $can_generate = $centreon->user->access->checkAction('generate_cfg');
 $can_create_edit = $centreon->user->access->checkAction('create_edit_poller_cfg');
 $can_delete = $centreon->user->access->checkAction('delete_poller_cfg');
 
-// nagios servers comes from DB
-$nagiosServers = [];
-$nagiosRestart = [];
-foreach ($serverResult as $nagiosServer) {
-    $nagiosServers[$nagiosServer['id']] = $nagiosServer['name'];
-    $nagiosRestart[$nagiosServer['id']] = $nagiosServer['last_restart'];
-}
-
-$pollerstring = implode(',', array_keys($nagiosServers));
-
-// Get information info RTM
-$nagiosInfo = [];
-$dbResult = $pearDBO->query(
-    'SELECT start_time AS program_start_time, running AS is_currently_running, pid AS process_id, instance_id, '
-    . 'name AS instance_name , last_alive FROM instances WHERE deleted = 0'
-);
-while ($info = $dbResult->fetch()) {
-    $nagiosInfo[$info['instance_id']] = $info;
-}
-$dbResult->closeCursor();
-
-// Get Scheduler version
-$dbResult = $pearDBO->query(
-    'SELECT DISTINCT instance_id, version AS program_version, engine AS program_name, name AS instance_name '
-    . 'FROM instances WHERE deleted = 0 '
-);
-while ($info = $dbResult->fetch()) {
-    if (isset($nagiosInfo[$info['instance_id']])) {
-        $nagiosInfo[$info['instance_id']]['version'] = $info['program_name'] . ' ' . $info['program_version'];
-    }
-}
-$dbResult->closeCursor();
-
-$query = 'SELECT ip FROM remote_servers';
-$dbResult = $pearDB->query($query);
-$remotesServerIPs = $dbResult->fetchAll(PDO::FETCH_COLUMN);
-$dbResult->closeCursor();
-
-// Smarty template initialization
-$tpl = SmartyBC::createSmartyTemplate($path);
-
-// Access level
-$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
-$tpl->assign('mode_access', $lvl_access);
-
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_ip_address', _('Address'));
 $tpl->assign('headerMenu_type', _('Server type'));
 $tpl->assign('headerMenu_is_running', _('Is running ?'));
 $tpl->assign('headerMenu_hasChanged', _('Conf Changed'));
-$tpl->assign('headerMenu_pid', _('PID'));
-$tpl->assign('headerMenu_version', _('Version'));
-$tpl->assign('headerMenu_uptime', _('Uptime'));
 $tpl->assign('headerMenu_lastUpdateTime', _('Last Update'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_default', _('Default'));
+$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Poller list
-$ACLString = $centreon->user->access->queryBuilder('WHERE', 'id', $pollerstring);
+$tpl->assign('pollerPage', $p);
 
-$query = 'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, updated '
-    . ', gorgone_communication_type, uid FROM `nagios_server` ' . $ACLString . ' '
-    . ($LCASearch != '' ? ($ACLString != '' ? 'AND ' : 'WHERE ') . $LCASearch : '')
-    . ' ORDER BY name LIMIT :offset, :limit';
-$dbResult = $pearDB->prepare($query);
-if (! is_null($searchBind)) {
-    $dbResult->bindValue(':search', $searchBind, PDO::PARAM_STR);
-}
-$dbResult->bindValue(':offset', (int) ($num * $limit), PDO::PARAM_INT);
-$dbResult->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
-$dbResult->execute();
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchP', $search);
 
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+// Default limit
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-$servers = [];
-while (($config = $dbResult->fetch())) {
-    $servers[] = $config;
-}
-
-include './include/common/checkPagination.php';
-
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$i = -1;
-$centreonToken = createCSRFToken();
-
-foreach ($servers as $config) {
-    $i++;
-    $moptions = '';
-    $selectedElements = $form->addElement(
-        'checkbox',
-        'select[' . $config['id'] . ']',
-        null,
-        '',
-        ['id' => 'poller_' . $config['id'], 'onClick' => 'hasPollersSelected();']
-    );
-    if (! $isRemote) {
-        if ($config['ns_activate']) {
-            $moptions .= "<a href='main.php?p=" . $p . '&server_id=' . $config['id'] . '&o=u&limit=' . $limit
-                . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-                . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-                . "border='0' alt='" . _('Disabled') . "'></a>";
-        } else {
-            $moptions .= "<a href='main.php?p=" . $p . '&server_id=' . $config['id'] . '&o=s&limit=' . $limit
-                . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-                . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-                . "border='0' alt='" . _('Enabled') . "'></a>";
-        }
-    }
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $config['id'] . "]' />";
-
-    // instances.instance_id holds the Snowflake uid for up-to-date pollers; legacy pollers
-    // (older Engine/Broker) still report their config id as instance_id. Resolve the runtime
-    // row by uid, then fall back to the config id so a mixed-version platform shows the real
-    // running state.
-    $runtimeKey = isset($nagiosInfo[$config['uid']]) ? $config['uid'] : $config['id'];
-
-    if (! isset($nagiosInfo[$runtimeKey]['is_currently_running'])) {
-        $nagiosInfo[$runtimeKey]['is_currently_running'] = 0;
-    }
-
-    // Manage flag for changes
-    $confChangedMessage = _('N/A');
-    if ($config['ns_activate'] && isset($nagiosRestart[$config['id']])) {
-        $confChangedMessage = $config['updated'] ? _('Yes') : _('No');
-    }
-
-    // Manage flag for update time
-    $lastUpdateTimeFlag = 0;
-    if (! isset($nagiosInfo[$runtimeKey]['last_alive'])) {
-        $lastUpdateTimeFlag = 0;
-    } elseif (time() - $nagiosInfo[$runtimeKey]['last_alive'] > 10 * 60) {
-        $lastUpdateTimeFlag = 1;
-    }
-
-    // Get cfg_id
-    $dbResult2 = $pearDB->query(
-        'SELECT nagios_id FROM cfg_nagios '
-        . 'WHERE nagios_server_id = ' . (int) $config['id'] . " AND nagios_activate = '1'"
-    );
-    $cfg_id = $dbResult2->rowCount() ? $dbResult2->fetch() : -1;
-
-    $uptime = '-';
-    $isRunning = (isset($nagiosInfo[$runtimeKey]['is_currently_running'])
-        && $nagiosInfo[$runtimeKey]['is_currently_running'] == 1)
-        ? true
-        : false;
-    $version = $nagiosInfo[$runtimeKey]['version'] ?? _('N/A');
-    $updateTime = (isset($nagiosInfo[$runtimeKey]['last_alive'])
-        && $nagiosInfo[$runtimeKey]['last_alive'])
-        ? $nagiosInfo[$runtimeKey]['last_alive']
-        : '-';
-    $serverType = $config['localhost'] ? _('Central') : _('Poller');
-    $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
-        ? _('Remote Server')
-        : $serverType;
-
-    if (
-        isset($nagiosInfo[$runtimeKey]['is_currently_running'])
-        && $nagiosInfo[$runtimeKey]['is_currently_running'] == 1
-    ) {
-        $now = new DateTime();
-        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$runtimeKey]['program_start_time']);
-        $interval = date_diff($now, $startDate);
-        if (intval($interval->format('%a')) >= 2) {
-            $uptime = $interval->format('%a days');
-        } elseif (intval($interval->format('%a')) == 1) {
-            $uptime = $interval->format('%a days %i minutes');
-        } elseif (intval($interval->format('%a')) < 1 && intval($interval->format('%h')) >= 1) {
-            $uptime = $interval->format('%h hours %i minutes');
-        } elseif (intval($interval->format('%h')) < 1) {
-            $uptime = $interval->format('%i minutes %s seconds');
-        } else {
-            $uptime = $interval->format('%a days %h hours %i minutes %s seconds');
-        }
-    }
-
-    $pollerProcessId = $isRunning
-        ? $nagiosInfo[$runtimeKey]['process_id']
-        : '-';
-
-    // Manage different styles between each line
-    $style = ($i % 2) ? 'two' : 'one';
-
-    $serverLink = $isRemote
-        ? "main.php?p={$p}&o=w&server_id={$config['id']}"
-        : "main.php?p={$p}&o=c&server_id={$config['id']}";
-
-    $elemArr[$i] = [
-        'MenuClass' => "list_{$style}",
-        'RowMenu_select' => $selectedElements->toHtml(),
-        'RowMenu_name' => HtmlSanitizer::createFromString($config['name'])->sanitize()->getString(),
-        'RowMenu_ip_address' => $config['ns_ip_address'],
-        'RowMenu_server_id' => $config['id'],
-        'RowMenu_gorgone_protocol' => $config['gorgone_communication_type'],
-        'RowMenu_link' => $serverLink,
-        'RowMenu_type' => $serverType,
-        'RowMenu_is_running' => $isRunning ? _('Yes') : _('No'),
-        'RowMenu_is_runningFlag' => $nagiosInfo[$runtimeKey]['is_currently_running'],
-        'RowMenu_is_default' => $config['is_default'] ? _('Yes') : _('No'),
-        'RowMenu_hasChanged' => $confChangedMessage,
-        'RowMenu_pid' => $pollerProcessId,
-        'RowMenu_hasChangedFlag' => $config['updated'],
-        'RowMenu_version' => $version,
-        'RowMenu_uptime' => $uptime,
-        'RowMenu_lastUpdateTime' => $updateTime,
-        'RowMenu_lastUpdateTimeFlag' => $lastUpdateTimeFlag,
-        'RowMenu_status' => $config['ns_activate'] ? _('Enabled') : _('Disabled'),
-        'RowMenu_badge' => $config['ns_activate'] ? 'service_ok' : 'service_critical',
-        'RowMenu_statusVal' => $config['ns_activate'],
-        'RowMenu_cfg_id' => ($cfg_id == -1) ? '' : $cfg_id['nagios_id'],
-        'RowMenu_options' => $moptions,
-    ];
-}
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('can_generate', $can_generate);
+$tpl->assign('can_create_edit', $can_create_edit);
+$tpl->assign('can_delete', $can_delete);
+$tpl->assign('is_admin', $is_admin);
+$tpl->assign('isRemote', $isRemote);
 
 $tpl->assign(
     'notice',
@@ -285,55 +71,74 @@ $tpl->assign(
 
 // Action buttons
 if (! $isRemote) {
-    $tpl->assign(
-        'wizardAddBtn',
-        ['link' => './poller-wizard/1', 'text' => _('Add'), 'class' => 'btc bt-poller-action bt_success', 'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16)]
-    );
-
-    $tpl->assign(
-        'addBtn',
-        ['link' => 'main.php?p=' . $p . '&o=a', 'text' => _('Add (advanced)'), 'class' => 'btc bt-poller-action bt_success', 'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16)]
-    );
-
-    $tpl->assign(
-        'duplicateBtn',
-        ['text' => _('Duplicate'), 'class' => 'btc bt-poller-action bt_success', 'name' => 'duplicate_action', 'icon' => returnSvg('www/img/icons/duplicate.svg', 'var(--button-icons-fill-color)', 16, 14), 'onClickAction' => 'javascript: '
+    $tpl->assign('wizardAddBtn', [
+        'link' => './poller-wizard/1',
+        'text' => _('Add'),
+        'class' => 'btc bt-poller-action bt_success',
+        'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16),
+    ]);
+    $tpl->assign('addBtn', [
+        'link' => 'main.php?p=' . $p . '&o=a',
+        'text' => _('Add (advanced)'),
+        'class' => 'btc bt-poller-action bt_success',
+        'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16),
+    ]);
+    $tpl->assign('duplicateBtn', [
+        'text' => _('Duplicate'),
+        'class' => 'btc bt-poller-action bt_success',
+        'name' => 'duplicate_action',
+        'icon' => returnSvg('www/img/icons/duplicate.svg', 'var(--button-icons-fill-color)', 16, 14),
+        'onClickAction' => 'javascript: '
             . ' var bChecked = isChecked(); '
             . " if (!bChecked) { alert('" . _('Please select one or more items') . "'); return false;} "
-            . " if (confirm('" . _('Do you confirm the duplication ?') . "')) { setO('m'); submit();} "]
-    );
-
-    $tpl->assign(
-        'deleteBtn',
-        ['text' => _('Delete'), 'class' => 'btc bt-poller-action bt_danger', 'name' => 'delete_action', 'icon' => returnSvg('www/img/icons/trash.svg', 'var(--button-icons-fill-color)', 16, 16), 'onClickAction' => 'javascript: '
+            . " if (confirm('" . _('Do you confirm the duplication ?') . "')) { setO('m'); submit();} ",
+    ]);
+    $tpl->assign('deleteBtn', [
+        'text' => _('Delete'),
+        'class' => 'btc bt-poller-action bt_danger',
+        'name' => 'delete_action',
+        'icon' => returnSvg('www/img/icons/trash.svg', 'var(--button-icons-fill-color)', 16, 16),
+        'onClickAction' => 'javascript: '
             . ' var bChecked = isChecked(); '
             . " if (!bChecked) { alert('" . _('Please select one or more items') . "'); return false;} "
-            . " if (confirm('"
-            . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\n'
-            . 'Do you confirm the deletion ?')
-            . "')) { setO('d'); submit();} "]
-    );
-
-    $tpl->assign(
-        'exportBtn',
-        [
-            'link' => 'DYNAMIC_LINK', // Placeholder for dynamic link
-            'text' => _('Export configuration'),
-            'class' => 'btc bt-poller-action bt_info',
-            'icon' => returnSvg('www/img/icons/export.svg', 'var(--button-icons-fill-color)', 14, 14),
-            'id' => 'exportConfigurationLink',
-        ]
-    );
-
+            . " if (confirm('" . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
+            . "')) { setO('d'); submit();} ",
+    ]);
+    $tpl->assign('exportBtn', [
+        'link' => 'DYNAMIC_LINK',
+        'text' => _('Export configuration'),
+        'class' => 'btc bt-poller-action bt_info',
+        'icon' => returnSvg('www/img/icons/export.svg', 'var(--button-icons-fill-color)', 14, 14),
+    ]);
 }
 
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 $tpl->assign('limit', $limit);
-$tpl->assign('searchP', $search);
-$tpl->assign('can_generate', $can_generate);
-$tpl->assign('can_create_edit', $can_create_edit);
-$tpl->assign('can_delete', $can_delete);
-$tpl->assign('is_admin', $is_admin);
-$tpl->assign('isRemote', $isRemote);
+
+?>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
+<?php
+
+if (! $isRemote) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['o1'].value); submit();} "
+        . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
+        . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
+        . "')) { setO(this.form.elements['o1'].value); submit();} "
+        . "this.form.elements['o1'].selectedIndex = 0"];
+    $form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $o1 = $form->getElement('o1');
+    $o1->setValue(null);
+}
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -25,242 +25,44 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-// Init GMT class
-$centreonGMT = new CentreonGMT();
-$centreonGMT->getMyGMTFromSession(session_id());
+// Smarty template initialization
+$tpl = SmartyBC::createSmartyTemplate($path);
 
-$search = $_POST['searchP'] ?? $_GET['searchP'] ?? null;
+// Access level and permissions
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
 
-if (! is_null($search)) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$LCASearch = '';
-if (! is_null($search)) {
-    $search = HtmlSanitizer::createFromString($search)->sanitize()->getString();
-    $LCASearch .= " name LIKE '%{$search}%'";
-}
-
-// Get Authorized Actions
 $can_generate = $centreon->user->access->checkAction('generate_cfg');
 $can_create_edit = $centreon->user->access->checkAction('create_edit_poller_cfg');
 $can_delete = $centreon->user->access->checkAction('delete_poller_cfg');
 
-// nagios servers comes from DB
-$nagiosServers = [];
-$nagiosRestart = [];
-foreach ($serverResult as $nagiosServer) {
-    $nagiosServers[$nagiosServer['id']] = $nagiosServer['name'];
-    $nagiosRestart[$nagiosServer['id']] = $nagiosServer['last_restart'];
-}
-
-$pollerstring = implode(',', array_keys($nagiosServers));
-
-// Get information info RTM
-$nagiosInfo = [];
-$dbResult = $pearDBO->query(
-    'SELECT start_time AS program_start_time, running AS is_currently_running, pid AS process_id, instance_id, '
-    . 'name AS instance_name , last_alive FROM instances WHERE deleted = 0'
-);
-while ($info = $dbResult->fetch()) {
-    $nagiosInfo[$info['instance_id']] = $info;
-}
-$dbResult->closeCursor();
-
-// Get Scheduler version
-$dbResult = $pearDBO->query(
-    'SELECT DISTINCT instance_id, version AS program_version, engine AS program_name, name AS instance_name '
-    . 'FROM instances WHERE deleted = 0 '
-);
-while ($info = $dbResult->fetch()) {
-    if (isset($nagiosInfo[$info['instance_id']])) {
-        $nagiosInfo[$info['instance_id']]['version'] = $info['program_name'] . ' ' . $info['program_version'];
-    }
-}
-$dbResult->closeCursor();
-
-$query = 'SELECT ip FROM remote_servers';
-$dbResult = $pearDB->query($query);
-$remotesServerIPs = $dbResult->fetchAll(PDO::FETCH_COLUMN);
-$dbResult->closeCursor();
-
-// Smarty template initialization
-$tpl = SmartyBC::createSmartyTemplate($path);
-
-// Access level
-$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
-$tpl->assign('mode_access', $lvl_access);
-
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_ip_address', _('Address'));
 $tpl->assign('headerMenu_type', _('Server type'));
 $tpl->assign('headerMenu_is_running', _('Is running ?'));
 $tpl->assign('headerMenu_hasChanged', _('Conf Changed'));
-$tpl->assign('headerMenu_pid', _('PID'));
-$tpl->assign('headerMenu_version', _('Version'));
-$tpl->assign('headerMenu_uptime', _('Uptime'));
 $tpl->assign('headerMenu_lastUpdateTime', _('Last Update'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_default', _('Default'));
+$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Poller list
-$ACLString = $centreon->user->access->queryBuilder('WHERE', 'id', $pollerstring);
+$tpl->assign('pollerPage', $p);
 
-$query = 'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, updated '
-    . ', gorgone_communication_type FROM `nagios_server` ' . $ACLString . ' '
-    . ($LCASearch != '' ? ($ACLString != '' ? 'AND ' : 'WHERE ') . $LCASearch : '')
-    . ' ORDER BY name LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($query);
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchP', $search);
 
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+// Default limit
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-$servers = [];
-while (($config = $dbResult->fetch())) {
-    $servers[] = $config;
-}
-
-include './include/common/checkPagination.php';
-
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$i = -1;
-$centreonToken = createCSRFToken();
-
-foreach ($servers as $config) {
-    $i++;
-    $moptions = '';
-    $selectedElements = $form->addElement(
-        'checkbox',
-        'select[' . $config['id'] . ']',
-        null,
-        '',
-        ['id' => 'poller_' . $config['id'], 'onClick' => 'hasPollersSelected();']
-    );
-    if (! $isRemote) {
-        if ($config['ns_activate']) {
-            $moptions .= "<a href='main.php?p=" . $p . '&server_id=' . $config['id'] . '&o=u&limit=' . $limit
-                . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-                . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-                . "border='0' alt='" . _('Disabled') . "'></a>";
-        } else {
-            $moptions .= "<a href='main.php?p=" . $p . '&server_id=' . $config['id'] . '&o=s&limit=' . $limit
-                . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-                . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-                . "border='0' alt='" . _('Enabled') . "'></a>";
-        }
-    }
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $config['id'] . "]' />";
-
-    if (! isset($nagiosInfo[$config['id']]['is_currently_running'])) {
-        $nagiosInfo[$config['id']]['is_currently_running'] = 0;
-    }
-
-    // Manage flag for changes
-    $confChangedMessage = _('N/A');
-    if ($config['ns_activate'] && isset($nagiosRestart[$config['id']])) {
-        $confChangedMessage = $config['updated'] ? _('Yes') : _('No');
-    }
-
-    // Manage flag for update time
-    $lastUpdateTimeFlag = 0;
-    if (! isset($nagiosInfo[$config['id']]['last_alive'])) {
-        $lastUpdateTimeFlag = 0;
-    } elseif (time() - $nagiosInfo[$config['id']]['last_alive'] > 10 * 60) {
-        $lastUpdateTimeFlag = 1;
-    }
-
-    // Get cfg_id
-    $dbResult2 = $pearDB->query(
-        'SELECT nagios_id FROM cfg_nagios '
-        . 'WHERE nagios_server_id = ' . (int) $config['id'] . " AND nagios_activate = '1'"
-    );
-    $cfg_id = $dbResult2->rowCount() ? $dbResult2->fetch() : -1;
-
-    $uptime = '-';
-    $isRunning = (isset($nagiosInfo[$config['id']]['is_currently_running'])
-        && $nagiosInfo[$config['id']]['is_currently_running'] == 1)
-        ? true
-        : false;
-    $version = $nagiosInfo[$config['id']]['version'] ?? _('N/A');
-    $updateTime = (isset($nagiosInfo[$config['id']]['last_alive'])
-        && $nagiosInfo[$config['id']]['last_alive'])
-        ? $nagiosInfo[$config['id']]['last_alive']
-        : '-';
-    $serverType = $config['localhost'] ? _('Central') : _('Poller');
-    $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
-        ? _('Remote Server')
-        : $serverType;
-
-    if (
-        isset($nagiosInfo[$config['id']]['is_currently_running'])
-        && $nagiosInfo[$config['id']]['is_currently_running'] == 1
-    ) {
-        $now = new DateTime();
-        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$config['id']]['program_start_time']);
-        $interval = date_diff($now, $startDate);
-        if (intval($interval->format('%a')) >= 2) {
-            $uptime = $interval->format('%a days');
-        } elseif (intval($interval->format('%a')) == 1) {
-            $uptime = $interval->format('%a days %i minutes');
-        } elseif (intval($interval->format('%a')) < 1 && intval($interval->format('%h')) >= 1) {
-            $uptime = $interval->format('%h hours %i minutes');
-        } elseif (intval($interval->format('%h')) < 1) {
-            $uptime = $interval->format('%i minutes %s seconds');
-        } else {
-            $uptime = $interval->format('%a days %h hours %i minutes %s seconds');
-        }
-    }
-
-    $pollerProcessId = $isRunning
-        ? $nagiosInfo[$config['id']]['process_id']
-        : '-';
-
-    // Manage different styles between each line
-    $style = ($i % 2) ? 'two' : 'one';
-
-    $serverLink = $isRemote
-        ? "main.php?p={$p}&o=w&server_id={$config['id']}"
-        : "main.php?p={$p}&o=c&server_id={$config['id']}";
-
-    $elemArr[$i] = [
-        'MenuClass' => "list_{$style}",
-        'RowMenu_select' => $selectedElements->toHtml(),
-        'RowMenu_name' => HtmlSanitizer::createFromString($config['name'])->sanitize()->getString(),
-        'RowMenu_ip_address' => $config['ns_ip_address'],
-        'RowMenu_server_id' => $config['id'],
-        'RowMenu_gorgone_protocol' => $config['gorgone_communication_type'],
-        'RowMenu_link' => $serverLink,
-        'RowMenu_type' => $serverType,
-        'RowMenu_is_running' => $isRunning ? _('Yes') : _('No'),
-        'RowMenu_is_runningFlag' => $nagiosInfo[$config['id']]['is_currently_running'],
-        'RowMenu_is_default' => $config['is_default'] ? _('Yes') : _('No'),
-        'RowMenu_hasChanged' => $confChangedMessage,
-        'RowMenu_pid' => $pollerProcessId,
-        'RowMenu_hasChangedFlag' => $config['updated'],
-        'RowMenu_version' => $version,
-        'RowMenu_uptime' => $uptime,
-        'RowMenu_lastUpdateTime' => $updateTime,
-        'RowMenu_lastUpdateTimeFlag' => $lastUpdateTimeFlag,
-        'RowMenu_status' => $config['ns_activate'] ? _('Enabled') : _('Disabled'),
-        'RowMenu_badge' => $config['ns_activate'] ? 'service_ok' : 'service_critical',
-        'RowMenu_statusVal' => $config['ns_activate'],
-        'RowMenu_cfg_id' => ($cfg_id == -1) ? '' : $cfg_id['nagios_id'],
-        'RowMenu_options' => $moptions,
-    ];
-}
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('can_generate', $can_generate);
+$tpl->assign('can_create_edit', $can_create_edit);
+$tpl->assign('can_delete', $can_delete);
+$tpl->assign('is_admin', $is_admin);
+$tpl->assign('isRemote', $isRemote);
 
 $tpl->assign(
     'notice',
@@ -271,55 +73,74 @@ $tpl->assign(
 
 // Action buttons
 if (! $isRemote) {
-    $tpl->assign(
-        'wizardAddBtn',
-        ['link' => './poller-wizard/1', 'text' => _('Add'), 'class' => 'btc bt-poller-action bt_success', 'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16)]
-    );
-
-    $tpl->assign(
-        'addBtn',
-        ['link' => 'main.php?p=' . $p . '&o=a', 'text' => _('Add (advanced)'), 'class' => 'btc bt-poller-action bt_success', 'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16)]
-    );
-
-    $tpl->assign(
-        'duplicateBtn',
-        ['text' => _('Duplicate'), 'class' => 'btc bt-poller-action bt_success', 'name' => 'duplicate_action', 'icon' => returnSvg('www/img/icons/duplicate.svg', 'var(--button-icons-fill-color)', 16, 14), 'onClickAction' => 'javascript: '
+    $tpl->assign('wizardAddBtn', [
+        'link' => './poller-wizard/1',
+        'text' => _('Add'),
+        'class' => 'btc bt-poller-action bt_success',
+        'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16),
+    ]);
+    $tpl->assign('addBtn', [
+        'link' => 'main.php?p=' . $p . '&o=a',
+        'text' => _('Add (advanced)'),
+        'class' => 'btc bt-poller-action bt_success',
+        'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16),
+    ]);
+    $tpl->assign('duplicateBtn', [
+        'text' => _('Duplicate'),
+        'class' => 'btc bt-poller-action bt_success',
+        'name' => 'duplicate_action',
+        'icon' => returnSvg('www/img/icons/duplicate.svg', 'var(--button-icons-fill-color)', 16, 14),
+        'onClickAction' => 'javascript: '
             . ' var bChecked = isChecked(); '
             . " if (!bChecked) { alert('" . _('Please select one or more items') . "'); return false;} "
-            . " if (confirm('" . _('Do you confirm the duplication ?') . "')) { setO('m'); submit();} "]
-    );
-
-    $tpl->assign(
-        'deleteBtn',
-        ['text' => _('Delete'), 'class' => 'btc bt-poller-action bt_danger', 'name' => 'delete_action', 'icon' => returnSvg('www/img/icons/trash.svg', 'var(--button-icons-fill-color)', 16, 16), 'onClickAction' => 'javascript: '
+            . " if (confirm('" . _('Do you confirm the duplication ?') . "')) { setO('m'); submit();} ",
+    ]);
+    $tpl->assign('deleteBtn', [
+        'text' => _('Delete'),
+        'class' => 'btc bt-poller-action bt_danger',
+        'name' => 'delete_action',
+        'icon' => returnSvg('www/img/icons/trash.svg', 'var(--button-icons-fill-color)', 16, 16),
+        'onClickAction' => 'javascript: '
             . ' var bChecked = isChecked(); '
             . " if (!bChecked) { alert('" . _('Please select one or more items') . "'); return false;} "
-            . " if (confirm('"
-            . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\n'
-            . 'Do you confirm the deletion ?')
-            . "')) { setO('d'); submit();} "]
-    );
-
-    $tpl->assign(
-        'exportBtn',
-        [
-            'link' => 'DYNAMIC_LINK', // Placeholder for dynamic link
-            'text' => _('Export configuration'),
-            'class' => 'btc bt-poller-action bt_info',
-            'icon' => returnSvg('www/img/icons/export.svg', 'var(--button-icons-fill-color)', 14, 14),
-            'id' => 'exportConfigurationLink',
-        ]
-    );
-
+            . " if (confirm('" . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
+            . "')) { setO('d'); submit();} ",
+    ]);
+    $tpl->assign('exportBtn', [
+        'link' => 'DYNAMIC_LINK',
+        'text' => _('Export configuration'),
+        'class' => 'btc bt-poller-action bt_info',
+        'icon' => returnSvg('www/img/icons/export.svg', 'var(--button-icons-fill-color)', 14, 14),
+    ]);
 }
 
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 $tpl->assign('limit', $limit);
-$tpl->assign('searchP', $search);
-$tpl->assign('can_generate', $can_generate);
-$tpl->assign('can_create_edit', $can_create_edit);
-$tpl->assign('can_delete', $can_delete);
-$tpl->assign('is_admin', $is_admin);
-$tpl->assign('isRemote', $isRemote);
+
+?>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
+<?php
+
+if (! $isRemote) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['o1'].value); submit();} "
+        . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
+        . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
+        . "')) { setO(this.form.elements['o1'].value); submit();} "
+        . "this.form.elements['o1'].selectedIndex = 0"];
+    $form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $o1 = $form->getElement('o1');
+    $o1->setValue(null);
+}
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered pollers listing with an AJAX-driven table using the shared `CentreonListing` framework. This listing has several unique features compared to other configuration pages.

## What changed

### New files (2)

- **`ajaxServerListing.php`** — AJAX endpoint with:
  - ACL (page 60901)
  - Poller status from centstorage `instances` table (running, last alive, PID, version, uptime)
  - LED status indicators (running / conf changed)
  - Engine stats in tooltips
  - Sanitized search, prepared statements

- **`ajaxServerToggle.php`** — Toggle with CSRF rotation, ACL write access, audit logging.

### Modified files (2)

- **`listServers.ihtml`** — Modern template with:
  - LED badges for running/conf status
  - Instant tooltips (PID, uptime, version)
  - Dropdown Add button (Wizard / Advanced)
  - Export Configuration button
  - 15s auto-refresh

- **`listServers.php`** — Simplified controller.

### Tests (9 scenarios)

1. AJAX listing loads — Central poller visible
2. Search filters by name
3. Toggle disables a poller
4. Toggle enables a poller
5. LED status indicators displayed
6. Tooltips with PID/uptime/version
7. Pagination info
8. Click navigates to edit form
9. Session state persistence

## How to test

1. Navigate to Configuration > Pollers > Pollers
2. Verify Central poller shows with LED status indicators
3. Hover LED badges → verify tooltips with engine info
4. Test search, toggle, pagination
5. Verify Export Configuration button
6. Verify no regression on poller add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Introduced AJAX listing endpoint providing poller status and paging.
* Added secure AJAX toggle endpoint with CSRF rotation and auditing.

**⚡ Enhancements**
* Replaced legacy Smarty poller list with AJAX-driven CentreonListing UI.
* Displayed LED status indicators, engine tooltips, export and auto-refresh.

**🔧 Refactors**
* Simplified listServers controller and moved logic to AJAX endpoints.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98617309?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
