### PR TITLE
fix(e2e): use actual upgrade target minor version in platform update test

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -447,6 +447,7 @@ const prepareUpdateFileForUpgrade = (): Cypress.Chainable => {
           targetMinor = (Number.parseInt(minor_version) + 1).toString();
           targetUpdateFile = `/usr/share/centreon/www/install/php/Update-${major_version}.${targetMinor}.php`;
         }
+        Cypress.env('upgrade_target_minor_version', targetMinor);
 
         // If version-specific file does not exist => copy content from Update-next.php
         return cy
@@ -519,8 +520,10 @@ When('administrator runs the update procedure', () => {
 
     if (['testing', 'stable'].includes(Cypress.env('STABILITY'))) {
       cy.getWebVersion().then(({ major_version, minor_version }) => {
+        const targetMinorVersion =
+          Cypress.env('upgrade_target_minor_version') || minor_version;
         cy.contains(
-          `upgraded from version ${installedVersion} to ${major_version}.${minor_version}`
+          `upgraded from version ${installedVersion} to ${major_version}.${targetMinorVersion}`
         ).should('be.visible');
       });
     }


### PR DESCRIPTION
## Summary
- Fix version check assertion in platform update E2E test
- `prepareUpdateFileForUpgrade` increments `targetMinor` when the version-specific update file already exists, but the assertion was still using `minor_version` from `getWebVersion()`, causing a mismatch
- Store the effective `targetMinor` in `Cypress.env('upgrade_target_minor_version')` and use it in the assertion

## Test plan
- [ ] Run `01-platform-update.feature` examples #1, #3, #4 and verify version check passes

Refs: MON-197617

Backport of https://github.com/centreon/centreon/pull/10153 for release-24.10.x