### PR TITLE
enh(ci): prevent web jobs from running when a PR is only related to translation

### DIFF
--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: ''
+      translation_paths:
+        required: false
+        type: string
+        default: ''
       is_nightly:
         required: true
         type: string
@@ -76,15 +80,6 @@ jobs:
       trigger_delivery: ${{ github.event_name == 'workflow_dispatch' && steps.get_dispatch_triggers.outputs.trigger_delivery || steps.get_triggers.outputs.trigger_delivery || 'true' }}
 
     steps:
-      - name: Checkout sources
-        if: github.event_name == 'pull_request' || inputs.base_sha != ''
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Fetch tags
-        if: inputs.base_sha != ''
-        run: git fetch origin tag ${{ inputs.base_sha }} --no-tags || true
-        shell: bash
-
       - name: Convert inputs to yaml list
         if: github.event_name == 'pull_request' || inputs.base_sha != ''
         id: inline_inputs
@@ -97,6 +92,7 @@ jobs:
           API_TEST_PATHS: ${{ inputs.api_test_paths }}
           E2E_TEST_PATHS: ${{ inputs.e2e_test_paths }}
           UPGRADE_TEST_PATHS: ${{ inputs.upgrade_test_paths }}
+          TRANSLATION_PATHS: ${{ inputs.translation_paths }}
         with:
           script: |
             const paths = {
@@ -107,6 +103,7 @@ jobs:
               api_test_paths: process.env.API_TEST_PATHS,
               e2e_test_paths: process.env.E2E_TEST_PATHS,
               upgrade_test_paths: process.env.UPGRADE_TEST_PATHS,
+              translation_paths: process.env.TRANSLATION_PATHS,
             };
 
             for (const [key, value] of Object.entries(paths)) {
@@ -126,6 +123,7 @@ jobs:
         id: get_changed_files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           base_sha: ${{ github.event_name == 'pull_request' && ' ' || inputs.base_sha }}
           files_yaml: |
             frontend_production:
@@ -142,6 +140,8 @@ jobs:
             ${{ steps.inline_inputs.outputs.e2e_test_paths }}
             upgrade_test:
             ${{ steps.inline_inputs.outputs.upgrade_test_paths }}
+            translation:
+            ${{ steps.inline_inputs.outputs.translation_paths }}
 
       - name: Determine triggers for event ${{ github.event_name }}
         if: github.event_name == 'pull_request' || inputs.base_sha != ''
@@ -156,74 +156,79 @@ jobs:
           HAS_API_TEST_CHANGES: ${{ steps.get_changed_files.outputs.api_test_any_changed }}
           HAS_E2E_TEST_CHANGES: ${{ steps.get_changed_files.outputs.e2e_test_any_changed }}
           HAS_UPGRADE_TEST_CHANGES: ${{ steps.get_changed_files.outputs.upgrade_test_any_changed }}
+          HAS_TRANSLATION_CHANGES: ${{ steps.get_changed_files.outputs.translation_any_changed }}
+          GITHUB_ACTOR: ${{ github.actor }}
           LABELS: ${{ inputs.labels }}
         with:
           script: |
+            const isNightly  = process.env.IS_NIGHTLY === 'true';
+            const isWeblate  = process.env.GITHUB_ACTOR === 'weblate-service-account';
+
+            let hasBackendProd  = process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true';
+            let hasFrontendProd = process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true';
+            let hasBackendTest  = process.env.HAS_BACKEND_TEST_CHANGES === 'true';
+            let hasFrontendTest = process.env.HAS_FRONTEND_TEST_CHANGES === 'true';
+            let hasApiTest      = process.env.HAS_API_TEST_CHANGES === 'true';
+            let hasE2eTest      = process.env.HAS_E2E_TEST_CHANGES === 'true';
+            let hasUpgradeTest  = process.env.HAS_UPGRADE_TEST_CHANGES === 'true';
+            let hasTranslation  = process.env.HAS_TRANSLATION_CHANGES === 'true';
+
             try {
               const labels = JSON.parse(process.env.LABELS);
               if (labels.includes('force-backend-tests')) {
                 core.info('Label force-backend-tests found: forcing backend testing trigger to true');
-                process.env.HAS_BACKEND_TEST_CHANGES = 'true';
+                hasBackendTest = true;
               }
               if (labels.includes('force-frontend-tests')) {
                 core.info('Label force-frontend-tests found: forcing frontend testing trigger to true');
-                process.env.HAS_FRONTEND_TEST_CHANGES = 'true';
+                hasFrontendTest = true;
               }
               if (labels.includes('force-api-tests')) {
                 core.info('Label force-api-tests found: forcing API testing trigger to true');
-                process.env.HAS_API_TEST_CHANGES = 'true';
+                hasApiTest = true;
               }
               if (labels.includes('force-e2e-tests')) {
                 core.info('Label force-e2e-tests found: forcing E2E testing trigger to true');
-                process.env.HAS_E2E_TEST_CHANGES = 'true';
+                hasE2eTest = true;
               }
               if (labels.includes('force-upgrade-tests')) {
                 core.info('Label force-upgrade-tests found: forcing upgrade testing trigger to true');
-                process.env.HAS_UPGRADE_TEST_CHANGES = 'true';
+                hasUpgradeTest = true;
               }
               if (labels.includes('force-all-tests')) {
                 core.info('Label force-all-tests found: forcing all testing triggers to true');
-                process.env.HAS_BACKEND_TEST_CHANGES = 'true';
-                process.env.HAS_FRONTEND_TEST_CHANGES = 'true';
-                process.env.HAS_API_TEST_CHANGES = 'true';
-                process.env.HAS_E2E_TEST_CHANGES = 'true';
-                process.env.HAS_UPGRADE_TEST_CHANGES = 'true';
+                hasBackendTest = hasFrontendTest = hasApiTest = hasE2eTest = hasUpgradeTest = true;
               }
             } catch (e) {
               core.warning(`Could not parse labels: ${e}`);
             }
 
+            // Non-weblate translation changes behave like backend production changes,
+            // except they don't trigger backend/frontend testing (lint + unit tests).
+            const nonWeblateTranslation = hasTranslation && !isWeblate;
+
+            const isWeblateTranslationOnly = isWeblate && hasTranslation
+              && !hasBackendProd && !hasFrontendProd
+              && !hasBackendTest && !hasFrontendTest
+              && !hasApiTest && !hasE2eTest && !hasUpgradeTest;
+
+            // On PRs, skip everything for Weblate translation-only changes.
+            // On direct pushes to unstable/testing branches, still trigger packaging so
+            // translations are included in the build artifacts.
+            const isPR = context.eventName === 'pull_request';
+
+            if (isWeblateTranslationOnly) {
+              core.info(`weblate-service-account with translation-only changes — skipping all test triggers${isPR ? ' (PR mode)' : ', but keeping packaging for branch push'}.`);
+            }
+
             const outputs = {
-              'trigger_backend_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_BACKEND_TEST_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true',
-              'trigger_frontend_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_TEST_CHANGES === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true',
-              'trigger_packaging':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_API_TEST_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true',
-              'trigger_api_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_API_TEST_CHANGES === 'true',
-              'trigger_e2e_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_E2E_TEST_CHANGES === 'true',
-              'trigger_upgrade_testing':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_UPGRADE_TEST_CHANGES === 'true',
-              'trigger_delivery':
-                process.env.IS_NIGHTLY === 'true'
-                || process.env.HAS_FRONTEND_PRODUCTION_CHANGES === 'true'
-                || process.env.HAS_BACKEND_PRODUCTION_CHANGES === 'true',
+              trigger_backend_testing:  !isWeblateTranslationOnly && (isNightly || hasBackendTest  || hasBackendProd),
+              trigger_frontend_testing: !isWeblateTranslationOnly && (isNightly || hasFrontendTest || hasFrontendProd),
+              trigger_packaging:        isNightly || hasFrontendProd || hasBackendProd || hasApiTest || hasE2eTest || nonWeblateTranslation || (isWeblateTranslationOnly && !isPR),
+              trigger_api_testing:      !isWeblateTranslationOnly && (isNightly || hasBackendProd  || hasApiTest || nonWeblateTranslation),
+              trigger_e2e_testing:      !isWeblateTranslationOnly && (isNightly || hasFrontendProd || hasBackendProd || hasE2eTest || nonWeblateTranslation),
+              trigger_upgrade_testing:  !isWeblateTranslationOnly && (isNightly || hasUpgradeTest),
+              trigger_delivery:         isNightly || hasFrontendProd || hasBackendProd || nonWeblateTranslation || (isWeblateTranslationOnly && !isPR),
             };
 
             for (const [key, value] of Object.entries(outputs)) {

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -80,7 +80,6 @@ jobs:
         "centreon/cron/**"
         "centreon/doc/API/**"
         "centreon/GPL_LIB/**"
-        "centreon/lang/**"
         "centreon/lib/**"
         "centreon/libinstall/**"
         "centreon/logrotate/**"
@@ -134,6 +133,8 @@ jobs:
         "centreon/www/install/**"
         "centreon/packaging/**"
         "centreon/tests/e2e/features/Platform-upgrade-update/**"
+      translation_paths: |
+        "centreon/lang/**"
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       base_sha: ${{ needs.get-environment.outputs.previous_release_bundle_tag }}
       labels: ${{ needs.get-environment.outputs.labels }}


### PR DESCRIPTION
## Description

This PR allows skipping web CI workflows when updates are only related to translations AND created by the related service account

Backport of #10126 to `dev-25.10.x`

See https://centreon.atlassian.net/browse/MON-196468

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

From this branch, update a .po file and try to run the web workflow

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added translation_paths input and changed-files handling in workflows
* Prevented web jobs from running when weblate-created PRs contained only translations


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101935525?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->