### PR TITLE
chore(ci): harden pnpm install with supply chain security flags (#10118)

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -33,7 +33,12 @@ runs:
         cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       working-directory: ${{ inputs.frontend_directory }}
       shell: bash
       env:

--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -39,7 +39,12 @@ runs:
         cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       working-directory: ${{ inputs.base_directory }}
       shell: bash
       env:

--- a/.github/actions/frontend-lint/action.yml
+++ b/.github/actions/frontend-lint/action.yml
@@ -38,7 +38,12 @@ runs:
         cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       working-directory: ${{ inputs.frontend_directory }}
       shell: bash
       env:

--- a/.github/actions/lighthouse-performance-testing/action.yml
+++ b/.github/actions/lighthouse-performance-testing/action.yml
@@ -32,7 +32,12 @@ runs:
         run_install: false
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install \
+          --frozen-lockfile \
+          --config.trustPolicy=no-downgrade \
+          --config.minimumReleaseAge=2880 \
+          --config.blockExoticSubdeps=true
       shell: bash
       working-directory: ${{ inputs.path }}
       env:

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -76,7 +76,12 @@ jobs:
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: ${{ inputs.module_name }}
         shell: bash
         env:

--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -171,7 +171,12 @@ jobs:
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         shell: bash
         env:
           CYPRESS_INSTALL_BINARY: "0"

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -117,7 +117,12 @@ jobs:
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
       - name: Install Dependencies for tests/rest_api
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         shell: bash
         env:
           CYPRESS_INSTALL_BINARY: "0"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -467,7 +467,12 @@ jobs:
           cache-dependency-path: ${{ env.base_directory }}/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         working-directory: centreon
         env:
           CYPRESS_INSTALL_BINARY: "0"


### PR DESCRIPTION
## Description

Add supply chain security flags to all `pnpm install` commands:
- `--config.trustPolicy=no-downgrade`
- `--config.minimumReleaseAge=2880`
- `--config.blockExoticSubdeps=true`

**Backports** MON-197308
**Fixes** MON-197661

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Hardened pnpm install commands with supply-chain security flags across CI


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101864955?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->