### PR TITLE
fix(symfony): resolve Symfony/Doctrine deprecations for Symfony 8 readiness

### DIFF
--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       CENTREON_DATASET: ${CENTREON_DATASET:-1}
       CENTREON_LANG: ${CENTREON_LANG:-en_US}
       DATABASE_PARTITIONING: ${DATABASE_PARTITIONING:-1}
+      DATABASE_SERVER_VERSION: ${DATABASE_SERVER_VERSION:-mariadb-10.11}
       DEBUG: ${DEBUG:-0}
     healthcheck:
       test: bash -c "[ -f /tmp/docker.ready ]" && curl --fail http://localhost/centreon/api/latest/platform/versions || exit 1

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       CENTREON_DATASET: ${CENTREON_DATASET:-1}
       CENTREON_LANG: ${CENTREON_LANG:-en_US}
       DATABASE_PARTITIONING: ${DATABASE_PARTITIONING:-1}
-      DATABASE_SERVER_VERSION: ${DATABASE_SERVER_VERSION:-mariadb-10.11}
       DEBUG: ${DEBUG:-0}
     healthcheck:
       test: bash -c "[ -f /tmp/docker.ready ]" && curl --fail http://localhost/centreon/api/latest/platform/versions || exit 1

--- a/centreon/.env.test
+++ b/centreon/.env.test
@@ -9,3 +9,5 @@ dbcstg=centreon_storage_test
 user=centreon
 password=centreon
 hostCentreon=localhost
+# DBAL server_version: 'mariadb-N.N' for MariaDB, '8' for MySQL 8+
+DATABASE_SERVER_VERSION=mariadb-10.11

--- a/centreon/.env.test
+++ b/centreon/.env.test
@@ -9,5 +9,5 @@ dbcstg=centreon_storage_test
 user=centreon
 password=centreon
 hostCentreon=localhost
-# DBAL server_version: 'mariadb-N.N' for MariaDB, '8' for MySQL 8+
-DATABASE_SERVER_VERSION=mariadb-10.11
+# DBAL server_version: 'mariadb-N.N.N' for MariaDB, '8' for MySQL 8+
+DATABASE_SERVER_VERSION=mariadb-10.11.0

--- a/centreon/config.new/packages/doctrine.yaml
+++ b/centreon/config.new/packages/doctrine.yaml
@@ -1,24 +1,27 @@
+parameters:
+    env(DATABASE_SERVER_VERSION): 'mariadb-10.11'
+
 doctrine:
    dbal:
        default_connection: default
        connections:
            default:
                use_savepoints: true
-               server_version: '8.0'
+               server_version: '%env(DATABASE_SERVER_VERSION)%'
                dbname: '%env(db)%'
                user: '%env(user)%'
                password: '%env(password)%'
                host: '%env(hostCentreon)%'
            realtime:
                use_savepoints: true
-               server_version: '8.0'
+               server_version: '%env(DATABASE_SERVER_VERSION)%'
                dbname: '%env(dbcstg)%'
                user: '%env(user)%'
                password: '%env(password)%'
                host: '%env(hostCentreon)%'
            test_setup_default:
                use_savepoints: true
-               server_version: '8.0'
+               server_version: '%env(DATABASE_SERVER_VERSION)%'
                dbname: '%env(db)%'
                user: '%env(user)%'
                password: '%env(password)%'

--- a/centreon/config.new/packages/doctrine.yaml
+++ b/centreon/config.new/packages/doctrine.yaml
@@ -4,18 +4,21 @@ doctrine:
        connections:
            default:
                use_savepoints: true
+               server_version: '8.0'
                dbname: '%env(db)%'
                user: '%env(user)%'
                password: '%env(password)%'
                host: '%env(hostCentreon)%'
            realtime:
                use_savepoints: true
+               server_version: '8.0'
                dbname: '%env(dbcstg)%'
                user: '%env(user)%'
                password: '%env(password)%'
                host: '%env(hostCentreon)%'
            test_setup_default:
                use_savepoints: true
+               server_version: '8.0'
                dbname: '%env(db)%'
                user: '%env(user)%'
                password: '%env(password)%'

--- a/centreon/config.new/packages/doctrine.yaml
+++ b/centreon/config.new/packages/doctrine.yaml
@@ -1,5 +1,5 @@
 parameters:
-    env(DATABASE_SERVER_VERSION): 'mariadb-10.11'
+    env(DATABASE_SERVER_VERSION): 'mariadb-10.11.0'
 
 doctrine:
    dbal:

--- a/centreon/config.new/packages/framework.yaml
+++ b/centreon/config.new/packages/framework.yaml
@@ -14,6 +14,9 @@ framework:
     php_errors:
         log: true
 
+    property_info:
+        with_constructor_extractor: true
+
 when@test:
     framework:
         test: true

--- a/centreon/config/packages/framework.yaml
+++ b/centreon/config/packages/framework.yaml
@@ -15,6 +15,9 @@ framework:
         cookie_httponly: false # handled by apache
         cookie_path: /
 
+    property_info:
+        with_constructor_extractor: true
+
     serializer:
         enabled: true
         name_converter: 'serializer.name_converter.camel_case_to_snake_case'

--- a/centreon/config/packages/validator/validation.yaml
+++ b/centreon/config/packages/validator/validation.yaml
@@ -117,13 +117,13 @@ Centreon\Domain\Check\Check:
             - Type:
                 type: int
                 groups: [Default, check_host, check_service, check_meta_service]
-            - GreaterThan: 0
+            - GreaterThan: { value: 0 }
             - NotNull: ~
         parentResourceId:
             - Type:
                 type: int
                 groups: [Default, check_service]
-            - GreaterThan: 0
+            - GreaterThan: { value: 0 }
         withServices:
             - Type:
                 type: boolean
@@ -143,20 +143,20 @@ Centreon\Domain\Monitoring\SubmitResult\SubmitResult:
             - Type:
                 type: int
                 groups: [Default, submit_result_host, submit_result_service]
-            - GreaterThan: 0
-            - LessThanOrEqual: 3
+            - GreaterThan: { value: 0 }
+            - LessThanOrEqual: { value: 3 }
             - NotNull: ~
         resourceId:
             - Type:
                 type: int
                 groups: [Default, submit_result_host, submit_result_service]
-            - GreaterThan: 0
+            - GreaterThan: { value: 0 }
             - NotNull: ~
         parentResourceId:
             - Type:
                 type: int
                 groups: [Default, submit_result_service]
-            - GreaterThan: 0
+            - GreaterThan: { value: 0 }
 
 # Used to validate the Proxy entity
 Centreon\Domain\Proxy\Proxy:
@@ -169,7 +169,7 @@ Centreon\Domain\Proxy\Proxy:
             - Type:
                   type: integer
             - PositiveOrZero: ~
-            - LessThanOrEqual: 65535
+            - LessThanOrEqual: { value: 65535 }
             - NotNull: ~
         user:
             - Type:

--- a/centreon/deptrac_bc.yaml
+++ b/centreon/deptrac_bc.yaml
@@ -45,12 +45,16 @@ parameters:
           collectors:
               - { type: classNameRegex, value: '#TypeAlias$#' }
 
+        - name: PhpNative # PHP built-in attributes and classes
+          collectors:
+              - { type: classNameRegex, value: '#^Deprecated$#' }
+
     ruleset:
-        ActivityLogging: [ MonitoringConfiguration, Security, Shared, Vendors, TypeAliases ]
-        MonitoringConfiguration: [ Security, Shared, Vendors, TypeAliases ]
-        Security: [ ActivityLogging, MonitoringConfiguration, Shared, Vendors, TypeAliases ]
-        Shared: [ Vendors, TypeAliases ]
-        Legacy: [ Vendors, TypeAliases ]
+        ActivityLogging: [ MonitoringConfiguration, Security, Shared, Vendors, TypeAliases, PhpNative ]
+        MonitoringConfiguration: [ Security, Shared, Vendors, TypeAliases, PhpNative ]
+        Security: [ ActivityLogging, MonitoringConfiguration, Shared, Vendors, TypeAliases, PhpNative ]
+        Shared: [ Vendors, TypeAliases, PhpNative ]
+        Legacy: [ Vendors, TypeAliases, PhpNative ]
 
     skip_violations:
         App\Shared\Infrastructure\Legacy\LegacyKernelWrapper:

--- a/centreon/deptrac_hexa.yaml
+++ b/centreon/deptrac_hexa.yaml
@@ -35,6 +35,7 @@ parameters:
               - { type: classNameRegex, value: '#^Symfony\\Component\\Uid\\#' }
               - { type: classNameRegex, value: '#^Webmozart\\Assert\\Assert#' }
               - { type: classNameRegex, value: '#TypeAlias$#' } # needed because deptrac does not parse phpstan type aliases
+              - { type: classNameRegex, value: '#^Deprecated$#' } # PHP built-in attribute
 
         - name: Legacy
           collectors:

--- a/centreon/src/App/Security/Infrastructure/Security/CredentialUser.php
+++ b/centreon/src/App/Security/Infrastructure/Security/CredentialUser.php
@@ -38,6 +38,7 @@ final readonly class CredentialUser implements UserInterface
         return array_map('strval', $this->credential->roles->toArray());
     }
 
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
     }

--- a/centreon/src/Centreon/Domain/Contact/Contact.php
+++ b/centreon/src/Centreon/Domain/Contact/Contact.php
@@ -583,6 +583,7 @@ class Contact implements UserInterface, ContactInterface
      * This is important if, at any given point, sensitive information like
      * the plain-text password is stored on this object.
      */
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
         // Nothing to do. But we must to define this method

--- a/centreon/src/Core/Media/Infrastructure/API/AddMedia/AddMediaValidator.php
+++ b/centreon/src/Core/Media/Infrastructure/API/AddMedia/AddMediaValidator.php
@@ -63,7 +63,7 @@ class AddMediaValidator
             MediaException::propertyNotPresent('directory');
         }
 
-        $value = $this->request->get('directory');
+        $value = $this->request->request->get('directory');
         if (empty($value)) {
             MediaException::stringPropertyCanNotBeEmpty('directory');
         }


### PR DESCRIPTION
## Description

Fixes 5 deprecation warnings detected during API test runs on the `oss` module,
as part of the Symfony 8 / DBAL 5 upgrade preparation.

- **`property_info.with_constructor_extractor`**: explicitly set to `true` in
  `framework.yaml` to avoid a breaking default change in Symfony 8 (deprecated since 7.3).
- **`eraseCredentials()`**: marked with `#[\Deprecated]` on `Contact` and `CredentialUser`.
  `UserInterface::eraseCredentials()` is deprecated in Symfony 7.3 and will be removed
  from the interface in Symfony 8. Both implementations are no-op.
- **Doctrine DBAL `server_version`**: added `server_version: '8.0'` to all three DBAL
  connections (`default`, `realtime`, `test_setup_default`). DBAL 4.x deprecates omitting
  this value; DBAL 5 drops MySQL < 8 support entirely.
- **`Request::get()`**: replaced with `$request->request->get()` in `AddMediaValidator`.
  `Request::get()` (searching all bags) is deprecated in Symfony 7.4.
- **Validator YAML constraints**: replaced positional shorthand (`GreaterThan: 0`) with
  explicit mapping format (`GreaterThan: { value: 0 }`) across `Check`, `SubmitResult`
  and `Proxy` entities, as required by Symfony 7.4.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Explicitly set property_info.with_constructor_extractor to true in config.
* Added DATABASE_SERVER_VERSION env parameter and applied DBAL server_version.
* Added PHP Deprecated attribute collector entries to deptrac configurations.

**🔧 Refactors**
* Marked eraseCredentials() methods as deprecated on user classes.
* Replaced Request::get() with request bag access in validator.
* Converted positional YAML validator constraints to explicit mapping format.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104602185?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->