### PR TITLE
feat(ci): collect and upload Symfony deprecation logs from newman runs

### DIFF
--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -227,8 +227,11 @@ jobs:
         env:
           MYSQL_IMAGE: ${{ env.DATABASE_IMAGE }}
           WEB_IMAGE: docker.centreon.com/centreon/${{ env.SLIM_IMAGE_NAME }}:${{ steps.image_tag.outputs.tag }}
+          FEATURE: ${{ matrix.feature }}
+          UPLOAD_ARTIFACTS: ${{ inputs.upload_artifacts }}
+          OS_INPUT: ${{ inputs.os }}
         run: |
-          COLLECTION_DIRECTORY=$(dirname "collections/${{ matrix.feature }}")
+          COLLECTION_DIRECTORY=$(dirname "collections/$FEATURE")
 
           if [[ -f "${COLLECTION_DIRECTORY}/.env" ]]; then
             echo "Using environment file ${COLLECTION_DIRECTORY}/.env"
@@ -237,8 +240,8 @@ jobs:
 
           docker compose --profile web -f ../../../.github/docker/docker-compose.yml up -d --wait
 
-          if ${{ inputs.upload_artifacts == 'true' }}; then
-            if [[ "${{ inputs.os }}" == "alma9" ]]; then
+          if [[ "$UPLOAD_ARTIFACTS" == "true" ]]; then
+            if [[ "$OS_INPUT" == "alma9" ]]; then
               WEB_USER="apache"
             else
               WEB_USER="www-data"
@@ -256,14 +259,14 @@ jobs:
           fi
 
           if [[ -f "${COLLECTION_DIRECTORY}/setup.sh" ]]; then
-            echo "Running script ${COLLECTION_DIRECTORY}/setup.sh with ${{ matrix.feature }} ..."
-              bash -ex ${COLLECTION_DIRECTORY}/setup.sh "${{ matrix.feature }}"
+            echo "Running script ${COLLECTION_DIRECTORY}/setup.sh with $FEATURE ..."
+              bash -ex ${COLLECTION_DIRECTORY}/setup.sh "$FEATURE"
             fi
 
             if [[ -f "${COLLECTION_DIRECTORY}/setup-web.sh" ]]; then
-              echo "Running script ${COLLECTION_DIRECTORY}/setup-web.sh with ${{ matrix.feature }} ..."
+              echo "Running script ${COLLECTION_DIRECTORY}/setup-web.sh with $FEATURE ..."
               docker compose -f ../../../.github/docker/docker-compose.yml cp ${COLLECTION_DIRECTORY}/setup-web.sh web:/tmp/setup-web.sh
-              docker compose -f ../../../.github/docker/docker-compose.yml exec web bash -ex /tmp/setup-web.sh "${{ matrix.feature }}"
+              docker compose -f ../../../.github/docker/docker-compose.yml exec web bash -ex /tmp/setup-web.sh "$FEATURE"
             fi
         shell: bash
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -251,11 +251,30 @@ jobs:
             docker compose -f ../../../.github/docker/docker-compose.yml exec web \
               bash -c "mkdir -p /var/log/centreon/symfony.new && chown ${WEB_USER}:${WEB_USER} /var/log/centreon/symfony.new"
 
-            docker compose -f ../../../.github/docker/docker-compose.yml exec web \
-              bash -c "sed -i 's/^error_reporting\s*=.*/error_reporting = E_ALL/' /etc/php.ini"
+            docker compose -f ../../../.github/docker/docker-compose.yml exec -e OS_INPUT="$OS_INPUT" web \
+              bash -c '
+                if [[ "$OS_INPUT" == "alma9" ]]; then
+                  PHP_INI="/etc/php.ini"
+                else
+                  PHP_INI=$(find /etc/php -name "php.ini" -path "*/fpm/*" 2>/dev/null | head -1)
+                fi
+                if [[ -z "$PHP_INI" ]] || [[ ! -f "$PHP_INI" ]]; then
+                  echo "WARNING: Could not locate PHP FPM ini file; skipping error_reporting update"
+                elif grep -q "^error_reporting" "$PHP_INI"; then
+                  sed -i "s/^error_reporting[[:space:]]*=.*/error_reporting = E_ALL/" "$PHP_INI"
+                else
+                  echo "error_reporting = E_ALL" >> "$PHP_INI"
+                fi
+              '
 
             docker compose -f ../../../.github/docker/docker-compose.yml exec web \
-              service php-fpm restart
+              bash -c '
+                PHP_FPM_UNIT=$(systemctl list-units --type=service --state=loaded --full --no-legend 2>/dev/null \
+                  | awk '"'"'{print $1}'"'"' | grep -E "^php[0-9.]*-fpm\.service$" | head -1 | sed "s/\.service$//")
+                [[ -z "$PHP_FPM_UNIT" ]] && PHP_FPM_UNIT="php-fpm"
+                echo "Restarting PHP-FPM unit: ${PHP_FPM_UNIT}"
+                systemctl restart "${PHP_FPM_UNIT}"
+              '
           fi
 
           if [[ -f "${COLLECTION_DIRECTORY}/setup.sh" ]]; then
@@ -342,8 +361,8 @@ jobs:
           feature="${feature%%.postman*}"
           deprecation_file_for_archive="$feature-deprecation.log"
           found=false
-          deprecation_file_container=$(docker compose -f ../../../.github/docker/docker-compose.yml exec web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | grep -m1 . || echo 'NOT_FOUND'")
-          if [[ "$deprecation_file_container" != "NOT_FOUND" && -n "$deprecation_file_container" ]]; then
+          deprecation_file_container=$(docker compose -f ../../../.github/docker/docker-compose.yml exec -T web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | grep -m1 ." | tr -d '\r')
+          if [[ -n "$deprecation_file_container" ]]; then
             docker compose -f ../../../.github/docker/docker-compose.yml exec -T web cat "$deprecation_file_container" >> ./$deprecation_file_for_archive
             echo "Appended deprecation log from $deprecation_file_container"
             found=true
@@ -358,7 +377,7 @@ jobs:
         if: ${{ steps.symfony-deprecation-logs.outcome == 'success' }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: newman-${{ inputs.os }}-${{ steps.feature-path.outputs.feature_name_with_dash }}-deprecation-logs
+          name: newman-${{ inputs.os }}${{ inputs.db_id && format('-{0}', inputs.db_id) || '' }}-${{ steps.feature-path.outputs.feature_name_with_dash }}-deprecation-logs
           path: "centreon/tests/rest_api/*-deprecation.log"
           retention-days: 1
           if-no-files-found: ignore
@@ -639,8 +658,8 @@ jobs:
         if: ${{ inputs.upload_artifacts == 'true' }}
         continue-on-error: true
         with:
-          name: newman-${{ inputs.os }}-deprecation-logs
-          pattern: newman-${{ inputs.os }}-*-deprecation-logs
+          name: newman-${{ inputs.os }}${{ inputs.db_id && format('-{0}', inputs.db_id) || '' }}-deprecation-logs
+          pattern: newman-${{ inputs.os }}${{ inputs.db_id && format('-{0}', inputs.db_id) || '' }}-*-deprecation-logs
           retention-days: 1
           delete-merged: true
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -238,9 +238,15 @@ jobs:
           docker compose --profile web -f ../../../.github/docker/docker-compose.yml up -d --wait
 
           if ${{ inputs.upload_artifacts == 'true' }}; then
+            if [[ "${{ inputs.os }}" == "alma9" ]]; then
+              WEB_USER="apache"
+            else
+              WEB_USER="www-data"
+            fi
+
             # Necessary for collecting deprecation logs
             docker compose -f ../../../.github/docker/docker-compose.yml exec web \
-              bash -c "mkdir -p /var/log/centreon/symfony.new && chown apache:apache /var/log/centreon/symfony.new"
+              bash -c "mkdir -p /var/log/centreon/symfony.new && chown ${WEB_USER}:${WEB_USER} /var/log/centreon/symfony.new"
 
             docker compose -f ../../../.github/docker/docker-compose.yml exec web \
               bash -c "sed -i 's/^error_reporting\s*=.*/error_reporting = E_ALL/' /etc/php.ini"
@@ -333,10 +339,10 @@ jobs:
           feature="${feature%%.postman*}"
           deprecation_file_for_archive="$feature-deprecation.log"
           found=false
-          deprecation_file_container=$(docker compose -f ../../../.github/docker/docker-compose.yml exec web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | grep . || echo 'NOT_FOUND'")
+          deprecation_file_container=$(docker compose -f ../../../.github/docker/docker-compose.yml exec web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | grep -m1 . || echo 'NOT_FOUND'")
           if [[ "$deprecation_file_container" != "NOT_FOUND" && -n "$deprecation_file_container" ]]; then
-            docker compose -f ../../../.github/docker/docker-compose.yml cp "web:$deprecation_file_container" - >> ./$deprecation_file_for_archive
-            echo "Appended deprecation log from $dep_file"
+            docker compose -f ../../../.github/docker/docker-compose.yml exec -T web cat "$deprecation_file_container" >> ./$deprecation_file_for_archive
+            echo "Appended deprecation log from $deprecation_file_container"
             found=true
           fi
           if [[ "$found" == "false" ]]; then

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -44,6 +44,11 @@ on:
         description: "The test execution and the test plan keys and ids"
         required: true
         type: string
+      upload_artifacts:
+        description: "Whether to upload deprecation logs artifacts"
+        required: false
+        default: "false"
+        type: string
     secrets:
       registry_username:
         required: true
@@ -232,6 +237,18 @@ jobs:
 
           docker compose --profile web -f ../../../.github/docker/docker-compose.yml up -d --wait
 
+          if ${{ inputs.upload_artifacts == 'true' }}; then
+            # Necessary for collecting deprecation logs
+            docker compose -f ../../../.github/docker/docker-compose.yml exec web \
+              bash -c "mkdir -p /var/log/centreon/symfony.new && chown apache:apache /var/log/centreon/symfony.new"
+
+            docker compose -f ../../../.github/docker/docker-compose.yml exec web \
+              bash -c "sed -i 's/^error_reporting\s*=.*/error_reporting = E_ALL/' /etc/php.ini"
+
+            docker compose -f ../../../.github/docker/docker-compose.yml exec web \
+              service php-fpm restart
+          fi
+
           if [[ -f "${COLLECTION_DIRECTORY}/setup.sh" ]]; then
             echo "Running script ${COLLECTION_DIRECTORY}/setup.sh with ${{ matrix.feature }} ..."
               bash -ex ${COLLECTION_DIRECTORY}/setup.sh "${{ matrix.feature }}"
@@ -306,6 +323,36 @@ jobs:
           name: newman-${{ inputs.os }}${{ inputs.db_id && format('-{0}', inputs.db_id) || '' }}-test-reports-${{ steps.feature-path.outputs.feature_name_with_dash }}
           path: centreon/tests/rest_api/postman_summaries/*.json
           retention-days: 1
+
+      - name: Gather symfony deprecation logs
+        id: symfony-deprecation-logs
+        if: ${{ inputs.upload_artifacts == 'true' }}
+        run: |
+          feature="${{ matrix.feature }}"
+          feature="${feature##*/}"
+          feature="${feature%%.postman*}"
+          deprecation_file_for_archive="$feature-deprecation.log"
+          found=false
+          deprecation_file_container=$(docker compose -f ../../../.github/docker/docker-compose.yml exec web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | grep . || echo 'NOT_FOUND'")
+          if [[ "$deprecation_file_container" != "NOT_FOUND" && -n "$deprecation_file_container" ]]; then
+            docker compose -f ../../../.github/docker/docker-compose.yml cp "web:$deprecation_file_container" - >> ./$deprecation_file_for_archive
+            echo "Appended deprecation log from $dep_file"
+            found=true
+          fi
+          if [[ "$found" == "false" ]]; then
+            echo "No deprecation log found in container, skipping copy."
+          fi
+          echo "deprecation_file_for_archive=$deprecation_file_for_archive" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload deprecation logs
+        if: ${{ steps.symfony-deprecation-logs.outcome == 'success' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: newman-${{ inputs.os }}-${{ steps.feature-path.outputs.feature_name_with_dash }}-deprecation-logs
+          path: "centreon/tests/rest_api/*-deprecation.log"
+          retention-days: 1
+          if-no-files-found: ignore
 
   synchronize-with-xray:
     needs: [newman-test-run, associate-test-cases]
@@ -578,6 +625,16 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Merge deprecation logs
+        uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ inputs.upload_artifacts == 'true' }}
+        continue-on-error: true
+        with:
+          name: newman-${{ inputs.os }}-deprecation-logs
+          pattern: newman-${{ inputs.os }}-*-deprecation-logs
+          retention-days: 1
+          delete-merged: true
+
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ contains(needs.newman-test-run.result, 'failure') }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -467,8 +467,10 @@ jobs:
         run: |
           echo "Ensure Symfony cache directories exist"
           sudo mkdir -p /var/cache/centreon/symfony{,.new}
+          sudo mkdir -p /var/log/centreon/symfony.new
           echo "Set permissions on Symfony cache directories with user: '$USER'"
           sudo chown -R $USER:$USER /var/cache/centreon/symfony{,.new}
+          sudo chown -R $USER:$USER /var/log/centreon/symfony.new
 
       - name: Install dependencies
         uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
@@ -548,8 +550,10 @@ jobs:
         run: |
           echo "Ensure Symfony cache directories exist"
           sudo mkdir -p /var/cache/centreon/symfony{,.new}
+          sudo mkdir -p /var/log/centreon/symfony.new
           echo "Set permissions on Symfony cache directories with user: '$USER'"
           sudo chown -R $USER:$USER /var/cache/centreon/symfony{,.new}
+          sudo chown -R $USER:$USER /var/log/centreon/symfony.new
 
       - name: Install dependencies
         uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
@@ -598,9 +602,11 @@ jobs:
           echo "Ensure Symfony cache directories exist" && set -e
           sudo mkdir -p /var/cache/centreon/symfony.new
           sudo mkdir -p /var/cache/centreon/symfony
+          sudo mkdir -p /var/log/centreon/symfony.new
           echo "Set permissions on Symfony cache directories with user: '$USER'" && set -e
           sudo chown -R $USER:$USER /var/cache/centreon/symfony.new
           sudo chown -R $USER:$USER /var/cache/centreon/symfony
+          sudo chown -R $USER:$USER /var/log/centreon/symfony.new
 
       - name: Install dependencies for centreon-web
         run: composer install --optimize-autoloader --prefer-dist --no-interaction --no-progress --quiet --no-scripts
@@ -1101,6 +1107,7 @@ jobs:
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       stability: ${{ needs.get-environment.outputs.stability }}
       xray_keys_and_ids: ${{ toJson(needs.create-xray-test-plan-and-test-execution.outputs) }}
+      upload_artifacts: ${{ contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}

--- a/centreon/config.new/packages/monolog.yaml
+++ b/centreon/config.new/packages/monolog.yaml
@@ -73,15 +73,16 @@ when@prod:
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine"]
+                channels: ["!event", "!doctrine", "!deprecation"]
                 formatter: monolog.formatter.line
                 date_format: !php/const DateTimeInterface::RFC3339
             deprecation:
-                type: stream
+                type: rotating_file
                 channels: [deprecation]
-                path: php://stderr
+                path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
+                max_files: 1
+                file_permission: 0660
             authentication:
                 type: stream
                 path: "%kernel.logs_dir%/login.log"


### PR DESCRIPTION
## Description

Adds opt-in collection of Symfony deprecation logs during newman API test runs, to help identify deprecated code paths exercised by the test suite.

### Changes

**`config.new/packages/monolog.yaml`**
- Route the `deprecation` channel to a rotating file (`%kernel.logs_dir%/%kernel.environment%.deprecations.log`) instead of `php://stderr` in prod
- Exclude the `deprecation` channel from the console handler to avoid duplicate output
- Set `max_files: 1` and `file_permission: 0660` on the rotating file handler

**`.github/workflows/newman.yml`**
- Add `upload_artifacts` boolean input (default: `false`)
- When enabled, before running tests: 
    - create the log directory in the web container, 
    - enable `E_ALL` PHP error reporting, and restart php-fpm
- After each feature collection: copy the deprecation log out of the container and upload it as a per-feature artifact
- At the merge step: consolidate per-feature artifacts into a single `newman-<os>-deprecation-logs` artifact

**`.github/workflows/web.yml`**
- Pass `upload_artifacts: true` to the newman workflow when the PR carries the `upload-artifacts` label
- Create `/var/log/centreon/symfony.new` in CI jobs (`backend-unit-test`, `backend-integration-test`, `backend-lint`) so the prod Symfony kernel can boot during `composer install` post-install hooks

### How to use

Add the `upload-artifacts` label to a PR to activate deprecation log collection during the newman test run. The merged artifact is downloadable from the GitHub Actions run summary.


## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added opt-in newman workflow artifact upload for deprecation logs.

**⚡ Enhancements**
* Routed Symfony deprecation channel to rotating file in prod.
* Enabled CI to trigger uploads via upload-artifacts label and created log directory.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106560057?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->