### PR TITLE
handle empty macros inherited from commands in H/HT/S/ST (#9891)

### DIFF
--- a/centreon/src/Core/Host/Application/InheritanceManager.php
+++ b/centreon/src/Core/Host/Application/InheritanceManager.php
@@ -65,6 +65,34 @@ class InheritanceManager
     }
 
     /**
+     * Return the check command ID of the first ancestor that defines one.
+     *
+     * @param int[] $inheritanceLine
+     *
+     * @throws \Throwable
+     *
+     * @return int|null
+     */
+    public function findInheritedCheckCommandId(array $inheritanceLine): ?int
+    {
+        if ($inheritanceLine === []) {
+            return null;
+        }
+        $templates = $this->readHostTemplateRepository->findByIds(...$inheritanceLine);
+        $indexed = [];
+        foreach ($templates as $template) {
+            $indexed[$template->getId()] = $template;
+        }
+        foreach ($inheritanceLine as $parentId) {
+            if (isset($indexed[$parentId]) && $indexed[$parentId]->getCheckCommandId() !== null) {
+                return $indexed[$parentId]->getCheckCommandId();
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Return false if a circular inheritance is detected, true otherwise.
      *
      * @param int $hostId

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -74,6 +74,7 @@ final class AddHost
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
+        private readonly InheritanceManager $inheritanceManager,
         private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
         private readonly ReadHostGroupRepositoryInterface $readHostGroupRepository,
         private readonly WriteHostCategoryRepositoryInterface $writeHostCategoryRepository,
@@ -410,9 +411,10 @@ final class AddHost
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($checkCommandId !== null) {
+        $effectiveCommandId = $checkCommandId ?? $this->inheritanceManager->findInheritedCheckCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $checkCommandId,
+                $effectiveCommandId,
                 CommandMacroType::Host
             );
 

--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -89,6 +89,7 @@ final class PartialUpdateHost
     public function __construct(
         private readonly WriteHostRepositoryInterface $writeHostRepository,
         private readonly ReadHostRepositoryInterface $readHostRepository,
+        private readonly InheritanceManager $inheritanceManager,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
         private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
         private readonly ReadHostGroupRepositoryInterface $readHostGroupRepository,
@@ -775,9 +776,11 @@ final class PartialUpdateHost
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($host->getCheckCommandId() !== null) {
+        $effectiveCommandId = $host->getCheckCommandId()
+            ?? $this->inheritanceManager->findInheritedCheckCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $host->getCheckCommandId(),
+                $effectiveCommandId,
                 CommandMacroType::Host
             );
 

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
@@ -65,6 +65,7 @@ final class AddHostTemplate
     public function __construct(
         private readonly WriteHostTemplateRepositoryInterface $writeHostTemplateRepository,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
+        private readonly InheritanceManager $inheritanceManager,
         private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
         private readonly WriteHostCategoryRepositoryInterface $writeHostCategoryRepository,
         private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
@@ -357,9 +358,10 @@ final class AddHostTemplate
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($checkCommandId !== null) {
+        $effectiveCommandId = $checkCommandId ?? $this->inheritanceManager->findInheritedCheckCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $checkCommandId,
+                $effectiveCommandId,
                 CommandMacroType::Host
             );
 

--- a/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
@@ -78,6 +78,7 @@ final class PartialUpdateHostTemplate
 
     public function __construct(
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
+        private readonly InheritanceManager $inheritanceManager,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
         private readonly ReadCommandMacroRepositoryInterface $readCommandMacroRepository,
         private readonly WriteHostMacroRepositoryInterface $writeHostMacroRepository,
@@ -485,9 +486,11 @@ final class PartialUpdateHostTemplate
 
         /** @var array<string,CommandMacro> */
         $commandMacros = [];
-        if ($hostTemplate->getCheckCommandId() !== null) {
+        $effectiveCommandId = $hostTemplate->getCheckCommandId()
+            ?? $this->inheritanceManager->findInheritedCheckCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $hostTemplate->getCheckCommandId(),
+                $effectiveCommandId,
                 CommandMacroType::Host
             );
 

--- a/centreon/src/Core/Macro/Domain/Model/MacroDifference.php
+++ b/centreon/src/Core/Macro/Domain/Model/MacroDifference.php
@@ -183,7 +183,12 @@ final class MacroDifference
         }
 
         // Macro doesn't match any previously known macros
-        $this->addedMacros[$macroName] = $computedMacro;
+        // Only save if it has a value or is a password — an empty unmatched macro has no override purpose
+        if ($computedMacro->getValue() !== '' || $computedMacro->isPassword()) {
+            $this->addedMacros[$macroName] = $computedMacro;
+        } else {
+            $this->unchangedMacros[$macroName] = $computedMacro;
+        }
     }
 
     private function isIdenticalToInheritedMacro(Macro $macro, Macro $existingMacro): bool

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -67,6 +67,7 @@ use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Domain\Model\ServiceGroup;
 use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 
 final class AddService
 {
@@ -100,6 +101,7 @@ final class AddService
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
+        private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -487,9 +489,10 @@ final class AddService
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($checkCommandId !== null) {
+        $effectiveCommandId = $checkCommandId ?? $this->findInheritedCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $checkCommandId,
+                $effectiveCommandId,
                 CommandMacroType::Service
             );
 
@@ -502,6 +505,34 @@ final class AddService
                 : $inheritedMacros,
             $commandMacros,
         ];
+    }
+
+    /**
+     * Return the command ID of the first ancestor service template that defines one.
+     *
+     * @param int[] $inheritanceLine
+     *
+     * @throws \Throwable
+     *
+     * @return int|null
+     */
+    private function findInheritedCommandId(array $inheritanceLine): ?int
+    {
+        if ($inheritanceLine === []) {
+            return null;
+        }
+        $templates = $this->readServiceTemplateRepository->findByIds(...$inheritanceLine);
+        $indexed = [];
+        foreach ($templates as $template) {
+            $indexed[$template->getId()] = $template;
+        }
+        foreach ($inheritanceLine as $parentId) {
+            if (isset($indexed[$parentId]) && $indexed[$parentId]->getCommandId() !== null) {
+                return $indexed[$parentId]->getCommandId();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
@@ -71,6 +71,7 @@ use Core\ServiceCategory\Domain\Model\ServiceCategory;
 use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Utility\Difference\BasicDifference;
 
 final class PartialUpdateService
@@ -105,6 +106,7 @@ final class PartialUpdateService
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
+        private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -585,9 +587,11 @@ final class PartialUpdateService
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($service->getCommandId() !== null) {
+        $effectiveCommandId = $service->getCommandId()
+            ?? $this->findInheritedCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $service->getCommandId(),
+                $effectiveCommandId,
                 CommandMacroType::Service
             );
 
@@ -603,6 +607,34 @@ final class PartialUpdateService
                 : $inheritedMacros,
             $commandMacros,
         ];
+    }
+
+    /**
+     * Return the command ID of the first ancestor service template that defines one.
+     *
+     * @param int[] $inheritanceLine
+     *
+     * @throws \Throwable
+     *
+     * @return int|null
+     */
+    private function findInheritedCommandId(array $inheritanceLine): ?int
+    {
+        if ($inheritanceLine === []) {
+            return null;
+        }
+        $templates = $this->readServiceTemplateRepository->findByIds(...$inheritanceLine);
+        $indexed = [];
+        foreach ($templates as $template) {
+            $indexed[$template->getId()] = $template;
+        }
+        foreach ($inheritanceLine as $parentId) {
+            if (isset($indexed[$parentId]) && $indexed[$parentId]->getCommandId() !== null) {
+                return $indexed[$parentId]->getCommandId();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
@@ -123,6 +123,17 @@ interface ReadServiceTemplateRepositoryInterface
     public function findByHostId(int $hostId): array;
 
     /**
+     * Find service templates by their IDs.
+     *
+     * @param int ...$serviceTemplateIds
+     *
+     * @throws \Throwable
+     *
+     * @return list<ServiceTemplate>
+     */
+    public function findByIds(int ...$serviceTemplateIds): array;
+
+    /**
      * Find service template IDs by command names.
      *
      * @param string[] $commandNames

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
@@ -488,9 +488,10 @@ final class AddServiceTemplate
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($checkCommandId !== null) {
+        $effectiveCommandId = $checkCommandId ?? $this->findInheritedCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $checkCommandId,
+                $effectiveCommandId,
                 CommandMacroType::Service
             );
 
@@ -503,6 +504,34 @@ final class AddServiceTemplate
                 : $inheritedMacros,
             $commandMacros,
         ];
+    }
+
+    /**
+     * Return the command ID of the first ancestor service template that defines one.
+     *
+     * @param int[] $inheritanceLine
+     *
+     * @throws \Throwable
+     *
+     * @return int|null
+     */
+    private function findInheritedCommandId(array $inheritanceLine): ?int
+    {
+        if ($inheritanceLine === []) {
+            return null;
+        }
+        $templates = $this->readServiceTemplateRepository->findByIds(...$inheritanceLine);
+        $indexed = [];
+        foreach ($templates as $template) {
+            $indexed[$template->getId()] = $template;
+        }
+        foreach ($inheritanceLine as $parentId) {
+            if (isset($indexed[$parentId]) && $indexed[$parentId]->getCommandId() !== null) {
+                return $indexed[$parentId]->getCommandId();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -393,9 +393,10 @@ final class PartialUpdateServiceTemplate
 
         /** @var array<string,CommandMacro> $commandMacros */
         $commandMacros = [];
-        if ($checkCommandId !== null) {
+        $effectiveCommandId = $checkCommandId ?? $this->findInheritedCommandId($inheritanceLine);
+        if ($effectiveCommandId !== null) {
             $existingCommandMacros = $this->readCommandMacroRepository->findByCommandIdAndType(
-                $checkCommandId,
+                $effectiveCommandId,
                 CommandMacroType::Service
             );
 
@@ -411,6 +412,34 @@ final class PartialUpdateServiceTemplate
                 : $inheritedMacros,
             $commandMacros,
         ];
+    }
+
+    /**
+     * Return the command ID of the first ancestor service template that defines one.
+     *
+     * @param int[] $inheritanceLine
+     *
+     * @throws \Throwable
+     *
+     * @return int|null
+     */
+    private function findInheritedCommandId(array $inheritanceLine): ?int
+    {
+        if ($inheritanceLine === []) {
+            return null;
+        }
+        $templates = $this->readServiceTemplateRepository->findByIds(...$inheritanceLine);
+        $indexed = [];
+        foreach ($templates as $template) {
+            $indexed[$template->getId()] = $template;
+        }
+        foreach ($inheritanceLine as $parentId) {
+            if (isset($indexed[$parentId]) && $indexed[$parentId]->getCommandId() !== null) {
+                return $indexed[$parentId]->getCommandId();
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
@@ -185,6 +185,97 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
     /**
      * @inheritDoc
      */
+    public function findByIds(int ...$serviceTemplateIds): array
+    {
+        if ($serviceTemplateIds === []) {
+            return [];
+        }
+
+        [$bindValues, $bindPlaceholders] = $this->createMultipleBindQuery($serviceTemplateIds, ':id_');
+
+        $request = <<<SQL
+                SELECT service_id,
+                       service.cg_additive_inheritance,
+                       service.contact_additive_inheritance,
+                       service.command_command_id,
+                       service.command_command_id2,
+                       service.command_command_id_arg,
+                       service.command_command_id_arg2,
+                       service.timeperiod_tp_id,
+                       service.timeperiod_tp_id2,
+                       service_acknowledgement_timeout,
+                       service_active_checks_enabled,
+                       service_event_handler_enabled,
+                       service_flap_detection_enabled,
+                       service_check_freshness,
+                       service_locked,
+                       service_notifications_enabled,
+                       service_passive_checks_enabled,
+                       service_is_volatile,
+                       service_low_flap_threshold,
+                       service_high_flap_threshold,
+                       service_max_check_attempts,
+                       service_description,
+                       service_comment,
+                       service_alias,
+                       service_freshness_threshold,
+                       service_normal_check_interval,
+                       service_notification_interval,
+                       service_notification_options,
+                       service_recovery_notification_delay,
+                       service_retry_check_interval,
+                       service_template_model_stm_id,
+                       service_first_notification_delay,
+                       esi.esi_action_url,
+                       esi.esi_icon_image,
+                       esi.esi_icon_image_alt,
+                       esi.esi_notes,
+                       esi.esi_notes_url,
+                       esi.graph_id,
+                       GROUP_CONCAT(DISTINCT severity.sc_id) as severity_id,
+                       GROUP_CONCAT(DISTINCT hsr.host_host_id) AS host_template_ids
+                FROM `:db`.service
+                LEFT JOIN `:db`.extended_service_information esi
+                    ON esi.service_service_id = service.service_id
+                LEFT JOIN `:db`.service_categories_relation scr
+                    ON scr.service_service_id = service.service_id
+                LEFT JOIN `:db`.service_categories severity
+                    ON severity.sc_id = scr.sc_id
+                    AND severity.level IS NOT NULL
+                LEFT JOIN `:db`.host_service_relation hsr
+                    ON hsr.service_service_id = service.service_id
+                LEFT JOIN `:db`.host
+                    ON host.host_id = hsr.host_host_id
+                    AND host.host_register = '0'
+                WHERE service.service_id IN ({$bindPlaceholders})
+                    AND service.service_register = '0'
+                GROUP BY
+                    service.service_id,
+                    esi.esi_action_url,
+                    esi.esi_icon_image,
+                    esi.esi_icon_image_alt,
+                    esi.esi_notes,
+                    esi.esi_notes_url,
+                    esi.graph_id
+            SQL;
+        $statement = $this->db->prepare($this->translateDbName($request));
+        foreach ($bindValues as $placeholder => $value) {
+            $statement->bindValue($placeholder, $value, \PDO::PARAM_INT);
+        }
+        $statement->execute();
+
+        $serviceTemplates = [];
+        while ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            /** @var _ServiceTemplate $result */
+            $serviceTemplates[] = $this->createServiceTemplate($result);
+        }
+
+        return $serviceTemplates;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findByIdAndAccessGroups(int $serviceTemplateId, array $accessGroups): ?ServiceTemplate
     {
         $accessGroupIds = array_map(

--- a/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
@@ -44,6 +44,7 @@ use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
+use Core\Host\Application\InheritanceManager;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteRealTimeHostRepositoryInterface;
@@ -80,6 +81,7 @@ beforeEach(function (): void {
         readHostRepository: $this->readHostRepository = $this->createMock(ReadHostRepositoryInterface::class),
         writeMonitoringServerRepository: $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
         readHostTemplateRepository: $this->readHostTemplateRepository = $this->createMock(ReadHostTemplateRepositoryInterface::class),
+        inheritanceManager: $this->inheritanceManager = $this->createMock(InheritanceManager::class),
         readHostCategoryRepository: $this->readHostCategoryRepository = $this->createMock(ReadHostCategoryRepositoryInterface::class),
         readHostGroupRepository: $this->readHostGroupRepository = $this->createMock(ReadHostGroupRepositoryInterface::class),
         writeHostCategoryRepository: $this->writeHostCategoryRepository = $this->createMock(WriteHostCategoryRepositoryInterface::class),
@@ -234,7 +236,7 @@ beforeEach(function (): void {
     $this->macroA->setOrder(0);
     $this->macroB = new Macro(2, $this->host->getId(), 'macroNameB', 'macroValueB');
     $this->macroB->setOrder(1);
-    $this->commandMacro = new CommandMacro(1, CommandMacroType::Host, 'commandMacroName');
+    $this->commandMacro = new CommandMacro(1, CommandMacroType::Host, 'COMMANDMACRONAME');
     $this->commandMacros = [
         $this->commandMacro->getName() => $this->commandMacro,
     ];
@@ -834,6 +836,128 @@ it('should return created object on success (with admin user)', function (): voi
         ->toBe($this->host->addInheritedContact())
         ->and($response->isActivated)
         ->toBe($this->host->isActivated());
+});
+
+it('should not save a command macro inherited from a parent template when its value is left empty', function (): void {
+    // Host has no own check command — it inherits one from a parent template.
+    // The user submits the command macro with an empty value (step 4).
+    // The macro must NOT be written to the host at all.
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $this->request->macros = [
+        ['name' => 'commandMacroName', 'value' => '', 'is_password' => false, 'description' => null],
+    ];
+
+    $this->user->expects($this->once())->method('hasTopologyRole')->willReturn(true);
+    $this->adminResolver->expects($this->any())->method('isAdmin')->willReturn(true);
+
+    $this->validation->expects($this->once())->method('assertIsValidMonitoringServer');
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->optionService->expects($this->once())->method('findSelectedOptions')
+        ->willReturn(['inheritance_mode' => $this->inheritanceModeOption]);
+    $this->writeHostRepository->expects($this->once())->method('add')->willReturn($this->host->getId());
+
+    $this->validation->expects($this->once())->method('assertAreValidCategories');
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->validation->expects($this->once())->method('assertAreValidGroups');
+    $this->writeHostGroupRepository->expects($this->once())->method('linkToHost');
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostRepository->expects($this->exactly(2))->method('addParent');
+
+    // Inherited command macro resolution; submitting empty value must not create a macro
+    $this->readHostRepository->expects($this->once())->method('findParents')->willReturn($this->inheritanceInfos);
+    $this->readHostMacroRepository->expects($this->once())->method('findByHostIds')->willReturn([]);
+    $this->inheritanceManager->expects($this->once())->method('findInheritedCheckCommandId')->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository->expects($this->once())->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)->willReturn($this->commandMacros);
+
+    $this->writeHostMacroRepository->expects($this->never())->method('add');
+    $this->writeHostMacroRepository->expects($this->never())->method('update');
+    $this->writeHostMacroRepository->expects($this->never())->method('delete');
+
+    $this->writeAccessGroupRepository->expects($this->once())->method('updateAclResourcesFlag');
+
+    $this->readHostRepository->expects($this->once())->method('findById')->willReturn($this->host);
+    $this->readHostCategoryRepository->expects($this->once())->method('findByHost')->willReturn([]);
+    $this->readHostGroupRepository->expects($this->once())->method('findByHost')->willReturn([]);
+    $this->readHostTemplateRepository->expects($this->once())->method('findNamesByIds')
+        ->willReturn(array_combine(
+            array_map(fn ($template) => $template['id'], $this->parentTemplates),
+            array_map(fn ($template) => $template['name'], $this->parentTemplates)
+        ));
+    $this->readHostMacroRepository->expects($this->once())->method('findByHostId')->willReturn([]);
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)->toBeInstanceOf(AddHostResponse::class);
+});
+
+it('should add a command macro inherited from a parent template when its value is filled', function (): void {
+    // Host has no own check command — it inherits one from a parent template.
+    // The user fills in a value for the command macro (step 6).
+    // The macro must be added to the host.
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $this->request->macros = [
+        ['name' => 'commandMacroName', 'value' => 'somevalue', 'is_password' => false, 'description' => null],
+    ];
+
+    $this->user->expects($this->once())->method('hasTopologyRole')->willReturn(true);
+    $this->adminResolver->expects($this->any())->method('isAdmin')->willReturn(true);
+
+    $this->validation->expects($this->once())->method('assertIsValidMonitoringServer');
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->optionService->expects($this->once())->method('findSelectedOptions')
+        ->willReturn(['inheritance_mode' => $this->inheritanceModeOption]);
+    $this->writeHostRepository->expects($this->once())->method('add')->willReturn($this->host->getId());
+
+    $this->validation->expects($this->once())->method('assertAreValidCategories');
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->validation->expects($this->once())->method('assertAreValidGroups');
+    $this->writeHostGroupRepository->expects($this->once())->method('linkToHost');
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostRepository->expects($this->exactly(2))->method('addParent');
+
+    // Inherited command macro resolution; filling in a value must add the macro to the host
+    $this->readHostRepository->expects($this->once())->method('findParents')->willReturn($this->inheritanceInfos);
+    $this->readHostMacroRepository->expects($this->once())->method('findByHostIds')->willReturn([]);
+    $this->inheritanceManager->expects($this->once())->method('findInheritedCheckCommandId')->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository->expects($this->once())->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)->willReturn($this->commandMacros);
+
+    $this->writeHostMacroRepository->expects($this->once())->method('add');
+    $this->writeHostMacroRepository->expects($this->never())->method('update');
+    $this->writeHostMacroRepository->expects($this->never())->method('delete');
+
+    $this->writeAccessGroupRepository->expects($this->once())->method('updateAclResourcesFlag');
+
+    $this->readHostRepository->expects($this->once())->method('findById')->willReturn($this->host);
+    $this->readHostCategoryRepository->expects($this->once())->method('findByHost')->willReturn([]);
+    $this->readHostGroupRepository->expects($this->once())->method('findByHost')->willReturn([]);
+    $this->readHostTemplateRepository->expects($this->once())->method('findNamesByIds')
+        ->willReturn(array_combine(
+            array_map(fn ($template) => $template['id'], $this->parentTemplates),
+            array_map(fn ($template) => $template['name'], $this->parentTemplates)
+        ));
+    $this->readHostMacroRepository->expects($this->once())->method('findByHostId')->willReturn([]);
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)->toBeInstanceOf(AddHostResponse::class);
 });
 
 it('should return created object on success (with non-admin user)', function (): void {

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
@@ -43,6 +43,7 @@ use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
+use Core\Host\Application\InheritanceManager;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Application\UseCase\PartialUpdateHost\PartialUpdateHost;
@@ -74,6 +75,7 @@ beforeEach(function (): void {
     $this->useCase = new PartialUpdateHost(
         writeHostRepository: $this->writeHostRepository = $this->createMock(WriteHostRepositoryInterface::class),
         readHostRepository: $this->readHostRepository = $this->createMock(ReadHostRepositoryInterface::class),
+        inheritanceManager: $this->inheritanceManager = $this->createMock(InheritanceManager::class),
         writeMonitoringServerRepository: $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
         readHostCategoryRepository: $this->readHostCategoryRepository = $this->createMock(ReadHostCategoryRepositoryInterface::class),
         readHostGroupRepository: $this->readHostGroupRepository = $this->createMock(ReadHostGroupRepositoryInterface::class),
@@ -210,7 +212,7 @@ beforeEach(function (): void {
     $this->macroA->setOrder(0);
     $this->macroB = new Macro(null, $this->hostId, 'macroNameB', 'macroValueB');
     $this->macroB->setOrder(1);
-    $this->commandMacro = new CommandMacro(1, CommandMacroType::Host, 'commandMacroName');
+    $this->commandMacro = new CommandMacro(1, CommandMacroType::Host, 'COMMANDMACRONAME');
     $this->commandMacros = [
         $this->commandMacro->getName() => $this->commandMacro,
     ];
@@ -906,6 +908,297 @@ it('should present a NoContentResponse on success', function (): void {
     $this->writeHostMacroRepository
         ->expects($this->once())
         ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostId);
+
+    expect($this->presenter->response)->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should load command macros from an inherited check command when the host defines none', function (): void {
+    $this->request->checkCommandId = null;
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->exactly(5))
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readHostRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->originalHost);
+
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn([$this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostRepository
+        ->expects($this->once())
+        ->method('update');
+
+    // Categories
+    $this->readHostCategoryRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([$this->categoryA]);
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostCategoryRepository->expects($this->once())->method('unlinkFromHost');
+
+    // Groups
+    $this->readHostGroupRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([$this->groupA]);
+    $this->writeHostGroupRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostGroupRepository->expects($this->once())->method('unlinkFromHost');
+
+    // Parent templates
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostRepository->expects($this->once())->method('deleteParents');
+    $this->writeHostRepository->expects($this->exactly(2))->method('addParent');
+
+    // Macros: host has no checkCommandId; InheritanceManager resolves it from a parent template
+    $inheritedCommandId = 42;
+    $this->readHostRepository
+        ->expects($this->exactly(2))
+        ->method('findParents')
+        ->willReturn($this->inheritanceLineIds);
+    $this->readHostMacroRepository
+        ->expects($this->once())
+        ->method('findByHostIds')
+        ->willReturn($this->hostMacros);
+    $this->inheritanceManager
+        ->expects($this->once())
+        ->method('findInheritedCheckCommandId')
+        ->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)
+        ->willReturn($this->commandMacros);
+    $this->writeHostMacroRepository->expects($this->once())->method('delete');
+    $this->writeHostMacroRepository->expects($this->once())->method('add');
+    $this->writeHostMacroRepository->expects($this->once())->method('update');
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostId);
+
+    expect($this->presenter->response)->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should delete a command macro from an inherited check command when its value is cleared', function (): void {
+    // Host has no own check command — it inherits one from a parent template.
+    // A macro from that command was previously saved on the host with a value.
+    // When the user clears the value, the macro must be deleted from the host (step 8).
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $savedCommandMacro = new Macro(null, $this->hostId, 'commandMacroName', 'somevalue');
+
+    $this->request->macros = [
+        ['name' => 'commandMacroName', 'value' => '', 'is_password' => false, 'description' => null],
+    ];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->exactly(5))
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readHostRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->originalHost);
+
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn([$this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostRepository
+        ->expects($this->once())
+        ->method('update');
+
+    // Categories
+    $this->readHostCategoryRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([$this->categoryA]);
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostCategoryRepository->expects($this->once())->method('unlinkFromHost');
+
+    // Groups
+    $this->readHostGroupRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([$this->groupA]);
+    $this->writeHostGroupRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostGroupRepository->expects($this->once())->method('unlinkFromHost');
+
+    // Parent templates
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostRepository->expects($this->once())->method('deleteParents');
+    $this->writeHostRepository->expects($this->exactly(2))->method('addParent');
+
+    // Macros: host has no checkCommandId; commandMacroName was previously saved with a value
+    $this->readHostRepository
+        ->expects($this->exactly(2))
+        ->method('findParents')
+        ->willReturn($this->inheritanceLineIds);
+    $this->readHostMacroRepository
+        ->expects($this->once())
+        ->method('findByHostIds')
+        ->willReturn([$savedCommandMacro]);
+    $this->inheritanceManager
+        ->expects($this->once())
+        ->method('findInheritedCheckCommandId')
+        ->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)
+        ->willReturn($this->commandMacros);
+
+    // Clearing the value must delete the macro, not update it
+    $this->writeHostMacroRepository->expects($this->once())->method('delete');
+    $this->writeHostMacroRepository->expects($this->never())->method('add');
+    $this->writeHostMacroRepository->expects($this->never())->method('update');
+
+    $this->writeAccessGroupRepository
+        ->expects($this->once())
+        ->method('updateAclResourcesFlag');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostId);
+
+    expect($this->presenter->response)->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should not save a command macro inherited from a parent template when its value is left empty', function (): void {
+    // Host has no own check command — it inherits one from a parent template.
+    // The user submits the command macro with an empty value (step 4).
+    // The macro must NOT be written to the host at all.
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $this->request->macros = [
+        ['name' => 'commandMacroName', 'value' => '', 'is_password' => false, 'description' => null],
+    ];
+
+    $this->user->expects($this->once())->method('hasTopologyRole')->willReturn(true);
+    $this->adminResolver->expects($this->exactly(5))->method('isAdmin')->willReturn(true);
+    $this->readHostRepository->expects($this->once())->method('findById')->willReturn($this->originalHost);
+    $this->optionService->expects($this->once())->method('findSelectedOptions')->willReturn([$this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostRepository->expects($this->once())->method('update');
+
+    $this->readHostCategoryRepository->expects($this->once())->method('findByHost')->willReturn([$this->categoryA]);
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostCategoryRepository->expects($this->once())->method('unlinkFromHost');
+
+    $this->readHostGroupRepository->expects($this->once())->method('findByHost')->willReturn([$this->groupA]);
+    $this->writeHostGroupRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostGroupRepository->expects($this->once())->method('unlinkFromHost');
+
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostRepository->expects($this->once())->method('deleteParents');
+    $this->writeHostRepository->expects($this->exactly(2))->method('addParent');
+
+    // No existing macro saved; submitting empty value must not create a new macro
+    $this->readHostRepository->expects($this->exactly(2))->method('findParents')->willReturn($this->inheritanceLineIds);
+    $this->readHostMacroRepository->expects($this->once())->method('findByHostIds')->willReturn([]);
+    $this->inheritanceManager->expects($this->once())->method('findInheritedCheckCommandId')->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository->expects($this->once())->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)->willReturn($this->commandMacros);
+
+    $this->writeHostMacroRepository->expects($this->never())->method('add');
+    $this->writeHostMacroRepository->expects($this->never())->method('update');
+    $this->writeHostMacroRepository->expects($this->never())->method('delete');
+
+    $this->writeAccessGroupRepository->expects($this->once())->method('updateAclResourcesFlag');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostId);
+
+    expect($this->presenter->response)->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should add a command macro inherited from a parent template when its value is filled', function (): void {
+    // Host has no own check command — it inherits one from a parent template.
+    // The user fills in a value for the command macro (step 6).
+    // The macro must be added to the host.
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $this->request->macros = [
+        ['name' => 'commandMacroName', 'value' => 'somevalue', 'is_password' => false, 'description' => null],
+    ];
+
+    $this->user->expects($this->once())->method('hasTopologyRole')->willReturn(true);
+    $this->adminResolver->expects($this->exactly(5))->method('isAdmin')->willReturn(true);
+    $this->readHostRepository->expects($this->once())->method('findById')->willReturn($this->originalHost);
+    $this->optionService->expects($this->once())->method('findSelectedOptions')->willReturn([$this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostRepository->expects($this->once())->method('update');
+
+    $this->readHostCategoryRepository->expects($this->once())->method('findByHost')->willReturn([$this->categoryA]);
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostCategoryRepository->expects($this->once())->method('unlinkFromHost');
+
+    $this->readHostGroupRepository->expects($this->once())->method('findByHost')->willReturn([$this->groupA]);
+    $this->writeHostGroupRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostGroupRepository->expects($this->once())->method('unlinkFromHost');
+
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostRepository->expects($this->once())->method('deleteParents');
+    $this->writeHostRepository->expects($this->exactly(2))->method('addParent');
+
+    // No existing macro saved; filling in a value must add the macro to the host
+    $this->readHostRepository->expects($this->exactly(2))->method('findParents')->willReturn($this->inheritanceLineIds);
+    $this->readHostMacroRepository->expects($this->once())->method('findByHostIds')->willReturn([]);
+    $this->inheritanceManager->expects($this->once())->method('findInheritedCheckCommandId')->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository->expects($this->once())->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)->willReturn($this->commandMacros);
+
+    $this->writeHostMacroRepository->expects($this->once())->method('add');
+    $this->writeHostMacroRepository->expects($this->never())->method('update');
+    $this->writeHostMacroRepository->expects($this->never())->method('delete');
+
+    $this->writeAccessGroupRepository->expects($this->once())->method('updateAclResourcesFlag');
 
     ($this->useCase)($this->request, $this->presenter, $this->hostId);
 

--- a/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
@@ -41,6 +41,7 @@ use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Host\Application\Converter\HostEventConverter;
+use Core\Host\Application\InheritanceManager;
 use Core\Host\Domain\Model\HostEvent;
 use Core\Host\Domain\Model\SnmpVersion;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
@@ -69,6 +70,7 @@ beforeEach(function (): void {
     $this->useCase = new AddHostTemplate(
         $this->writeHostTemplateRepository = $this->createMock(WriteHostTemplateRepositoryInterface::class),
         $this->readHostTemplateRepository = $this->createMock(ReadHostTemplateRepositoryInterface::class),
+        $this->inheritanceManager = $this->createMock(InheritanceManager::class),
         $this->readHostCategoryRepository = $this->createMock(ReadHostCategoryRepositoryInterface::class),
         $this->writeHostCategoryRepository = $this->createMock(WriteHostCategoryRepositoryInterface::class),
         $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),

--- a/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
@@ -42,6 +42,7 @@ use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Host\Application\Converter\HostEventConverter;
+use Core\Host\Application\InheritanceManager;
 use Core\Host\Domain\Model\HostEvent;
 use Core\Host\Domain\Model\SnmpVersion;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
@@ -74,6 +75,7 @@ beforeEach(function (): void {
 
     $this->useCase = new PartialUpdateHostTemplate(
         $this->readHostTemplateRepository = $this->createMock(ReadHostTemplateRepositoryInterface::class),
+        $this->inheritanceManager = $this->createMock(InheritanceManager::class),
         $this->readHostMacroRepository = $this->createMock(ReadHostMacroRepositoryInterface::class),
         $this->readCommandMacroRepository = $this->createMock(ReadCommandMacroRepositoryInterface::class),
         $this->writeHostMacroRepository = $this->createMock(WriteHostMacroRepositoryInterface::class),
@@ -199,7 +201,7 @@ beforeEach(function (): void {
     $this->macroA->setOrder(0);
     $this->macroB = new Macro(null, $this->hostTemplateId, 'macroNameB', 'macroValueB');
     $this->macroB->setOrder(1);
-    $this->commandMacro = new CommandMacro(1, CommandMacroType::Host, 'commandMacroName');
+    $this->commandMacro = new CommandMacro(1, CommandMacroType::Host, 'COMMANDMACRONAME');
     $this->commandMacros = [
         $this->commandMacro->getName() => $this->commandMacro,
     ];
@@ -797,6 +799,169 @@ it('should present a NoContentResponse on success', function (): void {
     $this->writeHostCategoryRepository
         ->expects($this->once())
         ->method('unlinkFromHost');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostTemplateId);
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should load command macros from an inherited check command when the host template defines none', function (): void {
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readHostTemplateRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->originalHostTemplate);
+
+    $this->readCommandRepository
+        ->expects($this->never())
+        ->method('findById');
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn(['inheritance_mode' => $this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostTemplateRepository
+        ->expects($this->once())
+        ->method('update');
+
+    // Parent templates
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostTemplateRepository->expects($this->once())->method('deleteParents');
+    $this->writeHostTemplateRepository->expects($this->exactly(2))->method('addParent');
+
+    // Macros: host template has no checkCommandId; InheritanceManager resolves it from a parent
+    $this->readHostTemplateRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn($this->inheritanceLineIds);
+    $this->readHostMacroRepository
+        ->expects($this->once())
+        ->method('findByHostIds')
+        ->willReturn($this->hostMacros);
+    $this->inheritanceManager
+        ->expects($this->once())
+        ->method('findInheritedCheckCommandId')
+        ->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)
+        ->willReturn($this->commandMacros);
+    $this->writeHostMacroRepository->expects($this->once())->method('delete');
+    $this->writeHostMacroRepository->expects($this->once())->method('add');
+    $this->writeHostMacroRepository->expects($this->once())->method('update');
+
+    // Categories
+    $this->validation->expects($this->once())->method('assertAreValidCategories');
+    $this->readHostCategoryRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([$this->categoryA]);
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostCategoryRepository->expects($this->once())->method('unlinkFromHost');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostTemplateId);
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should delete a command macro from an inherited check command when its value is cleared', function (): void {
+    // Host template has no own check command — it inherits one from a parent template.
+    // A macro from that command was previously saved on the host template with a value.
+    // When the user clears the value, the macro must be deleted (step 8).
+    $this->request->checkCommandId = null;
+    $inheritedCommandId = 42;
+
+    $savedCommandMacro = new Macro(null, $this->hostTemplateId, 'commandMacroName', 'somevalue');
+
+    $this->request->macros = [
+        ['name' => 'commandMacroName', 'value' => '', 'is_password' => false, 'description' => null],
+    ];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readHostTemplateRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->originalHostTemplate);
+
+    $this->readCommandRepository
+        ->expects($this->never())
+        ->method('findById');
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn(['inheritance_mode' => $this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostTemplateRepository
+        ->expects($this->once())
+        ->method('update');
+
+    // Parent templates
+    $this->validation->expects($this->once())->method('assertAreValidTemplates');
+    $this->writeHostTemplateRepository->expects($this->once())->method('deleteParents');
+    $this->writeHostTemplateRepository->expects($this->exactly(2))->method('addParent');
+
+    // Macros: host template has no checkCommandId; commandMacroName was previously saved with a value
+    $this->readHostTemplateRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn($this->inheritanceLineIds);
+    $this->readHostMacroRepository
+        ->expects($this->once())
+        ->method('findByHostIds')
+        ->willReturn([$savedCommandMacro]);
+    $this->inheritanceManager
+        ->expects($this->once())
+        ->method('findInheritedCheckCommandId')
+        ->willReturn($inheritedCommandId);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Host)
+        ->willReturn($this->commandMacros);
+
+    // Clearing the value must delete the macro, not update it
+    $this->writeHostMacroRepository->expects($this->once())->method('delete');
+    $this->writeHostMacroRepository->expects($this->never())->method('add');
+    $this->writeHostMacroRepository->expects($this->never())->method('update');
+
+    // Categories
+    $this->validation->expects($this->once())->method('assertAreValidCategories');
+    $this->readHostCategoryRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([$this->categoryA]);
+    $this->writeHostCategoryRepository->expects($this->once())->method('linkToHost');
+    $this->writeHostCategoryRepository->expects($this->once())->method('unlinkFromHost');
 
     ($this->useCase)($this->request, $this->presenter, $this->hostTemplateId);
 

--- a/centreon/tests/php/Core/Macro/Domain/Model/MacroDifferenceTest.php
+++ b/centreon/tests/php/Core/Macro/Domain/Model/MacroDifferenceTest.php
@@ -156,3 +156,23 @@ it('should compute macros has expected', function (): void {
         ->and($macrosDiff->removedMacros)->toEqual($removedMacros)
         ->and($macrosDiff->unchangedMacros)->toEqual($unchangedMacros);
 });
+
+it('should not save an empty non-password macro when there is no match context', function (): void {
+    $emptyMacro = new Macro(null, 1, 'ORPHAN', '');
+
+    $macrosDiff = new MacroDifference();
+    $macrosDiff->compute([], [], [], ['ORPHAN' => $emptyMacro]);
+
+    expect($macrosDiff->addedMacros)->toBeEmpty()
+        ->and($macrosDiff->unchangedMacros)->toHaveKey('ORPHAN');
+});
+
+it('should save an empty password macro even when there is no match context', function (): void {
+    $emptyPassword = new Macro(null, 1, 'SECRET', '');
+    $emptyPassword->setIsPassword(true);
+
+    $macrosDiff = new MacroDifference();
+    $macrosDiff->compute([], [], [], ['SECRET' => $emptyPassword]);
+
+    expect($macrosDiff->addedMacros)->toHaveKey('SECRET');
+});

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
@@ -33,6 +33,8 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Command\Domain\Model\Command;
 use Core\CommandMacro\Application\Repository\ReadCommandMacroRepositoryInterface;
+use Core\CommandMacro\Domain\Model\CommandMacro;
+use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Domain\YesNoDefault;
@@ -64,6 +66,8 @@ use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Domain\Model\ServiceGroup;
 use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
 use Tests\Core\Service\Infrastructure\API\AddService\AddServicePresenterStub;
 
@@ -95,6 +99,7 @@ beforeEach(function (): void {
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         $this->adminResolver = $this->createMock(AdminResolver::class),
+        $this->readServiceTemplateRepository = $this->createMock(ReadServiceTemplateRepositoryInterface::class),
     );
 
     $this->request = new AddServiceRequest();
@@ -788,4 +793,99 @@ it('should present an AddServiceResponse when everything has gone well', functio
             ['id' => $categoryB->getId(), 'name' => $categoryB->getName()],
         ]
     );
+});
+
+it('should load command macros from an inherited template command when the service defines none', function (): void {
+    $request = new AddServiceRequest();
+    $request->name = 'fake_name';
+    $request->hostId = 1;
+    $request->serviceTemplateParentId = 10;
+    $request->commandId = null;
+    $request->serviceCategories = [];
+    $request->serviceGroups = [];
+
+    $newServiceId = 99;
+    $inheritedCommandId = 42;
+    $serviceTemplateInheritances = [
+        new ServiceTemplateInheritance(9, $newServiceId),
+        new ServiceTemplateInheritance(8, 9),
+        new ServiceTemplateInheritance(1, 8),
+    ];
+
+    $serviceFound = new Service(id: $newServiceId, name: $request->name, hostId: $request->hostId);
+    $commandMacro = new CommandMacro(1, CommandMacroType::Service, 'MACRO_FROM_TPL');
+    $templateWithCommand = new ServiceTemplate(9, 'tpl-9', 'tpl-9-alias', commandId: $inheritedCommandId);
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->exactly(3))
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->validation->expects($this->once())->method('assertIsValidServiceTemplate');
+    $this->validation->expects($this->once())->method('assertIsValidCommandForOnPremPlatform');
+    $this->validation->expects($this->once())->method('assertIsValidHost');
+    $this->validation->expects($this->once())->method('assertServiceName');
+    $this->validation->expects($this->once())->method('assertIsValidServiceCategories');
+    $this->validation->expects($this->once())->method('assertIsValidServiceGroups');
+
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn(['inheritance_mode' => $this->inheritanceModeOption]);
+
+    $this->writeServiceRepository
+        ->expects($this->once())
+        ->method('add')
+        ->willReturn($newServiceId);
+
+    $this->readServiceRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn($serviceTemplateInheritances);
+    $this->readServiceMacroRepository
+        ->expects($this->exactly(2))
+        ->method('findByServiceIds')
+        ->willReturnMap([
+            [9, 8, 1, []],
+            [$newServiceId, []],
+        ]);
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findByIds')
+        ->willReturn([$templateWithCommand]);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Service)
+        ->willReturn([$commandMacro->getName() => $commandMacro]);
+
+    $this->readMonitoringServerRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn(new MonitoringServer(1, 'ms-name'));
+    $this->writeMonitoringServerRepository
+        ->expects($this->once())
+        ->method('notifyConfigurationChange');
+
+    $this->readServiceRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($serviceFound);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->willReturn([]);
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->willReturn([]);
+
+    ($this->addUseCase)($request, $this->useCasePresenter);
+
+    expect($this->useCasePresenter->response)->toBeInstanceOf(AddServiceResponse::class);
 });

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
@@ -64,6 +64,8 @@ use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Domain\Model\ServiceGroup;
 use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 use Exception;
 
 beforeEach(closure: function (): void {
@@ -94,6 +96,7 @@ beforeEach(closure: function (): void {
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         $this->adminResolver = $this->createMock(AdminResolver::class),
+        $this->readServiceTemplateRepository = $this->createMock(ReadServiceTemplateRepositoryInterface::class),
     );
 
     $this->service = new Service(id: 1, name: 'service-name', hostId: 2);
@@ -127,7 +130,7 @@ beforeEach(closure: function (): void {
     $this->macroA->setOrder(0);
     $this->macroB = new Macro(null, $this->service->getId(), 'macroNameB', 'macroValueB');
     $this->macroB->setOrder(1);
-    $this->commandMacro = new CommandMacro(1, CommandMacroType::Service, 'commandMacroName');
+    $this->commandMacro = new CommandMacro(1, CommandMacroType::Service, 'COMMANDMACRONAME');
     $this->commandMacros = [
         $this->commandMacro->getName() => $this->commandMacro,
     ];
@@ -433,6 +436,211 @@ it('should present a NoContentResponse on success', function (): void {
     $this->writeAccessGroupRepository
         ->expects($this->once())
         ->method('updateAclResourcesFlag');
+
+    ($this->useCase)($this->request, $this->presenter, $this->service->getId());
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should load command macros from an inherited template command when the service defines none', function (): void {
+    $this->request->commandId = null;
+    $inheritedCommandId = 42;
+    $templateWithCommand = new ServiceTemplate(
+        $this->parentTemplates[0],
+        'parent-tpl',
+        'parent-tpl-alias',
+        commandId: $inheritedCommandId
+    );
+    $commandMacro = new CommandMacro(1, CommandMacroType::Service, 'MACRO_FROM_TPL');
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->exactly(5))
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->service);
+
+    $this->readCommandRepository
+        ->expects($this->never())
+        ->method('findById');
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions');
+
+    $this->validation->expects($this->once())->method('assertIsValidHost');
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidGraphTemplate');
+    $this->validation->expects($this->once())->method('assertIsValidEventHandler');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+
+    $this->writeServiceRepository
+        ->expects($this->once())
+        ->method('update');
+
+    // Categories
+    $this->validation->expects($this->once())->method('assertAreValidCategories');
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->willReturn([$this->categoryA]);
+    $this->writeServiceCategoryRepository->expects($this->once())->method('linkToService');
+    $this->writeServiceCategoryRepository->expects($this->once())->method('unlinkFromService');
+
+    // Groups
+    $this->validation->expects($this->once())->method('assertAreValidGroups');
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->willReturn([
+            [
+                'relation' => new ServiceGroupRelation(
+                    $this->groupA->getId(),
+                    $this->service->getId(),
+                    $this->service->getHostId()
+                ),
+                'serviceGroup' => $this->groupA,
+            ],
+        ]);
+    $this->writeServiceGroupRepository->expects($this->once())->method('unlink');
+    $this->writeServiceGroupRepository->expects($this->once())->method('link');
+
+    // Macros: service has no commandId; parent template has commandId=42
+    $this->readServiceRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn($this->inheritance);
+    $this->readServiceMacroRepository
+        ->expects($this->once())
+        ->method('findByServiceIds')
+        ->willReturn($this->macros);
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findByIds')
+        ->willReturn([$templateWithCommand]);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Service)
+        ->willReturn([$commandMacro->getName() => $commandMacro]);
+    $this->writeServiceMacroRepository->expects($this->once())->method('delete');
+    $this->writeServiceMacroRepository->expects($this->once())->method('add');
+    $this->writeServiceMacroRepository->expects($this->once())->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->service->getId());
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should delete a command macro from an inherited template command when its value is cleared', function (): void {
+    // Service has no own command — it inherits one from a parent template.
+    // A macro from that command was previously saved on the service with a value.
+    // When the user clears the value, the macro must be deleted from the service (step 8).
+    $this->request->commandId = null;
+    $inheritedCommandId = 42;
+    $templateWithCommand = new ServiceTemplate(
+        $this->parentTemplates[0],
+        'parent-tpl',
+        'parent-tpl-alias',
+        commandId: $inheritedCommandId
+    );
+
+    $savedCommandMacro = new Macro(
+        null,
+        $this->service->getId(),
+        $this->commandMacro->getName(),
+        'somevalue'
+    );
+
+    $this->request->macros = [
+        new MacroDto(name: $this->commandMacro->getName(), value: '', isPassword: false, description: null),
+    ];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->adminResolver
+        ->expects($this->exactly(5))
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->service);
+
+    $this->readCommandRepository->expects($this->never())->method('findById');
+    $this->optionService->expects($this->once())->method('findSelectedOptions');
+
+    $this->validation->expects($this->once())->method('assertIsValidHost');
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidGraphTemplate');
+    $this->validation->expects($this->once())->method('assertIsValidEventHandler');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+
+    $this->writeServiceRepository->expects($this->once())->method('update');
+
+    // Categories
+    $this->validation->expects($this->once())->method('assertAreValidCategories');
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->willReturn([$this->categoryA]);
+    $this->writeServiceCategoryRepository->expects($this->once())->method('linkToService');
+    $this->writeServiceCategoryRepository->expects($this->once())->method('unlinkFromService');
+
+    // Groups
+    $this->validation->expects($this->once())->method('assertAreValidGroups');
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->willReturn([
+            [
+                'relation' => new ServiceGroupRelation(
+                    $this->groupA->getId(),
+                    $this->service->getId(),
+                    $this->service->getHostId()
+                ),
+                'serviceGroup' => $this->groupA,
+            ],
+        ]);
+    $this->writeServiceGroupRepository->expects($this->once())->method('unlink');
+    $this->writeServiceGroupRepository->expects($this->once())->method('link');
+
+    // Macros: service has no commandId; commandMacroName was previously saved with a value
+    $this->readServiceRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn($this->inheritance);
+    $this->readServiceMacroRepository
+        ->expects($this->once())
+        ->method('findByServiceIds')
+        ->willReturn([$savedCommandMacro]);
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findByIds')
+        ->willReturn([$templateWithCommand]);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Service)
+        ->willReturn($this->commandMacros);
+
+    // Clearing the value must delete the macro, not update it
+    $this->writeServiceMacroRepository->expects($this->once())->method('delete');
+    $this->writeServiceMacroRepository->expects($this->never())->method('add');
+    $this->writeServiceMacroRepository->expects($this->never())->method('update');
 
     ($this->useCase)($this->request, $this->presenter, $this->service->getId());
     expect($this->presenter->getResponseStatus())

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -35,6 +35,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Command\Domain\Model\Command;
 use Core\CommandMacro\Application\Repository\ReadCommandMacroRepositoryInterface;
+use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -604,6 +605,107 @@ it('should present a NoContentResponse when everything has gone well for a non-a
         ->expects($this->once())
         ->method('assertServiceCategories')
         ->with($request->serviceCategories, $this->user, $accessGroups);
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should load command macros from an inherited template command when the service template defines none', function (): void {
+    $serviceTemplateId = 20;
+    $parentTemplateId = 9;
+    $inheritedCommandId = 42;
+
+    $serviceTemplate = new ServiceTemplate(
+        id: $serviceTemplateId,
+        name: 'fake_name',
+        alias: 'fake_alias',
+        commandId: null,
+    );
+    $parentTemplate = new ServiceTemplate(
+        id: $parentTemplateId,
+        name: 'parent_name',
+        alias: 'parent_alias',
+        commandId: $inheritedCommandId,
+    );
+    $commandMacro = new CommandMacro(1, CommandMacroType::Service, 'TIMEOUT');
+
+    // Existing direct macro saved from a previous update with a non-empty value
+    $existingMacro = new Macro(null, $serviceTemplateId, 'TIMEOUT', 'myvalue');
+
+    $request = new PartialUpdateServiceTemplateRequest($serviceTemplateId);
+    // Submit TIMEOUT with empty value — should remove the macro from the service template
+    $request->macros = [new MacroDto('TIMEOUT', '', false, null)];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->with($serviceTemplateId)
+        ->willReturn($serviceTemplate);
+
+    $this->writeVaultRepository
+        ->method('isVaultConfigured')
+        ->willReturn(false);
+
+    $this->storageEngine
+        ->expects($this->once())
+        ->method('startTransaction');
+    $this->storageEngine
+        ->expects($this->once())
+        ->method('commitTransaction');
+
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn([]);
+
+    $this->writeServiceTemplateRepository
+        ->expects($this->once())
+        ->method('update');
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn([new ServiceTemplateInheritance($parentTemplateId, $serviceTemplateId)]);
+
+    $this->readServiceMacroRepository
+        ->expects($this->once())
+        ->method('findByServiceIds')
+        ->with($serviceTemplateId, $parentTemplateId)
+        ->willReturn([$existingMacro]);
+
+    // The fix: look up parent templates to find the inherited command
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findByIds')
+        ->with($parentTemplateId)
+        ->willReturn([$parentTemplate]);
+
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->with($inheritedCommandId, CommandMacroType::Service)
+        ->willReturn([$commandMacro->getName() => $commandMacro]);
+
+    // Clearing a previously-set value matching the command macro default should delete it
+    $this->writeServiceMacroRepository
+        ->expects($this->once())
+        ->method('delete');
+    $this->writeServiceMacroRepository
+        ->expects($this->never())
+        ->method('add');
+    $this->writeServiceMacroRepository
+        ->expects($this->never())
+        ->method('update');
 
     ($this->useCase)($request, $this->presenter);
 


### PR DESCRIPTION
## Description

BACKPORT #9891

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Ignored empty unmatched macros when computing macro differences to prevent overrides
* Added method to find inherited check command id and integrated
* Added bulk findByIds for service templates repository and DB implementation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101030039?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->