### PR TITLE
fix(cfgexport): fix macro parent not retrieved if overrided by child (for host and services) (#9724)

### DIFF
--- a/centreon/www/class/config-generate/host.class.php
+++ b/centreon/www/class/config-generate/host.class.php
@@ -360,7 +360,14 @@ class Host extends AbstractHost
             $isPollerEncryptionReady
         );
 
-        return  Macro::resolveInheritance($existingHostMacros, $inheritanceLine, $hostId);
+        [$directMacros] = Macro::resolveInheritance($existingHostMacros, $inheritanceLine, $hostId);
+
+        $allTemplateMacros = array_filter(
+            $existingHostMacros,
+            fn (Macro $macro): bool => $macro->getOwnerId() !== $hostId
+        );
+
+        return [$directMacros, array_values($allTemplateMacros)];
     }
 
     private function findServiceRelatedMacros(int $hostId, bool $isPollerEncryptionReady): array
@@ -380,9 +387,14 @@ class Host extends AbstractHost
                 $serviceTemplateInheritances
             );
             $existingMacros = $readServiceMacroRepository->findByServiceIds($serviceId, ...$inheritanceLine);
-            [$directMacros, $indirectMacros] = Macro::resolveInheritance($existingMacros, $inheritanceLine, $serviceId);
+            [$directMacros] = Macro::resolveInheritance($existingMacros, $inheritanceLine, $serviceId);
             $serviceMacros = array_merge($serviceMacros, array_values($directMacros));
-            $serviceTemplateMacros = array_merge($serviceTemplateMacros, array_values($indirectMacros));
+
+            $allTemplateMacros = array_filter(
+                $existingMacros,
+                fn (Macro $macro): bool => $macro->getOwnerId() !== $serviceId
+            );
+            $serviceTemplateMacros = array_merge($serviceTemplateMacros, array_values($allTemplateMacros));
         }
 
         array_walk(


### PR DESCRIPTION
## Description

Backport of #9724 to hotfix-26.01-next.

When a macro is overridden in a child resource (host or service template), the parent
resource's macro was missing from the generated export file.

**Fixes** MON-197157


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed parent macros not retrieved when child overrides macros.

**🔧 Refactors**
* Added import statements for repositories and inheritance classes.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99085404?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->