### PR TITLE
feat(configuration): modernize resources listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/18-resources-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/18-resources-listing.feature
@@ -6,50 +6,42 @@ Feature: Modern resources ($USERn$ macros) listing
   Background:
     Given an admin user is logged in Centreon
 
-  @TEST_LISTING-154
   Scenario: Resources listing loads via AJAX
     When the user navigates to the resources listing
     Then the AJAX listing table is displayed with resource rows
     And the USER1 resource is visible
 
-  @TEST_LISTING-155
   Scenario: Search filters resources by name
     When the user navigates to the resources listing
     And the user searches for a specific resource
     Then only the matching resource is displayed
 
-  @TEST_LISTING-156
   Scenario: Toggle disables a resource
     When the user navigates to the resources listing
     And the user clicks the toggle to disable a resource
     Then the resource toggle switches to disabled
     And the toggle response is successful
 
-  @TEST_LISTING-157
   Scenario: Toggle enables a resource
     When the user navigates to the resources listing
     And the resource is disabled
     And the user clicks the toggle to enable the resource
     Then the resource toggle switches to enabled
 
-  @TEST_LISTING-158
   Scenario: Pagination info is displayed
     When the user navigates to the resources listing
     Then the pagination info shows the total count
 
-  @TEST_LISTING-159
   Scenario: Bulk duplication works
     When the user navigates to the resources listing
     And the user selects a resource and duplicates it
     Then a duplicated resource appears in the listing
 
-  @TEST_LISTING-160
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the resources listing
     And the user clicks on a resource name
     Then the resource edit form is displayed
 
-  @TEST_LISTING-161
   Scenario: Session state persists across navigation
     When the user navigates to the resources listing
     And the user searches for a specific resource

--- a/centreon/tests/e2e/features/Listing-modernization/18-resources-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/18-resources-listing.feature
@@ -1,0 +1,58 @@
+Feature: Modern resources ($USERn$ macros) listing
+    As a Centreon admin
+    I want to manage engine resources from the modernized listing page
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-154
+  Scenario: Resources listing loads via AJAX
+    When the user navigates to the resources listing
+    Then the AJAX listing table is displayed with resource rows
+    And the USER1 resource is visible
+
+  @TEST_LISTING-155
+  Scenario: Search filters resources by name
+    When the user navigates to the resources listing
+    And the user searches for a specific resource
+    Then only the matching resource is displayed
+
+  @TEST_LISTING-156
+  Scenario: Toggle disables a resource
+    When the user navigates to the resources listing
+    And the user clicks the toggle to disable a resource
+    Then the resource toggle switches to disabled
+    And the toggle response is successful
+
+  @TEST_LISTING-157
+  Scenario: Toggle enables a resource
+    When the user navigates to the resources listing
+    And the resource is disabled
+    And the user clicks the toggle to enable the resource
+    Then the resource toggle switches to enabled
+
+  @TEST_LISTING-158
+  Scenario: Pagination info is displayed
+    When the user navigates to the resources listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-159
+  Scenario: Bulk duplication works
+    When the user navigates to the resources listing
+    And the user selects a resource and duplicates it
+    Then a duplicated resource appears in the listing
+
+  @TEST_LISTING-160
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the resources listing
+    And the user clicks on a resource name
+    Then the resource edit form is displayed
+
+  @TEST_LISTING-161
+  Scenario: Session state persists across navigation
+    When the user navigates to the resources listing
+    And the user searches for a specific resource
+    And the user clicks on a resource name
+    And the user navigates back to the resources listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/18-resources-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/18-resources-listing/index.ts
@@ -1,0 +1,213 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+// Resources page is p=60904
+const resourcesPage = '/centreon/main.php?p=60904';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(resourcesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the resources listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with resource rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+Then('the USER1 resource is visible', () => {
+  cy.getIframeBody().find('#clTableBody').contains('$USER1$').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific resource', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('$USER1$');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching resource is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('$USER1$').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a resource', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxResourceToggle.php'
+  }).as('toggleRes');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@toggleRes');
+});
+
+Then('the resource toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@toggleRes').its('response.statusCode').should('eq', 200);
+  cy.get('@toggleRes').its('response.body').should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the resource is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE cfg_resource SET resource_activate = '0' WHERE resource_name = '$USER1$'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the resource', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxResourceToggle.php'
+  }).as('toggleResOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@toggleResOn').its('response.statusCode').should('eq', 200);
+});
+
+Then('the resource toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a resource and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('$USER1$')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated resource appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  // Duplicated resource should appear
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a resource name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', '$USER1$').click();
+});
+
+Then('the resource edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="resource_name"]');
+  cy.getIframeBody().find('input[name="resource_name"]').should('have.value', '$USER1$');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the resources listing', () => {
+  cy.visit(resourcesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', '$USER1$');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/18-resources-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/18-resources-listing/index.ts
@@ -55,7 +55,9 @@ When('the user navigates to the resources listing', () => {
 
 Then('the AJAX listing table is displayed with resource rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 Then('the USER1 resource is visible', () => {
@@ -109,7 +111,9 @@ Then('the resource toggle switches to disabled', () => {
 
 Then('the toggle response is successful', () => {
   cy.get('@toggleRes').its('response.statusCode').should('eq', 200);
-  cy.get('@toggleRes').its('response.body').should('have.property', 'success', true);
+  cy.get('@toggleRes')
+    .its('response.body')
+    .should('have.property', 'success', true);
 });
 
 // ---------------------------------------------------------------------------
@@ -119,7 +123,8 @@ Then('the toggle response is successful', () => {
 When('the resource is disabled', () => {
   cy.executeSqlQuery({
     database: 'centreon',
-    query: "UPDATE cfg_resource SET resource_activate = '0' WHERE resource_name = '$USER1$'"
+    query:
+      "UPDATE cfg_resource SET resource_activate = '0' WHERE resource_name = '$USER1$'"
   });
   visitAndWait();
 });
@@ -174,7 +179,11 @@ When('the user selects a resource and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
@@ -182,7 +191,9 @@ Then('a duplicated resource appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
   // Duplicated resource should appear
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 1);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -195,7 +206,9 @@ When('the user clicks on a resource name', () => {
 
 Then('the resource edit form is displayed', () => {
   cy.waitForElementInIframe('#main-content', 'input[name="resource_name"]');
-  cy.getIframeBody().find('input[name="resource_name"]').should('have.value', '$USER1$');
+  cy.getIframeBody()
+    .find('input[name="resource_name"]')
+    .should('have.value', '$USER1$');
 });
 
 // ---------------------------------------------------------------------------

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -172,7 +172,8 @@ function multipleResourceInDB($resourceIds = [], $nbrDup = []): void
     global $pearDB;
 
     foreach (array_keys($resourceIds) as $resourceId) {
-        if (is_int($resourceId)) {
+        $resourceId = (int) $resourceId;
+        if ($resourceId > 0) {
             $dbResult = $pearDB->query("SELECT * FROM cfg_resource WHERE resource_id = {$resourceId} LIMIT 1");
             /**
              * @var array{

--- a/centreon/www/include/configuration/configResources/ajaxResourceListing.php
+++ b/centreon/www/include/configuration/configResources/ajaxResourceListing.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Server name cache
+$servers = [];
+$dbResult = $pearDB->query('SELECT id, name FROM nagios_server ORDER BY name');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $servers[(int) $row['id']] = $row['name'];
+}
+
+// ACL filtering
+$aclCond = '';
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    $pollerResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    $pollerIds = [];
+    foreach ($pollerResult as $p) {
+        $pollerIds[] = (int) $p['id'];
+    }
+    if (! empty($pollerIds)) {
+        $inList = implode(',', $pollerIds);
+        $resIds = [];
+        $stmt = $pearDB->query("SELECT DISTINCT resource_id FROM cfg_resource_instance_relations WHERE instance_id IN ({$inList})");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $resIds[] = (int) $row['resource_id'];
+        }
+        if (! empty($resIds)) {
+            $aclCond = 'AND resource_id IN (' . implode(',', $resIds) . ') ';
+        } else {
+            $helper->jsonResponse([], 0, 0, $limit);
+        }
+    }
+}
+
+// Query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND resource_name LIKE :search ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS resource_id, resource_name, resource_line, resource_comment, resource_activate, is_password'
+    . ' FROM cfg_resource WHERE 1=1 ' . $searchCond . $aclCond
+    . ' ORDER BY resource_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+// Linked pollers per resource
+$pollerStmt = $pearDB->prepare(
+    'SELECT instance_id FROM cfg_resource_instance_relations WHERE resource_id = :rid'
+);
+
+$rows = [];
+while ($res = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rid = (int) $res['resource_id'];
+
+    // Get linked poller names
+    $pollerStmt->execute([':rid' => $rid]);
+    $pollerNames = [];
+    while ($rel = $pollerStmt->fetch(PDO::FETCH_ASSOC)) {
+        $sid = (int) $rel['instance_id'];
+        if (isset($servers[$sid])) {
+            $pollerNames[] = $servers[$sid];
+        }
+    }
+
+    // Mask password values
+    $value = $res['is_password'] ? '**********' : $res['resource_line'];
+
+    $comment = $res['resource_comment'] ?? '';
+    if (mb_strlen($comment) > 40) {
+        $comment = mb_substr($comment, 0, 40) . '...';
+    }
+
+    $rows[] = [
+        'id'       => $rid,
+        'name'     => $res['resource_name'],
+        'value'    => $value,
+        'pollers'  => implode(', ', $pollerNames),
+        'comment'  => $comment,
+        'activate' => (int) $res['resource_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configResources/ajaxResourceToggle.php
+++ b/centreon/www/include/configuration/configResources/ajaxResourceToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60904);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT resource_id FROM cfg_resource WHERE resource_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT resource_name FROM cfg_resource WHERE resource_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE cfg_resource SET resource_activate = :activate WHERE resource_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('resource', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -78,42 +78,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    resListing.fetch(resListing.getState().num, resListing.getState().limit, resListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function() {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var resListing = new CentreonListing({
     instanceName:  'resListing',
@@ -146,5 +110,6 @@ var resListing = new CentreonListing({
     }
 });
 resListing.init();
+CentreonForm.initSidePanel(resListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Resources{/t}</h1>
+    <p class="cl-page-desc">{t}Define resource macros ($USER$) reused across your configuration.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$resPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchR" value="{$searchR}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchR" value="{$searchR}" class="cl-search-simple" placeholder="{t}Search resources{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -31,7 +44,7 @@
                     <th>{$headerMenu_value}</th>
                     <th class="cl-col-center">{$headerMenu_pollers}</th>
                     <th>{$headerMenu_comment}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -39,16 +52,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -56,8 +59,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    resListing.fetch(resListing.getState().num, resListing.getState().limit, resListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 var resListing = new CentreonListing({
     instanceName:  'resListing',
     ajaxListUrl:   './include/configuration/configResources/ajaxResourceListing.php',
@@ -68,15 +121,16 @@ var resListing = new CentreonListing({
     storageKey:    'res_listing_limit',
     emptyMessage:  'No resources found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'value', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.value)+'</a>';
+            var link = 'main.get.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.value)+'</a>';
         }},
         { id:'pollers', align:'center' },
         { id:'comment' }

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -1,80 +1,92 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Resource{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchR" value="{$searchR}"></td>
-        <td><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_values}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_associated_poller}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_comment}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_values}</a></td>
-			<td class="ListColCenter">{$elemArr[elem].RowMenu_associated_poller}</td>
-			<td class="ListColLeft">{$elemArr[elem].RowMenu_comment}</td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-		</tr>
-		{/section}
-	</table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			{ if $mode_access == 'w' }
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{ else }
-			<td>&nbsp;</td>
-			{ /if }
-            {pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchR" value="{$searchR}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="resListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_value}</th>
+                    <th class="cl-col-center">{$headerMenu_pollers}</th>
+                    <th>{$headerMenu_comment}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
-
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-	setDisabledRowStyle();
+<script type="text/javascript">
+var resListing = new CentreonListing({
+    instanceName:  'resListing',
+    ajaxListUrl:   './include/configuration/configResources/ajaxResourceListing.php',
+    ajaxToggleUrl: './include/configuration/configResources/ajaxResourceToggle.php',
+    pageId:        {/literal}'{$resPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'res_listing_limit',
+    emptyMessage:  'No resources found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'value', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.value)+'</a>';
+        }},
+        { id:'pollers', align:'center' },
+        { id:'comment' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="resListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+resListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -92,11 +92,11 @@ var resListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'value', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$resPage}{literal}&o=c&resource_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.value)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.value)+'</a>';
         }},
         { id:'pollers', align:'center' },
         { id:'comment' }

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Resources{/t}</h1>
-    <p class="cl-page-desc">{t}Define resource macros ($USER$) reused across your configuration.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Resources{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define resource macros ($USER$) reused across your configuration.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$resPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchR" value="{$searchR}" class="cl-search-simple" placeholder="{t}Search resources{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 

--- a/centreon/www/include/configuration/configResources/listResources.php
+++ b/centreon/www/include/configuration/configResources/listResources.php
@@ -41,9 +41,7 @@ $tpl->assign('resPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchR', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/configuration/configResources/listResources.php
+++ b/centreon/www/include/configuration/configResources/listResources.php
@@ -23,141 +23,36 @@ if (! isset($centreon)) {
     exit();
 }
 
-include_once './class/centreonUtils.class.php';
-
 include './include/common/autoNumLimit.php';
 
-const PASSWORD_REPLACEMENT_VALUE_LISTING = '**********';
-
-// Search engine
-
-$search = HtmlAnalyzer::sanitizeAndRemoveTags(
-    $_POST['searchR'] ?? $_GET['searchR'] ?? null
-);
-
-if (isset($_POST['searchR']) || isset($_GET['searchR'])) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$SearchTool = '';
-if ($search) {
-    $SearchTool .= " WHERE resource_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%'";
-}
-
-$aclCond = '';
-if (! $oreon->user->admin && count($allowedResourceConf)) {
-    $aclCond = isset($search) && $search ? ' AND ' : ' WHERE ';
-    $aclCond .= 'resource_id IN (' . implode(',', array_keys($allowedResourceConf)) . ') ';
-}
-
-// resources list
-$dbResult = $pearDB->query(
-    'SELECT SQL_CALC_FOUND_ROWS * FROM cfg_resource ' . $SearchTool . $aclCond
-    . ' ORDER BY resource_name LIMIT ' . $num * $limit . ', ' . $limit
-);
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// Access level
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_values', _('Values'));
-$tpl->assign('headerMenu_comment', _('Description'));
-$tpl->assign('headerMenu_associated_poller', _('Associated pollers'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_value', _('Value'));
+$tpl->assign('headerMenu_pollers', _('Linked pollers'));
+$tpl->assign('headerMenu_comment', _('Comment'));
 $tpl->assign('headerMenu_options', _('Options'));
+
+$tpl->assign('resPage', $p);
+
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchR', $search);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-for ($i = 0; $resource = $dbResult->fetch(); $i++) {
-    preg_match('$USER([0-9]*)$', $resource['resource_name'], $tabResources);
-    $selectedElements = $form->addElement('checkbox', 'select[' . $resource['resource_id'] . ']');
-    $moptions = '';
-    if ($resource['resource_activate']) {
-        $moptions .= "<a href='main.php?p=" . $p . '&resource_id=' . $resource['resource_id'] . '&o=u&limit='
-            . $limit . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' "
-            . "class='ico-14 margin_right' border='0' alt='" . _('Disabled') . "'></a>";
-    } else {
-        $moptions .= "<a href='main.php?p=" . $p . '&resource_id=' . $resource['resource_id'] . '&o=s&limit='
-            . $limit . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' "
-            . "class='ico-14 margin_right' border='0' alt='" . _('Enabled') . "'></a>";
-    }
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;" '
-        . "maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $resource['resource_id'] . "]' />";
-    $elemArr[$i] = ['order' => $tabResources[1] ?? null, 'MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure(
-        $resource['resource_name'],
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&resource_id=' . $resource['resource_id'], 'RowMenu_values' => CentreonUtils::escapeSecure(
-        $resource['is_password'] ? PASSWORD_REPLACEMENT_VALUE_LISTING : substr($resource['resource_line'], 0, 40),
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_comment' => CentreonUtils::escapeSecure(
-        substr(
-            html_entity_decode(
-                $resource['resource_comment'],
-                ENT_QUOTES,
-                'UTF-8'
-            ),
-            0,
-            40
-        ),
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_associated_poller' => getLinkedPollerList($resource['resource_id']), 'RowMenu_status' => $resource['resource_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $resource['resource_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
-}
-
-$flag = 1;
-while ($flag) {
-    $flag = 0;
-    foreach ($elemArr as $key => $value) {
-        $key1 = $key + 1;
-        if (isset($elemArr[$key + 1]) && $value['order'] > $elemArr[$key + 1]['order']) {
-            $swmapTab = $elemArr[$key + 1];
-            $elemArr[$key + 1] = $elemArr[$key];
-            $elemArr[$key] = $swmapTab;
-            $flag = 1;
-        } elseif (! isset($elemArr[$key + 1]) && isset($elemArr[$key - 1]['order'])) {
-            if ($value['order'] < $elemArr[$key - 1]['order']) {
-                $swmapTab = $elemArr[$key - 1];
-                $elemArr[$key - 1] = $elemArr[$key];
-                $elemArr[$key] = $swmapTab;
-                $flag = 1;
-            }
-        }
-    }
-}
-
-$tpl->assign('elemArr', $elemArr);
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -165,34 +60,29 @@ $tpl->assign(
     }
 </script>
 <?php
+
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
         . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
         . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
         . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3) {"
-        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
-        . ''];
-    $form->addElement(
-        'select',
-        $option,
-        null,
-        [null => _('More actions'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-        $attrs1
-    );
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
-    $o1->setSelected(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchR', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered resources ($USERn$ macros) listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (2)

- **`ajaxResourceListing.php`** — AJAX endpoint. ACL (page 60904), poller association, sanitized search, prepared statements.
- **`ajaxResourceToggle.php`** — Toggle with CSRF rotation, ACL write access, audit logging.

### Modified files (3)

- **`listResources.ihtml`** — Rewritten with `cl-*` classes: search, pagination, toggles, dup inputs.
- **`listResources.php`** — Simplified controller.
- **`DB-Func.php`** — Fix: `is_int()` on string keys in `duplicateResource()` always returned false, causing duplication to silently skip. Changed to `(int) $resourceId > 0`.

### Tests (8 scenarios)

1. AJAX listing loads — $USER1$ visible
2. Search filters by name
3. Toggle disables a resource
4. Toggle enables a resource
5. Pagination info displayed
6. Bulk duplication
7. Click navigates to edit form
8. Session state persistence

## Bug fix included

**`DB-Func.php`**: `is_int($resourceId)` always returns `false` for array keys from `$_POST` (which are strings like `"42"`). Changed to `(int) $resourceId > 0` to fix silent duplication failure.

## How to test

1. Navigate to Configuration > Pollers > Resources
2. Test search, toggle, duplicate
3. Specifically test duplication — verify it works correctly now
4. Verify no regression on resource edit form

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Replaced legacy listing with AJAX-driven table and new endpoints.

**⚡ Enhancements**
* Hardened listing and toggle with prepared statements and ACL checks.

**🐛 Bugfixes**
* Fixed duplication check by casting resource id to integer.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98624830?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
