### PR TITLE
enh(cfg) remove call to gorgone command SENDCBCFG (#8343)

### DIFF
--- a/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -139,20 +139,10 @@ class PollerInteractionService
 
         foreach ($tabServer as $host) {
             if (in_array($host['id'], $pollerIDs)) {
-                $listBrokerFile = glob($centreonBrokerPath . $host['id'] . '/*.{xml,cfg,sql}', GLOB_BRACE);
-
                 passthru("echo 'SENDCFGFILE:{$host['id']}' >> {$centCorePipe}", $return);
 
                 if ($return) {
                     throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
-                }
-
-                if (count($listBrokerFile) > 0) {
-                    passthru("echo 'SENDCBCFG:" . $host['id'] . "' >> {$centCorePipe}", $return);
-
-                    if ($return) {
-                        throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
-                    }
                 }
             }
         }
@@ -202,8 +192,8 @@ class PollerInteractionService
                 throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
             }
 
-            $restartTimeQuery = "UPDATE `nagios_server` 
-                SET `last_restart` = '" . time() . "' 
+            $restartTimeQuery = "UPDATE `nagios_server`
+                SET `last_restart` = '" . time() . "'
                 WHERE `id` = '{$poller['id']}'";
             $this->db->query($restartTimeQuery);
         }

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -353,15 +353,6 @@ try {
                 if (! isset($msg_restart[$host['id']])) {
                     $msg_restart[$host['id']] = '';
                 }
-                if (count($listBrokerFile) > 0) {
-                    passthru(
-                        escapeshellcmd("echo 'SENDCBCFG:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                        $return
-                    );
-                    if ($return) {
-                        throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
-                    }
-                }
                 $msg_restart[$host['id']] .= _('<br><b>Centreon : </b>All configuration will be send to '
                     . $host['name'] . ' by centcore in several minutes.');
             }


### PR DESCRIPTION
## Description

BACKPORT #8343


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Removed emission of SENDCBCFG command to centcore when exporting configurations.
* Stopped listing broker files before triggering SENDCBCFG during export process.
* Expanded broker file discovery to include JSON files during move operation.

**🔧 Refactors**
* Corrected nagios_server last_restart UPDATE query to include WHERE clause.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99820130?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->