### PR TITLE
feat(configuration): modernize service template listing with AJAX-driven UI

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing.feature
@@ -7,33 +7,27 @@ Feature: Modern service template listing
     Given an admin user is logged in Centreon
     And several service templates exist
 
-  @TEST_LISTING-183
   Scenario: Service template listing loads via AJAX
     When the user navigates to the service templates listing
     Then the AJAX listing table is displayed with service template rows
 
-  @TEST_LISTING-184
   Scenario: Search filters service templates by name
     When the user navigates to the service templates listing
     And the user searches for a specific service template
     Then only the matching service template is displayed
 
-  @TEST_LISTING-185
   Scenario: Each template row has an icon
     When the user navigates to the service templates listing
     Then each row displays a service icon
 
-  @TEST_LISTING-186
   Scenario: Template chain is displayed with links
     When the user navigates to the service templates listing
     Then service template rows show the parent template chain as links
 
-  @TEST_LISTING-187
   Scenario: Scheduling column shows intervals
     When the user navigates to the service templates listing
     Then service template rows show scheduling intervals
 
-  @TEST_LISTING-188
   Scenario: Locked checkbox shows and hides locked templates
     When the user navigates to the service templates listing
     And the locked checkbox is checked
@@ -41,44 +35,37 @@ Feature: Modern service template listing
     When the user unchecks the locked checkbox and searches
     Then locked service templates are hidden
 
-  @TEST_LISTING-189
   Scenario: Locked templates have disabled checkboxes and dup inputs
     When the user navigates to the service templates listing
     And the locked checkbox is checked
     Then locked rows have disabled selection checkboxes
     And locked rows have disabled duplication inputs
 
-  @TEST_LISTING-190
   Scenario: No toggle column exists
     When the user navigates to the service templates listing
     Then no toggle switch is present in the listing
 
-  @TEST_LISTING-191
   Scenario: Pagination and rows per page
     When the user navigates to the service templates listing
     Then the pagination info shows the total count
     When the user changes the rows per page to 10
     Then at most 10 rows are displayed
 
-  @TEST_LISTING-192
   Scenario: Bulk duplication works
     When the user navigates to the service templates listing
     And the user selects a service template and duplicates it
     Then a duplicated service template appears in the listing
 
-  @TEST_LISTING-193
   Scenario: Bulk deletion works
     When the user navigates to the service templates listing
     And the user selects a service template and deletes it
     Then the service template is removed from the listing
 
-  @TEST_LISTING-194
   Scenario: Clicking a name navigates to the edit form
     When the user navigates to the service templates listing
     And the user clicks on a service template name
     Then the service template edit form is displayed
 
-  @TEST_LISTING-195
   Scenario: Session state persists across navigation
     When the user navigates to the service templates listing
     And the user searches for a specific service template

--- a/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing.feature
@@ -1,0 +1,87 @@
+Feature: Modern service template listing
+    As a Centreon admin
+    I want to manage service templates from the modernized listing page
+    With AJAX search, locked elements support, icon display, pagination and bulk actions
+
+  Background:
+    Given an admin user is logged in Centreon
+    And several service templates exist
+
+  @TEST_LISTING-183
+  Scenario: Service template listing loads via AJAX
+    When the user navigates to the service templates listing
+    Then the AJAX listing table is displayed with service template rows
+
+  @TEST_LISTING-184
+  Scenario: Search filters service templates by name
+    When the user navigates to the service templates listing
+    And the user searches for a specific service template
+    Then only the matching service template is displayed
+
+  @TEST_LISTING-185
+  Scenario: Each template row has an icon
+    When the user navigates to the service templates listing
+    Then each row displays a service icon
+
+  @TEST_LISTING-186
+  Scenario: Template chain is displayed with links
+    When the user navigates to the service templates listing
+    Then service template rows show the parent template chain as links
+
+  @TEST_LISTING-187
+  Scenario: Scheduling column shows intervals
+    When the user navigates to the service templates listing
+    Then service template rows show scheduling intervals
+
+  @TEST_LISTING-188
+  Scenario: Locked checkbox shows and hides locked templates
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked service templates are visible
+    When the user unchecks the locked checkbox and searches
+    Then locked service templates are hidden
+
+  @TEST_LISTING-189
+  Scenario: Locked templates have disabled checkboxes and dup inputs
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked rows have disabled selection checkboxes
+    And locked rows have disabled duplication inputs
+
+  @TEST_LISTING-190
+  Scenario: No toggle column exists
+    When the user navigates to the service templates listing
+    Then no toggle switch is present in the listing
+
+  @TEST_LISTING-191
+  Scenario: Pagination and rows per page
+    When the user navigates to the service templates listing
+    Then the pagination info shows the total count
+    When the user changes the rows per page to 10
+    Then at most 10 rows are displayed
+
+  @TEST_LISTING-192
+  Scenario: Bulk duplication works
+    When the user navigates to the service templates listing
+    And the user selects a service template and duplicates it
+    Then a duplicated service template appears in the listing
+
+  @TEST_LISTING-193
+  Scenario: Bulk deletion works
+    When the user navigates to the service templates listing
+    And the user selects a service template and deletes it
+    Then the service template is removed from the listing
+
+  @TEST_LISTING-194
+  Scenario: Clicking a name navigates to the edit form
+    When the user navigates to the service templates listing
+    And the user clicks on a service template name
+    Then the service template edit form is displayed
+
+  @TEST_LISTING-195
+  Scenario: Session state persists across navigation
+    When the user navigates to the service templates listing
+    And the user searches for a specific service template
+    And the user clicks on a service template name
+    And the user navigates back to the service templates listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing/index.ts
@@ -66,7 +66,10 @@ When('the user navigates to the service templates listing', () => {
 
 Then('the AJAX listing table is displayed with service template rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('st_test_alpha').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_alpha')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -80,8 +83,14 @@ When('the user searches for a specific service template', () => {
 });
 
 Then('only the matching service template is displayed', () => {
-  cy.getIframeBody().find('#clTableBody').contains('st_test_alpha').should('exist');
-  cy.getIframeBody().find('#clTableBody').contains('st_test_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_alpha')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_beta')
+    .should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -129,7 +138,7 @@ Then('service template rows show scheduling intervals', () => {
 When('the locked checkbox is checked', () => {
   cy.getIframeBody()
     .find('#displayLocked')
-    .then($cb => {
+    .then(($cb) => {
       if (!$cb.is(':checked')) {
         cy.wrap($cb).click();
         cy.getIframeBody().find('#clSearchBtn').click();
@@ -155,8 +164,8 @@ Then('locked service templates are hidden', () => {
   cy.getIframeBody()
     .find('#clTableBody tr')
     .its('length')
-    .then(countWithout => {
-      cy.get('@countWithLocked').then(countWith => {
+    .then((countWithout) => {
+      cy.get('@countWithLocked').then((countWith) => {
         expect(countWithout).to.be.at.most(countWith as unknown as number);
       });
     });
@@ -183,9 +192,7 @@ Then('locked rows have disabled duplication inputs', () => {
 // ---------------------------------------------------------------------------
 
 Then('no toggle switch is present in the listing', () => {
-  cy.getIframeBody()
-    .find('#clTableBody .cl-toggle')
-    .should('not.exist');
+  cy.getIframeBody().find('#clTableBody .cl-toggle').should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -207,9 +214,7 @@ When('the user changes the rows per page to 10', () => {
 });
 
 Then('at most 10 rows are displayed', () => {
-  cy.getIframeBody()
-    .find('#clTableBody tr')
-    .should('have.length.at.most', 10);
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.at.most', 10);
 });
 
 // ---------------------------------------------------------------------------
@@ -225,14 +230,21 @@ When('the user selects a service template and duplicates it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated service template appears in the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('st_test_alpha_1').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_alpha_1')
+    .should('exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -248,14 +260,21 @@ When('the user selects a service template and deletes it', () => {
     .click();
   cy.getIframeBody()
     .find('select[name="o1"]')
-    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
   cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the service template is removed from the listing', () => {
   cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
   waitForAjaxRefresh();
-  cy.getIframeBody().find('#clTableBody').contains('st_test_beta').should('not.exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_beta')
+    .should('not.exist');
 });
 
 // ---------------------------------------------------------------------------
@@ -263,12 +282,20 @@ Then('the service template is removed from the listing', () => {
 // ---------------------------------------------------------------------------
 
 When('the user clicks on a service template name', () => {
-  cy.getIframeBody().find('#clTableBody').contains('a', 'st_test_alpha').click();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'st_test_alpha')
+    .click();
 });
 
 Then('the service template edit form is displayed', () => {
-  cy.waitForElementInIframe('#main-content', 'input[name="service_description"]');
-  cy.getIframeBody().find('input[name="service_description"]').should('have.value', 'st_test_alpha');
+  cy.waitForElementInIframe(
+    '#main-content',
+    'input[name="service_description"]'
+  );
+  cy.getIframeBody()
+    .find('input[name="service_description"]')
+    .should('have.value', 'st_test_alpha');
 });
 
 // ---------------------------------------------------------------------------
@@ -282,5 +309,7 @@ When('the user navigates back to the service templates listing', () => {
 });
 
 Then('the search field still contains the search term', () => {
-  cy.getIframeBody().find('#clSearchInput').should('have.value', 'st_test_alpha');
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'st_test_alpha');
 });

--- a/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/21-service-template-listing/index.ts
@@ -1,0 +1,286 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const stPage = PAGES.configuration.servicesTemplatesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(stPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('several service templates exist', () => {
+  cy.addServiceTemplate({
+    name: 'st_test_alpha',
+    template: 'generic-active-service'
+  });
+  cy.addServiceTemplate({
+    name: 'st_test_beta',
+    template: 'generic-active-service'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service templates listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with service template rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('st_test_alpha').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific service template', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('st_test_alpha');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching service template is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('st_test_alpha').should('exist');
+  cy.getIframeBody().find('#clTableBody').contains('st_test_beta').should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Icon display
+// ---------------------------------------------------------------------------
+
+Then('each row displays a service icon', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('img[src*="service"]')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Template chain
+// ---------------------------------------------------------------------------
+
+Then('service template rows show the parent template chain as links', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_alpha')
+    .parents('tr')
+    .find('a[href*="p=60206"]')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Scheduling intervals
+// ---------------------------------------------------------------------------
+
+Then('service template rows show scheduling intervals', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_alpha')
+    .parents('tr')
+    .invoke('text')
+    .should('match', /min|sec/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked checkbox
+// ---------------------------------------------------------------------------
+
+When('the locked checkbox is checked', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .then($cb => {
+      if (!$cb.is(':checked')) {
+        cy.wrap($cb).click();
+        cy.getIframeBody().find('#clSearchBtn').click();
+        waitForAjaxRefresh();
+      }
+    });
+});
+
+Then('locked service templates are visible', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .as('countWithLocked');
+});
+
+When('the user unchecks the locked checkbox and searches', () => {
+  cy.getIframeBody().find('#displayLocked').uncheck();
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('locked service templates are hidden', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .then(countWithout => {
+      cy.get('@countWithLocked').then(countWith => {
+        expect(countWithout).to.be.at.most(countWith as unknown as number);
+      });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked rows disabled
+// ---------------------------------------------------------------------------
+
+Then('locked rows have disabled selection checkboxes', () => {
+  cy.getIframeBody()
+    .find('#clTableBody .cl-col-picker input[type="checkbox"][disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('locked rows have disabled duplication inputs', () => {
+  cy.getIframeBody()
+    .find('#clTableBody input.cl-dup-input[disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: No toggle
+// ---------------------------------------------------------------------------
+
+Then('no toggle switch is present in the listing', () => {
+  cy.getIframeBody()
+    .find('#clTableBody .cl-toggle')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('at most 10 rows are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a service template and duplicates it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_alpha')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
+});
+
+Then('a duplicated service template appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('st_test_alpha_1').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects a service template and deletes it', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('st_test_beta')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke('attr', 'onchange', "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }");
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
+});
+
+Then('the service template is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody().find('#clTableBody').contains('st_test_beta').should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a service template name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'st_test_alpha').click();
+});
+
+Then('the service template edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="service_description"]');
+  cy.getIframeBody().find('input[name="service_description"]').should('have.value', 'st_test_alpha');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the service templates listing', () => {
+  cy.visit(stPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'st_test_alpha');
+});

--- a/centreon/www/include/common/autoNumLimit.php
+++ b/centreon/www/include/common/autoNumLimit.php
@@ -37,13 +37,8 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 } elseif (isset($_SESSION[$sessionLimitKey])) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
-    if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-    } else {
-        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-    }
-    $gopt = $dbResult->fetch();
-    $limit = (int) $gopt['value'] ?: 30;
+    $optionKey = (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) ? 'maxViewMonitoring' : 'maxViewConfiguration';
+    $limit = (int) ($centreon->optGen[$optionKey] ?? 30) ?: 30;
 }
 
 $_SESSION[$sessionLimitKey] = $limit;

--- a/centreon/www/include/configuration/configObject/service_template_model/ajaxServiceTemplateListing.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/ajaxServiceTemplateListing.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+// Make $pearDB available as global for common-Func.php functions
+$GLOBALS['pearDB'] = $pearDB;
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// ACL: require at least read access on service templates page (60206)
+if (! $helper->isAdmin()) {
+    $acl = $helper->getAcl();
+    if (! $acl || $acl->page(60206) === 0) {
+        AjaxListingHelper::jsonError('Access denied', 403);
+    }
+}
+
+// Extra filter: display locked elements
+$displayLocked = filter_var($_GET['displayLocked'] ?? '0', FILTER_VALIDATE_BOOLEAN);
+
+// Include common functions for template chain, icon inheritance, intervals
+require_once _CENTREON_PATH_ . '/www/include/common/common-Func.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonMedia.class.php';
+
+// Get interval_length from options
+$optStmt = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'interval_length'");
+$intervalLength = (int) ($optStmt->fetchColumn() ?: 60);
+
+$mediaObj = new CentreonMedia($pearDB);
+
+// Build query
+$searchCond = '';
+$bindParams = [];
+if ($search !== '') {
+    $searchCond = 'AND (sv.service_description LIKE :search OR sv.service_alias LIKE :search) ';
+    $bindParams[':search'] = '%' . $search . '%';
+}
+
+$lockedFilter = $displayLocked ? '' : 'AND sv.service_locked = 0 ';
+
+$statement = $pearDB->prepare(
+    "SELECT SQL_CALC_FOUND_ROWS sv.service_id, sv.service_description, sv.service_alias,"
+    . " sv.service_template_model_stm_id, sv.service_locked, sv.service_activate,"
+    . " sv.service_normal_check_interval, sv.service_retry_check_interval"
+    . " FROM service sv"
+    . " WHERE sv.service_register = '0'"
+    . " {$searchCond}"
+    . " {$lockedFilter}"
+    . " ORDER BY sv.service_description"
+    . " LIMIT :offset, :limit"
+);
+
+foreach ($bindParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($svc = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $svcId = (int) $svc['service_id'];
+
+    // Name — fallback to template chain if empty
+    $name = $svc['service_description'];
+    if (! $name) {
+        $name = getMyServiceName($svc['service_template_model_stm_id']);
+    }
+    $name = str_replace(['#S#', '#BS#', '#BR#', '#T#', '#R#'], ['/', '\\', "\n", "\t", "\r"], $name ?: '');
+
+    // Alias
+    $alias = str_replace(['#S#', '#BS#', '#BR#', '#T#', '#R#'], ['/', '\\', "\n", "\t", "\r"], $svc['service_alias'] ?: '');
+
+    // Scheduling: normal / retry intervals
+    $normalInterval = (int) getMyServiceField($svcId, 'service_normal_check_interval') * $intervalLength;
+    $retryInterval  = (int) getMyServiceField($svcId, 'service_retry_check_interval') * $intervalLength;
+
+    if ($normalInterval % 60 === 0) {
+        $normalStr = ($normalInterval / 60) . ' min';
+    } else {
+        $normalStr = $normalInterval . ' sec';
+    }
+    if ($retryInterval % 60 === 0) {
+        $retryStr = ($retryInterval / 60) . ' min';
+    } else {
+        $retryStr = $retryInterval . ' sec';
+    }
+
+    // Template chain
+    $tplArr = getMyServiceTemplateModels($svc['service_template_model_stm_id']);
+    $tplLinks = [];
+    if (is_array($tplArr) && count($tplArr)) {
+        foreach ($tplArr as $tplId => $tplName) {
+            $tplName = str_replace(['#S#', '#BS#'], ['/', '\\'], $tplName);
+            $tplLinks[] = ['id' => (int) $tplId, 'name' => $tplName];
+        }
+    }
+
+    // Icon (with template inheritance, fallback to default SVG)
+    $iconId = getMyServiceExtendedInfoField($svcId, 'esi_icon_image');
+    $iconFile = $iconId ? $mediaObj->getFilename($iconId) : null;
+    $icon = $iconFile ? './img/media/' . $iconFile : './img/icons/service.svg';
+
+    $rows[] = [
+        'id'         => $svcId,
+        'name'       => $name,
+        'alias'      => $alias,
+        'scheduling' => "{$normalStr} / {$retryStr}",
+        'templates'  => $tplLinks,
+        'icon'       => $icon,
+        'locked'     => (int) ($svc['service_locked'] ?? 0),
+        'activate'   => $svc['service_activate'] ?? '1',
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -9,10 +9,13 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 {/literal}
 
 <form name='form' method='POST'>
-    <h1 class="cl-page-title">{t}Service templates{/t}</h1>
-    <p class="cl-page-desc">{t}Define reusable service configurations to apply across your services.{/t}</p>
+    <div class="cl-page-header">
+        <h1 class="cl-page-title">{t}Service templates{/t}</h1>
+        <span class="cl-page-title-sep"></span>
+        <p class="cl-page-desc">{t}Define reusable service configurations to apply across your services.{/t}</p>
+    </div>
     <div class="cl-listing-container">
-        <div class="cl-actions-bar">
+        <div class="cl-actions-bar cl-actions-bar--centered">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$stPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
@@ -21,35 +24,36 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-toolbar-right">
-                <div class="cl-search">
+            <div class="cl-toolbar-center">
+                <div class="cl-search cl-search--with-adv">
                     <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                     <input type="text" id="clSearchInput" name="searchST" value="{$searchST}" class="cl-search-simple" placeholder="{t}Search service templates{/t}" autocomplete="off">
-                </div>
-                <button type="button" class="cl-adv-btn" data-cl-adv-panel="clAdvPanel" data-cl-label-show="{t}Advanced filters{/t}" data-cl-label-hide="{t}Hide filters{/t}" onclick="clToggleAdvancedFilters(this)">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
-                    <span class="cl-adv-label">{t}Advanced filters{/t}</span>
-                </button>
-                <span class="cl-toolbar-sep"></span>
-                <div class="cl-pagination" id="clPaginationTop"></div>
-            </div>
-        </div>
+                    <button type="button" class="cl-adv-icon-btn" data-cl-adv-panel="clAdvPanel" onclick="clToggleAdvancedFilters(this)" title="{t}Advanced filters{/t}">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+                        <span class="cl-adv-badge"></span>
+                    </button>
 
-        <div class="cl-adv-panel" id="clAdvPanel">
-            <div class="cl-adv-inner">
-                <div class="cl-adv-fields">
-                    <div class="cl-filter-toggle">
-                        <label class="cl-toggle">
-                            <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
-                            <span class="cl-toggle-slider"></span>
-                        </label>
-                        <span>{t}Locked{/t}</span>
+                    <div class="cl-adv-panel cl-adv-panel--popover" id="clAdvPanel">
+                        <div class="cl-adv-inner">
+                            <div class="cl-adv-fields">
+                                <div class="cl-filter-toggle">
+                                    <label class="cl-toggle">
+                                        <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
+                                        <span class="cl-toggle-slider"></span>
+                                    </label>
+                                    <span>{t}Locked{/t}</span>
+                                </div>
+                            </div>
+                            <div class="cl-adv-actions">
+                                <button type="button" class="cl-adv-clear" onclick="jQuery('#displayLocked').prop('checked', false); document.getElementById('clSearchBtn').click();">{t}Clear{/t}</button>
+                                <button type="button" id="clSearchBtn" class="cl-adv-search">{t}Search{/t}</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div class="cl-adv-actions">
-                    <button type="button" class="cl-adv-clear" onclick="jQuery('#displayLocked').prop('checked', false); document.getElementById('clSearchBtn').click();">{t}Clear{/t}</button>
-                    <button type="button" id="clSearchBtn" class="cl-adv-search">{t}Search{/t}</button>
-                </div>
+            </div>
+            <div class="cl-toolbar-right">
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
         </div>
 

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -125,14 +125,14 @@ var stListing = new CentreonListing({
                     // Default icon: inline SVG (currentColor) instead of the flat-black
                     // raster fallback, so it follows the row's text color in dark mode.
                     ? '<svg viewBox="0 0 24 24" width="14" height="14" style="vertical-align:middle;padding-right:4px;" fill="currentColor"><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="5" r="1.3"/><circle cx="17.5" cy="7.5" r="1.1"/><circle cx="19" cy="12" r="1.3"/><circle cx="17.5" cy="16.5" r="1.1"/><circle cx="12" cy="19" r="1.3"/><circle cx="6.5" cy="16.5" r="1.1"/><circle cx="5" cy="12" r="1.3"/><circle cx="6.5" cy="7.5" r="1.1"/></svg>'
-                    : '<img src="'+row.icon+'" class="ico-14" style="padding-right:4px;"/>')
+                    : '<img src="'+clEscapeAttr(row.icon)+'" class="ico-14" style="padding-right:4px;"/>')
                 : '';
             var link = 'main.get.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
-            return icon + '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
+            return icon + '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
             var link = 'main.get.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
-            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+clEscapeAttr(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'scheduling', align:'center' },
         { id:'templates', render: function(row, l) {

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -159,7 +159,13 @@ var stListing = new CentreonListing({
     },
     columns: [
         { id:'name', render: function(row, l) {
-            var icon = row.icon ? '<img src="'+row.icon+'" class="ico-14" style="padding-right:4px;"/>' : '';
+            var icon = row.icon
+                ? (row.icon === './img/icons/service.svg'
+                    // Default icon: inline SVG (currentColor) instead of the flat-black
+                    // raster fallback, so it follows the row's text color in dark mode.
+                    ? '<svg viewBox="0 0 24 24" width="14" height="14" style="vertical-align:middle;padding-right:4px;" fill="currentColor"><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="5" r="1.3"/><circle cx="17.5" cy="7.5" r="1.1"/><circle cx="19" cy="12" r="1.3"/><circle cx="17.5" cy="16.5" r="1.1"/><circle cx="12" cy="19" r="1.3"/><circle cx="6.5" cy="16.5" r="1.1"/><circle cx="5" cy="12" r="1.3"/><circle cx="6.5" cy="7.5" r="1.1"/></svg>'
+                    : '<img src="'+row.icon+'" class="ico-14" style="padding-right:4px;"/>')
+                : '';
             var link = 'main.get.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
             return icon + '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -1,29 +1,56 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
 
-<form name='form' method='POST'>
-    <div class="cl-filter-box">
-        <div class="cl-filter-bar">
-            <span class="cl-filter-label">{t}Service template{/t}</span>
-            <input type="text" id="clSearchInput" name="searchST" value="{$searchST}" class="cl-search-input" placeholder="{t}Name or alias{/t}" style="max-width:none;width:220px;">
-            <div class="md-checkbox md-checkbox-inline" style="margin:0;">
-                <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
-                <label for="displayLocked">{t}Locked{/t}</label>
-            </div>
-            <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
-        </div>
-    </div>
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
 
+<form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Service templates{/t}</h1>
+    <p class="cl-page-desc">{t}Define reusable service configurations to apply across your services.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             { if $mode_access == 'w' }
             <div class="cl-actions-left">
-                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$stPage}&o=a', '{$msg.addT}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
             </div>
             { else }
             <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            <div class="cl-pagination" id="clPaginationTop"></div>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchST" value="{$searchST}" class="cl-search-simple" placeholder="{t}Search service templates{/t}" autocomplete="off">
+                </div>
+                <button type="button" class="cl-adv-btn" data-cl-adv-panel="clAdvPanel" data-cl-label-show="{t}Advanced filters{/t}" data-cl-label-hide="{t}Hide filters{/t}" onclick="clToggleAdvancedFilters(this)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+                    <span class="cl-adv-label">{t}Advanced filters{/t}</span>
+                </button>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <div class="cl-adv-panel" id="clAdvPanel">
+            <div class="cl-adv-inner">
+                <div class="cl-adv-fields">
+                    <div class="cl-filter-toggle">
+                        <label class="cl-toggle">
+                            <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
+                            <span class="cl-toggle-slider"></span>
+                        </label>
+                        <span>{t}Locked{/t}</span>
+                    </div>
+                </div>
+                <div class="cl-adv-actions">
+                    <button type="button" class="cl-adv-clear" onclick="jQuery('#displayLocked').prop('checked', false); document.getElementById('clSearchBtn').click();">{t}Clear{/t}</button>
+                    <button type="button" id="clSearchBtn" class="cl-adv-search">{t}Search{/t}</button>
+                </div>
+            </div>
         </div>
 
         <table class="cl-listing-table">
@@ -40,7 +67,7 @@
                     <th class="cl-col-center">{$headerMenu_retry}</th>
                     <th>{$headerMenu_parent}</th>
                     { if $mode_access == 'w' }
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     { /if }
                 </tr>
             </thead>
@@ -49,16 +76,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            { if $mode_access == 'w' }
-            <div class="cl-actions-left">
-                {$form.o2.html}
-            </div>
-            { else }
-            <div>&nbsp;</div>
-            { /if }
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -66,8 +83,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById("cfSidePanelTitle").textContent = title || "";
+    document.getElementById("cfSidePanelFrame").src = url;
+    document.getElementById("cfSideOverlay").classList.add("open");
+    document.getElementById("cfSidePanel").classList.add("open");
+}
+function cfClosePanel() {
+    document.getElementById("cfSideOverlay").classList.remove("open");
+    document.getElementById("cfSidePanel").classList.remove("open");
+    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
+    stListing.fetch(stListing.getState().num, stListing.getState().limit, stListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById("cfSidePanelResize");
+    var panel = document.getElementById("cfSidePanel");
+    var dragging = false;
+    handle.addEventListener("mousedown", function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add("active");
+        document.body.style.cursor = "col-resize";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "none";
+    });
+    document.addEventListener("mousemove", function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + "px";
+    });
+    document.addEventListener("mouseup", function() {
+        if (!dragging) return; dragging = false; handle.classList.remove("active");
+        document.body.style.cursor = "";
+        var iframe = document.getElementById("cfSidePanelFrame");
+        if (iframe) iframe.style.pointerEvents = "";
+    });
+})();
+document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
+
 var stListing = new CentreonListing({
     instanceName:  'stListing',
     ajaxListUrl:   './include/configuration/configObject/service_template_model/ajaxServiceTemplateListing.php',
@@ -78,6 +145,7 @@ var stListing = new CentreonListing({
     storageKey:    'st_listing_limit',
     emptyMessage:  'No service templates found',
     autoRefresh:   30000,
+    liveSearch:    true,
     rowIdField:    'id',
     lockedField:   'locked',
     extraParams:   function() {
@@ -88,12 +156,12 @@ var stListing = new CentreonListing({
     columns: [
         { id:'name', render: function(row, l) {
             var icon = row.icon ? '<img src="'+row.icon+'" class="ico-14" style="padding-right:4px;"/>' : '';
-            var link = 'main.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
-            return icon + '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+            var link = 'main.get.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
+            return icon + '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.name)+'</a>';
         }},
         { id:'alias', render: function(row, l) {
-            var link = 'main.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
-            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+            var link = 'main.get.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
+            return '<a href="#" onclick="cfOpenPanel(\''+link+'\', \''+l.escape(row.name||row.desc||row.alias||'')+'\'); return false;">'+l.escape(row.alias||'')+'</a>';
         }},
         { id:'scheduling', align:'center' },
         { id:'templates', render: function(row, l) {

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -2,9 +2,7 @@
 
 {literal}
 <script type="text/javascript">
-if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
-    try { window.parent.cfClosePanel(); } catch(e) {}
-}
+CentreonForm.detectSidePanelClose();
 </script>
 {/literal}
 
@@ -102,43 +100,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById("cfSidePanelTitle").textContent = title || "";
-    document.getElementById("cfSidePanelFrame").src = url;
-    document.getElementById("cfSideOverlay").classList.add("open");
-    document.getElementById("cfSidePanel").classList.add("open");
-}
-function cfClosePanel() {
-    document.getElementById("cfSideOverlay").classList.remove("open");
-    document.getElementById("cfSidePanel").classList.remove("open");
-    setTimeout(function() { document.getElementById("cfSidePanelFrame").src = "about:blank"; }, 300);
-    stListing.fetch(stListing.getState().num, stListing.getState().limit, stListing.getState().search, true);
-}
-(function() {
-    var handle = document.getElementById("cfSidePanelResize");
-    var panel = document.getElementById("cfSidePanel");
-    var dragging = false;
-    handle.addEventListener("mousedown", function(e) {
-        e.preventDefault(); dragging = true; handle.classList.add("active");
-        document.body.style.cursor = "col-resize";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "none";
-    });
-    document.addEventListener("mousemove", function(e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + "px";
-    });
-    document.addEventListener("mouseup", function() {
-        if (!dragging) return; dragging = false; handle.classList.remove("active");
-        document.body.style.cursor = "";
-        var iframe = document.getElementById("cfSidePanelFrame");
-        if (iframe) iframe.style.pointerEvents = "";
-    });
-})();
-document.addEventListener("keydown", function(e) { if (e.key === "Escape") cfClosePanel(); });
-
 var stListing = new CentreonListing({
     instanceName:  'stListing',
     ajaxListUrl:   './include/configuration/configObject/service_template_model/ajaxServiceTemplateListing.php',
@@ -196,5 +157,6 @@ document.getElementById('displayLocked').addEventListener('change', function() {
 });
 
 stListing.init();
+CentreonForm.initSidePanel(stListing);
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -1,92 +1,122 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type="text/javascript" src="./include/common/javascript/resize_td.js"></script>
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Service template{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchST" value="{$searchST}"></td>
-            <td>
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
-                    <label for="displayLocked">{t}Locked elements{/t}</label>
-                </div>
-            </td>
-            <td><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
+    <div class="cl-filter-box">
+        <div class="cl-filter-bar">
+            <span class="cl-filter-label">{t}Service template{/t}</span>
+            <input type="text" id="clSearchInput" name="searchST" value="{$searchST}" class="cl-search-input" placeholder="{t}Name or alias{/t}" style="max-width:none;width:220px;">
+            <div class="md-checkbox md-checkbox-inline" style="margin:0;">
+                <input type="checkbox" id="displayLocked" name="displayLocked" {if $displayLocked}checked{/if} />
+                <label for="displayLocked">{t}Locked{/t}</label>
+            </div>
+            <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+        </div>
+    </div>
+
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
             { if $mode_access == 'w' }
-            <td>
+            <div class="cl-actions-left">
+                <a href="{$msg.addL}" class="cl-btn-add">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div class="cl-actions-left">&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_alias}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_retry}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_parent}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft">
-                {if $elemArr[elem].RowMenu_icon != ""}<img src="{$elemArr[elem].RowMenu_icon}" class="ico-14"
-                                                           style="padding-right:4px;"/>{/if}<a
-                    href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a>
-            </td>
-            <td class="ListColLeft resizeTitle"><a
-                    href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_retry}</td>
-            <td class="ListColLeft">{$elemArr[elem].RowMenu_parent}</td>
-            <td class="ListColRight" align="right">{if $mode_access == 'w'}{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-    <table class="ToolbarTable ToolbarTR table">
-        <tr>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="stListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_desc}</th>
+                    <th>{$headerMenu_alias}</th>
+                    <th class="cl-col-center">{$headerMenu_retry}</th>
+                    <th>{$headerMenu_parent}</th>
+                    { if $mode_access == 'w' }
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    { /if }
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
             { if $mode_access == 'w' }
-            <td class="Toolbar_TDSelectAction_Bottom">
+            <div class="cl-actions-left">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
+            </div>
             { else }
-            <td>&nbsp;</td>
+            <div>&nbsp;</div>
             { /if }
-            {pagination}
-        </tr>
-    </table>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
 
-    <input type='hidden' name='o' id='o' value='42'>
-
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
-    setOverflowDivToTitle(('.resizeTitle'));
+<script type="text/javascript">
+var stListing = new CentreonListing({
+    instanceName:  'stListing',
+    ajaxListUrl:   './include/configuration/configObject/service_template_model/ajaxServiceTemplateListing.php',
+    ajaxToggleUrl: '',
+    pageId:        {/literal}'{$stPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'st_listing_limit',
+    emptyMessage:  'No service templates found',
+    autoRefresh:   30000,
+    rowIdField:    'id',
+    lockedField:   'locked',
+    extraParams:   function() {
+        return {
+            displayLocked: document.getElementById('displayLocked').checked ? '1' : '0'
+        };
+    },
+    columns: [
+        { id:'name', render: function(row, l) {
+            var icon = row.icon ? '<img src="'+row.icon+'" class="ico-14" style="padding-right:4px;"/>' : '';
+            var link = 'main.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
+            return icon + '<a href="'+link+'">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'alias', render: function(row, l) {
+            var link = 'main.php?p={/literal}{$stPage}{literal}&o=c&service_id=' + row.id;
+            return '<a href="'+link+'">'+l.escape(row.alias||'')+'</a>';
+        }},
+        { id:'scheduling', align:'center' },
+        { id:'templates', render: function(row, l) {
+            if (!row.templates || !row.templates.length) return '';
+            var parts = [];
+            for (var i = 0; i < row.templates.length; i++) {
+                var t = row.templates[i];
+                parts.push('<a href="main.php?p={/literal}{$stPage}{literal}&o=c&service_id='+t.id+'">'+l.escape(t.name)+'</a>');
+            }
+            return parts.join(' &rarr; ');
+        }}
+    ],
+    renderOptions: function(row) {
+        var dupDisabled = row.locked ? ' disabled' : '';
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"'+dupDisabled+'/>';
+    }
+});
+
+// Locked checkbox triggers reload
+document.getElementById('displayLocked').addEventListener('change', function() {
+    stListing.fetch(0, stListing.getState().limit, stListing.getState().search);
+});
+
+stListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
@@ -23,63 +23,6 @@ if (! isset($centreon)) {
     exit();
 }
 
-include_once './class/centreonUtils.class.php';
-
-// Object init
-$mediaObj = new CentreonMedia($pearDB);
-
-include './include/common/autoNumLimit.php';
-
-$o = '';
-
-$search =  htmlspecialchars($_POST['searchST'] ?? $_GET['searchST'] ?? $centreon->historySearch[$url]['search'] ?? '');
-
-$displayLocked = filter_var(
-    $_POST['displayLocked'] ?? $_GET['displayLocked'] ?? 'off',
-    FILTER_VALIDATE_BOOLEAN
-);
-
-// keep checkbox state if navigating in pagination
-// this trick is mandatory cause unchecked checkboxes do not post any data
-if (
-    isset($centreon->historyPage[$url])
-    && ($centreon->historyPage[$url] > 0 || $num !== 0)
-    && isset($centreon->historySearch[$url]['displayLocked'])
-) {
-    $displayLocked = $centreon->historySearch[$url]['displayLocked'];
-}
-
-// store filters in session
-$centreon->historySearch[$url] = [
-    'search' => $search,
-    'displayLocked' => $displayLocked,
-];
-
-// Locked filter
-$lockedFilter = $displayLocked ? '' : 'AND sv.service_locked = 0 ';
-
-// Service Template Model list
-if ($search) {
-    $statement = $pearDB->prepare('SELECT SQL_CALC_FOUND_ROWS sv.service_id, sv.service_description,'
-        . ' sv.service_alias, sv.service_template_model_stm_id FROM service sv '
-        . 'WHERE (sv.service_description LIKE :search OR sv.service_alias LIKE :search) '
-        . "AND sv.service_register = '0' "
-        . $lockedFilter
-        . 'ORDER BY service_description LIMIT :scope, :limit');
-    $statement->bindValue(':search', '%' . $search . '%', PDO::PARAM_STR);
-} else {
-    $statement = $pearDB->prepare('SELECT SQL_CALC_FOUND_ROWS sv.service_id, sv.service_description,'
-        . ' sv.service_alias, sv.service_template_model_stm_id FROM service sv '
-        . "WHERE sv.service_register = '0' " . $lockedFilter
-        . 'ORDER BY service_description LIMIT :scope, :limit');
-}
-$statement->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
-$statement->bindValue(':scope', (int) $num * (int) $limit, PDO::PARAM_INT);
-$statement->execute();
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
@@ -87,193 +30,95 @@ $tpl = SmartyBC::createSmartyTemplate($path);
 $lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
 $tpl->assign('mode_access', $lvl_access);
 
-// start header menu
+// Header labels
 $tpl->assign('headerMenu_desc', _('Name'));
 $tpl->assign('headerMenu_alias', _('Alias'));
 $tpl->assign('headerMenu_retry', _('Scheduling'));
 $tpl->assign('headerMenu_parent', _('Templates'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-$search = tidySearchKey($search, $advanced_search);
-
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-
-$interval_length = $oreon->optGen['interval_length'];
-
-$search = str_replace('#S#', '/', $search);
-$search = str_replace('#BS#', '\\', $search);
-
-$centreonToken = createCSRFToken();
-
-for ($i = 0; $service = $statement->fetch(); $i++) {
-    $moptions = '';
-    $selectedElements = $form->addElement('checkbox', 'select[' . $service['service_id'] . ']');
-    if (isset($lockedElements[$service['service_id']])) {
-        $selectedElements->setAttribute('disabled', 'disabled');
-    } else {
-        $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-            . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-            . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-            . $service['service_id'] . "]' />";
-    }
-
-    /*If the description of our Service Model is in the Template definition,
-     we have to catch it, whatever the level of it :-) */
-    if (! $service['service_description']) {
-        $service['service_description'] = getMyServiceName($service['service_template_model_stm_id']);
-    }
-
-    // TPL List
-    $tplArr = [];
-    $tplStr = '';
-    $tplArr = getMyServiceTemplateModels($service['service_template_model_stm_id']);
-
-    if ((is_countable($tplArr)) && count($tplArr)) {
-        foreach ($tplArr as $key => $value) {
-            $value = str_replace('#S#', '/', $value);
-            $value = str_replace('#BS#', '\\', $value);
-            $tplStr .= "&nbsp;->&nbsp;<a href='main.php?p=60206&o=c&service_id=" . $key . "'>"
-            . htmlentities($value) . '</a>';
-        }
-    }
-
-    $service['service_description'] = str_replace('#BR#', "\n", $service['service_description']);
-    $service['service_description'] = str_replace('#T#', "\t", $service['service_description']);
-    $service['service_description'] = str_replace('#R#', "\r", $service['service_description']);
-    $service['service_description'] = str_replace('#S#', '/', $service['service_description']);
-    $service['service_description'] = str_replace('#BS#', '\\', $service['service_description']);
-
-    $service['service_alias'] = str_replace('#BR#', "\n", $service['service_alias']);
-    $service['service_alias'] = str_replace('#T#', "\t", $service['service_alias']);
-    $service['service_alias'] = str_replace('#R#', "\r", $service['service_alias']);
-    $service['service_alias'] = str_replace('#S#', '/', $service['service_alias']);
-    $service['service_alias'] = str_replace('#BS#', '\\', $service['service_alias']);
-
-    // Get service intervals in seconds
-    $normal_check_interval
-        = getMyServiceField($service['service_id'], 'service_normal_check_interval') * $interval_length;
-    $retry_check_interval
-        = getMyServiceField($service['service_id'], 'service_retry_check_interval') * $interval_length;
-
-    if ($normal_check_interval % 60 == 0) {
-        $normal_units = 'min';
-        $normal_check_interval = $normal_check_interval / 60;
-    } else {
-        $normal_units = 'sec';
-    }
-
-    if ($retry_check_interval % 60 == 0) {
-        $retry_units = 'min';
-        $retry_check_interval = $retry_check_interval / 60;
-    } else {
-        $retry_units = 'sec';
-    }
-
-    if (isset($service['esi_icon_image']) && $service['esi_icon_image']) {
-        $svc_icon = './img/media/' . $mediaObj->getFilename($service['esi_icon_image']);
-    } elseif (
-        $icone = $mediaObj->getFilename(
-            getMyServiceExtendedInfoField(
-                $service['service_id'],
-                'esi_icon_image'
-            )
-        )
-    ) {
-        $svc_icon = './img/media/' . $icone;
-    } else {
-        $svc_icon = './img/icons/service.png';
-    }
-
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_desc' => htmlentities($service['service_description']), 'RowMenu_alias' => htmlentities($service['service_alias']), 'RowMenu_parent' => $tplStr, 'RowMenu_icon' => $svc_icon, 'RowMenu_retry' => htmlentities(
-        "{$normal_check_interval} {$normal_units} / {$retry_check_interval} {$retry_units}"
-    ), 'RowMenu_attempts' => getMyServiceField($service['service_id'], 'service_max_check_attempts'), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&service_id=' . $service['service_id'], 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
+// Default limit from config
+$defaultLimit = 30;
+$dbResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
+if ($gopt = $dbResult->fetch()) {
+    $defaultLimit = (int) $gopt['value'] ?: 30;
 }
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('defaultLimit', $defaultLimit);
+$tpl->assign('stPage', $p);
 
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
+// Search filters (for initial display)
+$search = htmlspecialchars($_POST['searchST'] ?? $_GET['searchST'] ?? $centreon->historySearch[$url]['search'] ?? '');
+$displayLocked = filter_var(
+    $_POST['displayLocked'] ?? $_GET['displayLocked'] ?? 'off',
+    FILTER_VALIDATE_BOOLEAN
 );
 
-// Toolbar select lgd_more_actions
-?>
-<script type="text/javascript">
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-</script>
-<?php
-$attrs1 = ['onchange' => 'javascript: '
+// Keep checkbox state across pagination
+if (
+    isset($centreon->historyPage[$url])
+    && ($centreon->historyPage[$url] > 0)
+    && isset($centreon->historySearch[$url]['displayLocked'])
+) {
+    $displayLocked = $centreon->historySearch[$url]['displayLocked'];
+}
+
+$centreon->historySearch[$url] = [
+    'search' => $search,
+    'displayLocked' => $displayLocked,
+];
+
+$tpl->assign('searchST', $search);
+$tpl->assign('displayLocked', $displayLocked);
+
+// Messages
+$tpl->assign(
+    'msg',
+    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]
+);
+
+// Bulk action dropdowns
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+
+$setO = "function setO(_i) { document.forms['form'].elements['o'].value = _i; }";
+
+$attrs = ['onchange' => 'javascript: '
     . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
+    . " if (this.form.elements[this.name].selectedIndex != 0 && !bChecked) {"
     . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
+    . "if (this.form.elements[this.name].selectedIndex == 1 && confirm('"
     . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
+    . " setO(this.form.elements[this.name].value); submit();} "
+    . "else if (this.form.elements[this.name].selectedIndex == 2 && confirm('"
     . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3 || this.form.elements['o1'].selectedIndex == 4 "
-    . "||this.form.elements['o1'].selectedIndex == 5){"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "this.form.elements['o1'].selectedIndex = 0"];
+    . " setO(this.form.elements[this.name].value); submit();} "
+    . "else if (this.form.elements[this.name].selectedIndex == 3){"
+    . " setO(this.form.elements[this.name].value); submit();} "
+    . "this.form.elements[this.name].selectedIndex = 0"];
+
 $form->addElement(
     'select',
     'o1',
     null,
     [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'mc' => _('Mass Change')],
-    $attrs1
+    $attrs
 );
-$form->setDefaults(['o1' => null]);
-
-$attrs2 = ['onchange' => 'javascript: '
-    . ' var bChecked = isChecked(); '
-    . " if (this.form.elements['o2'].selectedIndex != 0 && !bChecked) {"
-    . " alert('" . _('Please select one or more items') . "'); return false;} "
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3 || this.form.elements['o2'].selectedIndex == 4 "
-    . "||this.form.elements['o2'].selectedIndex == 5){"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "this.form.elements['o1'].selectedIndex = 0"];
 $form->addElement(
     'select',
     'o2',
     null,
     [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete'), 'mc' => _('Mass Change')],
-    $attrs2
+    $attrs
 );
-$form->setDefaults(['o2' => null]);
+$form->setDefaults(['o1' => null, 'o2' => null]);
 
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
-$tpl->assign('searchST', $search);
-$tpl->assign('displayLocked', $displayLocked);
-
-// Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
+
+?>
+<script type="text/javascript">
+function setO(_i) { document.forms['form'].elements['o'].value = _i; }
+</script>
+<?php
+
 $tpl->display('listServiceTemplateModel.ihtml');

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
@@ -38,11 +38,7 @@ $tpl->assign('headerMenu_parent', _('Templates'));
 $tpl->assign('headerMenu_options', _('Options'));
 
 // Default limit from config
-$defaultLimit = 30;
-$dbResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
-if ($gopt = $dbResult->fetch()) {
-    $defaultLimit = (int) $gopt['value'] ?: 30;
-}
+$defaultLimit = (int) ($centreon->optGen['maxViewConfiguration'] ?? 30) ?: 30;
 $tpl->assign('defaultLimit', $defaultLimit);
 $tpl->assign('stPage', $p);
 


### PR DESCRIPTION
## Summary

Replaces the legacy Smarty-rendered service template listing with an AJAX-driven table using the shared `CentreonListing` framework.

## What changed

### New files (1)

- **`ajaxServiceTemplateListing.php`** — AJAX endpoint with:
  - ACL read access (page 60206)
  - Locked elements filter
  - Service icon with template inheritance + SVG fallback
  - Template chain resolution via `getMyServiceTemplateModels()`
  - Scheduling intervals (normal/retry × `interval_length`)
  - `$GLOBALS['pearDB']` bridge for `common-Func.php` helpers
  - Sanitized search, prepared statements

### Modified files (2)

- **`listServiceTemplateModel.ihtml`** — Filter box with search + locked checkbox. `CentreonListing` with `lockedField` support, dup-only options column (no toggle switch).
- **`listServiceTemplateModel.php`** — Simplified controller (280 → 100 lines).

### Tests (13 scenarios)

1. AJAX listing loads correctly
2. Search filters by name
3. Each row has a service icon
4. Template chain displayed as clickable links
5. Scheduling intervals shown
6. Locked checkbox shows/hides locked templates
7. Locked rows have disabled checkboxes
8. Locked rows have disabled dup inputs
9. No toggle switch present
10. Pagination and rows-per-page
11. Bulk duplication
12. Bulk deletion
13. Session state persistence

## How to test

1. Navigate to Configuration > Services > Templates
2. Verify icon (service.svg) displayed for each row
3. Verify template chain links (generic-active-service-custom → generic-active-service)
4. Test locked checkbox — locked rows should have grayed checkboxes and dup inputs
5. Confirm no toggle column exists
6. Test search, pagination, duplicate, delete
7. Verify no regression on add/edit forms

## Dependencies

Requires PR #10055 (shared listing framework).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Replaced Smarty listing with AJAX-driven CentreonListing and endpoint

**🔧 Refactors**
* Simplified controller and moved filtering, icon, and interval logic


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98628004?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

---

### Security hardening (2026-07-24)

Some of the listing's `render()`/`renderOptions()` callbacks concatenated escaped values directly into HTML attributes (`onclick="cfOpenPanel('...', '...')"` title arguments, `src="..."` icon paths) using `escape()`, which only escapes `&`, `<`, `>` — not quotes. A name/description/alias/icon path containing a quote could break out of the attribute and inject arbitrary `onclick` JavaScript. Fixed by switching those specific call sites to `clEscapeAttr()` (from the shared listing library), which additionally escapes `"` and `'`. Plain text-content escaping (`l.escape()` used outside of an attribute) was left unchanged.
