### PR TITLE
fix(ci): do not fail translation-build if technique-ci cannot push

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -376,7 +376,7 @@ jobs:
                 git status
                 git add .
                 git commit -m "chore(lang): update translations"
-                git push
+                git push || echo "::warning::Failed to push translations commit (technique-ci may not have push access)."
               else
                 echo "::notice::Last commit author is technique-ci. Skipping commit to avoid infinite loop."
                 cd ..


### PR DESCRIPTION
## Summary
- Replace `git push` with `git push || echo "::warning::..."` in the `translation-build` job of `web.yml`
- The job no longer fails when `technique-ci` cannot push; a GitHub Actions warning is displayed instead

## Jira
[MON-197764](https://centreon.atlassian.net/browse/MON-197764)

[MON-197764]: https://centreon.atlassian.net/browse/MON-197764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Prevented translation-build job failure when technique-ci push was denied


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103142855?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->