### PR TITLE
[Backport dev-25.10.x] fix(acls): prevent PHP warnings when non-admin user has incomplete topology hierarchy

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -326,25 +326,28 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
                 $lvl2Name = null;
                 $lvl3Name = null;
                 $lvl4Name = null;
-                if (strlen((string) $topologyPage) === 7) {
+                if (mb_strlen((string) $topologyPage) === 7) {
                     $lvl4Name = $topologies[$topologyPage]['name'];
-                    $topologyPage = (int) substr((string) $topologyPage, 0, 5);
+                    $topologyPage = (int) mb_substr((string) $topologyPage, 0, 5);
 
                     // To avoid create entry for the parent menu
                     $nameOfTopologiesRules[$topologyPage] = null;
                 }
-                if (strlen((string) $topologyPage) === 5) {
+                if (mb_strlen((string) $topologyPage) === 5) {
                     if ($lvl4Name === null && array_key_exists($topologyPage, $nameOfTopologiesRules)) {
                         continue;
                     }
-                    $lvl3Name = $topologies[$topologyPage]['name'];
-                    $topologyPage = (int) substr((string) $topologyPage, 0, 3);
+                    $lvl3Name = $topologies[$topologyPage]['name'] ?? null;
+                    $topologyPage = (int) mb_substr((string) $topologyPage, 0, 3);
                 }
-                if (strlen((string) $topologyPage) === 3) {
-                    $lvl2Name = $topologies[$topologyPage]['name'];
-                    $topologyPage = (int) substr((string) $topologyPage, 0, 1);
+                if (mb_strlen((string) $topologyPage) === 3) {
+                    $lvl2Name = $topologies[$topologyPage]['name'] ?? null;
+                    $topologyPage = (int) mb_substr((string) $topologyPage, 0, 1);
                 }
-                if (strlen((string) $topologyPage) === 1) {
+                if (mb_strlen((string) $topologyPage) === 1) {
+                    if (! isset($topologies[$topologyPage])) {
+                        continue;
+                    }
                     $ruleName = 'ROLE_' . $topologies[$topologyPage]['name'];
                 }
                 if ($lvl2Name !== null) {
@@ -364,7 +367,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             foreach ($nameOfTopologiesRules as $page => $name) {
                 if ($name !== null) {
                     $name = preg_replace(['/\s/', '/\W/'], ['_', ''], $name);
-                    $name = strtoupper($name);
+                    $name = mb_strtoupper($name);
                     $contact->addTopologyRule($name);
                 }
             }


### PR DESCRIPTION
## Summary

Backport of #9974 to `dev-25.10.x`.

## Jira

MON-197497

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Prevented PHP warnings for non-admin users with missing topology hierarchy.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101468615?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->