### PR TITLE
feat(docker): add grafana profile to docker-compose for manual integration test

### DIFF
--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -97,6 +97,17 @@ services:
     ports: ["3128"]
     profiles: ["squid-basic-auth"]
 
+  grafana:
+    image: grafana/grafana:12.0.0
+    ports: ["3000:3000"]
+    environment:
+      GF_INSTALL_PLUGINS: yesoreyeram-infinity-datasource
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    depends_on:
+      web:
+        condition: service_healthy
+    profiles: ["grafana"]
+
   mediawiki:
     image: docker.centreon.com/centreon/mon-mediawiki-22.10:latest
     ports: ["80"]


### PR DESCRIPTION
## Summary

- Adds a `grafana` profile to `.github/docker/docker-compose.yml`
- Starts Grafana 12 with `yesoreyeram-infinity-datasource` plugin pre-installed
- Grafana is connected to the existing Centreon stack and waits for it to be healthy

## Usage

```bash
cd .github/docker
docker compose --profile grafana up web db grafana -d
```

- Centreon: http://localhost:4000/centreon
- Grafana: http://localhost:3000

## Test plan

- [ ] `docker compose --profile grafana up web db grafana -d` starts without errors
- [ ] Grafana is accessible at http://localhost:3000
- [ ] Infinity datasource can be configured with `http://web/centreon/api/latest` as base URL
- [ ] Health check passes with a valid Centreon X-AUTH-TOKEN
- [ ] A Time Series panel displays Centreon performance data

Refs: MON-197678

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added grafana profile and service to docker-compose for testing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101917798?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->