### PR TITLE
feat(configuration): modernize ACL listings (groups, menus, actions, resources)

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/19-acl-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/19-acl-listing.feature
@@ -1,0 +1,73 @@
+Feature: Modern ACL listings (groups, menus, actions, resources)
+    As a Centreon admin
+    I want to manage ACL configurations from modernized listing pages
+    With AJAX search, toggle, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-162
+  Scenario: ACL groups listing loads via AJAX
+    When the user navigates to the ACL groups listing
+    Then the AJAX listing table is displayed with ACL group rows
+
+  @TEST_LISTING-163
+  Scenario: Search filters ACL groups by name
+    When the user navigates to the ACL groups listing
+    And the user searches for a specific ACL group
+    Then only the matching ACL group is displayed
+
+  @TEST_LISTING-164
+  Scenario: Toggle disables an ACL group
+    Given an ACL group exists
+    When the user navigates to the ACL groups listing
+    And the user clicks the toggle to disable an ACL group
+    Then the ACL group toggle switches to disabled
+
+  @TEST_LISTING-165
+  Scenario: ACL menus listing loads via AJAX
+    When the user navigates to the ACL menus listing
+    Then the AJAX listing table is displayed with ACL menu rows
+
+  @TEST_LISTING-166
+  Scenario: Toggle disables an ACL menu
+    When the user navigates to the ACL menus listing
+    And the user clicks the toggle on an ACL menu row
+    Then the ACL menu toggle response is successful
+
+  @TEST_LISTING-167
+  Scenario: ACL actions listing loads via AJAX
+    When the user navigates to the ACL actions listing
+    Then the AJAX listing table is displayed with ACL action rows
+
+  @TEST_LISTING-168
+  Scenario: Toggle disables an ACL action
+    When the user navigates to the ACL actions listing
+    And the user clicks the toggle on an ACL action row
+    Then the ACL action toggle response is successful
+
+  @TEST_LISTING-169
+  Scenario: ACL resources listing loads via AJAX
+    When the user navigates to the ACL resources listing
+    Then the AJAX listing table is displayed with ACL resource rows
+
+  @TEST_LISTING-170
+  Scenario: Toggle disables an ACL resource
+    When the user navigates to the ACL resources listing
+    And the user clicks the toggle on an ACL resource row
+    Then the ACL resource toggle response is successful
+
+  @TEST_LISTING-171
+  Scenario: Bulk duplication works on ACL groups
+    Given an ACL group exists
+    When the user navigates to the ACL groups listing
+    And the user selects an ACL group and duplicates it
+    Then a duplicated ACL group appears in the listing
+
+  @TEST_LISTING-172
+  Scenario: Session state persists on ACL groups listing
+    When the user navigates to the ACL groups listing
+    And the user searches for a specific ACL group
+    And the user clicks on an ACL group name
+    And the user navigates back to the ACL groups listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/19-acl-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/19-acl-listing.feature
@@ -6,65 +6,54 @@ Feature: Modern ACL listings (groups, menus, actions, resources)
   Background:
     Given an admin user is logged in Centreon
 
-  @TEST_LISTING-162
   Scenario: ACL groups listing loads via AJAX
     When the user navigates to the ACL groups listing
     Then the AJAX listing table is displayed with ACL group rows
 
-  @TEST_LISTING-163
   Scenario: Search filters ACL groups by name
     When the user navigates to the ACL groups listing
     And the user searches for a specific ACL group
     Then only the matching ACL group is displayed
 
-  @TEST_LISTING-164
   Scenario: Toggle disables an ACL group
     Given an ACL group exists
     When the user navigates to the ACL groups listing
     And the user clicks the toggle to disable an ACL group
     Then the ACL group toggle switches to disabled
 
-  @TEST_LISTING-165
   Scenario: ACL menus listing loads via AJAX
     When the user navigates to the ACL menus listing
     Then the AJAX listing table is displayed with ACL menu rows
 
-  @TEST_LISTING-166
   Scenario: Toggle disables an ACL menu
     When the user navigates to the ACL menus listing
     And the user clicks the toggle on an ACL menu row
     Then the ACL menu toggle response is successful
 
-  @TEST_LISTING-167
   Scenario: ACL actions listing loads via AJAX
     When the user navigates to the ACL actions listing
     Then the AJAX listing table is displayed with ACL action rows
 
-  @TEST_LISTING-168
   Scenario: Toggle disables an ACL action
     When the user navigates to the ACL actions listing
     And the user clicks the toggle on an ACL action row
     Then the ACL action toggle response is successful
 
-  @TEST_LISTING-169
   Scenario: ACL resources listing loads via AJAX
     When the user navigates to the ACL resources listing
     Then the AJAX listing table is displayed with ACL resource rows
 
-  @TEST_LISTING-170
   Scenario: Toggle disables an ACL resource
     When the user navigates to the ACL resources listing
     And the user clicks the toggle on an ACL resource row
     Then the ACL resource toggle response is successful
 
-  @TEST_LISTING-171
   Scenario: Bulk duplication works on ACL groups
     Given an ACL group exists
     When the user navigates to the ACL groups listing
     And the user selects an ACL group and duplicates it
     Then a duplicated ACL group appears in the listing
 
-  @TEST_LISTING-172
   Scenario: Session state persists on ACL groups listing
     When the user navigates to the ACL groups listing
     And the user searches for a specific ACL group

--- a/centreon/tests/e2e/features/Listing-modernization/19-acl-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/19-acl-listing/index.ts
@@ -1,0 +1,211 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const aclGroupsPage = PAGES.configuration.aclAccessGroupsLegacy;
+const aclMenusPage = PAGES.configuration.aclMenusAccessLegacy;
+const aclActionsPage = PAGES.configuration.aclActionsAccessLegacy;
+const aclResourcesPage = PAGES.configuration.aclResourcesAccessLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(page: string): void {
+  cy.visit(page);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('an ACL group exists', () => {
+  cy.addAclAccessGroup({
+    name: 'acl_grp_test',
+    alias: 'Test ACL Group'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ACL Groups
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the ACL groups listing', () => {
+  visitAndWait(aclGroupsPage);
+});
+
+Then('the AJAX listing table is displayed with ACL group rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+When('the user searches for a specific ACL group', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('acl_grp_test');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching ACL group is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('acl_grp_test').should('exist');
+});
+
+When('the user clicks the toggle to disable an ACL group', () => {
+  cy.intercept({ method: 'POST', url: '**/ajaxGroupAclToggle.php' }).as('toggleAclGrp');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('acl_grp_test')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .click();
+  cy.wait('@toggleAclGrp');
+});
+
+Then('the ACL group toggle switches to disabled', () => {
+  cy.get('@toggleAclGrp').its('response.statusCode').should('eq', 200);
+});
+
+When('the user selects an ACL group and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('acl_grp_test')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated ACL group appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('acl_grp_test_1').should('exist');
+});
+
+When('the user clicks on an ACL group name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'acl_grp_test').click();
+});
+
+When('the user navigates back to the ACL groups listing', () => {
+  cy.visit(aclGroupsPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'acl_grp_test');
+});
+
+// ---------------------------------------------------------------------------
+// ACL Menus
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the ACL menus listing', () => {
+  visitAndWait(aclMenusPage);
+});
+
+Then('the AJAX listing table is displayed with ACL menu rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+When('the user clicks the toggle on an ACL menu row', () => {
+  cy.intercept({ method: 'POST', url: '**/ajaxMenuAclToggle.php' }).as('toggleAclMenu');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-toggle input[type="checkbox"]')
+    .click();
+  cy.wait('@toggleAclMenu');
+});
+
+Then('the ACL menu toggle response is successful', () => {
+  cy.get('@toggleAclMenu').its('response.statusCode').should('eq', 200);
+  cy.get('@toggleAclMenu').its('response.body').should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// ACL Actions
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the ACL actions listing', () => {
+  visitAndWait(aclActionsPage);
+});
+
+Then('the AJAX listing table is displayed with ACL action rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+When('the user clicks the toggle on an ACL action row', () => {
+  cy.intercept({ method: 'POST', url: '**/ajaxActionAclToggle.php' }).as('toggleAclAction');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-toggle input[type="checkbox"]')
+    .click();
+  cy.wait('@toggleAclAction');
+});
+
+Then('the ACL action toggle response is successful', () => {
+  cy.get('@toggleAclAction').its('response.statusCode').should('eq', 200);
+  cy.get('@toggleAclAction').its('response.body').should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// ACL Resources
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the ACL resources listing', () => {
+  visitAndWait(aclResourcesPage);
+});
+
+Then('the AJAX listing table is displayed with ACL resource rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+When('the user clicks the toggle on an ACL resource row', () => {
+  cy.intercept({ method: 'POST', url: '**/ajaxResourceAclToggle.php' }).as('toggleAclRes');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-toggle input[type="checkbox"]')
+    .click();
+  cy.wait('@toggleAclRes');
+});
+
+Then('the ACL resource toggle response is successful', () => {
+  cy.get('@toggleAclRes').its('response.statusCode').should('eq', 200);
+  cy.get('@toggleAclRes').its('response.body').should('have.property', 'success', true);
+});

--- a/centreon/tests/e2e/features/Listing-modernization/19-acl-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/19-acl-listing/index.ts
@@ -50,8 +50,8 @@ Given('an admin user is logged in Centreon', () => {
 
 Given('an ACL group exists', () => {
   cy.addAclAccessGroup({
-    name: 'acl_grp_test',
-    alias: 'Test ACL Group'
+    alias: 'Test ACL Group',
+    name: 'acl_grp_test'
   });
 });
 
@@ -65,7 +65,9 @@ When('the user navigates to the ACL groups listing', () => {
 
 Then('the AJAX listing table is displayed with ACL group rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 When('the user searches for a specific ACL group', () => {
@@ -75,11 +77,16 @@ When('the user searches for a specific ACL group', () => {
 });
 
 Then('only the matching ACL group is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('acl_grp_test').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('acl_grp_test')
+    .should('exist');
 });
 
 When('the user clicks the toggle to disable an ACL group', () => {
-  cy.intercept({ method: 'POST', url: '**/ajaxGroupAclToggle.php' }).as('toggleAclGrp');
+  cy.intercept({ method: 'POST', url: '**/ajaxGroupAclToggle.php' }).as(
+    'toggleAclGrp'
+  );
   cy.getIframeBody()
     .find('#clTableBody')
     .contains('acl_grp_test')
@@ -102,14 +109,21 @@ When('the user selects an ACL group and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated ACL group appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('acl_grp_test_1').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('acl_grp_test_1')
+    .should('exist');
 });
 
 When('the user clicks on an ACL group name', () => {
@@ -123,7 +137,9 @@ When('the user navigates back to the ACL groups listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'acl_grp_test');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'acl_grp_test');
 });
 
 // ---------------------------------------------------------------------------
@@ -136,11 +152,15 @@ When('the user navigates to the ACL menus listing', () => {
 
 Then('the AJAX listing table is displayed with ACL menu rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 When('the user clicks the toggle on an ACL menu row', () => {
-  cy.intercept({ method: 'POST', url: '**/ajaxMenuAclToggle.php' }).as('toggleAclMenu');
+  cy.intercept({ method: 'POST', url: '**/ajaxMenuAclToggle.php' }).as(
+    'toggleAclMenu'
+  );
   cy.getIframeBody()
     .find('#clTableBody tr')
     .first()
@@ -151,7 +171,9 @@ When('the user clicks the toggle on an ACL menu row', () => {
 
 Then('the ACL menu toggle response is successful', () => {
   cy.get('@toggleAclMenu').its('response.statusCode').should('eq', 200);
-  cy.get('@toggleAclMenu').its('response.body').should('have.property', 'success', true);
+  cy.get('@toggleAclMenu')
+    .its('response.body')
+    .should('have.property', 'success', true);
 });
 
 // ---------------------------------------------------------------------------
@@ -164,11 +186,15 @@ When('the user navigates to the ACL actions listing', () => {
 
 Then('the AJAX listing table is displayed with ACL action rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 When('the user clicks the toggle on an ACL action row', () => {
-  cy.intercept({ method: 'POST', url: '**/ajaxActionAclToggle.php' }).as('toggleAclAction');
+  cy.intercept({ method: 'POST', url: '**/ajaxActionAclToggle.php' }).as(
+    'toggleAclAction'
+  );
   cy.getIframeBody()
     .find('#clTableBody tr')
     .first()
@@ -179,7 +205,9 @@ When('the user clicks the toggle on an ACL action row', () => {
 
 Then('the ACL action toggle response is successful', () => {
   cy.get('@toggleAclAction').its('response.statusCode').should('eq', 200);
-  cy.get('@toggleAclAction').its('response.body').should('have.property', 'success', true);
+  cy.get('@toggleAclAction')
+    .its('response.body')
+    .should('have.property', 'success', true);
 });
 
 // ---------------------------------------------------------------------------
@@ -192,11 +220,15 @@ When('the user navigates to the ACL resources listing', () => {
 
 Then('the AJAX listing table is displayed with ACL resource rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 When('the user clicks the toggle on an ACL resource row', () => {
-  cy.intercept({ method: 'POST', url: '**/ajaxResourceAclToggle.php' }).as('toggleAclRes');
+  cy.intercept({ method: 'POST', url: '**/ajaxResourceAclToggle.php' }).as(
+    'toggleAclRes'
+  );
   cy.getIframeBody()
     .find('#clTableBody tr')
     .first()
@@ -207,5 +239,7 @@ When('the user clicks the toggle on an ACL resource row', () => {
 
 Then('the ACL resource toggle response is successful', () => {
   cy.get('@toggleAclRes').its('response.statusCode').should('eq', 200);
-  cy.get('@toggleAclRes').its('response.body').should('have.property', 'success', true);
+  cy.get('@toggleAclRes')
+    .its('response.body')
+    .should('have.property', 'success', true);
 });

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/options/accessLists/actionsACL/ajaxActionAclListing.php
+++ b/centreon/www/include/options/accessLists/actionsACL/ajaxActionAclListing.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'WHERE (acl_action_name LIKE :search OR acl_action_description LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS acl_action_id, acl_action_name, acl_action_description, acl_action_activate'
+    . ' FROM acl_actions ' . $searchCond
+    . ' ORDER BY acl_action_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($acl = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'       => (int) $acl['acl_action_id'],
+        'name'     => $acl['acl_action_name'],
+        'desc'     => $acl['acl_action_description'],
+        'activate' => (int) $acl['acl_action_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/options/accessLists/actionsACL/ajaxActionAclToggle.php
+++ b/centreon/www/include/options/accessLists/actionsACL/ajaxActionAclToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(50204);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT acl_action_id FROM acl_actions WHERE acl_action_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT acl_action_name FROM acl_actions WHERE acl_action_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE acl_actions SET acl_action_activate = :activate WHERE acl_action_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('acl_action', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -76,43 +74,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    actAclListing.fetch(actAclListing.getState().num, actAclListing.getState().limit, actAclListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var actAclListing = new CentreonListing({
     instanceName:  'actAclListing',
     ajaxListUrl:   './include/options/accessLists/actionsACL/ajaxActionAclListing.php',
@@ -142,5 +103,6 @@ var actAclListing = new CentreonListing({
     }
 });
 actAclListing.init();
+CentreonForm.initSidePanel(actAclListing);
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
@@ -1,63 +1,88 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type="text/javascript" src="./include/common/javascript/resize_td.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}ACL Actions{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchACLA" value="{$searchACLA}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td> {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a></td>
-			{pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_alias}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias|escape:"html"}</a></td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-		</tr>
-		{/section}
-	</table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td>
-				 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			{pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchAA" value="{$searchAA}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="actAclListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
-    setOverflowDivToTitle(('.resizeTitle'));
+<script type="text/javascript">
+var actAclListing = new CentreonListing({
+    instanceName:  'actAclListing',
+    ajaxListUrl:   './include/options/accessLists/actionsACL/ajaxActionAclListing.php',
+    ajaxToggleUrl: './include/options/accessLists/actionsACL/ajaxActionAclToggle.php',
+    pageId:        {/literal}'{$actAclPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'act_acl_listing_limit',
+    emptyMessage:  'No action ACL found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="actAclListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+actAclListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
@@ -89,11 +89,11 @@ var actAclListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Actions access{/t}</h1>
+    <p class="cl-page-desc">{t}Control which monitoring actions each access group can perform.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$actAclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchAA" value="{$searchAA}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchAA" value="{$searchAA}" class="cl-search-simple" placeholder="{t}Search action access{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    actAclListing.fetch(actAclListing.getState().num, actAclListing.getState().limit, actAclListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var actAclListing = new CentreonListing({
     instanceName:  'actAclListing',
     ajaxListUrl:   './include/options/accessLists/actionsACL/ajaxActionAclListing.php',
@@ -66,15 +119,16 @@ var actAclListing = new CentreonListing({
     storageKey:    'act_acl_listing_limit',
     emptyMessage:  'No action ACL found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'desc', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.desc||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$actAclPage}{literal}&o=c&acl_action_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.desc||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Actions access{/t}</h1>
-    <p class="cl-page-desc">{t}Control which monitoring actions each access group can perform.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Actions access{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Control which monitoring actions each access group can perform.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$actAclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchAA" value="{$searchAA}" class="cl-search-simple" placeholder="{t}Search action access{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
@@ -19,137 +19,72 @@
  *
  */
 
+
 if (! isset($centreon)) {
     exit();
 }
 
 include './include/common/autoNumLimit.php';
 
-$SearchStr = '';
-$search = null;
-
-if (isset($_POST['searchACLA'])) {
-    $search = HtmlAnalyzer::sanitizeAndRemoveTags($_POST['searchACLA']);
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($_GET['searchACLA'])) {
-    $search = HtmlAnalyzer::sanitizeAndRemoveTags($_GET['searchACLA']);
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if ($search) {
-    $SearchStr .= ' WHERE (acl_action_name LIKE :search OR acl_action_description LIKE :search)';
-}
-
-$rq = "
-    SELECT SQL_CALC_FOUND_ROWS acl_action_id, acl_action_name, acl_action_description, acl_action_activate
-    FROM acl_actions
-    {$SearchStr}
-    ORDER BY acl_action_name LIMIT :num, :limit
-";
-
-$statement = $pearDB->prepare($rq);
-if ($search) {
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-}
-$statement->bindValue(':num', $num * $limit, PDO::PARAM_INT);
-$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
-$statement->execute();
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 
-// start header menu
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
 
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_alias', _('Description'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// end header menu
+$tpl->assign('actAclPage', $p);
 
-$search = tidySearchKey($search, $advanced_search);
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchAA', $search);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-// Different style between each lines
-$style = 'one';
 
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-for ($i = 0; $topo = $statement->fetchRow(); $i++) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $topo['acl_action_id'] . ']');
-    if ($topo['acl_action_activate']) {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_action_id=' . $topo['acl_action_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_action_id=' . $topo['acl_action_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;';
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $topo['acl_action_id'] . "]' />";
-    // Contacts
-    $elemArr[$i] = [
-        'MenuClass' => 'list_' . $style,
-        'RowMenu_select' => $selectedElements->toHtml(),
-        'RowMenu_name' => $topo['acl_action_name'],
-        'RowMenu_link' => 'main.php?p=' . $p . '&o=c&acl_action_id=' . $topo['acl_action_id'],
-        'RowMenu_alias' => $topo['acl_action_description'],
-        'RowMenu_status' => $topo['acl_action_activate'] ? _('Enabled') : _('Disabled'),
-        'RowMenu_badge' => $topo['acl_action_activate'] ? 'service_ok' : 'service_critical',
-        'RowMenu_options' => $moptions];
-
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </script>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
 
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
-        . "if (this.form.elements['{$option}'].selectedIndex == 1 && confirm('"
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 2 && confirm('"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 3 || "
-        . "this.form.elements['{$option}'].selectedIndex == 4) {"
-        . "setO(this.form.elements['{$option}'].value); submit();}"];
-    $form->addElement('select', $option, null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs1);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3 || "
+        . "this.form.elements['" . $option . "'].selectedIndex == 4) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchACLA', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
@@ -40,9 +40,7 @@ $tpl->assign('actAclPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchAA', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/options/accessLists/groupsACL/ajaxGroupAclListing.php
+++ b/centreon/www/include/options/accessLists/groupsACL/ajaxGroupAclListing.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (acl_group_name LIKE :search OR acl_group_alias LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS ag.acl_group_id, ag.acl_group_name, ag.acl_group_alias, ag.acl_group_activate,'
+    . ' (SELECT COUNT(*) FROM acl_group_contacts_relations agcr WHERE agcr.acl_group_id = ag.acl_group_id) AS contact_count,'
+    . ' (SELECT COUNT(*) FROM acl_group_contactgroups_relations agcgr WHERE agcgr.acl_group_id = ag.acl_group_id) AS cg_count'
+    . ' FROM acl_groups ag WHERE ag.cloud_specific = 0 ' . $searchCond
+    . ' ORDER BY ag.acl_group_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($grp = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'            => (int) $grp['acl_group_id'],
+        'name'          => $grp['acl_group_name'],
+        'alias'         => $grp['acl_group_alias'],
+        'contact_count' => (int) $grp['contact_count'],
+        'cg_count'      => (int) $grp['cg_count'],
+        'activate'      => (int) $grp['acl_group_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/options/accessLists/groupsACL/ajaxGroupAclToggle.php
+++ b/centreon/www/include/options/accessLists/groupsACL/ajaxGroupAclToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(50203);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT acl_group_id FROM acl_groups WHERE acl_group_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT acl_group_name FROM acl_groups WHERE acl_group_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE acl_groups SET acl_group_activate = :activate WHERE acl_group_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('acl_group', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -78,43 +76,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    aclListing.fetch(aclListing.getState().num, aclListing.getState().limit, aclListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var aclListing = new CentreonListing({
     instanceName:  'aclListing',
     ajaxListUrl:   './include/options/accessLists/groupsACL/ajaxGroupAclListing.php',
@@ -146,5 +107,6 @@ var aclListing = new CentreonListing({
     }
 });
 aclListing.init();
+CentreonForm.initSidePanel(aclListing);
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
@@ -91,11 +91,11 @@ var aclListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'contact_count', align:'center' },
         { id:'cg_count', align:'center' }

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Access groups{/t}</h1>
+    <p class="cl-page-desc">{t}Define access groups to assign permissions to your users.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$aclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchAG" value="{$searchAG}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchAG" value="{$searchAG}" class="cl-search-simple" placeholder="{t}Search access groups{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -31,7 +44,7 @@
                     <th>{$headerMenu_desc}</th>
                     <th class="cl-col-center">{$headerMenu_contacts}</th>
                     <th class="cl-col-center">{$headerMenu_cgroups}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -39,16 +52,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -56,8 +59,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    aclListing.fetch(aclListing.getState().num, aclListing.getState().limit, aclListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var aclListing = new CentreonListing({
     instanceName:  'aclListing',
     ajaxListUrl:   './include/options/accessLists/groupsACL/ajaxGroupAclListing.php',
@@ -68,15 +121,16 @@ var aclListing = new CentreonListing({
     storageKey:    'acl_group_listing_limit',
     emptyMessage:  'No ACL groups found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'contact_count', align:'center' },
         { id:'cg_count', align:'center' }

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
@@ -1,72 +1,92 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type="text/javascript" src="./include/common/javascript/resize_td.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}ACL Group{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchACLG" value="{$searchACLG}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
-                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_desc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_contacts}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_contactgroups}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColCenter"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_contacts}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_contactgroups}</td>
-            <td class="ListColCenter"><span
-                    class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColRight" align="right">{$elemArr[elem].RowMenu_options}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
-                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <input type='hidden' name='o' id='o' value='42'>
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchAG" value="{$searchAG}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="aclListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-center">{$headerMenu_contacts}</th>
+                    <th class="cl-col-center">{$headerMenu_cgroups}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
-    setOverflowDivToTitle(('.resizeTitle'));
+<script type="text/javascript">
+var aclListing = new CentreonListing({
+    instanceName:  'aclListing',
+    ajaxListUrl:   './include/options/accessLists/groupsACL/ajaxGroupAclListing.php',
+    ajaxToggleUrl: './include/options/accessLists/groupsACL/ajaxGroupAclToggle.php',
+    pageId:        {/literal}'{$aclPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'acl_group_listing_limit',
+    emptyMessage:  'No ACL groups found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$aclPage}{literal}&o=c&acl_group_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }},
+        { id:'contact_count', align:'center' },
+        { id:'cg_count', align:'center' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="aclListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+aclListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Access groups{/t}</h1>
-    <p class="cl-page-desc">{t}Define access groups to assign permissions to your users.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Access groups{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define access groups to assign permissions to your users.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$aclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchAG" value="{$searchAG}" class="cl-search-simple" placeholder="{t}Search access groups{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
@@ -41,9 +41,7 @@ $tpl->assign('aclPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchAG', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
@@ -25,116 +25,34 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$searchStr = '';
-$search = null;
-
-if (isset($_POST['searchACLG'])) {
-    $search = HtmlAnalyzer::sanitizeAndRemoveTags($_POST['searchACLG']);
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($_GET['searchACLG'])) {
-    $search = HtmlAnalyzer::sanitizeAndRemoveTags($_GET['searchACLG']);
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if ($search) {
-    $searchStr .= 'AND (acl_group_name LIKE :search OR acl_group_alias LIKE :search)';
-}
-
-$rq = "
-    SELECT SQL_CALC_FOUND_ROWS acl_group_id, acl_group_name, acl_group_alias, acl_group_activate
-    FROM acl_groups
-    WHERE cloud_specific = 0 {$searchStr}
-    ORDER BY acl_group_name LIMIT :num, :limit
-";
-$statement = $pearDB->prepare($rq);
-if ($search) {
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-}
-$statement->bindValue(':num', $num * $limit, PDO::PARAM_INT);
-$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
-$statement->execute();
-
-$search = tidySearchKey($search, $advanced_search);
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// start header menu
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_contacts', _('Contacts'));
-$tpl->assign('headerMenu_contactgroups', _('Contact Groups'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_cgroups', _('Contact Groups'));
 $tpl->assign('headerMenu_options', _('Options'));
+
+$tpl->assign('aclPage', $p);
+
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchAG', $search);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
-for ($i = 0; $group = $statement->fetchRow(); $i++) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $group['acl_group_id'] . ']');
-    if ($group['acl_group_activate']) {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_group_id=' . $group['acl_group_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_group_id=' . $group['acl_group_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-
-    $moptions .= '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $group['acl_group_id'] . "]' />";
-
-    // Contacts
-    $ctNbr = [];
-    $rq2 = 'SELECT COUNT(*) AS nbr FROM acl_group_contacts_relations WHERE acl_group_id = :aclGroupId ';
-    $dbResult2 = $pearDB->prepare($rq2);
-    $dbResult2->bindValue(':aclGroupId', $group['acl_group_id'], PDO::PARAM_INT);
-    $dbResult2->execute();
-    $ctNbr = $dbResult2->fetchRow();
-    $dbResult2->closeCursor();
-
-    $cgNbr = [];
-    $rq3 = 'SELECT COUNT(*) AS nbr FROM acl_group_contactgroups_relations WHERE acl_group_id = :aclGroupId ';
-    $dbResult3 = $pearDB->prepare($rq3);
-    $dbResult3->bindValue('aclGroupId', $group['acl_group_id'], PDO::PARAM_INT);
-    $dbResult3->execute();
-    $cgNbr = $dbResult3->fetchRow();
-    $dbResult3->closeCursor();
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeAll(
-        $group['acl_group_name']
-    ), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&acl_group_id=' . $group['acl_group_id'], 'RowMenu_desc' => CentreonUtils::escapeAll(
-        $group['acl_group_alias']
-    ), 'RowMenu_contacts' => $ctNbr['nbr'], 'RowMenu_contactgroups' => $cgNbr['nbr'], 'RowMenu_status' => $group['acl_group_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $group['acl_group_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-// Toolbar select lgd_more_actions
 ?>
 <script type="text/javascript">
     function setO(_i) {
@@ -144,29 +62,31 @@ $tpl->assign(
 <?php
 
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
-        . "if (this.form.elements['{$option}'].selectedIndex == 1 && confirm('"
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 2 && confirm('"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 3 || "
-        . "this.form.elements['{$option}'].selectedIndex == 4) {"
-        . "setO(this.form.elements['{$option}'].value); submit();}"];
-    $form->addElement('select', $option, null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs1);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3 || "
+        . "this.form.elements['" . $option . "'].selectedIndex == 4) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchACLG', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-
 $tpl->display('listGroupConfig.ihtml');
-
-?>

--- a/centreon/www/include/options/accessLists/menusACL/ajaxMenuAclListing.php
+++ b/centreon/www/include/options/accessLists/menusACL/ajaxMenuAclListing.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'WHERE (acl_topo_name LIKE :search OR acl_topo_alias LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS acl_topo_id, acl_topo_name, acl_topo_alias, acl_topo_activate'
+    . ' FROM acl_topology ' . $searchCond
+    . ' ORDER BY acl_topo_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($acl = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'       => (int) $acl['acl_topo_id'],
+        'name'     => $acl['acl_topo_name'],
+        'alias'    => $acl['acl_topo_alias'],
+        'activate' => (int) $acl['acl_topo_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/options/accessLists/menusACL/ajaxMenuAclToggle.php
+++ b/centreon/www/include/options/accessLists/menusACL/ajaxMenuAclToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(50201);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT acl_topo_id FROM acl_topology WHERE acl_topo_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT acl_topo_name FROM acl_topology WHERE acl_topo_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE acl_topology SET acl_topo_activate = :activate WHERE acl_topo_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('acl_menu', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -76,43 +74,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    menuAclListing.fetch(menuAclListing.getState().num, menuAclListing.getState().limit, menuAclListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var menuAclListing = new CentreonListing({
     instanceName:  'menuAclListing',
     ajaxListUrl:   './include/options/accessLists/menusACL/ajaxMenuAclListing.php',
@@ -142,5 +103,6 @@ var menuAclListing = new CentreonListing({
     }
 });
 menuAclListing.init();
+CentreonForm.initSidePanel(menuAclListing);
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Menu access{/t}</h1>
-    <p class="cl-page-desc">{t}Control which configuration menus each access group can see.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Menu access{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Control which configuration menus each access group can see.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$menuAclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchMA" value="{$searchMA}" class="cl-search-simple" placeholder="{t}Search menu access{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Menu access{/t}</h1>
+    <p class="cl-page-desc">{t}Control which configuration menus each access group can see.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$menuAclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchMA" value="{$searchMA}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchMA" value="{$searchMA}" class="cl-search-simple" placeholder="{t}Search menu access{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -29,7 +42,7 @@
                     </th>
                     <th>{$headerMenu_name}</th>
                     <th>{$headerMenu_desc}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -37,16 +50,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -54,8 +57,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    menuAclListing.fetch(menuAclListing.getState().num, menuAclListing.getState().limit, menuAclListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var menuAclListing = new CentreonListing({
     instanceName:  'menuAclListing',
     ajaxListUrl:   './include/options/accessLists/menusACL/ajaxMenuAclListing.php',
@@ -66,15 +119,16 @@ var menuAclListing = new CentreonListing({
     storageKey:    'menu_acl_listing_limit',
     emptyMessage:  'No menu ACL found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
@@ -89,11 +89,11 @@ var menuAclListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }}
     ],
     renderOptions: function(row, l) {

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
@@ -1,67 +1,88 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type="text/javascript" src="./include/common/javascript/resize_td.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}ACL Menu{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchACLM" value="{$searchACLM}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td> {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a></td>
-			
-            {pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchMA" value="{$searchMA}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_alias}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias}</a></td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-		</tr>
-		{/section}
-	</table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="menuAclListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="4" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
 
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td>
-				 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-			
-            {pagination}
-		</tr>
-	</table>
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
-    setOverflowDivToTitle(('.resizeTitle'));
+<script type="text/javascript">
+var menuAclListing = new CentreonListing({
+    instanceName:  'menuAclListing',
+    ajaxListUrl:   './include/options/accessLists/menusACL/ajaxMenuAclListing.php',
+    ajaxToggleUrl: './include/options/accessLists/menusACL/ajaxMenuAclToggle.php',
+    pageId:        {/literal}'{$menuAclPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'menu_acl_listing_limit',
+    emptyMessage:  'No menu ACL found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$menuAclPage}{literal}&o=c&acl_topo_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="menuAclListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+menuAclListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
@@ -39,9 +39,7 @@ $tpl->assign('menuAclPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchMA', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
@@ -23,176 +23,67 @@ if (! isset($centreon)) {
     exit();
 }
 
-use Adaptation\Database\Connection\Collection\QueryParameters;
-use Adaptation\Database\Connection\Exception\ConnectionException;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
-use Core\Common\Domain\Exception\CollectionException;
-use Core\Common\Domain\Exception\ValueObjectException;
-
 include './include/common/autoNumLimit.php';
 
-$searchStr = '';
-
-$search = $_POST['searchACLM'] ?? $_GET['searchACLM'] ?? null;
-if (! is_null($search)) {
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if (! is_null($search)) {
-    $search = HtmlSanitizer::createFromString($search)
-        ->removeTags()
-        ->sanitize()
-        ->getString();
-}
-
-$rows = 0;
-$dataRows = [];
-
-try {
-    $offset = (int) ($num * $limit);
-    $max = (int) $limit;
-
-    $paramsList = [];
-
-    // ---------- COUNT query ----------
-    $countSql = <<<'SQL'
-            SELECT COUNT(*) AS total
-            FROM acl_topology
-        SQL;
-
-    if ($search !== null && $search !== '') {
-        $countSql .= ' WHERE (acl_topo_name LIKE :searchLike OR acl_topo_alias = :searchAlias)';
-        $paramsList[] = QueryParameter::string('searchLike', '%' . $search . '%');
-        $paramsList[] = QueryParameter::string('searchAlias', $search);
-    }
-
-    $countParams = QueryParameters::create($paramsList);
-    $rows = (int) $pearDB->fetchOne($countSql, $countParams);
-
-    // ---------- DATA query ----------
-    $listSql = <<<'SQL'
-            SELECT acl_topo_id, acl_topo_name, acl_topo_alias, acl_topo_activate
-            FROM acl_topology
-        SQL;
-
-    if ($search !== null && $search !== '') {
-        $listSql .= ' WHERE (acl_topo_name LIKE :searchLike OR acl_topo_alias = :searchAlias)';
-    }
-
-    $listSql .= " ORDER BY acl_topo_name ASC LIMIT {$offset}, {$max}";
-
-    $dataParams = QueryParameters::create($paramsList);
-    $dataRows = $pearDB->fetchAllAssociative($listSql, $dataParams);
-} catch (CollectionException|ValueObjectException|ConnectionException $exception) {
-    CentreonLog::create()->error(
-        CentreonLog::TYPE_SQL,
-        'Error while listing ACL topologies: ' . $exception->getMessage(),
-        [
-            'search' => $search ?? null,
-            'limit' => $limit ?? null,
-            'num' => $num ?? null,
-        ],
-        $exception
-    );
-    $msg = new CentreonMsg();
-    $msg->setImage('./img/icons/warning.png');
-    $msg->setTextStyle('bold');
-    $msg->setText(_('Error while fetching ACL topologies'));
-}
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// start header menu
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_alias', _('Description'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// end header menu
+$tpl->assign('menuAclPage', $p);
 
-$search = tidySearchKey($search, $advanced_search);
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchMA', $search);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-$i = 0;
-foreach ($dataRows as $topo) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $topo['acl_topo_id'] . ']');
-    if ($topo['acl_topo_activate']) {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_topo_id=' . $topo['acl_topo_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_topo_id=' . $topo['acl_topo_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;';
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $topo['acl_topo_id'] . "]' />";
-    // Contacts
-    $elemArr[$i++] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure(
-        $topo['acl_topo_name'],
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&acl_topo_id=' . $topo['acl_topo_id'], 'RowMenu_alias' => CentreonUtils::escapeSecure(
-        $topo['acl_topo_alias'],
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    ), 'RowMenu_status' => $topo['acl_topo_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $topo['acl_topo_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
-
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </script>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
-foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
-        . "if (this.form.elements['{$option}'].selectedIndex == 1 && confirm('"
-        . _('Do you confirm the duplication ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 2 && confirm('"
-        . _('Do you confirm the deletion ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 3 || "
-        . "this.form.elements['{$option}'].selectedIndex == 4) {"
-        . "setO(this.form.elements['{$option}'].value); submit();}"];
-    $form->addElement('select', $option, null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs1);
 
+foreach (['o1', 'o2'] as $option) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
+        . _('Do you confirm the deletion ?') . "')) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3 || "
+        . "this.form.elements['" . $option . "'].selectedIndex == 4) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs);
     $form->setDefaults([$option => null]);
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchACLM', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/options/accessLists/resourcesACL/ajaxResourceAclListing.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/ajaxResourceAclListing.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (acl_res_name LIKE :search OR acl_res_alias LIKE :search) ';
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS acl_res_id, acl_res_name, acl_res_alias, acl_res_activate,'
+    . ' all_hosts, all_hostgroups, all_servicegroups, all_image_folders'
+    . ' FROM acl_resources WHERE locked = 0 AND cloud_specific = 0 ' . $searchCond
+    . ' ORDER BY acl_res_name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($acl = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id'             => (int) $acl['acl_res_id'],
+        'name'           => $acl['acl_res_name'],
+        'alias'          => $acl['acl_res_alias'],
+        'all_hosts'      => (int) $acl['all_hosts'],
+        'all_hostgroups' => (int) $acl['all_hostgroups'],
+        'all_svcgroups'  => (int) $acl['all_servicegroups'],
+        'all_imgfolders' => (int) $acl['all_image_folders'],
+        'activate'       => (int) $acl['acl_res_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/options/accessLists/resourcesACL/ajaxResourceAclToggle.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/ajaxResourceAclToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(50202);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT acl_res_id FROM acl_resources WHERE acl_res_id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT acl_res_name FROM acl_resources WHERE acl_res_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE acl_resources SET acl_res_activate = :activate WHERE acl_res_id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('acl_resource', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -1,21 +1,34 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Resource access{/t}</h1>
+    <p class="cl-page-desc">{t}Define which resources each access group can access.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$resAclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchRA" value="{$searchRA}" placeholder="{t}Search{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchRA" value="{$searchRA}" class="cl-search-simple" placeholder="{t}Search resource access{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -33,7 +46,7 @@
                     <th class="cl-col-center">{$headerMenu_hg}</th>
                     <th class="cl-col-center">{$headerMenu_sg}</th>
                     <th class="cl-col-center">{$headerMenu_img}</th>
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                 </tr>
             </thead>
             <tbody id="clTableBody">
@@ -41,16 +54,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -58,8 +61,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    resAclListing.fetch(resAclListing.getState().num, resAclListing.getState().limit, resAclListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var resAclListing = new CentreonListing({
     instanceName:  'resAclListing',
     ajaxListUrl:   './include/options/accessLists/resourcesACL/ajaxResourceAclListing.php',
@@ -70,15 +123,16 @@ var resAclListing = new CentreonListing({
     storageKey:    'res_acl_listing_limit',
     emptyMessage:  'No resource ACL found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'all_hosts', align:'center', render: function(row) {
             return row.all_hosts ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : '';

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -1,75 +1,104 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type="text/javascript" src="./include/common/javascript/resize_td.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}ACL Resource{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchACLR" value="{$searchACLR}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-            {pagination}
-		</tr>
-	</table>
-	<table class="ListTable">
-		<tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-			<td class="ListColHeaderLeft">{$headerMenu_name}</td>
-			<td class="ListColHeaderLeft">{$headerMenu_alias}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_allH}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_allHG}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_allSG}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_allImageFolders}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
-			<td class="ListColHeaderRight">{$headerMenu_options}</td>
-		</tr>
-		{section name=elem loop=$elemArr}
-		<tr class={$elemArr[elem].MenuClass}>
-			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias|escape:"html"}</a></td>
-			<td class="ListColCenter">{$elemArr[elem].RowMenu_all_hosts}</td>
-			<td class="ListColCenter">{$elemArr[elem].RowMenu_all_hostgroups}</td>
-			<td class="ListColCenter">{$elemArr[elem].RowMenu_all_servicegroups}</td>
-			<td class="ListColCenter">{$elemArr[elem].RowMenu_all_image_folders}</td>
-			<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-			<td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-		</tr>
-		{/section}
-	</table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-			</td>
-            {pagination}
-		</tr>
-	</table>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchRA" value="{$searchRA}" placeholder="{t}Search{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="resAclListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-center">{$headerMenu_hosts}</th>
+                    <th class="cl-col-center">{$headerMenu_hg}</th>
+                    <th class="cl-col-center">{$headerMenu_sg}</th>
+                    <th class="cl-col-center">{$headerMenu_img}</th>
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="8" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                {$form.o2.html}
+            </div>
+            { else }
+            <div>&nbsp;</div>
+            { /if }
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
-    setOverflowDivToTitle(('.resizeTitle'));
+<script type="text/javascript">
+var resAclListing = new CentreonListing({
+    instanceName:  'resAclListing',
+    ajaxListUrl:   './include/options/accessLists/resourcesACL/ajaxResourceAclListing.php',
+    ajaxToggleUrl: './include/options/accessLists/resourcesACL/ajaxResourceAclToggle.php',
+    pageId:        {/literal}'{$resAclPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'res_acl_listing_limit',
+    emptyMessage:  'No resource ACL found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }},
+        { id:'all_hosts', align:'center', render: function(row) {
+            return row.all_hosts ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : '';
+        }},
+        { id:'all_hostgroups', align:'center', render: function(row) {
+            return row.all_hostgroups ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : '';
+        }},
+        { id:'all_svcgroups', align:'center', render: function(row) {
+            return row.all_svcgroups ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : '';
+        }},
+        { id:'all_imgfolders', align:'center', render: function(row) {
+            return row.all_imgfolders ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : '';
+        }}
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="resAclListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+resAclListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -93,11 +93,11 @@ var resAclListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$resAclPage}{literal}&o=c&acl_res_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'all_hosts', align:'center', render: function(row) {
             return row.all_hosts ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : '';

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Resource access{/t}</h1>
-    <p class="cl-page-desc">{t}Define which resources each access group can access.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Resource access{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define which resources each access group can access.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$resAclPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,12 +24,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--wide">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchRA" value="{$searchRA}" class="cl-search-simple" placeholder="{t}Search resource access{/t}" autocomplete="off">
                 </div>
-                <span class="cl-toolbar-sep"></span>
+            </div>
+            <div class="cl-toolbar-right">
                 <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -80,43 +78,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    resAclListing.fetch(resAclListing.getState().num, resAclListing.getState().limit, resAclListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var resAclListing = new CentreonListing({
     instanceName:  'resAclListing',
     ajaxListUrl:   './include/options/accessLists/resourcesACL/ajaxResourceAclListing.php',
@@ -158,5 +119,6 @@ var resAclListing = new CentreonListing({
     }
 });
 resAclListing.init();
+CentreonForm.initSidePanel(resAclListing);
 </script>
 {/literal}

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
@@ -25,154 +25,69 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$searchStr = '';
-$search = null;
-
-if (isset($_POST['searchACLR'])) {
-    $search = HtmlSanitizer::createFromString($_POST['searchACLR'])
-        ->removeTags()
-        ->getString();
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($_GET['searchACLR'])) {
-    $search = HtmlSanitizer::createFromString($_GET['searchACLR'])
-        ->removeTags()
-        ->getString();
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if ($search) {
-    $searchStr = 'AND (acl_res_name LIKE :search OR acl_res_alias LIKE :search)';
-}
-$rq = "
-    SELECT SQL_CALC_FOUND_ROWS acl_res_id, acl_res_name, acl_res_alias, all_hosts, all_hostgroups,
-    all_servicegroups, all_image_folders, acl_res_activate FROM acl_resources
-    WHERE locked = 0 AND cloud_specific = 0 {$searchStr}
-    ORDER BY acl_res_name
-    LIMIT :num, :limit
-";
-$statement = $pearDB->prepare($rq);
-if ($search) {
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-}
-$statement->bindValue(':num', $num * $limit, PDO::PARAM_INT);
-$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
-$statement->execute();
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
-// Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate(__DIR__);
 
-// start header menu
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_alias', _('Description'));
-$tpl->assign('headerMenu_contacts', _('Contacts'));
-$tpl->assign('headerMenu_allH', _('All Hosts'));
-$tpl->assign('headerMenu_allHG', _('All Hostgroups'));
-$tpl->assign('headerMenu_allSG', _('All Servicegroups'));
-$tpl->assign('headerMenu_allImageFolders', _('All image folders'));
-$tpl->assign('headerMenu_status', _('Status'));
+$tpl->assign('headerMenu_desc', _('Description'));
+$tpl->assign('headerMenu_hosts', _('All Hosts'));
+$tpl->assign('headerMenu_hg', _('All Hostgroups'));
+$tpl->assign('headerMenu_sg', _('All Servicegroups'));
+$tpl->assign('headerMenu_img', _('All Image Folders'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
+$tpl->assign('resAclPage', $p);
+
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchRA', $search);
+
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 
-// Different style between each lines
-$style = 'one';
+$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
+$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
 
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-for ($i = 0; $resources = $statement->fetchRow(); $i++) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $resources['acl_res_id'] . ']');
-
-    if ($resources['acl_res_activate']) {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_res_id=' . $resources['acl_res_id']
-            . '&o=u&limit=' . $limit . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' border='0' alt='"
-            . _('Disabled') . "'></a>&nbsp;&nbsp;";
-    } else {
-        $moptions = "<a href='main.php?p=" . $p . '&acl_res_id=' . $resources['acl_res_id']
-            . '&o=s&limit=' . $limit . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' border='0' alt='"
-            . _('Enabled') . "'></a>&nbsp;&nbsp;";
-    }
-    $moptions .= '&nbsp;';
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57))'
-        . ' event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $resources['acl_res_id'] . "]'></input>";
-
-    $allHostgroups = (isset($resources['all_hostgroups']) && $resources['all_hostgroups'] == 1 ? _('Yes') : _('No'));
-    $allServicegroups = (isset($resources['all_servicegroups']) && $resources['all_servicegroups'] == 1
-        ? _('Yes')
-        : _('No'));
-
-    $allImageFolders = (isset($resources['all_image_folders']) && $resources['all_image_folders'] == 1 ? _('Yes') : _('No'));
-
-    $elemArr[$i] = [
-        'MenuClass' => 'list_' . $style,
-        'RowMenu_select' => $selectedElements->toHtml(),
-        'RowMenu_name' => $resources['acl_res_name'],
-        'RowMenu_alias' => myDecode($resources['acl_res_alias']),
-        'RowMenu_all_hosts' => (isset($resources['all_hosts']) && $resources['all_hosts'] == 1 ? _('Yes') : _('No')),
-        'RowMenu_all_hostgroups' => $allHostgroups,
-        'RowMenu_all_servicegroups' => $allServicegroups,
-        'RowMenu_all_image_folders' => $allImageFolders,
-        'RowMenu_link' => 'main.php?p=' . $p . '&o=c&acl_res_id=' . $resources['acl_res_id'],
-        'RowMenu_status' => $resources['acl_res_activate'] ? _('Enabled') : _('Disabled'),
-        'RowMenu_badge' => $resources['acl_res_activate'] ? 'service_ok' : 'service_critical',
-        'RowMenu_options' => $moptions,
-    ];
-
-    $style = $style != 'two' ? 'two' : 'one';
-}
-$tpl->assign('elemArr', $elemArr);
-
-// Different messages we put in the template
-$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </script>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
 
 foreach (['o1', 'o2'] as $option) {
-    $attrs1 = ['onchange' => 'javascript: '
-        . "if (this.form.elements['{$option}'].selectedIndex == 1 && confirm('"
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['" . $option . "'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['" . $option . "'].selectedIndex == 1 && confirm('"
         . _('Do you confirm the duplication ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 2 && confirm('"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 2 && confirm('"
         . _('Do you confirm the deletion ?') . "')) {"
-        . "setO(this.form.elements['{$option}'].value); submit();} "
-        . "else if (this.form.elements['{$option}'].selectedIndex == 3 || "
-        . "this.form.elements['{$option}'].selectedIndex == 4) {"
-        . "setO(this.form.elements['{$option}'].value); submit();}"];
-
-    $form->addElement(
-        'select',
-        $option,
-        null,
-        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')],
-        $attrs1
-    );
-    $o1 = $form->getElement($option);
-    $o1->setValue(null);
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "else if (this.form.elements['" . $option . "'].selectedIndex == 3 || "
+        . "this.form.elements['" . $option . "'].selectedIndex == 4) {"
+        . " 	setO(this.form.elements['" . $option . "'].value); submit();} "
+        . "this.form.elements['" . $option . "'].selectedIndex = 0"];
+    $form->addElement('select', $option, null,
+        [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'ms' => _('Enable'), 'mu' => _('Disable')], $attrs);
+    $form->setDefaults([$option => null]);
+    $el = $form->getElement($option);
+    $el->setValue(null);
+    $el->setSelected(null);
 }
 
 $tpl->assign('limit', $limit);
-$tpl->assign('searchACLR', $search);
 
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
@@ -43,9 +43,7 @@ $tpl->assign('resAclPage', $p);
 $search = $centreon->historySearch[$url]['search'] ?? '';
 $tpl->assign('searchRA', $search);
 
-$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-$gopt = $dbResult->fetch();
-$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 
 $form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);


### PR DESCRIPTION
## Summary

Replaces the 4 legacy Smarty-rendered ACL listings with AJAX-driven tables using the shared `CentreonListing` framework.

## What changed

### 4 pages migrated (16 files)

| Page | AJAX endpoint | Toggle endpoint | ACL page |
|------|--------------|----------------|----------|
| ACL Groups | `ajaxGroupAclListing.php` | `ajaxGroupAclToggle.php` | 50203 |
| ACL Menus | `ajaxMenuAclListing.php` | `ajaxMenuAclToggle.php` | 50201 |
| ACL Actions | `ajaxActionAclListing.php` | `ajaxActionAclToggle.php` | 50204 |
| ACL Resources | `ajaxResourceAclListing.php` | `ajaxResourceAclToggle.php` | 50202 |

Each page: AJAX listing endpoint + toggle endpoint + rewritten ihtml + simplified PHP controller. All toggles include CSRF rotation, ACL write access check, and audit logging.

### Tests (11 scenarios)

- **ACL Groups:** AJAX load, search, toggle, duplicate, session persistence
- **ACL Menus:** AJAX load, toggle
- **ACL Actions:** AJAX load, toggle
- **ACL Resources:** AJAX load, toggle

## How to test

1. Navigate to Administration > ACL > each ACL page
2. Test search, toggle enable/disable, duplicate
3. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added AJAX listing endpoints that returned sanitized JSON with pagination.
* Implemented AJAX toggle endpoints with CSRF rotation and ACL checks.
* Added audit logging for enable/disable actions on ACL objects.
* Added Cypress test scenarios covering load, search, toggle, duplicate behaviors.

**🔧 Refactors**
* Replaced legacy Smarty ACL listings with AJAX-driven CentreonListing tables.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98626405?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
