### PR TITLE
fix(ceip): rm harcoded db name (#10022)

### DIFF
--- a/centreon/www/api/class/centreon_ceip.class.php
+++ b/centreon/www/api/class/centreon_ceip.class.php
@@ -55,6 +55,9 @@ class CentreonCeip extends CentreonWebService
     /** @var FeatureFlags */
     private FeatureFlags $featureFlags;
 
+    /** @var CentreonDB */
+    private $pearDBO;
+
     /**
      * CentreonCeip constructor
      *
@@ -64,6 +67,8 @@ class CentreonCeip extends CentreonWebService
      */
     public function __construct()
     {
+        $this->pearDBO = new CentreonDB('centstorage');
+
         parent::__construct();
 
         global $centreon;
@@ -117,11 +122,10 @@ class CentreonCeip extends CentreonWebService
         try {
             $query = <<<'SQL'
                     SELECT `poller_id`, `enabled`, `infos`
-                    FROM `centreon_storage`.`agent_information`
+                    FROM `agent_information`
                 SQL;
-            $statement = $this->pearDB->executeStatement($query);
 
-            $rows = $this->pearDB->fetchAllAssociative($statement);
+            $rows = $this->pearDBO->fetchAllAssociative($query);
             foreach ($rows as $row) {
                 /** @var array{poller_id:int,enabled:int,infos:string} $row */
                 if ((bool) $row['enabled'] === false) {


### PR DESCRIPTION
## Description

Backport of #10022

[MON-197108](https://centreon.atlassian.net/browse/MON-197108)

[MON-197108]: https://centreon.atlassian.net/browse/MON-197108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Removed hardcoded database schema and used CentreonDB instance property for queries


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99016504?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->