### PR TITLE
fix(open-ticket): fix warning messages (backport #9607)

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/display_selected_lists.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/display_selected_lists.ihtml
@@ -1,6 +1,6 @@
 {foreach from=$select item=v}
 {if $v.id ne "-1"}
-    {if $v.placeholder != ""}
+    {if isset($v.placeholder) and $v.placeholder != ""}
         {$v.label}: {$v.placeholder} - {$v.value}{$separator}
     {else}
         {$v.label}: {$v.value}{$separator}

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -14,10 +14,10 @@
             <option value="-1"> -- select -- </option>
         {/if}
         {foreach from=$group key=k item=v}
-        {if $groups.$groupId.placeholder.$k != ""}
+        {if isset($groups.$groupId.placeholder) and $groups.$groupId.placeholder.$k != ""}
             <option value='{$k}___{$v}___{$groups.$groupId.placeholder.$k}' {if $v eq $groups.$groupId.default}selected{/if}>{$groups.$groupId.placeholder.$k}</option>
         {else}
-            <option value='{$k}___{$v}' {if $v eq $groups.$groupId.default}selected{/if}>{$v}</option>
+            <option value='{$k}___{$v}' {if isset($groups.$groupId.default) and $v eq $groups.$groupId.default}selected{/if}>{$v}</option>
         {/if}
         {/foreach}
         </select>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -15,7 +15,7 @@
         {/if}
         {foreach from=$group key=k item=v}
         {if isset($groups.$groupId.placeholder) and $groups.$groupId.placeholder.$k != ""}
-            <option value='{$k}___{$v}___{$groups.$groupId.placeholder.$k}' {if $v eq $groups.$groupId.default}selected{/if}>{$groups.$groupId.placeholder.$k}</option>
+            <option value='{$k}___{$v}___{$groups.$groupId.placeholder.$k}' {if isset($groups.$groupId.default) and $v eq $groups.$groupId.default}selected{/if}>{$groups.$groupId.placeholder.$k}</option>
         {else}
             <option value='{$k}___{$v}' {if isset($groups.$groupId.default) and $v eq $groups.$groupId.default}selected{/if}>{$v}</option>
         {/if}


### PR DESCRIPTION
## Summary

- Backport of #9607 to `dev-25.10.x`
- Fixes PHP warnings ("Undefined array key") spamming `/var/log/php-fpm/centreon-error.log` when opening the open ticket popup

## Jira

MON-197685

## Test plan

- [ ] Open the ticket popup and verify no PHP warnings are logged
- [ ] Verify default values in custom lists are pre-selected
- [ ] Verify lists with a single value have it pre-selected