### PR TITLE
fix(media): add validation for directory names (#10000)

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -9272,6 +9272,11 @@ msgstr ""
 msgid "Invalid Image Format."
 msgstr "Ungültiges Bildformat."
 
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed."
+msgstr ""
+
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid LDAP Host parameters"
 msgstr "Ungültige LDAP-Hostparameter"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10611,6 +10611,11 @@ msgstr ""
 msgid "Invalid Image Format."
 msgstr ""
 
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed."
+msgstr ""
+
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid LDAP Host parameters"
 msgstr "Configuración de servidor LDAP no válida"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9426,6 +9426,11 @@ msgstr "Adresse IP invalide"
 msgid "Invalid Image Format."
 msgstr "Format d'image invalide."
 
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed."
+msgstr "Nom de répertoire invalide. Seuls les caractères alphanumériques, les tirets et les underscores sont autorisés."
+
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid LDAP Host parameters"
 msgstr "Paramètres du serveur LDAP invalides"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -9619,6 +9619,11 @@ msgstr ""
 msgid "Invalid Image Format."
 msgstr ""
 
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed."
+msgstr ""
+
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid LDAP Host parameters"
 msgstr "Parametros de endereço do host do LDAP invalidos"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -9490,6 +9490,11 @@ msgstr ""
 msgid "Invalid Image Format."
 msgstr ""
 
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed."
+msgstr ""
+
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid LDAP Host parameters"
 msgstr "Parametros de endereço do host do LDAP invalidos"

--- a/centreon/www/include/options/media/images/DB-Func.php
+++ b/centreon/www/include/options/media/images/DB-Func.php
@@ -49,6 +49,19 @@ function sanitizePath($path)
     );
 }
 
+function assertValidDirectoryAlias(string $alias): string
+{
+    $alias = trim($alias);
+
+    if ($alias === '' || ! preg_match('/^[a-zA-Z0-9_-]+$/', $alias)) {
+        throw new InvalidArgumentException(
+            'Invalid directory alias. Only alphanumeric characters, hyphens and underscores are allowed.'
+        );
+    }
+
+    return $alias;
+}
+
 function extractDir($zipfile, $path)
 {
     if (file_exists($zipfile)) {
@@ -225,7 +238,7 @@ function moveImg($img_id, $dir_alias)
     $img_info = $prepare->fetch(PDO::FETCH_ASSOC);
     $image_info_path = basename($img_info['img_path']);
     $image_info_dir_alias = basename($img_info['dir_alias']);
-    $dir_alias = $dir_alias ? sanitizePath($dir_alias) : $image_info_dir_alias;
+    $dir_alias = $dir_alias ? assertValidDirectoryAlias(sanitizePath($dir_alias)) : $image_info_dir_alias;
     if ($dir_alias != $img_info['dir_alias']) {
         $oldpath = $mediadir . $image_info_dir_alias . '/' . $image_info_path;
         $newpath = $mediadir . $dir_alias . '/' . $image_info_path;
@@ -304,6 +317,7 @@ function insertDirectory($dir_alias, $dir_comment = '')
 {
     global $pearDB;
     $mediadir = './img/media/';
+    $dir_alias = assertValidDirectoryAlias($dir_alias);
     $dir_alias_safe = basename($dir_alias);
     @mkdir($mediadir . $dir_alias_safe);
     if (is_dir($mediadir . $dir_alias_safe)) {
@@ -384,7 +398,7 @@ function updateDirectory($dir_id, $dir_alias, $dir_comment = '')
     $prepare->bindValue(':dir_id', $dir_id, PDO::PARAM_INT);
     $prepare->execute();
     $old_dir = $prepare->fetch(PDO::FETCH_ASSOC);
-    $dir_alias = sanitizePath($dir_alias);
+    $dir_alias = assertValidDirectoryAlias(sanitizePath($dir_alias));
     if (! is_dir($mediadir . $old_dir['dir_alias'])) {
         mkdir($mediadir . $dir_alias);
     } else {

--- a/centreon/www/include/options/media/images/formDirectory.php
+++ b/centreon/www/include/options/media/images/formDirectory.php
@@ -202,6 +202,7 @@ $redirect->setValue($o);
 // # Form Rules
 //
 $form->applyFilter('__ALL__', 'myTrim');
+$form->addRule('dir_name', _('Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed.'), 'regex', '/^[a-zA-Z0-9_-]+$/');
 if ($o == IMAGE_MODIFY_DIRECTORY && $directoryId) {
     $form->addRule('dir_name', _('Compulsory Name'), 'required');
     $form->setRequiredNote(_('Required Field'));

--- a/centreon/www/include/options/media/images/formImg.php
+++ b/centreon/www/include/options/media/images/formImg.php
@@ -217,6 +217,7 @@ $redirect->setValue($o);
 // Form Rules
 $form->applyFilter('__ALL__', 'myTrim');
 $form->addRule('directories', _('Required Field'), 'required');
+$form->addRule('directories', _('Invalid directory name. Only alphanumeric characters, hyphens and underscores are allowed.'), 'regex', '/^[a-zA-Z0-9_-]+$/');
 $form->setRequiredNote(_('Required Field'));
 
 // watch/view


### PR DESCRIPTION
## Description

Backport of #10000

[MON-197534](https://centreon.atlassian.net/browse/MON-197534)

[MON-197534]: https://centreon.atlassian.net/browse/MON-197534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added regex validation for directory field in image form.
* Added regex validation for directory name in directory form.
* Introduced assertValidDirectoryAlias helper and applied it to moveImg.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101477381?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->