### PR TITLE
fix(configuration): update shell command handling in poller, traps and broker classes

### DIFF
--- a/centreon/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
+++ b/centreon/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
@@ -45,7 +45,7 @@ class RemoteServerRepositoryFile implements RemoteServerLocalConfigurationReposi
     {
         system(
             "sed -i -r 's/(\\\$instance_mode?\s+=?\s+\")([a-z]+)(\";)/\\1central\\3/' "
-            . $this->centreonConfFilePath
+            . escapeshellarg($this->centreonConfFilePath)
         );
     }
 
@@ -56,7 +56,7 @@ class RemoteServerRepositoryFile implements RemoteServerLocalConfigurationReposi
     {
         system(
             "sed -i -r 's/(\\\$instance_mode?\s+=?\s+\")([a-z]+)(\";)/\\1remote\\3/' "
-            . $this->centreonConfFilePath
+            . escapeshellarg($this->centreonConfFilePath)
         );
     }
 }

--- a/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -26,6 +26,7 @@ use Centreon\ServiceProvider;
 use CentreonBroker;
 use CentreonContactgroup;
 use CentreonDB;
+use Core\MonitoringServer\Model\MonitoringServer;
 use Exception;
 use Generate;
 use Pimple\Container;
@@ -139,9 +140,7 @@ class PollerInteractionService
 
         foreach ($tabServer as $host) {
             if (in_array($host['id'], $pollerIDs)) {
-                passthru("echo 'SENDCFGFILE:{$host['id']}' >> {$centCorePipe}", $return);
-
-                if ($return) {
+                if (file_put_contents($centCorePipe, 'SENDCFGFILE:' . (int) $host['id'] . "\n", FILE_APPEND) === false) {
                     throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
                 }
             }
@@ -182,8 +181,11 @@ class PollerInteractionService
 
         foreach ($tabServers as $poller) {
             if (isset($poller['localhost']) && $poller['localhost'] == 1) {
-                if ($poller['engine_restart_command'] != '') {
-                    shell_exec(escapeshellcmd("sudo -n -- {$poller['engine_restart_command']}"));
+                if (
+                    ! empty($poller['engine_restart_command'])
+                    && preg_match(MonitoringServer::VALID_COMMAND_RESTART_REGEX, $poller['engine_restart_command'])
+                ) {
+                    shell_exec('sudo -n -- ' . escapeshellcmd($poller['engine_restart_command']));
                 }
             } elseif ($fh = @fopen($centCorePipe, 'a+')) {
                 fwrite($fh, 'RESTART:' . $poller['id'] . "\n");

--- a/centreon/www/class/centreonBroker.class.php
+++ b/centreon/www/class/centreonBroker.class.php
@@ -47,8 +47,11 @@ class CentreonBroker
      */
     public function reload(): void
     {
-        if ($command = $this->getReloadCommand()) {
-            shell_exec(escapeshellcmd("sudo -n -- {$command}"));
+        if (
+            ($command = $this->getReloadCommand())
+            && preg_match(Core\MonitoringServer\Model\MonitoringServer::VALID_COMMAND_RELOAD_REGEX, $command)
+        ) {
+            shell_exec('sudo -n -- ' . escapeshellcmd($command));
         }
     }
 

--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1213,7 +1213,7 @@ class CentreonGraph
         $commandLine = preg_replace('/(\\$|`)/', '', $commandLine);
         $timezone = $this->GMT->getMyTimezone();
         if (! empty($timezone)) {
-            $gmt_export = "export TZ='" . $timezone . "'; ";
+            $gmt_export = 'export TZ=' . escapeshellarg($timezone) . '; ';
         }
         $this->log($commandLine);
         // Send Binary Data

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -343,11 +343,12 @@ try {
                     ));
                 }
             } else {
-                passthru(
-                    escapeshellcmd("echo 'SENDCFGFILE:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                    $return
+                $written = file_put_contents(
+                    $centcore_pipe,
+                    'SENDCFGFILE:' . (int) $host['id'] . "\n",
+                    FILE_APPEND
                 );
-                if ($return) {
+                if ($written === false) {
                     throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
                 }
                 if (! isset($msg_restart[$host['id']])) {

--- a/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -125,7 +125,10 @@ if ($form->validate()) {
                 $output = [];
                 $returnVal = 0;
                 exec(
-                    escapeshellcmd(_CENTREON_PATH_ . "/bin/generateSqlLite '{$host['id']}' '{$filename}'") . ' 2>&1',
+                    escapeshellarg(_CENTREON_PATH_ . '/bin/generateSqlLite')
+                    . ' ' . escapeshellarg((string) $host['id'])
+                    . ' ' . escapeshellarg($filename)
+                    . ' 2>&1',
                     $output,
                     $returnVal
                 );
@@ -139,11 +142,7 @@ if ($form->validate()) {
         if (isset($ret['apply']) && $ret['apply'] && $returnVal == 0) {
             $msg_generate .= sprintf('<strong>%s</strong><br/>', _('Centcore commands'));
             foreach ($tab_server as $host) {
-                passthru(
-                    escapeshellcmd("echo 'SYNCTRAP:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                    $return
-                );
-                if ($return) {
+                if (file_put_contents($centcore_pipe, 'SYNCTRAP:' . (int) $host['id'] . "\n", FILE_APPEND) === false) {
                     $msg_generate .= "Error while writing into {$centcore_pipe}<br/>";
                 } else {
                     $msg_generate .= "Poller (id:{$host['id']}): SYNCTRAP sent to centcore.cmd<br/>";
@@ -152,11 +151,12 @@ if ($form->validate()) {
         }
         if (isset($ret['signal']) && in_array($ret['signal'], ['RELOADCENTREONTRAPD', 'RESTARTCENTREONTRAPD'])) {
             foreach ($tab_server as $host) {
-                passthru(
-                    escapeshellcmd("echo '{$ret['signal']}:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                    $return
+                $written = file_put_contents(
+                    $centcore_pipe,
+                    $ret['signal'] . ':' . (int) $host['id'] . "\n",
+                    FILE_APPEND
                 );
-                if ($return) {
+                if ($written === false) {
                     $msg_generate .= "Error while writing into {$centcore_pipe}<br/>";
                 } else {
                     $msg_generate .= "Poller (id:{$host['id']}): {$ret['signal']} sent to centcore.cmd<br/>";

--- a/centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+++ b/centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
@@ -87,8 +87,8 @@ if ($form->validate()) {
         $msg .= str_replace("\n", '<br />', $stdout);
         $msg .= '<br />Moving traps in database...';
 
-        $command = "@CENTREONTRAPD_BINDIR@/centFillTrapDB -f '" . $values['tmp_name']
-            . "' -m " . $manufacturerId . ' --severity=info 2>&1';
+        $command = '@CENTREONTRAPD_BINDIR@/centFillTrapDB -f ' . escapeshellarg($values['tmp_name'])
+            . ' -m ' . $manufacturerId . ' --severity=info 2>&1';
 
         if ($debug) {
             echo $command;


### PR DESCRIPTION
## Description

Update shell command handling in several legacy configuration classes:

- Replace `passthru()`/echo pipe writes with `file_put_contents()` in `PollerInteractionService`, `moveFiles` and `formGenerateTraps`
- Add command validation against `MonitoringServer` allowlist before `shell_exec()` in `PollerInteractionService` and `CentreonBroker`
- Use `escapeshellarg()` on file path arguments in `RemoteServerRepositoryFile`, `formMibs` and `centreonGraph`

**Fixes** MON-196793

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Navigate to Configuration > Pollers and generate/export poller configuration — verify it completes without error
2. Navigate to Configuration > Traps > Generate traps — verify the generation works correctly
3. Navigate to Configuration > Broker and apply a broker configuration — verify no regression
4. Check that file operations (moveFiles, formMibs, centreonGraph) behave as expected with standard and special-character paths

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 3 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Validated shell commands against monitoring-server allowlist before executing them.
* Applied escapeshellarg to file path arguments and command arguments.

**🔧 Refactors**
* Replaced passthru/echo pipe writes with file_put_contents for centcore interactions.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99507603?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->