### PR TITLE
enh(ci): prevent web jobs from running when a PR is only related to translation

### DIFF
--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -228,7 +228,7 @@ jobs:
               trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest || nonWeblateTranslation),
               trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || nonWeblateTranslation),
               trigger_upgrade_testing:  !isWeblateTranslationOnly && (isNightly || hasUpgradeTest),
-              trigger_delivery:         isNightly || hasFrontendProd || hasBackendProd || nonWeblateTranslation || isWeblateTranslationOnly,
+              trigger_delivery:         isNightly || hasFrontendProd || hasBackendProd || nonWeblateTranslation || (isWeblateTranslationOnly && !isPR),
             };
 
             for (const [key, value] of Object.entries(outputs)) {

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -212,14 +212,19 @@ jobs:
               && !hasBackendTest && !hasFrontendTest
               && !hasApiTest && !hasE2eTest && !hasUpgradeTest;
 
+            // On PRs, skip everything for Weblate translation-only changes.
+            // On direct pushes to unstable/testing branches, still trigger packaging so
+            // translations are included in the build artifacts.
+            const isPR = context.eventName === 'pull_request';
+
             if (isWeblateTranslationOnly) {
-              core.info('weblate-service-account with translation-only changes — skipping all test triggers.');
+              core.info(`weblate-service-account with translation-only changes — skipping all test triggers${isPR ? ' (PR mode)' : ', but keeping packaging for branch push'}.`);
             }
 
             const outputs = {
               trigger_backend_testing:  !isWeblateTranslationOnly && (isNightly || hasBackendTest  || hasBackendProd),
               trigger_frontend_testing: !isWeblateTranslationOnly && (isNightly || hasFrontendTest || hasFrontendProd),
-              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || nonWeblateTranslation,
+              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || nonWeblateTranslation || (isWeblateTranslationOnly && !isPR),
               trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest || nonWeblateTranslation),
               trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || nonWeblateTranslation),
               trigger_upgrade_testing:  !isWeblateTranslationOnly && (isNightly || hasUpgradeTest),

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -203,7 +203,9 @@ jobs:
               core.warning(`Could not parse labels: ${e}`);
             }
 
-            const translationTriggersE2e = hasTranslation && !isWeblate;
+            // Non-weblate translation changes behave like backend production changes,
+            // except they don't trigger backend/frontend testing (lint + unit tests).
+            const nonWeblateTranslation = hasTranslation && !isWeblate;
 
             const isWeblateTranslationOnly = isWeblate && hasTranslation
               && !hasBackendProd && !hasFrontendProd
@@ -217,11 +219,11 @@ jobs:
             const outputs = {
               trigger_backend_testing:  !isWeblateTranslationOnly && (isNightly || hasBackendTest  || hasBackendProd),
               trigger_frontend_testing: !isWeblateTranslationOnly && (isNightly || hasFrontendTest || hasFrontendProd),
-              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || isWeblateTranslationOnly,
-              trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest),
-              trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || translationTriggersE2e),
+              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || nonWeblateTranslation || isWeblateTranslationOnly,
+              trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest || nonWeblateTranslation),
+              trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || nonWeblateTranslation),
               trigger_upgrade_testing:  !isWeblateTranslationOnly && (isNightly || hasUpgradeTest),
-              trigger_delivery:         isNightly || hasFrontendProd || hasBackendProd || isWeblateTranslationOnly,
+              trigger_delivery:         isNightly || hasFrontendProd || hasBackendProd || nonWeblateTranslation || isWeblateTranslationOnly,
             };
 
             for (const [key, value] of Object.entries(outputs)) {

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -123,7 +123,7 @@ jobs:
         id: get_changed_files
         uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
         with:
-          use_rest_api: true
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           base_sha: ${{ github.event_name == 'pull_request' && ' ' || inputs.base_sha }}
           files_yaml: |
             frontend_production:
@@ -219,7 +219,7 @@ jobs:
             const outputs = {
               trigger_backend_testing:  !isWeblateTranslationOnly && (isNightly || hasBackendTest  || hasBackendProd),
               trigger_frontend_testing: !isWeblateTranslationOnly && (isNightly || hasFrontendTest || hasFrontendProd),
-              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || nonWeblateTranslation || isWeblateTranslationOnly,
+              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || nonWeblateTranslation,
               trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest || nonWeblateTranslation),
               trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || nonWeblateTranslation),
               trigger_upgrade_testing:  !isWeblateTranslationOnly && (isNightly || hasUpgradeTest),

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        if: github.event_name == 'pull_request' || inputs.base_sha != ''
+        if: inputs.base_sha != ''
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Fetch tags
@@ -126,6 +126,7 @@ jobs:
         id: get_changed_files
         uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
         with:
+          use_rest_api: true
           base_sha: ${{ github.event_name == 'pull_request' && ' ' || inputs.base_sha }}
           files_yaml: |
             frontend_production:

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -161,101 +161,67 @@ jobs:
           LABELS: ${{ inputs.labels }}
         with:
           script: |
+            const isNightly  = process.env.IS_NIGHTLY === 'true';
+            const isWeblate  = process.env.GITHUB_ACTOR === 'weblate-service-account';
+
+            let hasBackendProd  = process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true';
+            let hasFrontendProd = process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true';
+            let hasBackendTest  = process.env.HAS_BACKEND_TEST_CHANGES === 'true';
+            let hasFrontendTest = process.env.HAS_FRONTEND_TEST_CHANGES === 'true';
+            let hasApiTest      = process.env.HAS_API_TEST_CHANGES === 'true';
+            let hasE2eTest      = process.env.HAS_E2E_TEST_CHANGES === 'true';
+            let hasUpgradeTest  = process.env.HAS_UPGRADE_TEST_CHANGES === 'true';
+            let hasTranslation  = process.env.HAS_TRANSLATION_CHANGES === 'true';
+
             try {
               const labels = JSON.parse(process.env.LABELS);
               if (labels.includes('force-backend-tests')) {
                 core.info('Label force-backend-tests found: forcing backend testing trigger to true');
-                process.env.HAS_BACKEND_TEST_CHANGES = 'true';
+                hasBackendTest = true;
               }
               if (labels.includes('force-frontend-tests')) {
                 core.info('Label force-frontend-tests found: forcing frontend testing trigger to true');
-                process.env.HAS_FRONTEND_TEST_CHANGES = 'true';
+                hasFrontendTest = true;
               }
               if (labels.includes('force-api-tests')) {
                 core.info('Label force-api-tests found: forcing API testing trigger to true');
-                process.env.HAS_API_TEST_CHANGES = 'true';
+                hasApiTest = true;
               }
               if (labels.includes('force-e2e-tests')) {
                 core.info('Label force-e2e-tests found: forcing E2E testing trigger to true');
-                process.env.HAS_E2E_TEST_CHANGES = 'true';
+                hasE2eTest = true;
               }
               if (labels.includes('force-upgrade-tests')) {
                 core.info('Label force-upgrade-tests found: forcing upgrade testing trigger to true');
-                process.env.HAS_UPGRADE_TEST_CHANGES = 'true';
+                hasUpgradeTest = true;
               }
               if (labels.includes('force-all-tests')) {
                 core.info('Label force-all-tests found: forcing all testing triggers to true');
-                process.env.HAS_BACKEND_TEST_CHANGES = 'true';
-                process.env.HAS_FRONTEND_TEST_CHANGES = 'true';
-                process.env.HAS_API_TEST_CHANGES = 'true';
-                process.env.HAS_E2E_TEST_CHANGES = 'true';
-                process.env.HAS_UPGRADE_TEST_CHANGES = 'true';
+                hasBackendTest = hasFrontendTest = hasApiTest = hasE2eTest = hasUpgradeTest = true;
               }
             } catch (e) {
               core.warning(`Could not parse labels: ${e}`);
             }
 
-            // When weblate-service-account only changed translation files, skip all testing
-            // but keep packaging and delivery enabled.
-            const isWeblateTranslationOnly =
-              process.env.GITHUB_ACTOR === 'weblate-service-account'
-              && process.env.HAS_TRANSLATION_CHANGES === 'true'
-              && process.env.HAS_BACKEND_PRODUCTION_CHANGES !== 'true'
-              && process.env.HAS_FRONTEND_PRODUCTION_CHANGES !== 'true'
-              && process.env.HAS_BACKEND_TEST_CHANGES !== 'true'
-              && process.env.HAS_FRONTEND_TEST_CHANGES !== 'true'
-              && process.env.HAS_API_TEST_CHANGES !== 'true'
-              && process.env.HAS_E2E_TEST_CHANGES !== 'true'
-              && process.env.HAS_UPGRADE_TEST_CHANGES !== 'true';
+            const translationTriggersE2e = hasTranslation && !isWeblate;
+
+            const isWeblateTranslationOnly = isWeblate && hasTranslation
+              && !hasBackendProd && !hasFrontendProd
+              && !hasBackendTest && !hasFrontendTest
+              && !hasApiTest && !hasE2eTest && !hasUpgradeTest;
 
             if (isWeblateTranslationOnly) {
-              core.info('weblate-service-account with translation-only changes detected — skipping all test and lint triggers.');
+              core.info('weblate-service-account with translation-only changes — skipping all test triggers.');
             }
 
             const outputs = {
-              'trigger_backend_testing':
-                !isWeblateTranslationOnly && (
-                  process.env.IS_NIGHTLY === 'true'
-                  || process.env.HAS_BACKEND_TEST_CHANGES === 'true'
-                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                ),
-              'trigger_frontend_testing':
-                !isWeblateTranslationOnly && (
-                  process.env.IS_NIGHTLY === 'true'
-                  || process.env.HAS_FRONTEND_TEST_CHANGES === 'true'
-                  || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                ),
-              'trigger_packaging':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_API_TEST_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true'
-                || isWeblateTranslationOnly,
-              'trigger_api_testing':
-                !isWeblateTranslationOnly && (
-                  process.env.IS_NIGHTLY === 'true'
-                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                  || process.env.HAS_API_TEST_CHANGES === 'true'
-                ),
-              'trigger_e2e_testing':
-                !isWeblateTranslationOnly && (
-                  process.env.IS_NIGHTLY === 'true'
-                  || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                  || process.env.HAS_E2E_TEST_CHANGES === 'true'
-                  || (process.env.HAS_TRANSLATION_CHANGES === 'true' && process.env.GITHUB_ACTOR !== 'weblate-service-account')
-                ),
-              'trigger_upgrade_testing':
-                !isWeblateTranslationOnly && (
-                  process.env.IS_NIGHTLY === 'true'
-                  || process.env.HAS_UPGRADE_TEST_CHANGES === 'true'
-                ),
-              'trigger_delivery':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || isWeblateTranslationOnly,
+              trigger_backend_testing:  !isWeblateTranslationOnly && (isNightly || hasBackendTest  || hasBackendProd),
+              trigger_frontend_testing: !isWeblateTranslationOnly && (isNightly || hasFrontendTest || hasFrontendProd),
+              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || isWeblateTranslationOnly,
+              trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest),
+              trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || translationTriggersE2e),
+              trigger_upgrade_testing:  !isWeblateTranslationOnly && (isNightly || hasUpgradeTest),
+              trigger_delivery:         isNightly || hasFrontendProd || hasBackendProd || isWeblateTranslationOnly,
             };
 
             for (const [key, value] of Object.entries(outputs)) {

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -244,6 +244,7 @@ jobs:
                   || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
                   || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
                   || process.env.HAS_E2E_TEST_CHANGES === 'true'
+                  || (process.env.HAS_TRANSLATION_CHANGES === 'true' && process.env.GITHUB_ACTOR !== 'weblate-service-account')
                 ),
               'trigger_upgrade_testing':
                 !isWeblateTranslationOnly && (

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -80,15 +80,6 @@ jobs:
       trigger_delivery: ${{ github.event_name == 'workflow_dispatch' && steps.get_dispatch_triggers.outputs.trigger_delivery || steps.get_triggers.outputs.trigger_delivery || 'true' }}
 
     steps:
-      - name: Checkout sources
-        if: inputs.base_sha != ''
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Fetch tags
-        if: inputs.base_sha != ''
-        run: git fetch origin tag ${{ inputs.base_sha }} --no-tags || true
-        shell: bash
-
       - name: Convert inputs to yaml list
         if: github.event_name == 'pull_request' || inputs.base_sha != ''
         id: inline_inputs

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: ''
+      translation_paths:
+        required: false
+        type: string
+        default: ''
       is_nightly:
         required: true
         type: string
@@ -97,6 +101,7 @@ jobs:
           API_TEST_PATHS: ${{ inputs.api_test_paths }}
           E2E_TEST_PATHS: ${{ inputs.e2e_test_paths }}
           UPGRADE_TEST_PATHS: ${{ inputs.upgrade_test_paths }}
+          TRANSLATION_PATHS: ${{ inputs.translation_paths }}
         with:
           script: |
             const paths = {
@@ -107,6 +112,7 @@ jobs:
               api_test_paths: process.env.API_TEST_PATHS,
               e2e_test_paths: process.env.E2E_TEST_PATHS,
               upgrade_test_paths: process.env.UPGRADE_TEST_PATHS,
+              translation_paths: process.env.TRANSLATION_PATHS,
             };
 
             for (const [key, value] of Object.entries(paths)) {
@@ -143,6 +149,8 @@ jobs:
             ${{ steps.inline_inputs.outputs.e2e_test_paths }}
             upgrade_test:
             ${{ steps.inline_inputs.outputs.upgrade_test_paths }}
+            translation:
+            ${{ steps.inline_inputs.outputs.translation_paths }}
 
       - name: Determine triggers for event ${{ github.event_name }}
         if: github.event_name == 'pull_request' || inputs.base_sha != ''
@@ -157,6 +165,8 @@ jobs:
           HAS_API_TEST_CHANGES: ${{ steps.get_changed_files.outputs.api_test_any_changed }}
           HAS_E2E_TEST_CHANGES: ${{ steps.get_changed_files.outputs.e2e_test_any_changed }}
           HAS_UPGRADE_TEST_CHANGES: ${{ steps.get_changed_files.outputs.upgrade_test_any_changed }}
+          HAS_TRANSLATION_CHANGES: ${{ steps.get_changed_files.outputs.translation_any_changed }}
+          GITHUB_ACTOR: ${{ github.actor }}
           LABELS: ${{ inputs.labels }}
         with:
           script: |
@@ -194,37 +204,66 @@ jobs:
               core.warning(`Could not parse labels: ${e}`);
             }
 
+            // When weblate-service-account only changed translation files, skip all testing
+            // but keep packaging and delivery enabled.
+            const isWeblateTranslationOnly =
+              process.env.GITHUB_ACTOR === 'weblate-service-account'
+              && process.env.HAS_TRANSLATION_CHANGES === 'true'
+              && process.env.HAS_BACKEND_PRODUCTION_CHANGES !== 'true'
+              && process.env.HAS_FRONTEND_PRODUCTION_CHANGES !== 'true'
+              && process.env.HAS_BACKEND_TEST_CHANGES !== 'true'
+              && process.env.HAS_FRONTEND_TEST_CHANGES !== 'true'
+              && process.env.HAS_API_TEST_CHANGES !== 'true'
+              && process.env.HAS_E2E_TEST_CHANGES !== 'true'
+              && process.env.HAS_UPGRADE_TEST_CHANGES !== 'true';
+
+            if (isWeblateTranslationOnly) {
+              core.info('weblate-service-account with translation-only changes detected — skipping all test and lint triggers.');
+            }
+
             const outputs = {
               'trigger_backend_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_BACKEND_TEST_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_BACKEND_TEST_CHANGES === 'true'
+                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                ),
               'trigger_frontend_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_TEST_CHANGES === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_FRONTEND_TEST_CHANGES === 'true'
+                  || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
+                ),
               'trigger_packaging':
                 process.env.IS_NIGHTLY === 'true'
                 || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
                 || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
                 || process.env.HAS_API_TEST_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true',
+                || process.env.HAS_E2E_TEST_CHANGES === 'true'
+                || isWeblateTranslationOnly,
               'trigger_api_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_API_TEST_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                  || process.env.HAS_API_TEST_CHANGES === 'true'
+                ),
               'trigger_e2e_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
+                  || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                  || process.env.HAS_E2E_TEST_CHANGES === 'true'
+                ),
               'trigger_upgrade_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_UPGRADE_TEST_CHANGES === 'true',
+                !isWeblateTranslationOnly && (
+                  process.env.IS_NIGHTLY === 'true'
+                  || process.env.HAS_UPGRADE_TEST_CHANGES === 'true'
+                ),
               'trigger_delivery':
                 process.env.IS_NIGHTLY === 'true'
                 || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true',
+                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
+                || isWeblateTranslationOnly,
             };
 
             for (const [key, value] of Object.entries(outputs)) {

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -49,12 +49,20 @@ env:
 jobs:
   check-actor:
     runs-on: ubuntu-24.04
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
-      - name: Skip workflow if weblate-service-account only changed translation files
-        if: github.actor == 'weblate-service-account'
+      - name: Check if weblate-service-account only changed translation files
+        id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [[ "${{ github.actor }}" != "weblate-service-account" ]]; then
+            echo "Actor is not weblate-service-account — not skipping."
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
           elif [[ "${{ github.event_name }}" == "push" ]]; then
@@ -65,15 +73,19 @@ jobs:
             fi
             FILES=$(gh api "repos/${{ github.repository }}/compare/${BASE}...${{ github.sha }}" --jq '.files[].filename')
           else
-            echo "Event '${{ github.event_name }}' or initial push — not skipping."
+            echo "Event '${{ github.event_name }}' — not skipping."
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
           NON_TRANSLATION=$(echo "$FILES" | grep -vE '\.pot?$' || true)
           if [[ -z "$NON_TRANSLATION" ]]; then
-            echo "Only .po/.pot files changed by weblate-service-account — skipping workflow."
-            exit 1
+            echo "Only .po/.pot files changed by weblate-service-account — skipping lint and test jobs."
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-translation files detected — proceeding."
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "Non-translation files detected — proceeding."
 
   dependency-scan:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
@@ -97,7 +109,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   get-environment:
-    needs: [dependency-scan, check-actor]
+    needs: [dependency-scan]
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql
@@ -439,8 +451,9 @@ jobs:
 
   frontend-web-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -457,8 +470,9 @@ jobs:
 
   frontend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -495,8 +509,9 @@ jobs:
           path: "centreon/junit.xml"
 
   frontend-component-test:
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -516,8 +531,9 @@ jobs:
 
   backend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -562,8 +578,9 @@ jobs:
 
   backend-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
+    needs: [changes, get-environment, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -703,8 +720,9 @@ jobs:
 
   gherkin-lint:
     runs-on: ubuntu-24.04
-    needs: [get-environment, changes]
+    needs: [get-environment, changes, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -717,8 +735,9 @@ jobs:
 
   e2e-lint:
     runs-on: ubuntu-22.04
-    needs: [get-environment, changes]
+    needs: [get-environment, changes, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -1055,9 +1074,11 @@ jobs:
         get-environment,
         changes,
         create-xray-test-plan-and-test-execution,
-        dockerize
+        dockerize,
+        check-actor
       ]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_api_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1096,8 +1117,9 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   legacy-e2e-test:
-    needs: [get-environment, changes, dockerize]
+    needs: [get-environment, changes, dockerize, check-actor]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1140,8 +1162,10 @@ jobs:
         create-xray-test-plan-and-test-execution,
         gherkin-lint,
         e2e-lint,
+        check-actor,
       ]
     if: |
+      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -47,10 +47,39 @@ env:
   e2e_directory: centreon/tests/e2e
 
 jobs:
+  check-actor:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Skip workflow if weblate-service-account only changed translation files
+        if: github.actor == 'weblate-service-account'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+              BASE="develop"
+            else
+              BASE="${{ github.event.before }}"
+            fi
+            FILES=$(gh api "repos/${{ github.repository }}/compare/${BASE}...${{ github.sha }}" --jq '.files[].filename')
+          else
+            echo "Event '${{ github.event_name }}' or initial push — not skipping."
+            exit 0
+          fi
+          NON_TRANSLATION=$(echo "$FILES" | grep -vE '\.pot?$' || true)
+          if [[ -z "$NON_TRANSLATION" ]]; then
+            echo "Only .po/.pot files changed by weblate-service-account — skipping workflow."
+            exit 1
+          fi
+          echo "Non-translation files detected — proceeding."
+
   dependency-scan:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
 
   dispatch-to-maintenance-branches:
+    needs: [check-actor]
     if: |
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
@@ -68,7 +97,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   get-environment:
-    needs: [dependency-scan]
+    needs: [dependency-scan, check-actor]
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -47,46 +47,6 @@ env:
   e2e_directory: centreon/tests/e2e
 
 jobs:
-  check-actor:
-    runs-on: ubuntu-24.04
-    outputs:
-      should_skip: ${{ steps.check.outputs.should_skip }}
-    steps:
-      - name: Check if weblate-service-account only changed translation files
-        id: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [[ "${{ github.actor }}" != "weblate-service-account" ]]; then
-            echo "Actor is not weblate-service-account — not skipping."
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
-              BASE="develop"
-            else
-              BASE="${{ github.event.before }}"
-            fi
-            FILES=$(gh api "repos/${{ github.repository }}/compare/${BASE}...${{ github.sha }}" --jq '.files[].filename')
-          else
-            echo "Event '${{ github.event_name }}' — not skipping."
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          NON_TRANSLATION=$(echo "$FILES" | grep -vE '\.pot?$' || true)
-          if [[ -z "$NON_TRANSLATION" ]]; then
-            echo "Only .po/.pot files changed by weblate-service-account — skipping lint and test jobs."
-            echo "should_skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Non-translation files detected — proceeding."
-            echo "should_skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
   dependency-scan:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
 
@@ -138,7 +98,6 @@ jobs:
         "centreon/cron/**"
         "centreon/doc/API/**"
         "centreon/GPL_LIB/**"
-        "centreon/lang/**"
         "centreon/lib/**"
         "centreon/libinstall/**"
         "centreon/logrotate/**"
@@ -192,6 +151,8 @@ jobs:
         "centreon/www/install/**"
         "centreon/packaging/**"
         "centreon/tests/e2e/features/Platform-upgrade-update/**"
+      translation_paths: |
+        "centreon/lang/**"
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       base_sha: ${{ needs.get-environment.outputs.previous_release_bundle_tag }}
       labels: ${{ needs.get-environment.outputs.labels }}
@@ -451,9 +412,8 @@ jobs:
 
   frontend-web-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -470,9 +430,8 @@ jobs:
 
   frontend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -509,9 +468,8 @@ jobs:
           path: "centreon/junit.xml"
 
   frontend-component-test:
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_frontend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -531,9 +489,8 @@ jobs:
 
   backend-unit-test:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -578,9 +535,8 @@ jobs:
 
   backend-lint:
     runs-on: ubuntu-24.04
-    needs: [changes, get-environment, check-actor]
+    needs: [changes, get-environment]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_backend_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -720,9 +676,8 @@ jobs:
 
   gherkin-lint:
     runs-on: ubuntu-24.04
-    needs: [get-environment, changes, check-actor]
+    needs: [get-environment, changes]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -735,9 +690,8 @@ jobs:
 
   e2e-lint:
     runs-on: ubuntu-22.04
-    needs: [get-environment, changes, check-actor]
+    needs: [get-environment, changes]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -1074,11 +1028,9 @@ jobs:
         get-environment,
         changes,
         create-xray-test-plan-and-test-execution,
-        dockerize,
-        check-actor
+        dockerize
       ]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_api_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1117,9 +1069,8 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   legacy-e2e-test:
-    needs: [get-environment, changes, dockerize, check-actor]
+    needs: [get-environment, changes, dockerize]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&
@@ -1162,10 +1113,8 @@ jobs:
         create-xray-test-plan-and-test-execution,
         gherkin-lint,
         e2e-lint,
-        check-actor,
       ]
     if: |
-      needs.check-actor.outputs.should_skip != 'true' &&
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,7 +51,6 @@ jobs:
     uses: centreon/security-tools/.github/workflows/dependency-analysis.yml@main
 
   dispatch-to-maintenance-branches:
-    needs: [check-actor]
     if: |
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1,4 +1,3 @@
-
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1,3 +1,4 @@
+
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.


### PR DESCRIPTION
## Description

This PR allows skipping web CI workflows when updates are only related to translations AND created by the related service account

See https://centreon.atlassian.net/browse/MON-196468


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

From this branch, update a .po file and try to run the web workflow

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added translation_paths input and detection to get-changes-triggers workflow.
* Prevented web jobs from running for Weblate-only PRs by actor.
* Kept packaging and delivery on direct branch pushes for translations.

**🔧 Refactors**
* Switched changed-files detection to REST API and removed checkout/fetch.
* Simplified trigger condition logic using boolean variables throughout workflows.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101824227?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->