### PR TITLE
fix(upgrade): move graph template upgrade to 25.10.11

### DIFF
--- a/centreon/www/install/php/Update-25.10.11.php
+++ b/centreon/www/install/php/Update-25.10.11.php
@@ -37,6 +37,21 @@ $errorMessage = '';
  * @var ConnectionInterface $pearDB
  * @var ConnectionInterface $pearDBO
  */
+$clearDefaultCurveTemplateLegend = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to clear ds_legend for default curve templates';
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Clearing ds_legend for default curve templates",
+    );
+    $pearDB->executeStatement(
+        <<<'SQL'
+            UPDATE `giv_components_template`
+            SET `ds_legend` = NULL
+            WHERE `default_tpl1` = '1'
+            SQL
+    );
+};
+
 $deployDefaultAgentConfiguration = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Unable to deploy default agent configuration to central poller';
     CentreonLog::create()->info(
@@ -116,6 +131,7 @@ try {
 
     try {
         $deployDefaultAgentConfiguration();
+        $clearDefaultCurveTemplateLegend();
     } catch (Throwable $e) {
         CentreonLog::create()->warning(
             logTypeId: CentreonLog::TYPE_UPGRADE,

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -32,20 +32,8 @@ $errorMessage = '';
  * @var ConnectionInterface $pearDB
  * @var ConnectionInterface $pearDBO
  */
-$clearDefaultCurveTemplateLegend = function () use ($pearDB, &$errorMessage, $version): void {
-    $errorMessage = 'Unable to clear ds_legend for default curve templates';
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Clearing ds_legend for default curve templates",
-    );
-    $pearDB->executeStatement(
-        <<<'SQL'
-            UPDATE `giv_components_template`
-            SET `ds_legend` = NULL
-            WHERE `default_tpl1` = '1'
-            SQL
-    );
-};
+
+// TODO add your functions here
 
 try {
     // DDL statements for real time database
@@ -59,7 +47,7 @@ try {
         $pearDB->startTransaction();
     }
 
-    $clearDefaultCurveTemplateLegend();
+    // TODO add your function calls to update the configuration database data here
 
     $pearDB->commitTransaction();
 


### PR DESCRIPTION
Fixing small upgrade issue, moving upgrade from next to 25.10.11 for https://github.com/centreon/centreon/pull/10120

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Moved ds_legend clearing for default curve templates to 25.10.11.

**🔧 Refactors**
* Removed ds_legend clearing from Update-next and added TODO placeholders.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101448139?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->