### PR TITLE
feat(configuration): modernize engine config listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing.feature
@@ -1,0 +1,58 @@
+Feature: Modern engine configuration listing
+    As a Centreon admin
+    I want to manage engine configurations from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-138
+  Scenario: Engine config listing loads via AJAX
+    When the user navigates to the engine config listing
+    Then the AJAX listing table is displayed with engine config rows
+    And the Central engine config is visible
+
+  @TEST_LISTING-139
+  Scenario: Search filters engine configs by name
+    When the user navigates to the engine config listing
+    And the user searches for a specific engine config
+    Then only the matching engine config is displayed
+
+  @TEST_LISTING-140
+  Scenario: Toggle disables an engine config
+    When the user navigates to the engine config listing
+    And the user clicks the toggle to disable an engine config
+    Then the engine config toggle switches to disabled
+    And the toggle response is successful
+
+  @TEST_LISTING-141
+  Scenario: Toggle enables an engine config
+    When the user navigates to the engine config listing
+    And the engine config is disabled
+    And the user clicks the toggle to enable the engine config
+    Then the engine config toggle switches to enabled
+
+  @TEST_LISTING-142
+  Scenario: Pagination info is displayed
+    When the user navigates to the engine config listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-143
+  Scenario: Bulk duplication works
+    When the user navigates to the engine config listing
+    And the user selects an engine config and duplicates it
+    Then a duplicated engine config appears in the listing
+
+  @TEST_LISTING-144
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the engine config listing
+    And the user clicks on an engine config name
+    Then the engine config edit form is displayed
+
+  @TEST_LISTING-145
+  Scenario: Session state persists across navigation
+    When the user navigates to the engine config listing
+    And the user searches for a specific engine config
+    And the user clicks on an engine config name
+    And the user navigates back to the engine config listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing.feature
@@ -6,50 +6,42 @@ Feature: Modern engine configuration listing
   Background:
     Given an admin user is logged in Centreon
 
-  @TEST_LISTING-138
   Scenario: Engine config listing loads via AJAX
     When the user navigates to the engine config listing
     Then the AJAX listing table is displayed with engine config rows
     And the Central engine config is visible
 
-  @TEST_LISTING-139
   Scenario: Search filters engine configs by name
     When the user navigates to the engine config listing
     And the user searches for a specific engine config
     Then only the matching engine config is displayed
 
-  @TEST_LISTING-140
   Scenario: Toggle disables an engine config
     When the user navigates to the engine config listing
     And the user clicks the toggle to disable an engine config
     Then the engine config toggle switches to disabled
     And the toggle response is successful
 
-  @TEST_LISTING-141
   Scenario: Toggle enables an engine config
     When the user navigates to the engine config listing
     And the engine config is disabled
     And the user clicks the toggle to enable the engine config
     Then the engine config toggle switches to enabled
 
-  @TEST_LISTING-142
   Scenario: Pagination info is displayed
     When the user navigates to the engine config listing
     Then the pagination info shows the total count
 
-  @TEST_LISTING-143
   Scenario: Bulk duplication works
     When the user navigates to the engine config listing
     And the user selects an engine config and duplicates it
     Then a duplicated engine config appears in the listing
 
-  @TEST_LISTING-144
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the engine config listing
     And the user clicks on an engine config name
     Then the engine config edit form is displayed
 
-  @TEST_LISTING-145
   Scenario: Session state persists across navigation
     When the user navigates to the engine config listing
     And the user searches for a specific engine config

--- a/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing/index.ts
@@ -1,0 +1,218 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+// Engine config page is p=60903
+const enginePage = '/centreon/main.php?p=60903';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(enginePage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the engine config listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with engine config rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+Then('the Central engine config is visible', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Centreon Engine').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific engine config', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('Centreon Engine');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching engine config is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Centreon Engine').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable an engine config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxNagiosToggle.php'
+  }).as('toggleEngine');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleEngine');
+});
+
+Then('the engine config toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleEngine')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@toggleEngine')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the engine config is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE cfg_nagios SET nagios_activate = '0' WHERE nagios_name LIKE '%Centreon Engine%'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the engine config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxNagiosToggle.php'
+  }).as('toggleEngineOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleEngineOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the engine config toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects an engine config and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated engine config appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('Centreon Engine_1').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on an engine config name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'Centreon Engine').click();
+});
+
+Then('the engine config edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="nagios_name"]');
+  cy.getIframeBody().find('input[name="nagios_name"]').should('contain.value', 'Centreon Engine');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the engine config listing', () => {
+  cy.visit(enginePage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'Centreon Engine');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/16-engine-config-listing/index.ts
@@ -55,11 +55,16 @@ When('the user navigates to the engine config listing', () => {
 
 Then('the AJAX listing table is displayed with engine config rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 Then('the Central engine config is visible', () => {
-  cy.getIframeBody().find('#clTableBody').contains('Centreon Engine').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -73,7 +78,10 @@ When('the user searches for a specific engine config', () => {
 });
 
 Then('only the matching engine config is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('Centreon Engine').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine')
+    .should('exist');
   cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
 });
 
@@ -108,9 +116,7 @@ Then('the engine config toggle switches to disabled', () => {
 });
 
 Then('the toggle response is successful', () => {
-  cy.get('@toggleEngine')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@toggleEngine').its('response.statusCode').should('eq', 200);
   cy.get('@toggleEngine')
     .its('response.body')
     .should('have.property', 'success', true);
@@ -123,7 +129,8 @@ Then('the toggle response is successful', () => {
 When('the engine config is disabled', () => {
   cy.executeSqlQuery({
     database: 'centreon',
-    query: "UPDATE cfg_nagios SET nagios_activate = '0' WHERE nagios_name LIKE '%Centreon Engine%'"
+    query:
+      "UPDATE cfg_nagios SET nagios_activate = '0' WHERE nagios_name LIKE '%Centreon Engine%'"
   });
   visitAndWait();
 });
@@ -142,9 +149,7 @@ When('the user clicks the toggle to enable the engine config', () => {
     .should('not.be.checked')
     .click();
 
-  cy.wait('@toggleEngineOn')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.wait('@toggleEngineOn').its('response.statusCode').should('eq', 200);
 });
 
 Then('the engine config toggle switches to enabled', () => {
@@ -180,14 +185,21 @@ When('the user selects an engine config and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated engine config appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('Centreon Engine_1').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Centreon Engine_1')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -195,12 +207,17 @@ Then('a duplicated engine config appears in the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on an engine config name', () => {
-  cy.getIframeBody().find('#clTableBody').contains('a', 'Centreon Engine').click();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'Centreon Engine')
+    .click();
 });
 
 Then('the engine config edit form is displayed', () => {
   cy.waitForElementInIframe('#main-content', 'input[name="nagios_name"]');
-  cy.getIframeBody().find('input[name="nagios_name"]').should('contain.value', 'Centreon Engine');
+  cy.getIframeBody()
+    .find('input[name="nagios_name"]')
+    .should('contain.value', 'Centreon Engine');
 });
 
 // ---------------------------------------------------------------------------
@@ -214,5 +231,7 @@ When('the user navigates back to the engine config listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'Centreon Engine');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'Centreon Engine');
 });

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configNagios/DB-Func.php
+++ b/centreon/www/include/configuration/configNagios/DB-Func.php
@@ -227,7 +227,7 @@ function duplicateLoggerV2Cfg(CentreonDB $pearDB, int $originalNagiosId, int $du
                `log_level_config`, `log_level_events`, `log_level_checks`,
                `log_level_notifications`, `log_level_eventbroker`, `log_level_external_command`,
                `log_level_commands`, `log_level_downtimes`, `log_level_comments`,
-               `log_level_macros`, `log_level_process`, `log_level_runtime`
+               `log_level_macros`, `log_level_process`, `log_level_runtime`, `log_level_otl`
                FROM cfg_nagios_logger
                WHERE cfg_nagios_id = :originalNagiosId'
     );

--- a/centreon/www/include/configuration/configNagios/ajaxNagiosListing.php
+++ b/centreon/www/include/configuration/configNagios/ajaxNagiosListing.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Server name cache
+$servers = [];
+$dbResult = $pearDB->query('SELECT id, name FROM nagios_server ORDER BY name');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $servers[(int) $row['id']] = $row['name'];
+}
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    $pollerIds = [];
+    foreach ($pollerResult as $p) {
+        $pollerIds[] = (int) $p['id'];
+    }
+    if (! empty($pollerIds)) {
+        // Get nagios_ids for allowed pollers
+        $inList = implode(',', $pollerIds);
+        $nagiosIds = [];
+        $stmt = $pearDB->query("SELECT nagios_id FROM cfg_nagios WHERE nagios_server_id IN ({$inList})");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $nagiosIds[] = (int) $row['nagios_id'];
+        }
+        if (! empty($nagiosIds)) {
+            $aclCond = 'AND nagios_id IN (' . implode(',', $nagiosIds) . ') ';
+        } else {
+            $helper->jsonResponse([], 0, 0, $limit);
+        }
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND nagios_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS nagios_id, nagios_name, nagios_comment, nagios_activate, nagios_server_id'
+    . ' FROM cfg_nagios WHERE 1=1 ' . $searchCond . $aclCond
+    . ' ORDER BY nagios_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($cfg = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $desc = $cfg['nagios_comment'] ?? '';
+    if (mb_strlen($desc) > 40) {
+        $desc = mb_substr($desc, 0, 40) . '...';
+    }
+    $rows[] = [
+        'id'       => (int) $cfg['nagios_id'],
+        'name'     => $cfg['nagios_name'],
+        'desc'     => $desc,
+        'instance' => $servers[(int) $cfg['nagios_server_id']] ?? '',
+        'activate' => (int) $cfg['nagios_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configNagios/ajaxNagiosToggle.php
+++ b/centreon/www/include/configuration/configNagios/ajaxNagiosToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60903);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT nagios_id FROM cfg_nagios WHERE nagios_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT nagios_name FROM cfg_nagios WHERE nagios_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE cfg_nagios SET nagios_activate = :activate WHERE nagios_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('engine_cfg', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -77,43 +75,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    nagiosListing.fetch(nagiosListing.getState().num, nagiosListing.getState().limit, nagiosListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var nagiosListing = new CentreonListing({
     instanceName:  'nagiosListing',
     ajaxListUrl:   './include/configuration/configNagios/ajaxNagiosListing.php',
@@ -144,5 +105,6 @@ var nagiosListing = new CentreonListing({
     }
 });
 nagiosListing.init();
+CentreonForm.initSidePanel(nagiosListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -90,11 +90,11 @@ var nagiosListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }},
         { id:'instance' }
     ],

--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Engine configuration{/t}</h1>
+    <p class="cl-page-desc">{t}Configure the monitoring engine settings applied to your pollers.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$nagiosPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchN" value="{$searchN}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchN" value="{$searchN}" class="cl-search-simple" placeholder="{t}Search engine configurations{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -30,7 +43,7 @@
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
                     <th>{$headerMenu_instance}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -38,16 +51,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -55,8 +58,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    nagiosListing.fetch(nagiosListing.getState().num, nagiosListing.getState().limit, nagiosListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var nagiosListing = new CentreonListing({
     instanceName:  'nagiosListing',
     ajaxListUrl:   './include/configuration/configNagios/ajaxNagiosListing.php',
@@ -67,15 +120,16 @@ var nagiosListing = new CentreonListing({
     storageKey:    'nagios_listing_limit',
     emptyMessage:  'No monitoring engine configurations found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }},
         { id:'instance' }
     ],

--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -1,79 +1,90 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-{if isset($msg_interval)}<center><span class='msg'>{$msg_interval}</span></center>{/if}
-<form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Monitoring engine config{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchN" value="{$searchN}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_instance}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-			<td class="ListColLeft">{$elemArr[elem].RowMenu_instance}</td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	</table>
 
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-			{pagination}
-		</tr>
-	</table>
+<form name='form' method='POST'>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchN" value="{$searchN}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="nagiosListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th>{$headerMenu_instance}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="5" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-	setDisabledRowStyle();
+<script type="text/javascript">
+var nagiosListing = new CentreonListing({
+    instanceName:  'nagiosListing',
+    ajaxListUrl:   './include/configuration/configNagios/ajaxNagiosListing.php',
+    ajaxToggleUrl: './include/configuration/configNagios/ajaxNagiosToggle.php',
+    pageId:        {/literal}'{$nagiosPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'nagios_listing_limit',
+    emptyMessage:  'No monitoring engine configurations found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$nagiosPage}{literal}&o=c&nagios_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }},
+        { id:'instance' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="nagiosListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+nagiosListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Engine configuration{/t}</h1>
-    <p class="cl-page-desc">{t}Configure the monitoring engine settings applied to your pollers.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Engine configuration{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Configure the monitoring engine settings applied to your pollers.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$nagiosPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchN" value="{$searchN}" class="cl-search-simple" placeholder="{t}Search engine configurations{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configNagios/listNagios.php
+++ b/centreon/www/include/configuration/configNagios/listNagios.php
@@ -34,7 +34,7 @@ $tpl->assign('mode_access', $lvl_access);
 
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Description'));
-$tpl->assign('headerMenu_instance', _('Satellites/Instances'));
+$tpl->assign('headerMenu_instance', _('Poller'));
 $tpl->assign('headerMenu_options', _('Options'));
 
 $tpl->assign('nagiosPage', $p);

--- a/centreon/www/include/configuration/configNagios/listNagios.php
+++ b/centreon/www/include/configuration/configNagios/listNagios.php
@@ -44,9 +44,7 @@ $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchN', $search);
 
 // Default limit
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 // Form for bulk actions

--- a/centreon/www/include/configuration/configNagios/listNagios.php
+++ b/centreon/www/include/configuration/configNagios/listNagios.php
@@ -25,46 +25,6 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$search = $_POST['searchN'] ?? $_GET['searchN'] ?? null;
-
-if (! is_null($search)) {
-    $search = HtmlSanitizer::createFromString($search)->sanitize()->getString();
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$SearchTool = '';
-if (! is_null($search)) {
-    $SearchTool .= " WHERE nagios_name LIKE '%{$search}%' ";
-}
-
-$aclCond = '';
-if (! $centreon->user->admin && count($allowedMainConf)) {
-    $aclCond = isset($search) && $search ? ' AND ' : ' WHERE ';
-    $aclCond .= 'nagios_id IN (' . implode(',', array_keys($allowedMainConf)) . ') ';
-}
-
-// nagios servers comes from DB
-$nagios_servers = [null => ''];
-$dbResult = $pearDB->query('SELECT * FROM nagios_server ORDER BY name');
-while ($nagios_server = $dbResult->fetch()) {
-    $nagios_servers[$nagios_server['id']] = HtmlSanitizer::createFromString($nagios_server['name'])->sanitize()->getString();
-}
-$dbResult->closeCursor();
-
-$dbResult = $pearDB->query(
-    'SELECT SQL_CALC_FOUND_ROWS nagios_id, nagios_name, nagios_comment, nagios_activate, nagios_server_id '
-    . 'FROM cfg_nagios ' . $SearchTool . $aclCond . ' ORDER BY nagios_name LIMIT ' . $num * $limit . ', ' . $limit
-);
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 
@@ -72,52 +32,30 @@ $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_instance', _('Satellites'));
 $tpl->assign('headerMenu_desc', _('Description'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_instance', _('Satellites/Instances'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Nagios list
+$tpl->assign('nagiosPage', $p);
+
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchN', $search);
+
+// Default limit
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
+
+// Form for bulk actions
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-for ($i = 0; $nagios = $dbResult->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $nagios['nagios_id'] . ']');
-    if ($nagios['nagios_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&nagios_id=' . $nagios['nagios_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14' border='0' "
-            . "alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&nagios_id=' . $nagios['nagios_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' "
-            . "class='ico-14' border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $nagios['nagios_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $nagios['nagios_name'], 'RowMenu_instance' => $nagios_servers[$nagios['nagios_server_id']], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&nagios_id=' . $nagios['nagios_id'], 'RowMenu_desc' => substr($nagios['nagios_comment'], 0, 40), 'RowMenu_status' => $nagios['nagios_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $nagios['nagios_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
 ?>
 <script type="text/javascript">
@@ -129,15 +67,16 @@ $tpl->assign(
 
 foreach (['o1', 'o2'] as $option) {
     $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
         . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
         . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3) {"
-        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . ''];
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
     $form->addElement(
         'select',
         $option,
@@ -146,12 +85,12 @@ foreach (['o1', 'o2'] as $option) {
         $attrs
     );
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchN', $search);
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered engine configuration listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (2)

- **`ajaxNagiosListing.php`** — AJAX endpoint. ACL (page 60903), poller association, sanitized search, prepared statements.
- **`ajaxNagiosToggle.php`** — Toggle with CSRF rotation, ACL write access, audit logging.

### Modified files (3)

- **`listNagios.ihtml`** — Rewritten with `cl-*` classes: search, pagination, toggles, dup inputs.
- **`listNagios.php`** — Simplified controller.
- **`DB-Func.php`** — Fix: added missing `log_level_otl` column in `duplicateLoggerV2Cfg()` which caused SQL errors when duplicating engine configurations.

### Tests (8 scenarios)

1. AJAX listing loads — Central engine config visible
2. Search filters by name
3. Toggle disables an engine config
4. Toggle enables an engine config
5. Pagination info displayed
6. Bulk duplication
7. Click navigates to edit form
8. Session state persistence

## Bug fix included

**`DB-Func.php`**: The `duplicateLoggerV2Cfg()` function was missing the `log_level_otl` column added in a recent schema migration. This caused duplication to fail silently. Fixed by adding the column to the INSERT/SELECT query.

## How to test

1. Navigate to Configuration > Pollers > Engine configuration
2. Test search, toggle, duplicate
3. Specifically test duplication — verify it no longer fails
4. Verify no regression on engine config edit form

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Implemented AJAX-driven listing and secure toggle endpoints with tests

**🐛 Bugfixes**
* Fixed duplication failure by adding missing log_level_otl column

**🔧 Refactors**
* Refactored template and controller to use shared CentreonListing framework


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98622654?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
