### PR TITLE
fix(virtualMetrics): validate RPN syntax with rrdtool before saving

### DIFF
--- a/centreon/www/include/views/virtualMetrics/DB-Func.php
+++ b/centreon/www/include/views/virtualMetrics/DB-Func.php
@@ -23,6 +23,99 @@ if (! isset($oreon)) {
     exit;
 }
 
+/**
+ * Validates the RPN function syntax by building a minimal rrdtool command
+ * and executing it. Works for both CDEF (def_type=0) and VDEF (def_type=1).
+ *
+ * @param array<string,mixed> $fields Form fields
+ *
+ * @return true|array<string,string>
+ */
+function testRpnSyntaxWithRrdtool(array $fields): array|true
+{
+    global $pearDBO, $oreon;
+
+    if (! isset($fields['def_type'])) {
+        return true;
+    }
+
+    $rpnFunction = trim($fields['rpn_function'] ?? '');
+    if ($rpnFunction === '') {
+        return true;
+    }
+
+    $defType = (int) $fields['def_type'] === 1 ? 'VDEF' : 'CDEF';
+    $hostServiceId = $fields['host_id'] ?? '';
+
+    $indexId = getIndexIdFromHostServiceId($pearDBO, $hostServiceId);
+    if ($indexId === null) {
+        return true;
+    }
+
+    $config = $pearDBO->fetchAssociative('SELECT RRDdatabase_path FROM config LIMIT 1');
+    $rrdPath = rtrim($config['RRDdatabase_path'] ?? '/var/lib/centreon/metrics', '/') . '/';
+
+    $metricsStmt = $pearDBO->prepare(
+        'SELECT metric_id, metric_name FROM metrics WHERE index_id = :index_id'
+    );
+    $metricsStmt->bindValue(':index_id', (int) $indexId, PDO::PARAM_INT);
+    $metricsStmt->execute();
+
+    $metrics = [];
+    while ($row = $metricsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $metrics[$row['metric_name']] = $row['metric_id'];
+    }
+
+    if ($metrics === []) {
+        return true;
+    }
+
+    $rpnParts = explode(',', $rpnFunction);
+    $defArgs = [];
+    $usedMetrics = [];
+
+    foreach ($rpnParts as &$part) {
+        $trimmed = trim($part);
+        if (isset($metrics[$trimmed]) && ! isset($usedMetrics[$trimmed])) {
+            $metricId = $metrics[$trimmed];
+            $rrdFile = $rrdPath . $metricId . '.rrd';
+            if (file_exists($rrdFile)) {
+                $defArgs[] = 'DEF:v' . $metricId . '=' . $rrdFile . ':value:AVERAGE';
+                $usedMetrics[$trimmed] = 'v' . $metricId;
+            }
+        }
+        if (isset($usedMetrics[$trimmed])) {
+            $part = $usedMetrics[$trimmed];
+        }
+    }
+    unset($part);
+
+    $rpnResolved = implode(',', $rpnParts);
+
+    if ($defType === 'VDEF' && $defArgs === []) {
+        return true;
+    }
+
+    $rrdtoolBin = $oreon->optGen['rrdtool_path_bin'] ?? '/usr/bin/rrdtool';
+    $cmd = escapeshellarg($rrdtoolBin) . ' graph /dev/null --start now-1h';
+    foreach ($defArgs as $def) {
+        $cmd .= ' ' . escapeshellarg($def);
+    }
+    $cmd .= ' ' . escapeshellarg($defType . ':vtest=' . $rpnResolved);
+    $cmd .= ' 2>&1';
+
+    exec($cmd, $output, $rc);
+
+    if ($rc !== 0) {
+        $lastLine = end($output) ?: 'unknown error';
+        $rrdtoolError = preg_replace('/^ERROR:\s*/', '', $lastLine);
+
+        return ['rpn_function' => 'Invalid RPN syntax (RRDtool: ' . $rrdtoolError . ')'];
+    }
+
+    return true;
+}
+
 function _TestRPNInfinityLoop()
 {
     global $form;

--- a/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+++ b/centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
@@ -154,6 +154,7 @@ $form->addRule(
             : '') . "' In This RPN Function"),
     'RPNInfinityLoop'
 );
+$form->addFormRule('testRpnSyntaxWithRrdtool');
 
 $form->setRequiredNote("<font style='color: red;'>*</font>" . _(' Required fields'));
 


### PR DESCRIPTION
## Description

Backport of #10044 to dev-25.10.x.

Add server-side RPN syntax validation using rrdtool before saving virtual metrics. This prevents errors when adding or editing a virtual metric with "VDEF" as the DEF Type by catching invalid RPN expressions early and returning a clear error message to the user.

**Fixes** MON-197300

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Navigate to Monitoring > Performances > Virtual Metrics
2. Create or edit a virtual metric with DEF Type set to "VDEF"
3. Enter an invalid RPN expression and save — an error message should be displayed
4. Enter a valid VDEF RPN expression (e.g., `metric_name,AVERAGE`) and save — it should succeed without errors

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added server-side RPN syntax validation using rrdtool before saving
* Registered new form rule to run RPN validation on submission


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101859246?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->