### PR TITLE
chore(upgrade): create Update-26.04.0.php

### DIFF
--- a/centreon/www/install/php/Update-26.04.0.php
+++ b/centreon/www/install/php/Update-26.04.0.php
@@ -18,3 +18,69 @@
  * For more information : contact@centreon.com
  *
  */
+
+use Adaptation\Database\Connection\ConnectionInterface;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+\$version = '26.04.0';
+
+$errorMessage = '';
+
+/**
+ * @var ConnectionInterface $pearDB
+ * @var ConnectionInterface $pearDBO
+ */
+
+// TODO add your functions here
+
+try {
+    // DDL statements for real time database
+    $pearDBO->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `log_action` MODIFY COLUMN `log_contact_id` int(11) DEFAULT NULL
+            SQL
+    );
+
+    // DDL statements for configuration database
+    // TODO add your function calls to update the configuration database structure here
+
+    // Transactional queries for configuration database
+    if (! $pearDB->isTransactionActive()) {
+        $pearDB->startTransaction();
+    }
+
+    // TODO add your function calls to update the configuration database data here
+
+    $pearDB->commitTransaction();
+
+} catch (Throwable $throwable) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: " . $errorMessage,
+        exception: $throwable
+    );
+
+    try {
+        if ($pearDB->isTransactionActive()) {
+            $pearDB->rollBackTransaction();
+        }
+    } catch (ConnectionException $rollbackException) {
+        CentreonLog::create()->error(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
+            exception: $rollbackException
+        );
+
+        throw new RuntimeException(
+            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
+            previous: $rollbackException
+        );
+    }
+
+    throw new RuntimeException(
+        message: "UPGRADE - {$version}: " . $errorMessage,
+        previous: $throwable
+    );
+}


### PR DESCRIPTION
## Description

Create `Update-26.04.0.php` upgrade script from the `Update-next.php` of the `release-26.04-next` branch (PR #10203). This bumps the upgrade script so the CI on `release-26.04-next` can find the expected version file.

**Fixes** bump-upgrade-script

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

- Verify that `www/install/php/Update-26.04.0.php` exists and contains the ALTER TABLE for `log_action.log_contact_id`
- Verify that the version variable is set to `26.04.0`

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added new upgrade script file Update-26.04.0.php to repository

**⚡ Enhancements**
* Changed log_action.log_contact_id column to int(11) DEFAULT NULL in real-time database


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103576302?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->