### PR TITLE
[Backport 24.10] fix(open-tickets): fix wrong host/service redirection when using deprecated pages

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -570,11 +570,11 @@ while ($row = $res->fetch()) {
     );
 
     $data[$row['host_id'] . '_' . $row['service_id']]['h_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20202&o=hd&host_name=' . $row['hostname']
         : $resourceController->buildHostDetailsUri($row['host_id']);
 
     $data[$row['host_id'] . '_' . $row['service_id']]['s_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        ? '../../main.php?p=20201&o=svcd&host_name=' . $row['hostname']
             . '&service_description=' . $row['description']
         : $resourceController->buildServiceDetailsUri($row['host_id'], $row['service_id']);
 }


### PR DESCRIPTION
## Summary

Backport of #10011 to `dev-24.10.x`.

## Jira

MON-197451

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed incorrect host/service redirection when using deprecated pages.

**🔧 Refactors**
* Introduced input validation and safer session checks for widget parameters.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101105515?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->