### PR TITLE
feat(configuration): modernize broker config listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing.feature
@@ -1,0 +1,57 @@
+Feature: Modern broker configuration listing
+    As a Centreon admin
+    I want to manage broker configurations from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-146
+  Scenario: Broker config listing loads via AJAX
+    When the user navigates to the broker config listing
+    Then the AJAX listing table is displayed with broker config rows
+
+  @TEST_LISTING-147
+  Scenario: Search filters broker configs by name
+    When the user navigates to the broker config listing
+    And the user searches for a specific broker config
+    Then only the matching broker config is displayed
+
+  @TEST_LISTING-148
+  Scenario: Toggle disables a broker config
+    When the user navigates to the broker config listing
+    And the user clicks the toggle to disable a broker config
+    Then the broker config toggle switches to disabled
+    And the toggle response is successful
+
+  @TEST_LISTING-149
+  Scenario: Toggle enables a broker config
+    When the user navigates to the broker config listing
+    And the broker config is disabled
+    And the user clicks the toggle to enable the broker config
+    Then the broker config toggle switches to enabled
+
+  @TEST_LISTING-150
+  Scenario: Pagination info is displayed
+    When the user navigates to the broker config listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-151
+  Scenario: Bulk duplication works
+    When the user navigates to the broker config listing
+    And the user selects a broker config and duplicates it
+    Then a duplicated broker config appears in the listing
+
+  @TEST_LISTING-152
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the broker config listing
+    And the user clicks on a broker config name
+    Then the broker config edit form is displayed
+
+  @TEST_LISTING-153
+  Scenario: Session state persists across navigation
+    When the user navigates to the broker config listing
+    And the user searches for a specific broker config
+    And the user clicks on a broker config name
+    And the user navigates back to the broker config listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing.feature
@@ -6,49 +6,41 @@ Feature: Modern broker configuration listing
   Background:
     Given an admin user is logged in Centreon
 
-  @TEST_LISTING-146
   Scenario: Broker config listing loads via AJAX
     When the user navigates to the broker config listing
     Then the AJAX listing table is displayed with broker config rows
 
-  @TEST_LISTING-147
   Scenario: Search filters broker configs by name
     When the user navigates to the broker config listing
     And the user searches for a specific broker config
     Then only the matching broker config is displayed
 
-  @TEST_LISTING-148
   Scenario: Toggle disables a broker config
     When the user navigates to the broker config listing
     And the user clicks the toggle to disable a broker config
     Then the broker config toggle switches to disabled
     And the toggle response is successful
 
-  @TEST_LISTING-149
   Scenario: Toggle enables a broker config
     When the user navigates to the broker config listing
     And the broker config is disabled
     And the user clicks the toggle to enable the broker config
     Then the broker config toggle switches to enabled
 
-  @TEST_LISTING-150
   Scenario: Pagination info is displayed
     When the user navigates to the broker config listing
     Then the pagination info shows the total count
 
-  @TEST_LISTING-151
   Scenario: Bulk duplication works
     When the user navigates to the broker config listing
     And the user selects a broker config and duplicates it
     Then a duplicated broker config appears in the listing
 
-  @TEST_LISTING-152
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the broker config listing
     And the user clicks on a broker config name
     Then the broker config edit form is displayed
 
-  @TEST_LISTING-153
   Scenario: Session state persists across navigation
     When the user navigates to the broker config listing
     And the user searches for a specific broker config

--- a/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing/index.ts
@@ -1,0 +1,209 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+// Broker config page is p=60909
+const brokerPage = '/centreon/main.php?p=60909';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(brokerPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the broker config listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with broker config rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific broker config', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('central-broker');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching broker config is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('central-broker').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a broker config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxBrokerToggle.php'
+  }).as('toggleBroker');
+
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-toggle input[type="checkbox"]')
+    .then($toggle => {
+      if ($toggle.is(':checked')) {
+        cy.wrap($toggle).click();
+      }
+    });
+
+  cy.wait('@toggleBroker');
+});
+
+Then('the broker config toggle switches to disabled', () => {
+  cy.get('@toggleBroker')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleBroker')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the broker config is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE cfg_centreonbroker SET config_activate = '0' WHERE config_name LIKE '%central-broker%'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the broker config', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxBrokerToggle.php'
+  }).as('toggleBrokerOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('central-broker')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleBrokerOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the broker config toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('central-broker')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a broker config and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated broker config appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  // Duplicated config gets _1 suffix
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 3);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a broker config name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'central-broker').click();
+});
+
+Then('the broker config edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="name"]');
+  cy.getIframeBody().find('input[name="name"]').should('contain.value', 'central-broker');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the broker config listing', () => {
+  cy.visit(brokerPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'central-broker');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/17-broker-config-listing/index.ts
@@ -55,7 +55,9 @@ When('the user navigates to the broker config listing', () => {
 
 Then('the AJAX listing table is displayed with broker config rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -69,7 +71,10 @@ When('the user searches for a specific broker config', () => {
 });
 
 Then('only the matching broker config is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('central-broker').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('central-broker')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -86,7 +91,7 @@ When('the user clicks the toggle to disable a broker config', () => {
     .find('#clTableBody tr')
     .first()
     .find('.cl-toggle input[type="checkbox"]')
-    .then($toggle => {
+    .then(($toggle) => {
       if ($toggle.is(':checked')) {
         cy.wrap($toggle).click();
       }
@@ -96,9 +101,7 @@ When('the user clicks the toggle to disable a broker config', () => {
 });
 
 Then('the broker config toggle switches to disabled', () => {
-  cy.get('@toggleBroker')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@toggleBroker').its('response.statusCode').should('eq', 200);
 });
 
 Then('the toggle response is successful', () => {
@@ -114,7 +117,8 @@ Then('the toggle response is successful', () => {
 When('the broker config is disabled', () => {
   cy.executeSqlQuery({
     database: 'centreon',
-    query: "UPDATE cfg_centreonbroker SET config_activate = '0' WHERE config_name LIKE '%central-broker%'"
+    query:
+      "UPDATE cfg_centreonbroker SET config_activate = '0' WHERE config_name LIKE '%central-broker%'"
   });
   visitAndWait();
 });
@@ -133,9 +137,7 @@ When('the user clicks the toggle to enable the broker config', () => {
     .should('not.be.checked')
     .click();
 
-  cy.wait('@toggleBrokerOn')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.wait('@toggleBrokerOn').its('response.statusCode').should('eq', 200);
 });
 
 Then('the broker config toggle switches to enabled', () => {
@@ -170,7 +172,11 @@ When('the user selects a broker config and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
@@ -178,7 +184,9 @@ Then('a duplicated broker config appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
   // Duplicated config gets _1 suffix
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 3);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 3);
 });
 
 // ---------------------------------------------------------------------------
@@ -186,12 +194,17 @@ Then('a duplicated broker config appears in the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a broker config name', () => {
-  cy.getIframeBody().find('#clTableBody').contains('a', 'central-broker').click();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'central-broker')
+    .click();
 });
 
 Then('the broker config edit form is displayed', () => {
   cy.waitForElementInIframe('#main-content', 'input[name="name"]');
-  cy.getIframeBody().find('input[name="name"]').should('contain.value', 'central-broker');
+  cy.getIframeBody()
+    .find('input[name="name"]')
+    .should('contain.value', 'central-broker');
 });
 
 // ---------------------------------------------------------------------------
@@ -205,5 +218,7 @@ When('the user navigates back to the broker config listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'central-broker');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'central-broker');
 });

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerListing.php
+++ b/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerListing.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Server name cache
+$servers = [];
+$dbResult = $pearDB->query('SELECT id, name FROM nagios_server ORDER BY name');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $servers[(int) $row['id']] = $row['name'];
+}
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    $pollerIds = [];
+    foreach ($pollerResult as $p) {
+        $pollerIds[] = (int) $p['id'];
+    }
+    if (! empty($pollerIds)) {
+        $aclCond = 'AND ns_nagios_server IN (' . implode(',', $pollerIds) . ') ';
+    } else {
+        $helper->jsonResponse([], 0, 0, $limit);
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND config_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate'
+    . ' FROM cfg_centreonbroker WHERE 1=1 ' . $searchCond . $aclCond
+    . ' ORDER BY config_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+// Count inputs/outputs per config
+$countStmt = $pearDB->prepare(
+    "SELECT COUNT(DISTINCT config_group_id) AS cnt FROM cfg_centreonbroker_info WHERE config_id = :id AND config_group = :grp"
+);
+
+$rows = [];
+while ($cfg = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $configId = (int) $cfg['config_id'];
+
+    $countStmt->execute([':id' => $configId, ':grp' => 'input']);
+    $inputs = (int) $countStmt->fetch(PDO::FETCH_ASSOC)['cnt'];
+
+    $countStmt->execute([':id' => $configId, ':grp' => 'output']);
+    $outputs = (int) $countStmt->fetch(PDO::FETCH_ASSOC)['cnt'];
+
+    $rows[] = [
+        'id'        => $configId,
+        'name'      => $cfg['config_name'],
+        'requester' => $servers[(int) $cfg['ns_nagios_server']] ?? '',
+        'inputs'    => $inputs,
+        'outputs'   => $outputs,
+        'activate'  => (int) $cfg['config_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerToggle.php
+++ b/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerToggle.php
@@ -36,12 +36,27 @@ $newToken = $helper->validateCsrfToken();
 
 $helper->requireWriteAccess(60909);
 
-// Verify exists
-$checkStmt = $pearDB->prepare('SELECT config_id FROM cfg_centreonbroker WHERE config_id = :id');
+// Verify exists and capture its poller for the ACL check below
+$checkStmt = $pearDB->prepare('SELECT ns_nagios_server FROM cfg_centreonbroker WHERE config_id = :id');
 $checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
 $checkStmt->execute();
-if (! $checkStmt->fetch()) {
+$brokerCfg = $checkStmt->fetch(PDO::FETCH_ASSOC);
+if (! $brokerCfg) {
     AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Resource-level ACL: page-level write access is not enough - a user could
+// otherwise toggle any broker configuration by id (IDOR). The configuration's
+// poller must be one the user is allowed to manage (same scope as the listing).
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerIds = [];
+    foreach ($acl->getPollerAclConf(['fields' => ['id']]) as $poller) {
+        $pollerIds[] = (int) $poller['id'];
+    }
+    if (! in_array((int) $brokerCfg['ns_nagios_server'], $pollerIds, true)) {
+        AjaxListingHelper::jsonError('Access denied', 403);
+    }
 }
 
 // Get name for logging

--- a/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerToggle.php
+++ b/centreon/www/include/configuration/configCentreonBroker/ajaxBrokerToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60909);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT config_id FROM cfg_centreonbroker WHERE config_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT config_name FROM cfg_centreonbroker WHERE config_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE cfg_centreonbroker SET config_activate = :activate WHERE config_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('broker_cfg', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -133,7 +133,7 @@ var brokerListing = new CentreonListing({
             return row.inputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.inputs+'</span>' : '<span style="opacity:.4;">0</span>';
         }},
         { id:'outputs', align:'center', render: function(row) {
-            return row.outputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-success,#88B922);background:rgba(136,185,34,.12);">'+row.outputs+'</span>' : '<span style="opacity:.4;">0</span>';
+            return row.outputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.outputs+'</span>' : '<span style="opacity:.4;">0</span>';
         }}
     ],
     renderOptions: function(row, l) {

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -1,77 +1,93 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Centreon Broker{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchCB" value="{$searchCB}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_inputs}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_outputs}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_inputs}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_outputs}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchCB" value="{$searchCB}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="brokerListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_requester}</th>
+                    <th class="cl-col-center">{$headerMenu_inputs}</th>
+                    <th class="cl-col-center">{$headerMenu_outputs}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
+<script type="text/javascript">
+var brokerListing = new CentreonListing({
+    instanceName:  'brokerListing',
+    ajaxListUrl:   './include/configuration/configCentreonBroker/ajaxBrokerListing.php',
+    ajaxToggleUrl: './include/configuration/configCentreonBroker/ajaxBrokerToggle.php',
+    pageId:        {/literal}'{$brokerPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'broker_listing_limit',
+    emptyMessage:  'No broker configurations found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$brokerPage}{literal}&o=c&id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'requester' },
+        { id:'inputs', align:'center', render: function(row) {
+            return row.inputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-primary-light,#2E68AA);background:rgba(46,104,170,.12);">'+row.inputs+'</span>' : '<span style="opacity:.4;">0</span>';
+        }},
+        { id:'outputs', align:'center', render: function(row) {
+            return row.outputs ? '<span style="display:inline-block;min-width:22px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;color:var(--color-success,#88B922);background:rgba(136,185,34,.12);">'+row.outputs+'</span>' : '<span style="opacity:.4;">0</span>';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="brokerListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+brokerListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Broker configuration{/t}</h1>
+    <p class="cl-page-desc">{t}Configure how monitoring data is collected and forwarded.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$brokerPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchCB" value="{$searchCB}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchCB" value="{$searchCB}" class="cl-search-simple" placeholder="{t}Search broker configurations{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -31,7 +44,7 @@
                     <th>{$headerMenu_requester}</th>
                     <th class="cl-col-center">{$headerMenu_inputs}</th>
                     <th class="cl-col-center">{$headerMenu_outputs}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -39,16 +52,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -56,8 +59,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    brokerListing.fetch(brokerListing.getState().num, brokerListing.getState().limit, brokerListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var brokerListing = new CentreonListing({
     instanceName:  'brokerListing',
     ajaxListUrl:   './include/configuration/configCentreonBroker/ajaxBrokerListing.php',
@@ -68,11 +121,12 @@ var brokerListing = new CentreonListing({
     storageKey:    'broker_listing_limit',
     emptyMessage:  'No broker configurations found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$brokerPage}{literal}&o=c&id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$brokerPage}{literal}&o=c&id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'requester' },
         { id:'inputs', align:'center', render: function(row) {

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -78,43 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    brokerListing.fetch(brokerListing.getState().num, brokerListing.getState().limit, brokerListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var brokerListing = new CentreonListing({
     instanceName:  'brokerListing',
     ajaxListUrl:   './include/configuration/configCentreonBroker/ajaxBrokerListing.php',
@@ -147,5 +108,6 @@ var brokerListing = new CentreonListing({
     }
 });
 brokerListing.init();
+CentreonForm.initSidePanel(brokerListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -91,7 +91,7 @@ var brokerListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$brokerPage}{literal}&o=c&id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'requester' },
         { id:'inputs', align:'center', render: function(row) {

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Broker configuration{/t}</h1>
-    <p class="cl-page-desc">{t}Configure how monitoring data is collected and forwarded.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Broker configuration{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Configure how monitoring data is collected and forwarded.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$brokerPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchCB" value="{$searchCB}" class="cl-search-simple" placeholder="{t}Search broker configurations{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
@@ -41,9 +41,7 @@ $tpl->assign('brokerPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchCB', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
@@ -23,147 +23,36 @@ if (! isset($centreon)) {
     exit();
 }
 
-include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-// nagios servers comes from DB
-$nagios_servers = [];
-$dbResult = $pearDB->query('SELECT * FROM nagios_server ORDER BY name');
-while ($nagios_server = $dbResult->fetch()) {
-    $nagios_servers[$nagios_server['id']] = $nagios_server['name'];
-}
-$dbResult->closeCursor();
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_desc', _('Requester'));
-$tpl->assign('headerMenu_outputs', _('Outputs'));
+$tpl->assign('headerMenu_requester', _('Requester'));
 $tpl->assign('headerMenu_inputs', _('Inputs'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_outputs', _('Outputs'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Centreon Broker config list
+$tpl->assign('brokerPage', $p);
 
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchCB'] ?? $_GET['searchCB'] ?? null,
-);
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchCB', $search);
 
-if (isset($_POST['searchCB']) || isset($_GET['searchCB'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$aclCond = '';
-if (! $centreon->user->admin && count($allowedBrokerConf)) {
-    $aclCond = $search !== '' ? ' AND ' : ' WHERE ';
-    $aclCond .= 'config_id IN (' . implode(',', array_keys($allowedBrokerConf)) . ') ';
-}
-
-if ($search !== '') {
-    $cfgBrokerStmt = $pearDB->prepare(
-        'SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate '
-        . 'FROM cfg_centreonbroker '
-        . 'WHERE config_name LIKE :search' . $aclCond
-        . ' ORDER BY config_name '
-        . 'LIMIT :scoop, :limit'
-    );
-    $cfgBrokerStmt->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-} else {
-    $cfgBrokerStmt = $pearDB->prepare(
-        'SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate '
-        . 'FROM cfg_centreonbroker ' . $aclCond
-        . ' ORDER BY config_name '
-        . 'LIMIT :scoop, :limit'
-    );
-}
-
-$cfgBrokerStmt->bindValue(':scoop', (int) $num * (int) $limit, PDO::PARAM_INT);
-$cfgBrokerStmt->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
-$cfgBrokerStmt->execute();
-
-// Get results numbers
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-$statementBrokerInfo = $pearDB->prepare(
-    'SELECT COUNT(DISTINCT(config_group_id)) as num '
-    . 'FROM cfg_centreonbroker_info '
-    . 'WHERE config_group = :config_group '
-    . 'AND config_id = :config_id'
-);
-
-for ($i = 0; $config = $cfgBrokerStmt->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $config['config_id'] . ']');
-
-    if ($config['config_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&id=' . $config['config_id'] . '&o=u&limit=' . $limit . '&num='
-            . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14' border='0' alt='"
-            . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&id=' . $config['config_id'] . '&o=s&limit=' . $limit . '&num='
-            . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14' border='0' alt='"
-            . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;<input onKeypress="if(event.keyCode > 31 '
-        . '&& (event.keyCode < 45 || event.keyCode > 57)) event.returnValue = false; '
-        . 'if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;"'
-        . "  maxlength=\"3\" size=\"3\" value='1' "
-        . "style=\"margin-bottom:0px;\" name='dupNbr[" . $config['config_id'] . "]'></input>";
-
-    // Number of output
-    $statementBrokerInfo->bindValue(':config_id', (int) $config['config_id'], PDO::PARAM_INT);
-    $statementBrokerInfo->bindValue(':config_group', 'output', PDO::PARAM_STR);
-    $statementBrokerInfo->execute();
-    $row = $statementBrokerInfo->fetch(PDO::FETCH_ASSOC);
-    $outputNumber = $row['num'];
-
-    // Number of input
-    $statementBrokerInfo->bindValue(':config_group', 'input', PDO::PARAM_STR);
-    $statementBrokerInfo->execute();
-    $row = $statementBrokerInfo->fetch(PDO::FETCH_ASSOC);
-    $inputNumber = $row['num'];
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => htmlentities($config['config_name'], ENT_QUOTES, 'UTF-8'), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&id=' . $config['config_id'], 'RowMenu_desc' => CentreonUtils::escapeSecure(
-        substr(
-            $nagios_servers[$config['ns_nagios_server']],
-            0,
-            40
-        )
-    ), 'RowMenu_inputs' => $inputNumber, 'RowMenu_outputs' => $outputNumber, 'RowMenu_status' => $config['config_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $config['config_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'addWizard' => _('Add with wizard'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -171,58 +60,29 @@ $tpl->assign(
     }
 </script>
 <?php
-$attrs = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o1' => null]);
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
 
-$attrs = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o2' => null]);
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
+}
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchCB', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered Centreon Broker configuration listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (2)

- **`ajaxBrokerListing.php`** — AJAX endpoint. ACL (page 60909), poller association, config type display, sanitized search, prepared statements.
- **`ajaxBrokerToggle.php`** — Toggle with CSRF rotation, ACL write access, audit logging.

### Modified files (2)

- **`listCentreonBroker.ihtml`** — Rewritten with `cl-*` classes: search, pagination, toggles, dup inputs.
- **`listCentreonBroker.php`** — Simplified controller.

### Tests (8 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Toggle disables a broker config
4. Toggle enables a broker config
5. Pagination info displayed
6. Bulk duplication
7. Click navigates to edit form
8. Session state persistence

## How to test

1. Navigate to Configuration > Pollers > Broker configuration
2. Test search, toggle, duplicate
3. Verify no regression on broker config edit form

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Implemented AJAX-driven broker listing and toggle with Cypress tests

**⚡ Enhancements**
* Hardened endpoints with prepared statements, ACL checks and CSRF rotation

**🔧 Refactors**
* Refactored template and controller to use CentreonListing framework


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98624208?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
