### PR TITLE
fix(actionLog): Allowed null contact id for action log

### DIFF
--- a/centreon/config/centreon.config.php.template
+++ b/centreon/config/centreon.config.php.template
@@ -117,9 +117,7 @@ if (file_exists(_CENTREON_ETC_ . '/centreon.conf.php')) {
 
 
     if (
-        ! defined('user')
-        && ! defined('password')
-        && file_exists(_CENTREON_VARLIB_ . '/vault/vault.json')
+        file_exists(_CENTREON_VARLIB_ . '/vault/vault.json')
         && str_starts_with($conf_centreon['user'], 'secret::')
         && str_starts_with($conf_centreon['password'], 'secret::')
     ) {

--- a/centreon/src/Core/ActionLog/Domain/Model/ActionLog.php
+++ b/centreon/src/Core/ActionLog/Domain/Model/ActionLog.php
@@ -98,7 +98,7 @@ class ActionLog
      * @param int $objectId
      * @param string $objectName
      * @param string $actionType
-     * @param int $contactId
+     * @param int|null $contactId
      * @param \DateTime|null $creationDate
      */
     public function __construct(
@@ -106,7 +106,7 @@ class ActionLog
         private readonly int $objectId,
         private readonly string $objectName,
         private readonly string $actionType,
-        private readonly int $contactId,
+        private readonly ?int $contactId,
         ?\DateTime $creationDate = null,
     ) {
         if ($creationDate === null) {
@@ -175,9 +175,9 @@ class ActionLog
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getContactId(): int
+    public function getContactId(): ?int
     {
         return $this->contactId;
     }

--- a/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
@@ -42,6 +42,6 @@ services:
         arguments:
         - '@.inner'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Centreon\Infrastructure\DatabaseConnection'
 

--- a/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/DbWriteCommandActionLogRepository.php
@@ -38,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\CommandMacro\Domain\Model\NewCommandMacro;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements WriteCommandRepositoryInterface
 {
@@ -57,7 +58,7 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
     public function __construct(
         private readonly WriteCommandRepositoryInterface $writeCommandRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -76,7 +77,7 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
                 objectId: $commandId,
                 objectName: $command->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->contact->getId()
+                contactId: $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -96,6 +97,13 @@ class DbWriteCommandActionLogRepository extends AbstractRepositoryRDB implements
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/Host/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Host/Infrastructure/Configuration/symfony.yaml
@@ -30,7 +30,7 @@ services:
         decorates: Core\Host\Application\Repository\WriteHostRepositoryInterface
         arguments:
           - '@.inner'
-          - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+          - '@security.token_storage'
           - '@Core\Host\Application\Repository\ReadHostRepositoryInterface'
           - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
           - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
@@ -40,6 +40,7 @@ use Core\Host\Domain\Model\Host;
 use Core\Host\Domain\Model\HostEvent;
 use Core\Host\Domain\Model\NewHost;
 use Core\Host\Domain\Model\SnmpVersion;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements WriteHostRepositoryInterface
 {
@@ -90,14 +91,14 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 
     /**
      * @param WriteHostRepositoryInterface $writeHostRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadHostRepositoryInterface $readHostRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostRepositoryInterface $writeHostRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -121,7 +122,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -159,7 +160,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 $hostId,
                 $host->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -196,7 +197,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -210,7 +211,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -219,7 +220,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -235,7 +236,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                     $host->getId(),
                     $host->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -265,6 +266,13 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
     public function deleteParents(int $childId): void
     {
         $this->writeHostRepository->deleteParents($childId);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostCategory/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostCategory/Infrastructure/Configuration/symfony.yaml
@@ -20,5 +20,5 @@ services:
         - '@.inner'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
         - '@Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbWriteHostCategoryActionLogRepository.php
@@ -34,6 +34,7 @@ use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface
 use Core\HostCategory\Application\Repository\WriteHostCategoryRepositoryInterface;
 use Core\HostCategory\Domain\Model\HostCategory;
 use Core\HostCategory\Domain\Model\NewHostCategory;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB implements WriteHostCategoryRepositoryInterface
 {
@@ -49,7 +50,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
         private readonly WriteHostCategoryRepositoryInterface $writeHostCategoryRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
-        private readonly ContactInterface $user,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -71,7 +72,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $this->user->getId(),
+                contactId: $this->getContactId(),
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -96,7 +97,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategoryId,
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->user->getId(),
+                contactId: $this->getContactId(),
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -138,7 +139,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $this->user->getId(),
+                        contactId: $this->getContactId(),
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                 }
@@ -151,7 +152,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         actionType: $diff['hc_activate']
                             ? ActionLog::ACTION_TYPE_ENABLE
                             : ActionLog::ACTION_TYPE_DISABLE,
-                        contactId: $this->user->getId(),
+                        contactId: $this->getContactId(),
                     );
                     $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog = new ActionLog(
@@ -159,7 +160,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                         objectId: $hostCategory->getId(),
                         objectName: $hostCategory->getName(),
                         actionType: ActionLog::ACTION_TYPE_CHANGE,
-                        contactId: $this->user->getId(),
+                        contactId: $this->getContactId(),
                     );
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
                     $actionLog->setId($actionLogId);
@@ -175,7 +176,7 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
                 objectId: $hostCategory->getId(),
                 objectName: $hostCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_CHANGE,
-                contactId: $this->user->getId(),
+                contactId: $this->getContactId(),
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -201,6 +202,13 @@ class DbWriteHostCategoryActionLogRepository extends AbstractRepositoryRDB imple
     public function unlinkFromHost(int $hostId, array $categoryIds): void
     {
         $this->writeHostCategoryRepository->unlinkFromHost($hostId, $categoryIds);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostGroup/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostGroup/Infrastructure/Configuration/symfony.yaml
@@ -23,7 +23,7 @@ services:
     decorates: Core\HostGroup\Application\Repository\WriteHostGroupRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
@@ -35,6 +35,7 @@ use Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface;
 use Core\HostGroup\Application\Repository\WriteHostGroupRepositoryInterface;
 use Core\HostGroup\Domain\Model\HostGroup;
 use Core\HostGroup\Domain\Model\NewHostGroup;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implements WriteHostGroupRepositoryInterface
 {
@@ -50,14 +51,14 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 
     /**
      * @param WriteHostGroupRepositoryInterface $writeHostGroupRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadHostGroupRepositoryInterface $readHostGroupRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostGroupRepositoryInterface $writeHostGroupRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadHostGroupRepositoryInterface $readHostGroupRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -83,7 +84,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $hostGroupId,
                 $hostGroup->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -109,7 +110,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $hostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -151,7 +152,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }
@@ -165,7 +166,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     $action,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
 
@@ -174,7 +175,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -190,7 +191,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                     $hostGroup->getId(),
                     $hostGroup->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $actionLogChangeId = $this->writeActionLogRepository->addAction($actionLogChange);
                 if ($actionLogChangeId === 0) {
@@ -245,7 +246,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $hostGroupId,
                 $hostGroup->getName(),
                 $isEnable ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
 
@@ -277,7 +278,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $newHostGroupId,
                 $newHostGroup->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -297,6 +298,13 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
     public function deleteHostLinks(int $hostGroupId, array $hostIds): void
     {
         $this->writeHostGroupRepository->deleteHostLinks($hostGroupId, $hostIds);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostSeverity/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Configuration/symfony.yaml
@@ -21,5 +21,5 @@ services:
       - '@.inner'
       - '@Core\HostSeverity\Application\Repository\ReadHostSeverityRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityActionLogRepository.php
@@ -33,6 +33,7 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\HostSeverity\Application\Repository\ReadHostSeverityRepositoryInterface;
 use Core\HostSeverity\Application\Repository\WriteHostSeverityRepositoryInterface;
 use Core\HostSeverity\Domain\Model\NewHostSeverity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB implements WriteHostSeverityRepositoryInterface
 {
@@ -50,14 +51,14 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
      * @param WriteHostSeverityRepositoryInterface $writeHostSeverityRepository
      * @param ReadHostSeverityRepositoryInterface $readHostSeverityRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostSeverityRepositoryInterface $writeHostSeverityRepository,
         private readonly ReadHostSeverityRepositoryInterface $readHostSeverityRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -82,7 +83,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -107,7 +108,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverityId,
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -155,7 +156,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -172,7 +173,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         $action,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -183,7 +184,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                         $hostSeverity->getId(),
                         $hostSeverity->getName(),
                         ActionLog::ACTION_TYPE_CHANGE,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -200,7 +201,7 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
                 $hostSeverity->getId(),
                 $hostSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -215,6 +216,13 @@ class DbWriteHostSeverityActionLogRepository extends AbstractRepositoryRDB imple
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/HostTemplate/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Configuration/symfony.yaml
@@ -19,7 +19,7 @@ services:
     decorates: Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateActionLogRepository.php
@@ -39,6 +39,7 @@ use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface
 use Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterface;
 use Core\HostTemplate\Domain\Model\HostTemplate;
 use Core\HostTemplate\Domain\Model\NewHostTemplate;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB implements WriteHostTemplateRepositoryInterface
 {
@@ -46,14 +47,14 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
 
     /**
      * @param WriteHostTemplateRepositoryInterface $writeHostTemplateRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadHostTemplateRepositoryInterface $readHostTemplateRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteHostTemplateRepositoryInterface $writeHostTemplateRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -79,7 +80,7 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -105,7 +106,7 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 $hostTemplateId,
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -145,7 +146,7 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
                 $hostTemplate->getId(),
                 $hostTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -174,6 +175,13 @@ class DbWriteHostTemplateActionLogRepository extends AbstractRepositoryRDB imple
     public function deleteParents(int $childId): void
     {
         $this->writeHostTemplateRepository->deleteParents($childId);
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/Service/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Service/Infrastructure/Configuration/symfony.yaml
@@ -23,7 +23,7 @@ services:
     decorates: Core\Service\Application\Repository\WriteServiceRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\Service\Application\Repository\ReadServiceRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -39,21 +39,24 @@ use Core\Service\Domain\Model\NewService;
 use Core\Service\Domain\Model\NotificationType;
 use Core\Service\Domain\Model\Service;
 use Core\Service\Infrastructure\Model\NotificationTypeConverter;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements WriteServiceRepositoryInterface
 {
     use LoggerTrait;
 
+    public mixed $contact;
+
     /**
      * @param WriteServiceRepositoryInterface $writeServiceRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadServiceRepositoryInterface $readServiceRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteServiceRepositoryInterface $writeServiceRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadServiceRepositoryInterface $readServiceRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -79,7 +82,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                 $serviceId,
                 $service->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -111,7 +114,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $serviceId,
                     $serviceName,
                     ActionLog::ACTION_TYPE_DELETE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             } catch (\Throwable $ex) {
@@ -141,7 +144,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                 $serviceId,
                 $newService->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -186,7 +189,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     $actionType,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
 
                 unset($diff['isActivated']);
@@ -198,7 +201,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service->getId(),
                     $service->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
             }
 
@@ -263,5 +266,12 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
         }
 
         return $servicePropertiesArray;
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 }

--- a/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
+++ b/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\ServiceCategory\Application\Repository;
 
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 interface WriteServiceCategoryRepositoryInterface
 {
@@ -66,4 +67,13 @@ interface WriteServiceCategoryRepositoryInterface
      * @throws \Throwable
      */
     public function unlinkFromService(int $serviceId, array $serviceCategoriesIds): void;
+
+    /**
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceCategory $serviceCategory): void;
 }

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Configuration/symfony.yaml
@@ -21,5 +21,5 @@ services:
         - '@.inner'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
         - '@Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -33,6 +33,8 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {
@@ -47,7 +49,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         private readonly WriteServiceCategoryRepositoryInterface $writeServiceCategoryRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
-        private readonly ContactInterface $user,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -69,7 +71,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_DELETE,
-                contactId: $this->user->getId()
+                contactId: $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -97,7 +99,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
                 objectId: $serviceCategoryId,
                 objectName: $serviceCategory->getName(),
                 actionType: ActionLog::ACTION_TYPE_ADD,
-                contactId: $this->user->getId()
+                contactId: $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -129,6 +131,45 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
     public function unlinkFromService(int $serviceId, array $serviceCategoriesIds): void
     {
         $this->writeServiceCategoryRepository->unlinkFromService($serviceId, $serviceCategoriesIds);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(ServiceCategory $serviceCategory): void
+    {
+        try {
+            $this->writeServiceCategoryRepository->update($serviceCategory);
+
+            $actionLog = new ActionLog(
+                objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
+                objectId: $serviceCategory->getId(),
+                objectName: $serviceCategory->getName(),
+                actionType: ActionLog::ACTION_TYPE_CHANGE,
+                contactId: $this->getContactId()
+            );
+            $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
+            $actionLog->setId($actionLogId);
+            $details = $this->getServiceCategoryAsArray($serviceCategory);
+
+            $this->writeActionLogRepository->addActionDetails($actionLog, $details);
+
+            return;
+        } catch (\Throwable $ex) {
+            $this->error(
+                'Error while updating a service category',
+                ['serviceCategory' => $serviceCategory, 'trace' => (string) $ex]
+            );
+
+            throw $ex;
+        }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
@@ -29,6 +29,7 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {
@@ -172,5 +173,30 @@ class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements 
 
             throw $ex;
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(ServiceCategory $serviceCategory): void
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                UPDATE `:db`.service_categories
+                SET
+                    `sc_name` = :name,
+                    `sc_description` = :alias,
+                    `sc_activate` = :isActivated
+                WHERE sc_id = :id
+                SQL
+        );
+        $statement = $this->db->prepare($request);
+
+        $statement->bindValue(':name', $serviceCategory->getName(), \PDO::PARAM_STR);
+        $statement->bindValue(':alias', $serviceCategory->getAlias(), \PDO::PARAM_STR);
+        $statement->bindValue(':isActivated', (new BoolToEnumNormalizer())->normalize($serviceCategory->isActivated()), \PDO::PARAM_STR);
+        $statement->bindValue(':id', $serviceCategory->getId(), \PDO::PARAM_INT);
+
+        $statement->execute();
     }
 }

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Configuration/symfony.yaml
@@ -21,5 +21,5 @@ services:
       - '@.inner'
       - '@Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
+++ b/centreon/src/Core/ServiceSeverity/Infrastructure/Repository/DbWriteServiceSeverityActionLogRepository.php
@@ -34,6 +34,7 @@ use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInt
 use Core\ServiceSeverity\Application\Repository\WriteServiceSeverityRepositoryInterface;
 use Core\ServiceSeverity\Domain\Model\NewServiceSeverity;
 use Core\ServiceSeverity\Domain\Model\ServiceSeverity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB implements WriteServiceSeverityRepositoryInterface
 {
@@ -50,7 +51,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
         private readonly WriteServiceSeverityRepositoryInterface $writeServiceSeverityRepository,
         private readonly ReadServiceSeverityRepositoryInterface $readServiceSeverityRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         DatabaseConnection $db,
     ) {
         $this->db = $db;
@@ -75,7 +76,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $this->writeActionLogRepository->addAction($actionLog);
@@ -101,7 +102,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverityId,
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -145,7 +146,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                         $serviceSeverity->getId(),
                         $serviceSeverity->getName(),
                         (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                        $this->contact->getId()
+                        $this->getContactId()
                     );
 
                     $this->writeActionLogRepository->addAction($actionLog);
@@ -158,7 +159,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     (bool) $diff['sc_activate'] ? ActionLog::ACTION_TYPE_ENABLE : ActionLog::ACTION_TYPE_DISABLE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
 
                 $this->writeActionLogRepository->addAction($actionLog);
@@ -169,7 +170,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                     $serviceSeverity->getId(),
                     $serviceSeverity->getName(),
                     ActionLog::ACTION_TYPE_CHANGE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
 
                 $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -185,7 +186,7 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
                 $serviceSeverity->getId(),
                 $serviceSeverity->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -200,6 +201,13 @@ class DbWriteServiceSeverityActionLogRepository extends AbstractRepositoryRDB im
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Configuration/symfony.yaml
@@ -20,7 +20,7 @@ services:
     decorates: Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface
     arguments:
       - '@.inner'
-      - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+      - '@security.token_storage'
       - '@Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface'
       - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
       - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateActionLogRepository.php
@@ -37,6 +37,7 @@ use Core\ServiceTemplate\Domain\Model\NewServiceTemplate;
 use Core\ServiceTemplate\Domain\Model\NotificationType;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 use Core\ServiceTemplate\Infrastructure\Model\NotificationTypeConverter;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB implements WriteServiceTemplateRepositoryInterface
 {
@@ -44,14 +45,14 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
     /**
      * @param WriteServiceTemplateRepositoryInterface $writeServiceTemplateRepository
-     * @param ContactInterface $contact
+     * @param TokenStorageInterface $tokenStorage
      * @param ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository
      * @param WriteActionLogRepositoryInterface $writeActionLogRepository
      * @param DatabaseConnection $db
      */
     public function __construct(
         private readonly WriteServiceTemplateRepositoryInterface $writeServiceTemplateRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly ReadServiceTemplateRepositoryInterface $readServiceTemplateRepository,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
@@ -71,7 +72,7 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
                 $serviceTemplateId,
                 $serviceTemplate ? $serviceTemplate->getName() : '',
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -91,7 +92,7 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
                 $serviceTemplateId,
                 $newServiceTemplate->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -136,7 +137,7 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
                 $serviceTemplate->getId(),
                 $serviceTemplate->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             $actionLog->setId($actionLogId);
@@ -146,6 +147,13 @@ class DbWriteServiceTemplateActionLogRepository extends AbstractRepositoryRDB im
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/src/Core/TimePeriod/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Configuration/symfony.yaml
@@ -33,6 +33,6 @@ services:
         arguments:
         - '@.inner'
         - '@Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface'
-        - '@Centreon\Domain\Contact\Interfaces\ContactInterface'
+        - '@security.token_storage'
         - '@Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface'
         - '@Centreon\Infrastructure\DatabaseConnection'

--- a/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
+++ b/centreon/src/Core/TimePeriod/Infrastructure/Repository/DbWriteTimePeriodActionLogRepository.php
@@ -34,6 +34,7 @@ use Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface;
 use Core\TimePeriod\Application\Repository\WriteTimePeriodRepositoryInterface;
 use Core\TimePeriod\Domain\Model\Day;
 use Core\TimePeriod\Domain\Model\{NewExtraTimePeriod, NewTimePeriod, Template, TimePeriod};
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB implements WriteTimePeriodRepositoryInterface
 {
@@ -43,7 +44,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
     public function __construct(
         private readonly WriteTimePeriodRepositoryInterface $writeTimePeriodRepository,
         private readonly ReadTimePeriodRepositoryInterface $readTimePeriodRepository,
-        private readonly ContactInterface $contact,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
         DatabaseConnection $db,
     ) {
@@ -68,7 +69,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_DELETE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $this->writeActionLogRepository->addAction($actionLog);
         } catch (\Throwable $ex) {
@@ -94,7 +95,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 $timePeriodId,
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_ADD,
-                $this->contact->getId()
+                $this->getContactId()
             );
 
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
@@ -132,7 +133,7 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
                 $timePeriod->getId(),
                 $timePeriod->getName(),
                 ActionLog::ACTION_TYPE_CHANGE,
-                $this->contact->getId()
+                $this->getContactId()
             );
             $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
             if ($actionLogId === 0) {
@@ -145,6 +146,13 @@ class DbWriteTimePeriodActionLogRepository extends AbstractRepositoryRDB impleme
 
             throw $ex;
         }
+    }
+
+    private function getContactId(): ?int
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        return $user instanceof ContactInterface ? $user->getId() : null;
     }
 
     /**

--- a/centreon/www/include/Administration/configChangelog/viewLogs.php
+++ b/centreon/www/include/Administration/configChangelog/viewLogs.php
@@ -228,9 +228,11 @@ if ($prepareSelect->execute()) {
                 CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
             );
 
-            $author = empty($contactList[$res['log_contact_id']])
-                ? _('unknown')
-                : $contactList[$res['log_contact_id']];
+            $author = $res['log_contact_id'] === null
+                ? 'system'
+                : (empty($contactList[$res['log_contact_id']])
+                    ? _('unknown')
+                    : $contactList[$res['log_contact_id']]);
 
             $element = [
                 'date' => $res['action_log_date'] ?? null,

--- a/centreon/www/install/createTablesCentstorage.sql
+++ b/centreon/www/install/createTablesCentstorage.sql
@@ -154,7 +154,7 @@ CREATE TABLE `log_action` (
   `object_id` int(11) NOT NULL,
   `object_name` varchar(255) NOT NULL,
   `action_type` varchar(255) NOT NULL,
-  `log_contact_id` int(11) NOT NULL,
+  `log_contact_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`action_log_id`),
   KEY `log_contact_id` (`log_contact_id`),
   KEY `action_log_date` (`action_log_date`),

--- a/centreon/www/install/php/Update-26.04.0.php
+++ b/centreon/www/install/php/Update-26.04.0.php
@@ -18,3 +18,68 @@
  * For more information : contact@centreon.com
  *
  */
+
+use Adaptation\Database\Connection\Exception\ConnectionException;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+$version = '26.04.0';
+
+$errorMessage = '';
+
+/**
+ * @var ConnectionInterface $pearDB
+ * @var ConnectionInterface $pearDBO
+ */
+
+// TODO add your functions here
+
+try {
+    // DDL statements for real time database
+    $pearDBO->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `log_action` MODIFY COLUMN `log_contact_id` int(11) DEFAULT NULL
+            SQL
+    );
+
+    // DDL statements for configuration database
+    // TODO add your function calls to update the configuration database structure here
+
+    // Transactional queries for configuration database
+    if (! $pearDB->isTransactionActive()) {
+        $pearDB->startTransaction();
+    }
+
+    // TODO add your function calls to update the configuration database data here
+
+    $pearDB->commitTransaction();
+
+} catch (Throwable $throwable) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: " . $errorMessage,
+        exception: $throwable
+    );
+
+    try {
+        if ($pearDB->isTransactionActive()) {
+            $pearDB->rollBackTransaction();
+        }
+    } catch (ConnectionException $rollbackException) {
+        CentreonLog::create()->error(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
+            exception: $rollbackException
+        );
+
+        throw new RuntimeException(
+            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
+            previous: $rollbackException
+        );
+    }
+
+    throw new RuntimeException(
+        message: "UPGRADE - {$version}: " . $errorMessage,
+        previous: $throwable
+    );
+}

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -37,11 +37,7 @@ $errorMessage = '';
 
 try {
     // DDL statements for real time database
-    $pearDBO->executeStatement(
-        <<<'SQL'
-            ALTER TABLE `log_action` MODIFY COLUMN `log_contact_id` int(11) DEFAULT NULL
-            SQL
-    );
+    // TODO add your function calls to update the real time database structure here
 
     // DDL statements for configuration database
     // TODO add your function calls to update the configuration database structure here

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -37,7 +37,11 @@ $errorMessage = '';
 
 try {
     // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
+    $pearDBO->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `log_action` MODIFY COLUMN `log_contact_id` int(11) DEFAULT NULL
+            SQL
+    );
 
     // DDL statements for configuration database
     // TODO add your function calls to update the configuration database structure here


### PR DESCRIPTION
## Description

Backport of #10053 — Allows null contact id for action log entries. This fixes cases where action logs fail when no contact is associated (e.g. automated actions).

**Fixes** MON-197719

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.04.x

## How this pull request can be tested ?

- Trigger an action log entry without an associated contact (e.g. via API token or automated process)
- Verify the action log is created successfully with a null contact_id
- Verify existing action logs with a contact_id still work as expected

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added update method to WriteServiceCategoryRepositoryInterface and implementation.

**🐛 Bugfixes**
* Allowed null contact id for action log entries to persist.

**🔧 Refactors**
* Replaced ContactInterface injections with TokenStorageInterface across repositories.
* Introduced getContactId helper methods to safely resolve current user.
* Updated Symfony service configurations to inject security.token_storage instead.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103595513?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->