### PR TITLE
chore(ci): harden pnpm install with supply chain security flags

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -33,7 +33,12 @@ runs:
         cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       working-directory: ${{ inputs.frontend_directory }}
       shell: bash
       env:

--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -39,7 +39,12 @@ runs:
         cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       working-directory: ${{ inputs.base_directory }}
       shell: bash
       env:

--- a/.github/actions/frontend-lint/action.yml
+++ b/.github/actions/frontend-lint/action.yml
@@ -38,7 +38,12 @@ runs:
         cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       working-directory: ${{ inputs.frontend_directory }}
       shell: bash
       env:

--- a/.github/actions/lighthouse-performance-testing/action.yml
+++ b/.github/actions/lighthouse-performance-testing/action.yml
@@ -32,7 +32,12 @@ runs:
         run_install: false
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       shell: bash
       working-directory: ${{ inputs.path }}
       env:

--- a/.github/workflows/centreon-ui-tests.yml
+++ b/.github/workflows/centreon-ui-tests.yml
@@ -56,7 +56,12 @@ jobs:
         with:
           version: 10
       - name: Install Centreon dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: centreon
       - name: Unit test
         run: pnpm t

--- a/.github/workflows/clean-npm-tags.yml
+++ b/.github/workflows/clean-npm-tags.yml
@@ -25,7 +25,12 @@ jobs:
           version: 10
 
       - name: Install action dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: ./.github/actions/clean-up-npm-tags
         shell: bash
 

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -76,7 +76,12 @@ jobs:
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: ${{ inputs.module_name }}
         shell: bash
         env:
@@ -200,7 +205,12 @@ jobs:
         shell: bash
 
       - name: Install action dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: ./.github/actions/code-coverage-gate-keeper
         shell: bash
 

--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -169,7 +169,12 @@ jobs:
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         shell: bash
         env:
           CYPRESS_INSTALL_BINARY: "0"

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -415,7 +415,12 @@ jobs:
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
       - name: Install Dependencies for tests/rest_api
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         shell: bash
         env:
           CYPRESS_INSTALL_BINARY: "0"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -449,7 +449,12 @@ jobs:
           cache-dependency-path: ${{ env.base_directory }}/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: centreon
         env:
           CYPRESS_INSTALL_BINARY: "0"


### PR DESCRIPTION
## Description

Add supply chain security flags to all `pnpm install` commands in GitHub Actions workflows and composite actions:
- `--config.trustPolicy=no-downgrade`
- `--config.minimumReleaseAge=2880`
- `--config.blockExoticSubdeps=true`

**Fixes** MON-197308

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Hardened pnpm installs in CI with supply-chain security flags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99831653?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->