### PR TITLE
fix(CI): backend-lint fail

### DIFF
--- a/centreon/phpstan.legacy.www.baseline.neon
+++ b/centreon/phpstan.legacy.www.baseline.neon
@@ -419,15 +419,3 @@ parameters:
 			identifier: function.notFound
 			count: 1
 			path: www/include/configuration/configObject/meta_service/DB-Func.php
-
-		-
-			message: '#^Missing parameter \$hostGroupId \(int\) in call to function createNewDatasetFilter\.$#'
-			identifier: argument.missing
-			count: 1
-			path: www/include/configuration/configObject/servicegroup/DB-Func.php
-
-		-
-			message: '#^Unknown parameter \$serviceGroupId in call to function createNewDatasetFilter\.$#'
-			identifier: argument.unknown
-			count: 1
-			path: www/include/configuration/configObject/servicegroup/DB-Func.php

--- a/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
@@ -575,7 +575,7 @@ function updateHostGroupAcl(int $hostGroupId, bool $isCloudPlatform, $submittedV
                         $datasetId = createNewDataset(datasetName: $newDatasetName);
                         linkDatasetToRule(datasetId: $datasetId, ruleId: $ruleId);
                         linkHostGroupToDataset(datasetId: $datasetId, hostGroupId: $hostGroupId);
-                        createNewDatasetFilter(datasetId: $datasetId, ruleId: $ruleId, hostGroupId: $hostGroupId);
+                        createNewHostGroupDatasetFilter(datasetId: $datasetId, ruleId: $ruleId, hostGroupId: $hostGroupId);
                         $pearDB->commit();
                     } catch (Throwable $exception) {
                         $pearDB->rollBack();
@@ -613,7 +613,7 @@ function updateHostGroupAcl(int $hostGroupId, bool $isCloudPlatform, $submittedV
                             $datasetId = createNewDataset(datasetName: $newDatasetName);
                             linkDatasetToRule(datasetId: $datasetId, ruleId: $ruleId);
                             linkHostGroupToDataset(datasetId: $datasetId, hostGroupId: $hostGroupId);
-                            createNewDatasetFilter(datasetId: $datasetId, ruleId: $ruleId, hostGroupId: $hostGroupId);
+                            createNewHostGroupDatasetFilter(datasetId: $datasetId, ruleId: $ruleId, hostGroupId: $hostGroupId);
                             $pearDB->commit();
                         } catch (Throwable $exception) {
                             $pearDB->rollBack();
@@ -798,7 +798,7 @@ function createNewDataset(string $datasetName): int
  * @param int $ruleId
  * @param int $hostGroupId
  */
-function createNewDatasetFilter(int $datasetId, int $ruleId, int $hostGroupId): void
+function createNewHostGroupDatasetFilter(int $datasetId, int $ruleId, int $hostGroupId): void
 {
     global $pearDB;
 

--- a/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -308,7 +308,7 @@ function updateServiceGroupAcl(int $serviceGroupId, array $submittedValues = [])
                     $datasetId = createNewDataset(datasetName: $newDatasetName);
                     linkDatasetToRule(datasetId: $datasetId, ruleId: $ruleId);
                     linkServiceGroupToDataset(datasetId: $datasetId, serviceGroupId: $serviceGroupId);
-                    createNewDatasetFilter(datasetId: $datasetId, ruleId: $ruleId, serviceGroupId: $serviceGroupId);
+                    createNewServiceGroupDatasetFilter(datasetId: $datasetId, ruleId: $ruleId, serviceGroupId: $serviceGroupId);
                     $pearDB->commit();
                 } catch (Throwable $exception) {
                     $pearDB->rollBack();
@@ -377,7 +377,7 @@ function linkServiceGroupToDataset(int $datasetId, int $serviceGroupId): void
  * @param int $ruleId
  * @param int $serviceGroupId
  */
-function createNewDatasetFilter(int $datasetId, int $ruleId, int $serviceGroupId): void
+function createNewServiceGroupDatasetFilter(int $datasetId, int $ruleId, int $serviceGroupId): void
 {
     global $pearDB;
 


### PR DESCRIPTION
## Description

- rename duplicate createNewDatasetFilter functions in hostgroup and servicegroup
- update phpstan baseline


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Renamed duplicate createNewDatasetFilter functions in hostgroup and servicegroup
* Updated PHPStan baseline to reflect recent code changes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98720559?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->