### PR TITLE
fix(configuration): unlink ht services after unlinking template (#9960)

### DIFF
--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -69,6 +69,8 @@ use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepository
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Utility\Difference\BasicDifference;
 
 final class PartialUpdateHost
@@ -98,6 +100,8 @@ final class PartialUpdateHost
         private readonly PartialUpdateHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
+        private readonly WriteServiceRepositoryInterface $writeServiceRepository,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -546,6 +550,18 @@ final class PartialUpdateHost
         $parentTemplateIds = array_unique($dto->templates);
         $this->validation->assertAreValidTemplates($parentTemplateIds, $host->getId());
 
+        // Read current DIRECT parent templates BEFORE deleting them, to compute which were removed.
+        // findParents() returns the full inheritance chain, so we filter to direct parents only
+        // (rows where child_id matches the host) to avoid false positives with indirect ancestors.
+        $currentParents = $this->readHostRepository->findParents($host->getId());
+        $currentDirectParentIds = [];
+        foreach ($currentParents as $parent) {
+            if ((int) $parent['child_id'] === $host->getId()) {
+                $currentDirectParentIds[] = (int) $parent['parent_id'];
+            }
+        }
+        $currentDirectParentIds = array_values(array_unique($currentDirectParentIds));
+
         $this->info('Remove parent templates from a host', ['host_id' => $host->getId()]);
         $this->writeHostRepository->deleteParents($host->getId());
 
@@ -555,6 +571,105 @@ final class PartialUpdateHost
             ]);
             $this->writeHostRepository->addParent($host->getId(), $templateId, $order);
         }
+
+        $this->cleanServicesFromRemovedTemplates($host->getId(), $currentDirectParentIds, $parentTemplateIds);
+    }
+
+    /**
+     * Clean up services from templates that were removed from a host.
+     *
+     * @param int $hostId
+     * @param int[] $previousDirectParentIds Direct parent template IDs before the update
+     * @param int[] $newDirectParentIds Direct parent template IDs after the update
+     */
+    private function cleanServicesFromRemovedTemplates(
+        int $hostId,
+        array $previousDirectParentIds,
+        array $newDirectParentIds,
+    ): void {
+        $removedTemplateIds = array_values(array_diff($previousDirectParentIds, $newDirectParentIds));
+        if ($removedTemplateIds === []) {
+            return;
+        }
+
+        $this->info('Clean up services from removed templates', [
+            'host_id' => $hostId,
+            'removed_template_ids' => $removedTemplateIds,
+        ]);
+
+        // Expand remaining templates to include their full inheritance chains
+        $allRemainingIds = $this->expandTemplateChain($newDirectParentIds);
+
+        // Process each removed template and its inheritance chain
+        $visited = [];
+        foreach ($removedTemplateIds as $removedTemplateId) {
+            $this->deleteServicesFromTemplate($hostId, $removedTemplateId, $allRemainingIds, $visited);
+        }
+    }
+
+    /**
+     * Recursively process a template and its parents to delete services
+     * that are no longer provided by any remaining template.
+     *
+     * @param int $hostId
+     * @param int $templateId
+     * @param int[] $allRemainingIds Expanded remaining template IDs
+     * @param array<int, bool> $visited Anti-loop tracker
+     */
+    private function deleteServicesFromTemplate(
+        int $hostId,
+        int $templateId,
+        array $allRemainingIds,
+        array &$visited,
+    ): void {
+        if (isset($visited[$templateId])) {
+            return;
+        }
+        $visited[$templateId] = true;
+
+        // Find service templates linked to this host template
+        $serviceTemplateIds = $this->readServiceTemplateRepository->findIdsByHostTemplateId($templateId);
+
+        foreach ($serviceTemplateIds as $serviceTemplateId) {
+            // Only delete if this service template is not provided by any remaining template
+            if (! $this->readServiceTemplateRepository->isLinkedToAnyHostTemplate($serviceTemplateId, $allRemainingIds)) {
+                $this->writeServiceRepository->deleteByHostIdAndServiceTemplateId($hostId, $serviceTemplateId);
+            }
+        }
+
+        // Recursively process this template's own parent templates
+        $parentChain = $this->readHostRepository->findParents($templateId);
+        $directParentIds = [];
+        foreach ($parentChain as $row) {
+            if ((int) $row['child_id'] === $templateId) {
+                $directParentIds[] = (int) $row['parent_id'];
+            }
+        }
+
+        foreach ($directParentIds as $parentId) {
+            $this->deleteServicesFromTemplate($hostId, $parentId, $allRemainingIds, $visited);
+        }
+    }
+
+    /**
+     * Expand a list of template IDs to include their full inheritance chains.
+     *
+     * @param int[] $templateIds
+     *
+     * @return int[]
+     */
+    private function expandTemplateChain(array $templateIds): array
+    {
+        $allIds = [];
+        foreach ($templateIds as $templateId) {
+            $allIds[] = $templateId;
+            $parentChain = $this->readHostRepository->findParents($templateId);
+            foreach ($parentChain as $row) {
+                $allIds[] = (int) $row['parent_id'];
+            }
+        }
+
+        return array_values(array_unique($allIds));
     }
 
     /**

--- a/centreon/src/Core/Service/Application/Repository/ReadServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/ReadServiceRepositoryInterface.php
@@ -209,4 +209,16 @@ interface ReadServiceRepositoryInterface
         array $pollerIds = [],
         array $hostIds = [],
     ): array;
+
+    /**
+     * Find services on a host that are based on a given service template.
+     *
+     * @param int $hostId
+     * @param int $serviceTemplateId
+     *
+     * @throws \Throwable
+     *
+     * @return list<array{id: int, name: string}>
+     */
+    public function findByHostIdAndServiceTemplateId(int $hostId, int $serviceTemplateId): array;
 }

--- a/centreon/src/Core/Service/Application/Repository/WriteServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/WriteServiceRepositoryInterface.php
@@ -63,4 +63,14 @@ interface WriteServiceRepositoryInterface
      * @throws \Throwable
      */
     public function update(Service $service): void;
+
+    /**
+     * Delete deployed services on a host that are based on a given service template.
+     *
+     * @param int $hostId
+     * @param int $serviceTemplateId
+     *
+     * @throws \Throwable
+     */
+    public function deleteByHostIdAndServiceTemplateId(int $hostId, int $serviceTemplateId): void;
 }

--- a/centreon/src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
@@ -212,4 +212,12 @@ class ApiReadServiceRepository implements ReadServiceRepositoryInterface
     {
         throw RepositoryException::notYetImplemented();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByHostIdAndServiceTemplateId(int $hostId, int $serviceTemplateId): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
 }

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -655,6 +655,38 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
     }
 
     /**
+     * @inheritDoc
+     */
+    public function findByHostIdAndServiceTemplateId(int $hostId, int $serviceTemplateId): array
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                SELECT svc.service_id, svc.service_description
+                FROM `:db`.`service` svc
+                INNER JOIN `:db`.`host_service_relation` hsr
+                    ON hsr.service_service_id = svc.service_id
+                WHERE hsr.host_host_id = :hostId
+                    AND svc.service_template_model_stm_id = :serviceTemplateId
+                    AND svc.service_register = '1'
+                SQL
+        ));
+        $statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
+        $statement->bindValue(':serviceTemplateId', $serviceTemplateId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        $services = [];
+        while ($row = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            /** @var array{service_id: int, service_description: string} $row */
+            $services[] = [
+                'id' => (int) $row['service_id'],
+                'name' => $row['service_description'],
+            ];
+        }
+
+        return $services;
+    }
+
+    /**
      * @param int[] $accessGroupIds
      *
      * @throws \Throwable

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -219,6 +219,37 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
     }
 
     /**
+     * @inheritDoc
+     */
+    public function deleteByHostIdAndServiceTemplateId(int $hostId, int $serviceTemplateId): void
+    {
+        try {
+            $services = $this->readServiceRepository->findByHostIdAndServiceTemplateId($hostId, $serviceTemplateId);
+
+            $this->writeServiceRepository->deleteByHostIdAndServiceTemplateId($hostId, $serviceTemplateId);
+
+            foreach ($services as $service) {
+                $actionLog = new ActionLog(
+                    ActionLog::OBJECT_TYPE_SERVICE,
+                    $service['id'],
+                    $service['name'],
+                    ActionLog::ACTION_TYPE_DELETE,
+                    $this->contact->getId()
+                );
+                $this->writeActionLogRepository->addAction($actionLog);
+            }
+        } catch (\Throwable $ex) {
+            $this->error($ex->getMessage(), [
+                'host_id' => $hostId,
+                'service_template_id' => $serviceTemplateId,
+                'trace' => $ex->getTraceAsString(),
+            ]);
+
+            throw $ex;
+        }
+    }
+
+    /**
      * @param NewService|Service $service
      *
      * @return array<string,int|bool|string>

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceRepository.php
@@ -225,6 +225,26 @@ class DbWriteServiceRepository extends AbstractRepositoryRDB implements WriteSer
 
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function deleteByHostIdAndServiceTemplateId(int $hostId, int $serviceTemplateId): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                DELETE svc
+                FROM `:db`.`service` svc
+                INNER JOIN `:db`.`host_service_relation` hsr ON hsr.service_service_id = svc.service_id
+                WHERE svc.service_template_model_stm_id = :serviceTemplateId
+                AND svc.service_register = '1'
+                AND hsr.host_host_id = :hostId
+                SQL
+        ));
+        $statement->bindValue(':serviceTemplateId', $serviceTemplateId, \PDO::PARAM_INT);
+        $statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
+        $statement->execute();
+    }
+
     private function updateBasicInformations(Service $service): void
     {
         $request = $this->translateDbName(<<<'SQL'

--- a/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
@@ -132,4 +132,27 @@ interface ReadServiceTemplateRepositoryInterface
      * @return int[]
      */
     public function findIdsByCommandNames(array $commandNames): array;
+
+    /**
+     * Find service template IDs linked to a host template via the host_service_relation table.
+     *
+     * @param int $hostTemplateId
+     *
+     * @throws \Throwable
+     *
+     * @return int[]
+     */
+    public function findIdsByHostTemplateId(int $hostTemplateId): array;
+
+    /**
+     * Check if a service template is linked to any of the given host template IDs.
+     *
+     * @param int $serviceTemplateId
+     * @param int[] $hostTemplateIds
+     *
+     * @throws \Throwable
+     *
+     * @return bool
+     */
+    public function isLinkedToAnyHostTemplate(int $serviceTemplateId, array $hostTemplateIds): bool;
 }

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
@@ -578,6 +578,59 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
     }
 
     /**
+     * @inheritDoc
+     */
+    public function findIdsByHostTemplateId(int $hostTemplateId): array
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                SELECT hsr.service_service_id
+                FROM `:db`.`host_service_relation` hsr
+                INNER JOIN `:db`.`service` svc ON svc.service_id = hsr.service_service_id
+                WHERE svc.service_register = '0'
+                AND hsr.host_host_id = :hostTemplateId
+                SQL
+        ));
+        $statement->bindValue(':hostTemplateId', $hostTemplateId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        return array_map('intval', $statement->fetchAll(\PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isLinkedToAnyHostTemplate(int $serviceTemplateId, array $hostTemplateIds): bool
+    {
+        if ($hostTemplateIds === []) {
+            return false;
+        }
+
+        $bindIds = [];
+        foreach ($hostTemplateIds as $index => $id) {
+            $bindIds[':tmpl_' . $index] = $id;
+        }
+        $inClause = implode(', ', array_keys($bindIds));
+
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<SQL
+                SELECT 1
+                FROM `:db`.`host_service_relation` hsr
+                WHERE hsr.service_service_id = :serviceTemplateId
+                AND hsr.host_host_id IN ({$inClause})
+                LIMIT 1
+                SQL
+        ));
+        $statement->bindValue(':serviceTemplateId', $serviceTemplateId, \PDO::PARAM_INT);
+        foreach ($bindIds as $key => $id) {
+            $statement->bindValue($key, $id, \PDO::PARAM_INT);
+        }
+        $statement->execute();
+
+        return $statement->fetchColumn() !== false;
+    }
+
+    /**
      * @param _ServiceTemplate $data
      *
      * @throws AssertionFailedException

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
@@ -60,6 +60,8 @@ use Core\Macro\Application\Repository\WriteHostMacroRepositoryInterface;
 use Core\Macro\Domain\Model\Macro;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Tests\Core\Host\Infrastructure\API\PartialUpdateHost\PartialUpdateHostPresenterStub;
 
 beforeEach(function (): void {
@@ -83,6 +85,8 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(PartialUpdateHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        readServiceTemplateRepository: $this->readServiceTemplateRepository = $this->createMock(ReadServiceTemplateRepositoryInterface::class),
+        writeServiceRepository: $this->writeServiceRepository = $this->createMock(WriteServiceRepositoryInterface::class),
     );
 
     $this->inheritanceModeOption = new Option();
@@ -628,6 +632,145 @@ it('should present a ConflictResponse when a parent template creates a circular 
         );
 });
 
+// Test for template removal and service cleanup
+
+it('should call deleteServicesFromRemovedTemplates when a template is removed', function (): void {
+    // Host initially has direct parents [2, 3, 4], request updates to [2, 3] => template 4 is removed
+    $this->request->templates = [2, 3];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->exactly(4))
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readHostRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->originalHost);
+
+    $this->optionService
+        ->expects($this->once())
+        ->method('findSelectedOptions')
+        ->willReturn([$this->inheritanceModeOption]);
+
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidSeverity');
+    $this->validation->expects($this->once())->method('assertIsValidTimezone');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidTimePeriod');
+    $this->validation->expects($this->exactly(2))->method('assertIsValidCommand');
+    $this->validation->expects($this->once())->method('assertIsValidIcon');
+
+    $this->writeHostRepository
+        ->expects($this->once())
+        ->method('update');
+
+    // Categories
+    $this->readHostCategoryRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([]);
+    $this->writeHostCategoryRepository
+        ->expects($this->once())
+        ->method('linkToHost');
+
+    // Groups
+    $this->readHostGroupRepository
+        ->expects($this->once())
+        ->method('findByHost')
+        ->willReturn([]);
+    $this->writeHostGroupRepository
+        ->expects($this->once())
+        ->method('linkToHost');
+
+    // Parent templates
+    $this->validation
+        ->expects($this->once())
+        ->method('assertAreValidTemplates');
+    $this->writeHostRepository
+        ->expects($this->once())
+        ->method('deleteParents');
+    $this->writeHostRepository
+        ->expects($this->exactly(2))
+        ->method('addParent');
+
+    // findParents is called multiple times:
+    //   1st: in updateParentTemplates to compute removed templates (before delete)
+    //   2nd+3rd: in cleanServicesFromRemovedTemplates to expand template chains
+    //   4th: in deleteServicesFromTemplate to find parents of removed template 4
+    //   5th: in updateMacros to resolve inheritance chain
+    $initialParents = [
+        ['child_id' => 1, 'parent_id' => 2, 'order' => 0],
+        ['child_id' => 1, 'parent_id' => 3, 'order' => 1],
+        ['child_id' => 1, 'parent_id' => 4, 'order' => 2],
+        ['child_id' => 2, 'parent_id' => 3, 'order' => 0],
+    ];
+    $template2Parents = [
+        ['child_id' => 2, 'parent_id' => 3, 'order' => 0],
+    ];
+    $template3Parents = [];
+    $template4Parents = [];
+    $updatedParents = [
+        ['child_id' => 1, 'parent_id' => 2, 'order' => 0],
+        ['child_id' => 1, 'parent_id' => 3, 'order' => 1],
+        ['child_id' => 2, 'parent_id' => 3, 'order' => 0],
+    ];
+    $this->readHostRepository
+        ->expects($this->exactly(5))
+        ->method('findParents')
+        ->willReturnOnConsecutiveCalls(
+            $initialParents,      // updateParentTemplates: compute removed templates
+            $template2Parents,    // expandTemplateChain: expand template 2
+            $template3Parents,    // expandTemplateChain: expand template 3
+            $template4Parents,    // deleteServicesFromTemplate: parents of template 4
+            $updatedParents,      // updateMacros: resolve inheritance chain
+        );
+
+    // Service template cleanup for removed template 4
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findIdsByHostTemplateId')
+        ->with(4)
+        ->willReturn([10]); // template 4 provides service template 10
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('isLinkedToAnyHostTemplate')
+        ->with(10, [2, 3]) // check against remaining expanded template IDs
+        ->willReturn(false); // not provided by remaining templates
+
+    $this->writeServiceRepository
+        ->expects($this->once())
+        ->method('deleteByHostIdAndServiceTemplateId')
+        ->with($this->hostId, 10);
+
+    // Macros
+    $this->readHostMacroRepository
+        ->expects($this->once())
+        ->method('findByHostIds')
+        ->willReturn($this->hostMacros);
+    $this->readCommandMacroRepository
+        ->expects($this->once())
+        ->method('findByCommandIdAndType')
+        ->willReturn([]);
+    $this->writeHostMacroRepository
+        ->expects($this->once())
+        ->method('delete');
+    $this->writeHostMacroRepository
+        ->expects($this->once())
+        ->method('add');
+    $this->writeHostMacroRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->hostId);
+
+    expect($this->presenter->response)->toBeInstanceOf(NoContentResponse::class);
+});
+
 // Test for successful request
 
 it('should present a NoContentResponse on success', function (): void {
@@ -698,7 +841,7 @@ it('should present a NoContentResponse on success', function (): void {
 
     // Macros
     $this->readHostRepository
-        ->expects($this->once())
+        ->expects($this->exactly(2))
         ->method('findParents')
         ->willReturn($this->inheritanceLineIds);
     $this->readHostMacroRepository


### PR DESCRIPTION
## Description

Backport of #9960

[MON-197020](https://centreon.atlassian.net/browse/MON-197020)

[MON-197020]: https://centreon.atlassian.net/browse/MON-197020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added deleteByHostIdAndServiceTemplateId to service write interfaces and implementations.
* Added findByHostIdAndServiceTemplateId to service read interfaces and repositories.
* Added host-template related lookup methods to service template read repository.
* Integrated service template and service repositories into PartialUpdateHost constructor.

**🐛 Bugfixes**
* Fixed unlinking of host services after removing a service template.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101077182?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->