### PR TITLE
fix(web): convert ACL SQL queries to prepared statements

### DIFF
--- a/centreon/phpstan.legacy.www.baseline.neon
+++ b/centreon/phpstan.legacy.www.baseline.neon
@@ -380,12 +380,6 @@ parameters:
 			path: www/include/options/accessLists/menusACL/DB-Func.php
 
 		-
-			message: '#^Undefined variable\: \$acl_res_name$#'
-			identifier: variable.undefined
-			count: 1
-			path: www/include/options/accessLists/resourcesACL/DB-Func.php
-
-		-
 			message: '#^Instantiated class graph not found\.$#'
 			identifier: class.notFound
 			count: 1

--- a/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -214,8 +214,23 @@ function multipleActionInDB($actions = [], $nbrDup = [])
 {
     global $pearDB, $centreon;
 
+    $selectStmt = $pearDB->prepare('SELECT * FROM acl_actions WHERE acl_action_id = :id LIMIT 1');
+    $selectGroupStmt = $pearDB->prepare(
+        'SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations '
+        . 'WHERE acl_action_id = :id'
+    );
+    $insertGroupStmt = $pearDB->prepare(
+        'INSERT INTO acl_group_actions_relations VALUES (:acl_action_id, :acl_group_id)'
+    );
+    $selectRulesStmt = $pearDB->prepare(
+        'SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules '
+        . 'WHERE acl_action_rule_id = :id'
+    );
+    $insertRulesStmt = $pearDB->prepare(
+        'INSERT INTO acl_actions_rules VALUES (NULL, :acl_action_id, :acl_action_name)'
+    );
+
     foreach (array_keys($actions) as $key) {
-        $selectStmt = $pearDB->prepare('SELECT * FROM acl_actions WHERE acl_action_id = :id LIMIT 1');
         $selectStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
         $selectStmt->execute();
         $row = $selectStmt->fetch();
@@ -244,33 +259,21 @@ function multipleActionInDB($actions = [], $nbrDup = [])
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();
                 if (isset($maxId['MAX(acl_action_id)'])) {
-                    $selectGroupStmt = $pearDB->prepare(
-                        'SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations '
-                        . 'WHERE acl_action_id = :id'
-                    );
                     $selectGroupStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
                     $selectGroupStmt->execute();
-                    $query = 'INSERT INTO acl_group_actions_relations VALUES (:acl_action_id, :acl_group_id)';
-                    $statement = $pearDB->prepare($query);
                     while ($cct = $selectGroupStmt->fetch()) {
-                        $statement->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
-                        $statement->bindValue(':acl_group_id', (int) $cct['acl_group_id'], PDO::PARAM_INT);
-                        $statement->execute();
+                        $insertGroupStmt->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
+                        $insertGroupStmt->bindValue(':acl_group_id', (int) $cct['acl_group_id'], PDO::PARAM_INT);
+                        $insertGroupStmt->execute();
                     }
 
                     // Duplicate Actions
-                    $selectRulesStmt = $pearDB->prepare(
-                        'SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules '
-                        . 'WHERE acl_action_rule_id = :id'
-                    );
                     $selectRulesStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
                     $selectRulesStmt->execute();
-                    $query = 'INSERT INTO acl_actions_rules VALUES (NULL, :acl_action_id, :acl_action_name)';
-                    $statement = $pearDB->prepare($query);
                     while ($acl = $selectRulesStmt->fetch()) {
-                        $statement->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
-                        $statement->bindValue(':acl_action_name', $acl['acl_action_name'], PDO::PARAM_STR);
-                        $statement->execute();
+                        $insertRulesStmt->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
+                        $insertRulesStmt->bindValue(':acl_action_name', $acl['acl_action_name'], PDO::PARAM_STR);
+                        $insertRulesStmt->execute();
                     }
 
                     $centreon->CentreonLogAction->insertLog(

--- a/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -39,16 +39,19 @@ function testActionExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('acl_action_id');
     }
-    $query = 'SELECT acl_action_id, acl_action_name FROM acl_actions '
-        . "WHERE acl_action_name = '" . htmlentities($name, ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $action = $dbResult->fetch();
+    $statement = $pearDB->prepare(
+        'SELECT acl_action_id, acl_action_name FROM acl_actions '
+        . 'WHERE acl_action_name = :name'
+    );
+    $statement->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
+    $action = $statement->fetch();
     // Modif case
-    if ($dbResult->rowCount() >= 1 && $action['acl_action_id'] == $id) {
+    if ($statement->rowCount() >= 1 && $action['acl_action_id'] == $id) {
         return true;
     } // Duplicate entry
 
-    return ! ($dbResult->rowCount() >= 1 && $action['acl_action_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $action['acl_action_id'] != $id);
 }
 
 /**
@@ -203,9 +206,15 @@ function deleteActionInDB($actions = [])
         while ($result = $statement->fetch()) {
             $aclGroupIds[] = (int) $result['acl_group_id'];
         }
-        $pearDB->query("DELETE FROM acl_actions WHERE acl_action_id = '" . $key . "'");
-        $pearDB->query("DELETE FROM acl_actions_rules WHERE acl_action_rule_id = '" . $key . "'");
-        $pearDB->query("DELETE FROM acl_group_actions_relations WHERE acl_action_id = '" . $key . "'");
+        $deleteStmt = $pearDB->prepare('DELETE FROM acl_actions WHERE acl_action_id = :id');
+        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
+        $deleteStmt = $pearDB->prepare('DELETE FROM acl_actions_rules WHERE acl_action_rule_id = :id');
+        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
+        $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_actions_relations WHERE acl_action_id = :id');
+        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
         $centreon->CentreonLogAction->insertLog('action access', $key, $row['acl_action_name'], 'd');
     }
     flagUpdatedAclForAuthentifiedUsers($aclGroupIds);
@@ -221,8 +230,10 @@ function multipleActionInDB($actions = [], $nbrDup = [])
     global $pearDB, $centreon;
 
     foreach (array_keys($actions) as $key) {
-        $dbResult = $pearDB->query("SELECT * FROM acl_actions WHERE acl_action_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
+        $selectStmt = $pearDB->prepare('SELECT * FROM acl_actions WHERE acl_action_id = :id LIMIT 1');
+        $selectStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
 
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $aclActionName = $row['acl_action_name'] . '_' . $i;
@@ -248,30 +259,35 @@ function multipleActionInDB($actions = [], $nbrDup = [])
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();
                 if (isset($maxId['MAX(acl_action_id)'])) {
-                    $query = 'SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations '
-                        . " WHERE acl_action_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectGroupStmt = $pearDB->prepare(
+                        'SELECT DISTINCT acl_group_id,acl_action_id FROM acl_group_actions_relations '
+                        . 'WHERE acl_action_id = :id'
+                    );
+                    $selectGroupStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+                    $selectGroupStmt->execute();
                     $query = 'INSERT INTO acl_group_actions_relations VALUES (:acl_action_id, :acl_group_id)';
-                    $statement =  $pearDB->prepare($query);
-                    while ($cct = $dbResult->fetch()) {
+                    $statement = $pearDB->prepare($query);
+                    while ($cct = $selectGroupStmt->fetch()) {
                         $statement->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':acl_group_id', (int) $cct['acl_group_id'], PDO::PARAM_INT);
                         $statement->execute();
                     }
 
                     // Duplicate Actions
-                    $query = 'SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules '
-                        . "WHERE acl_action_rule_id = '" . $key . "'";
-                    $dbResult = $pearDB->query($query);
+                    $selectRulesStmt = $pearDB->prepare(
+                        'SELECT acl_action_rule_id,acl_action_name FROM acl_actions_rules '
+                        . 'WHERE acl_action_rule_id = :id'
+                    );
+                    $selectRulesStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+                    $selectRulesStmt->execute();
                     $query = 'INSERT INTO acl_actions_rules VALUES (NULL, :acl_action_id, :acl_action_name)';
                     $statement = $pearDB->prepare($query);
-                    while ($acl = $dbResult->fetch()) {
+                    while ($acl = $selectRulesStmt->fetch()) {
                         $statement->bindValue(':acl_action_id', (int) $maxId['MAX(acl_action_id)'], PDO::PARAM_INT);
                         $statement->bindValue(':acl_action_name', $acl['acl_action_name'], PDO::PARAM_STR);
                         $statement->execute();
                     }
 
-                    $dbResult->closeCursor();
                     $centreon->CentreonLogAction->insertLog(
                         'action access',
                         $maxId['MAX(acl_action_id)'],
@@ -423,12 +439,14 @@ function updateGroupActions($aclActionId, $ret = [])
     $statement->bindValue(':acl_action_id', (int) $aclActionId, PDO::PARAM_INT);
     $statement->execute();
     if (isset($_POST['acl_groups'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_actions_relations (acl_group_id, acl_action_id) '
+            . 'VALUES (:acl_group_id, :acl_action_id)'
+        );
         foreach ($_POST['acl_groups'] as $id) {
-            $rq = 'INSERT INTO acl_group_actions_relations ';
-            $rq .= '(acl_group_id, acl_action_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $aclActionId . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':acl_group_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':acl_action_id', (int) $aclActionId, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -454,13 +472,15 @@ function updateRulesActions($aclActionId, $ret = [])
     $actions = [];
     $actions = listActions();
 
+    $insertStmt = $pearDB->prepare(
+        'INSERT INTO acl_actions_rules (acl_action_rule_id, acl_action_name) '
+        . 'VALUES (:acl_action_rule_id, :acl_action_name)'
+    );
     foreach ($actions as $action) {
         if (isset($_POST[$action])) {
-            $rq = 'INSERT INTO acl_actions_rules ';
-            $rq .= '(acl_action_rule_id, acl_action_name) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $aclActionId . "', '" . $action . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':acl_action_rule_id', (int) $aclActionId, PDO::PARAM_INT);
+            $insertStmt->bindValue(':acl_action_name', $action, PDO::PARAM_STR);
+            $insertStmt->execute();
         }
     }
 }

--- a/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -72,34 +72,26 @@ function enableActionInDB($aclActionId = null, $actions = [])
 
     $queryValues = [];
 
+    $updateStmt = $pearDB->prepare(
+        "UPDATE acl_actions SET acl_action_activate = '1' WHERE acl_action_id = :id"
+    );
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_action_name FROM `acl_actions` WHERE acl_action_id = :id LIMIT 1'
+    );
+
     foreach ($actions as $key => $value) {
         $sanitizedAclActionId = filter_var($key, FILTER_VALIDATE_INT);
         if ($sanitizedAclActionId === false) {
             throw new InvalidArgumentException('Invalid id');
         }
         $queryValues[':acl_action_id_' . $sanitizedAclActionId] = $sanitizedAclActionId;
-        $statement = $pearDB->prepare(
-            "UPDATE acl_actions SET acl_action_activate = '1' WHERE acl_action_id = :acl_action_id_"
-                . $sanitizedAclActionId
-        );
-        $statement->bindValue(
-            ':acl_action_id_' . $sanitizedAclActionId,
-            $queryValues[':acl_action_id_' . $sanitizedAclActionId],
-            PDO::PARAM_INT
-        );
-        $statement->execute();
 
-        $statementSelect = $pearDB->prepare(
-            'SELECT acl_action_name FROM `acl_actions` WHERE acl_action_id = :acl_action_id_'
-                . $sanitizedAclActionId . ' LIMIT 1'
-        );
-        $statementSelect->bindValue(
-            ':acl_action_id_' . $sanitizedAclActionId,
-            $queryValues[':acl_action_id_' . $sanitizedAclActionId],
-            PDO::PARAM_INT
-        );
-        $statementSelect->execute();
-        $row = $statementSelect->fetch();
+        $updateStmt->bindValue(':id', $sanitizedAclActionId, PDO::PARAM_INT);
+        $updateStmt->execute();
+
+        $selectStmt->bindValue(':id', $sanitizedAclActionId, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         $centreon->CentreonLogAction->insertLog(
             'action access',
             $sanitizedAclActionId,
@@ -129,34 +121,26 @@ function disableActionInDB($aclActionId = null, $actions = [])
 
     $queryValues = [];
 
+    $updateStmt = $pearDB->prepare(
+        "UPDATE acl_actions SET acl_action_activate = '0' WHERE acl_action_id = :id"
+    );
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_action_name FROM `acl_actions` WHERE acl_action_id = :id LIMIT 1'
+    );
+
     foreach ($actions as $key => $value) {
         $sanitizedAclActionId = filter_var($key, FILTER_VALIDATE_INT);
         if ($sanitizedAclActionId === false) {
             throw new InvalidArgumentException('Invalid id');
         }
         $queryValues[':acl_action_id_' . $sanitizedAclActionId] = $sanitizedAclActionId;
-        $statement = $pearDB->prepare(
-            "UPDATE acl_actions SET acl_action_activate = '0' WHERE acl_action_id = :acl_action_id_"
-                . $sanitizedAclActionId
-        );
-        $statement->bindValue(
-            ':acl_action_id_' . $sanitizedAclActionId,
-            $queryValues[':acl_action_id_' . $sanitizedAclActionId],
-            PDO::PARAM_INT
-        );
-        $statement->execute();
 
-        $statementSelect = $pearDB->prepare(
-            'SELECT acl_action_name FROM `acl_actions` WHERE acl_action_id = :acl_action_id_'
-                . $sanitizedAclActionId . ' LIMIT 1'
-        );
-        $statementSelect->bindValue(
-            ':acl_action_id_' . $sanitizedAclActionId,
-            $queryValues[':acl_action_id_' . $sanitizedAclActionId],
-            PDO::PARAM_INT
-        );
-        $statementSelect->execute();
-        $row = $statementSelect->fetch();
+        $updateStmt->bindValue(':id', $sanitizedAclActionId, PDO::PARAM_INT);
+        $updateStmt->execute();
+
+        $selectStmt->bindValue(':id', $sanitizedAclActionId, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         $centreon->CentreonLogAction->insertLog(
             'action access',
             $sanitizedAclActionId,
@@ -177,6 +161,10 @@ function deleteActionInDB($actions = [])
     global $pearDB, $centreon;
 
     $aclGroupIds = [];
+    $deleteActionStmt = $pearDB->prepare('DELETE FROM acl_actions WHERE acl_action_id = :id');
+    $deleteRulesStmt = $pearDB->prepare('DELETE FROM acl_actions_rules WHERE acl_action_rule_id = :id');
+    $deleteRelStmt = $pearDB->prepare('DELETE FROM acl_group_actions_relations WHERE acl_action_id = :id');
+
     foreach ($actions as $key => $value) {
         $sanitizedAclActionId = filter_var($key, FILTER_VALIDATE_INT);
         if ($sanitizedAclActionId === false) {
@@ -206,15 +194,12 @@ function deleteActionInDB($actions = [])
         while ($result = $statement->fetch()) {
             $aclGroupIds[] = (int) $result['acl_group_id'];
         }
-        $deleteStmt = $pearDB->prepare('DELETE FROM acl_actions WHERE acl_action_id = :id');
-        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
-        $deleteStmt->execute();
-        $deleteStmt = $pearDB->prepare('DELETE FROM acl_actions_rules WHERE acl_action_rule_id = :id');
-        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
-        $deleteStmt->execute();
-        $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_actions_relations WHERE acl_action_id = :id');
-        $deleteStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
-        $deleteStmt->execute();
+        $deleteActionStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteActionStmt->execute();
+        $deleteRulesStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteRulesStmt->execute();
+        $deleteRelStmt->bindValue(':id', (int) $key, PDO::PARAM_INT);
+        $deleteRelStmt->execute();
         $centreon->CentreonLogAction->insertLog('action access', $key, $row['acl_action_name'], 'd');
     }
     flagUpdatedAclForAuthentifiedUsers($aclGroupIds);

--- a/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -280,11 +280,6 @@ function insertGroup($groupInfos)
         PDO::PARAM_STR
     );
     $prepare->bindValue(
-        ':group_alias',
-        $groupInfos['acl_group_alias'],
-        PDO::PARAM_STR
-    );
-    $prepare->bindValue(
         ':is_activate',
         ($isAclGroupActivate ? '1' : '0'),
         PDO::PARAM_STR

--- a/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -56,16 +56,18 @@ function testGroupExistence($name = null)
     if (isset($form)) {
         $id = $form->getSubmitValue('acl_group_id');
     }
-    $query = 'SELECT acl_group_id, acl_group_name '
-        . 'FROM acl_groups '
-        . "WHERE acl_group_name = '" . htmlentities($name, ENT_QUOTES, 'UTF-8') . "' ";
-    $dbResult = $pearDB->query($query);
-    $cg = $dbResult->fetch();
-    if ($dbResult->rowCount() >= 1 && $cg['acl_group_id'] == $id) {
+    $statement = $pearDB->prepare(
+        'SELECT acl_group_id, acl_group_name FROM acl_groups '
+        . 'WHERE acl_group_name = :name'
+    );
+    $statement->bindValue(':name', htmlentities($name, ENT_QUOTES, 'UTF-8'), PDO::PARAM_STR);
+    $statement->execute();
+    $cg = $statement->fetch();
+    if ($statement->rowCount() >= 1 && $cg['acl_group_id'] == $id) {
         return true;
     }
 
-    return ! ($dbResult->rowCount() >= 1 && $cg['acl_group_id'] != $id);
+    return ! ($statement->rowCount() >= 1 && $cg['acl_group_id'] != $id);
     // Duplicate entry
 
 }
@@ -89,7 +91,7 @@ function enableGroupInDB($acl_group_id = null, $groups = [])
     foreach ($groups as $key => $value) {
         $dbResult = $pearDB->prepare(
             <<<'SQL'
-                UPDATE acl_groups 
+                UPDATE acl_groups
                 SET acl_group_activate = '1',
                     acl_group_changed = '1'
                 WHERE acl_group_id = :aclGroupId
@@ -176,29 +178,24 @@ function multipleGroupInDB($groups = [], $nbrDup = [])
         $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
         $dbResult->execute();
         $row = $dbResult->fetch();
-        $row['acl_group_id'] = '';
+        unset($row['acl_group_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_groups (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
 
+        $originalName = $row['acl_group_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $val = null;
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'acl_group_name') {
-                    $acl_group_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $val ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ', NULL')
-                    : $val .= ($value2 != null ? ("'" . $value2 . "'") : 'NULL');
-                if ($key2 != 'acl_group_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($acl_group_name)) {
-                    $fields['acl_group_name'] = $acl_group_name;
-                }
-            }
+            $acl_group_name = $originalName . '_' . $i;
+            $row['acl_group_name'] = $acl_group_name;
 
             if (testGroupExistence($acl_group_name)) {
-                $rq = $val ? 'INSERT INTO acl_groups VALUES (' . $val . ')' : null;
-                $pearDB->query($rq);
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
+                $insertStmt->execute();
+                $fields = $row;
                 $dbResult = $pearDB->query('SELECT MAX(acl_group_id) FROM acl_groups');
                 $maxId = $dbResult->fetch();
                 $dbResult->closeCursor();
@@ -392,15 +389,18 @@ function updateGroupContacts($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_contacts_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_contacts_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['cg_contacts'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_contacts_relations (contact_contact_id, acl_group_id) '
+            . 'VALUES (:contact_id, :group_id)'
+        );
         foreach ($_POST['cg_contacts'] as $id) {
-            $rq = 'INSERT INTO acl_group_contacts_relations ';
-            $rq .= '(contact_contact_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':contact_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -418,10 +418,15 @@ function updateGroupContactGroups($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_contactgroups_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_contactgroups_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['cg_contactGroups'])) {
         $cg = new CentreonContactgroup($pearDB);
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_contactgroups_relations (cg_cg_id, acl_group_id) '
+            . 'VALUES (:cg_id, :group_id)'
+        );
         foreach ($_POST['cg_contactGroups'] as $id) {
             if (! is_numeric($id)) {
                 $res = $cg->insertLdapGroup($id);
@@ -431,11 +436,9 @@ function updateGroupContactGroups($acl_group_id, $ret = [])
                     continue;
                 }
             }
-            $rq = 'INSERT INTO acl_group_contactgroups_relations ';
-            $rq .= '(cg_cg_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':cg_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -453,15 +456,18 @@ function updateGroupActions($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_actions_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_actions_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['actionAccess'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_actions_relations (acl_action_id, acl_group_id) '
+            . 'VALUES (:action_id, :group_id)'
+        );
         foreach ($_POST['actionAccess'] as $id) {
-            $rq = 'INSERT INTO acl_group_actions_relations ';
-            $rq .= '(acl_action_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':action_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -479,15 +485,18 @@ function updateGroupMenus($acl_group_id, $ret = [])
         return;
     }
 
-    $rq = "DELETE FROM acl_group_topology_relations WHERE acl_group_id = '" . $acl_group_id . "'";
-    $dbResult = $pearDB->query($rq);
+    $deleteStmt = $pearDB->prepare('DELETE FROM acl_group_topology_relations WHERE acl_group_id = :group_id');
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['menuAccess'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_group_topology_relations (acl_topology_id, acl_group_id) '
+            . 'VALUES (:topology_id, :group_id)'
+        );
         foreach ($_POST['menuAccess'] as $id) {
-            $rq = 'INSERT INTO acl_group_topology_relations ';
-            $rq .= '(acl_topology_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $dbResult = $pearDB->query($rq);
+            $insertStmt->bindValue(':topology_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }
@@ -505,19 +514,23 @@ function updateGroupResources($acl_group_id, $ret = [])
         return;
     }
 
-    $query = 'DELETE argr '
-        . 'FROM acl_res_group_relations argr '
+    $deleteStmt = $pearDB->prepare(
+        'DELETE argr FROM acl_res_group_relations argr '
         . 'JOIN acl_resources ar ON argr.acl_res_id = ar.acl_res_id '
-        . 'WHERE argr.acl_group_id = ' . $acl_group_id . ' '
-        . 'AND ar.locked = 0 ';
-    $pearDB->query($query);
+        . 'WHERE argr.acl_group_id = :group_id '
+        . 'AND ar.locked = 0'
+    );
+    $deleteStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+    $deleteStmt->execute();
     if (isset($_POST['resourceAccess'])) {
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) '
+            . 'VALUES (:res_id, :group_id)'
+        );
         foreach ($_POST['resourceAccess'] as $id) {
-            $rq = 'INSERT INTO acl_res_group_relations ';
-            $rq .= '(acl_res_id, acl_group_id) ';
-            $rq .= 'VALUES ';
-            $rq .= "('" . $id . "', '" . $acl_group_id . "')";
-            $pearDB->query($rq);
+            $insertStmt->bindValue(':res_id', (int) $id, PDO::PARAM_INT);
+            $insertStmt->bindValue(':group_id', (int) $acl_group_id, PDO::PARAM_INT);
+            $insertStmt->execute();
         }
     }
 }

--- a/centreon/www/include/options/accessLists/menusACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/menusACL/DB-Func.php
@@ -252,11 +252,16 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
 
         $topology = $prepareSelect->fetch(PDO::FETCH_ASSOC);
 
-        $topology['acl_topo_id'] = '';
+        unset($topology['acl_topo_id']);
+        $columns = array_keys($topology);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_topology (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
+
         for ($newIndex = 1; $newIndex <= $duplicateNbr[$currentTopologyId]; $newIndex++) {
             $aclName = null;
             $fields = [];
-            $columns = [];
             $values = [];
 
             foreach ($topology as $column => $value) {
@@ -271,25 +276,16 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
                     $fields['acl_topo_name'] = $aclName;
                 }
 
-                if ($column !== 'acl_topo_id' && $column !== 'acl_topo_name') {
+                if ($column !== 'acl_topo_name') {
                     $fields[$column] = $value;
                 }
 
-                $columns[] = $column;
                 $values[$column] = $value;
             }
 
             if ($values !== []) {
-                $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
-                $insertStmt = $pearDB->prepare(
-                    'INSERT INTO acl_topology (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
-                );
                 foreach ($values as $col => $val) {
-                    if ($val === null || $val === '') {
-                        $insertStmt->bindValue(':' . $col, null, PDO::PARAM_NULL);
-                    } else {
-                        $insertStmt->bindValue(':' . $col, $val, PDO::PARAM_STR);
-                    }
+                    $insertStmt->bindValue(':' . $col, $val, $val === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
                 }
                 $insertStmt->execute();
                 $newTopologyId = $pearDB->lastInsertId();

--- a/centreon/www/include/options/accessLists/menusACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/menusACL/DB-Func.php
@@ -81,31 +81,22 @@ function enableLCAInDB($aclTopologyId = null, $acls = [])
         $acls = [$aclTopologyId => '1'];
     }
 
-    foreach (array_keys($acls) as $currentAclTopologyId) {
-        $prepareUpdate = $pearDB->prepare(
-            "UPDATE `acl_topology` SET acl_topo_activate = '1' "
-            . 'WHERE `acl_topo_id` = :topology_id'
-        );
-        $prepareUpdate->bindValue(
-            ':topology_id',
-            $currentAclTopologyId,
-            PDO::PARAM_INT
-        );
+    $prepareUpdate = $pearDB->prepare(
+        "UPDATE `acl_topology` SET acl_topo_activate = '1' "
+        . 'WHERE `acl_topo_id` = :topology_id'
+    );
+    $prepareSelect = $pearDB->prepare(
+        'SELECT acl_topo_name FROM `acl_topology` '
+        . 'WHERE acl_topo_id = :topology_id LIMIT 1'
+    );
 
+    foreach (array_keys($acls) as $currentAclTopologyId) {
+        $prepareUpdate->bindValue(':topology_id', $currentAclTopologyId, PDO::PARAM_INT);
         if (! $prepareUpdate->execute()) {
             continue;
         }
 
-        $prepareSelect = $pearDB->prepare(
-            'SELECT acl_topo_name FROM `acl_topology` '
-            . 'WHERE acl_topo_id = :topology_id LIMIT 1'
-        );
-        $prepareSelect->bindValue(
-            ':topology_id',
-            $currentAclTopologyId,
-            PDO::PARAM_INT
-        );
-
+        $prepareSelect->bindValue(':topology_id', $currentAclTopologyId, PDO::PARAM_INT);
         if ($prepareSelect->execute()) {
             $result = $prepareSelect->fetch(PDO::FETCH_ASSOC);
             $centreon->CentreonLogAction->insertLog(
@@ -137,31 +128,22 @@ function disableLCAInDB($aclTopologyId = null, $acls = [])
         $acls = [$aclTopologyId => '1'];
     }
 
-    foreach (array_keys($acls) as $currentTopologyId) {
-        $prepareUpdate = $pearDB->prepare(
-            "UPDATE `acl_topology` SET acl_topo_activate = '0' "
-            . 'WHERE `acl_topo_id` = :topology_id'
-        );
-        $prepareUpdate->bindValue(
-            ':topology_id',
-            $currentTopologyId,
-            PDO::PARAM_INT
-        );
+    $prepareUpdate = $pearDB->prepare(
+        "UPDATE `acl_topology` SET acl_topo_activate = '0' "
+        . 'WHERE `acl_topo_id` = :topology_id'
+    );
+    $prepareSelect = $pearDB->prepare(
+        'SELECT acl_topo_name FROM `acl_topology` '
+        . 'WHERE acl_topo_id = :topology_id LIMIT 1'
+    );
 
+    foreach (array_keys($acls) as $currentTopologyId) {
+        $prepareUpdate->bindValue(':topology_id', $currentTopologyId, PDO::PARAM_INT);
         if (! $prepareUpdate->execute()) {
             continue;
         }
 
-        $prepareSelect = $pearDB->prepare(
-            'SELECT acl_topo_name FROM `acl_topology` '
-            . 'WHERE acl_topo_id = :topology_id LIMIT 1'
-        );
-        $prepareSelect->bindValue(
-            ':topology_id',
-            $currentTopologyId,
-            PDO::PARAM_INT
-        );
-
+        $prepareSelect->bindValue(':topology_id', $currentTopologyId, PDO::PARAM_INT);
         if ($prepareSelect->execute()) {
             $result = $prepareSelect->fetch(PDO::FETCH_ASSOC);
             $centreon->CentreonLogAction->insertLog(
@@ -185,17 +167,16 @@ function deleteLCAInDB($acls = [])
 {
     global $pearDB, $centreon;
 
-    foreach (array_keys($acls) as $currentTopologyId) {
-        $prepareSelect = $pearDB->prepare(
-            'SELECT acl_topo_name FROM `acl_topology` '
-            . 'WHERE acl_topo_id = :topology_id LIMIT 1'
-        );
-        $prepareSelect->bindValue(
-            ':topology_id',
-            $currentTopologyId,
-            PDO::PARAM_INT
-        );
+    $prepareSelect = $pearDB->prepare(
+        'SELECT acl_topo_name FROM `acl_topology` '
+        . 'WHERE acl_topo_id = :topology_id LIMIT 1'
+    );
+    $prepareDelete = $pearDB->prepare(
+        'DELETE FROM `acl_topology` WHERE acl_topo_id = :topology_id'
+    );
 
+    foreach (array_keys($acls) as $currentTopologyId) {
+        $prepareSelect->bindValue(':topology_id', $currentTopologyId, PDO::PARAM_INT);
         if (! $prepareSelect->execute()) {
             continue;
         }
@@ -203,14 +184,7 @@ function deleteLCAInDB($acls = [])
         $result = $prepareSelect->fetch(PDO::FETCH_ASSOC);
         $topologyName = $result['acl_topo_name'];
 
-        $prepareDelete = $pearDB->prepare(
-            'DELETE FROM `acl_topology` WHERE acl_topo_id = :topology_id'
-        );
-        $prepareDelete->bindValue(
-            ':topology_id',
-            $currentTopologyId,
-            PDO::PARAM_INT
-        );
+        $prepareDelete->bindValue(':topology_id', $currentTopologyId, PDO::PARAM_INT);
         if ($prepareDelete->execute()) {
             $centreon->CentreonLogAction->insertLog(
                 'menu access',
@@ -258,6 +232,20 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
         $insertStmt = $pearDB->prepare(
             'INSERT INTO acl_topology (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
         );
+        $prepareInsertRelation = $pearDB->prepare(
+            'INSERT INTO acl_topology_relations '
+            . '(acl_topo_id, topology_topology_id, access_right) '
+            . '(SELECT :new_topology_id, topology_topology_id, access_right '
+            . 'FROM acl_topology_relations '
+            . 'WHERE acl_topo_id = :current_topology_id)'
+        );
+        $prepareInsertGroup = $pearDB->prepare(
+            'INSERT INTO acl_group_topology_relations '
+            . '(acl_topology_id, acl_group_id) '
+            . '(SELECT :new_topology_id, acl_group_id '
+            . 'FROM acl_group_topology_relations '
+            . 'WHERE acl_topology_id = :current_topology_id)'
+        );
 
         for ($newIndex = 1; $newIndex <= $duplicateNbr[$currentTopologyId]; $newIndex++) {
             $aclName = null;
@@ -290,45 +278,15 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
                 $insertStmt->execute();
                 $newTopologyId = $pearDB->lastInsertId();
 
-                $prepareInsertRelation = $pearDB->prepare(
-                    'INSERT INTO acl_topology_relations '
-                    . '(acl_topo_id, topology_topology_id, access_right) '
-                    . '(SELECT :new_topology_id, topology_topology_id, access_right '
-                    . 'FROM acl_topology_relations '
-                    . 'WHERE acl_topo_id = :current_topology_id)'
-                );
-                $prepareInsertRelation->bindValue(
-                    ':new_topology_id',
-                    $newTopologyId,
-                    PDO::PARAM_INT
-                );
-                $prepareInsertRelation->bindValue(
-                    ':current_topology_id',
-                    $currentTopologyId,
-                    PDO::PARAM_INT
-                );
+                $prepareInsertRelation->bindValue(':new_topology_id', $newTopologyId, PDO::PARAM_INT);
+                $prepareInsertRelation->bindValue(':current_topology_id', $currentTopologyId, PDO::PARAM_INT);
 
                 if (! $prepareInsertRelation->execute()) {
                     continue;
                 }
 
-                $prepareInsertGroup = $pearDB->prepare(
-                    'INSERT INTO acl_group_topology_relations '
-                    . '(acl_topology_id, acl_group_id) '
-                    . '(SELECT :new_topology_id, acl_group_id '
-                    . 'FROM acl_group_topology_relations '
-                    . 'WHERE acl_topology_id = :current_topology_id)'
-                );
-                $prepareInsertGroup->bindValue(
-                    ':new_topology_id',
-                    $newTopologyId,
-                    PDO::PARAM_INT
-                );
-                $prepareInsertGroup->bindValue(
-                    ':current_topology_id',
-                    $currentTopologyId,
-                    PDO::PARAM_INT
-                );
+                $prepareInsertGroup->bindValue(':new_topology_id', $newTopologyId, PDO::PARAM_INT);
+                $prepareInsertGroup->bindValue(':current_topology_id', $currentTopologyId, PDO::PARAM_INT);
 
                 if ($prepareInsertGroup->execute()) {
                     $centreon->CentreonLogAction->insertLog(
@@ -531,16 +489,15 @@ function updateLCARelation($aclId = null)
 
     if ($prepareDelete->execute()) {
         $submitedValues = $form->getSubmitValue('acl_r_topos');
+        $prepare = $pearDB->prepare(
+            'INSERT INTO acl_topology_relations (acl_topo_id, topology_topology_id, access_right) '
+            . 'VALUES (:aclId, :key, :value)'
+        );
         foreach ($submitedValues as $key => $value) {
             if (isset($submitedValues) && $key != 0) {
-                $prepare = $pearDB->prepare(
-                    'INSERT INTO acl_topology_relations (acl_topo_id, topology_topology_id, access_right) '
-                    . 'VALUES (:aclId, :key, :value)'
-                );
                 $prepare->bindValue(':aclId', $aclId, PDO::PARAM_INT);
                 $prepare->bindValue(':key', $key, PDO::PARAM_INT);
                 $prepare->bindValue(':value', $value, PDO::PARAM_INT);
-
                 $prepare->execute();
             }
         }
@@ -572,14 +529,11 @@ function updateGroups($aclId = null)
     if ($prepareDelete->execute()) {
         $submitedValues = $form->getSubmitValue('acl_groups');
         if (isset($submitedValues)) {
+            $statement = $pearDB->prepare(
+                'INSERT INTO acl_group_topology_relations (acl_topology_id, acl_group_id) VALUES (:aclId, :value)'
+            );
             foreach ($submitedValues as $key => $value) {
                 if (isset($value)) {
-                    $query = <<<'SQL'
-                        INSERT INTO acl_group_topology_relations
-                        (acl_topology_id, acl_group_id)
-                        VALUES (:aclId, :value)
-                        SQL;
-                    $statement = $pearDB->prepare($query);
                     $statement->bindValue(':aclId', $aclId, PDO::PARAM_INT);
                     $statement->bindValue(':value', $value, PDO::PARAM_INT);
                     $statement->execute();

--- a/centreon/www/include/options/accessLists/menusACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/menusACL/DB-Func.php
@@ -254,9 +254,11 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
 
         $topology['acl_topo_id'] = '';
         for ($newIndex = 1; $newIndex <= $duplicateNbr[$currentTopologyId]; $newIndex++) {
-            $val = null;
             $aclName = null;
             $fields = [];
+            $columns = [];
+            $values = [];
+
             foreach ($topology as $column => $value) {
                 if ($column === 'acl_topo_name') {
                     $count = 1;
@@ -268,25 +270,28 @@ function multipleLCAInDB($acls = [], $duplicateNbr = [])
                     $value = $aclName;
                     $fields['acl_topo_name'] = $aclName;
                 }
-                if (is_null($val)) {
-                    $val .= (is_null($value) || empty($value))
-                        ? 'NULL'
-                        : "'" . $pearDB->escape($value) . "'";
-                } else {
-                    $val .= (is_null($value) || empty($value))
-                        ? ', NULL'
-                        : ", '" . $pearDB->escape($value) . "'";
-                }
 
                 if ($column !== 'acl_topo_id' && $column !== 'acl_topo_name') {
                     $fields[$column] = $value;
                 }
+
+                $columns[] = $column;
+                $values[$column] = $value;
             }
 
-            if (! is_null($val)) {
-                $pearDB->query(
-                    "INSERT INTO acl_topology VALUES ({$val})"
+            if ($values !== []) {
+                $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+                $insertStmt = $pearDB->prepare(
+                    'INSERT INTO acl_topology (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
                 );
+                foreach ($values as $col => $val) {
+                    if ($val === null || $val === '') {
+                        $insertStmt->bindValue(':' . $col, null, PDO::PARAM_NULL);
+                    } else {
+                        $insertStmt->bindValue(':' . $col, $val, PDO::PARAM_STR);
+                    }
+                }
+                $insertStmt->execute();
                 $newTopologyId = $pearDB->lastInsertId();
 
                 $prepareInsertRelation = $pearDB->prepare(

--- a/centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -62,16 +62,25 @@ function enableLCAInDB($aclResId = null, $acls = [])
         $acls = [$aclResId => '1'];
     }
 
+    $updateGroupStmt = $pearDB->prepare(
+        "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
+        . 'WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = :acl_res_id)'
+    );
+    $updateResourceStmt = $pearDB->prepare(
+        "UPDATE `acl_resources` SET acl_res_activate = '1', `changed` = '1' WHERE `acl_res_id` = :acl_res_id"
+    );
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1'
+    );
+
     foreach ($acls as $key => $value) {
-        $query = "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
-            . "WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = '{$key}')";
-        $pearDB->query($query);
-        $query = "UPDATE `acl_resources` SET acl_res_activate = '1', `changed` = '1' "
-            . "WHERE `acl_res_id` = '" . $key . "'";
-        $pearDB->query($query);
-        $query = "SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = '" . (int) $key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
+        $updateGroupStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateGroupStmt->execute();
+        $updateResourceStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateResourceStmt->execute();
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         $centreon->CentreonLogAction->insertLog('resource access', $key, $row['acl_res_name'], 'enable');
     }
 }
@@ -92,16 +101,25 @@ function disableLCAInDB($aclResId = null, $acls = [])
         $acls = [$aclResId => '1'];
     }
 
+    $updateGroupStmt = $pearDB->prepare(
+        "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
+        . 'WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = :acl_res_id)'
+    );
+    $updateResourceStmt = $pearDB->prepare(
+        "UPDATE `acl_resources` SET acl_res_activate = '0', `changed` = '1' WHERE `acl_res_id` = :acl_res_id"
+    );
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1'
+    );
+
     foreach ($acls as $key => $value) {
-        $query = "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
-            . "WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = '{$key}')";
-        $pearDB->query($query);
-        $query = "UPDATE `acl_resources` SET acl_res_activate = '0', `changed` = '1' "
-            . "WHERE `acl_res_id` = '" . $key . "'";
-        $pearDB->query($query);
-        $query = "SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = '" . (int) $key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
+        $updateGroupStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateGroupStmt->execute();
+        $updateResourceStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateResourceStmt->execute();
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
         $centreon->CentreonLogAction->insertLog('resource access', $key, $row['acl_res_name'], 'disable');
     }
 }
@@ -114,15 +132,26 @@ function deleteLCAInDB($acls = [])
 {
     global $pearDB, $centreon;
 
-    foreach ($acls as $key => $value) {
-        $query = "SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = '" . (int) $key . "' LIMIT 1";
-        $dbResult = $pearDB->query($query);
-        $row = $dbResult->fetch();
-        $query = "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
-            . "WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = '{$key}')";
-        $pearDB->query($query);
+    $selectStmt = $pearDB->prepare(
+        'SELECT acl_res_name FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1'
+    );
+    $updateGroupStmt = $pearDB->prepare(
+        "UPDATE `acl_groups` SET `acl_group_changed` = '1' "
+        . 'WHERE acl_group_id IN (SELECT acl_group_id FROM acl_res_group_relations WHERE acl_res_id = :acl_res_id)'
+    );
+    $deleteStmt = $pearDB->prepare(
+        'DELETE FROM `acl_resources` WHERE acl_res_id = :acl_res_id'
+    );
 
-        $pearDB->query("DELETE FROM `acl_resources` WHERE acl_res_id = '" . $key . "'");
+    foreach ($acls as $key => $value) {
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        $updateGroupStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $updateGroupStmt->execute();
+
+        $deleteStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $deleteStmt->execute();
         $centreon->CentreonLogAction->insertLog('resource access', $key, $row['acl_res_name'], 'd');
     }
 }
@@ -137,34 +166,28 @@ function multipleLCAInDB($lcas = [], $nbrDup = [])
     global $pearDB, $centreon;
 
     foreach ($lcas as $key => $value) {
-        $dbResult = $pearDB->query("SELECT * FROM `acl_resources` WHERE acl_res_id = '" . $key . "' LIMIT 1");
-        $row = $dbResult->fetch();
-        $row['acl_res_id'] = '';
+        $selectStmt = $pearDB->prepare('SELECT * FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1');
+        $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
+        $selectStmt->execute();
+        $row = $selectStmt->fetch();
+        unset($row['acl_res_id']);
+        $columns = array_keys($row);
+        $placeholders = implode(', ', array_map(fn ($col) => ':' . $col, $columns));
+        $insertStmt = $pearDB->prepare(
+            'INSERT INTO acl_resources (' . implode(', ', $columns) . ') VALUES (' . $placeholders . ')'
+        );
 
+        $originalName = $row['acl_res_name'];
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
-            $values = [];
-
-            foreach ($row as $key2 => $value2) {
-                $value2 = is_int($value2) ? (string) $value2 : $value2;
-                if ($key2 == 'acl_res_name') {
-                    $acl_name = $value2 . '_' . $i;
-                    $value2 = $value2 . '_' . $i;
-                }
-                $values[] = $value2 != null
-                    ? "'" . $value2 . "'"
-                    : 'NULL';
-                if ($key2 != 'acl_res_id') {
-                    $fields[$key2] = $value2;
-                }
-                if (isset($acl_res_name)) {
-                    $fields['acl_res_name'] = $acl_res_name;
-                }
-            }
+            $acl_name = $originalName . '_' . $i;
+            $row['acl_res_name'] = $acl_name;
 
             if (testExistence($acl_name)) {
-                if ($values !== []) {
-                    $pearDB->query('INSERT INTO acl_resources VALUES (' . implode(',', $values) . ')');
+                foreach ($columns as $col) {
+                    $insertStmt->bindValue(':' . $col, $row[$col], $row[$col] === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
                 }
+                $insertStmt->execute();
+                $fields = $row;
 
                 $dbResult = $pearDB->query('SELECT MAX(acl_res_id) FROM acl_resources');
                 $maxId = $dbResult->fetch();
@@ -269,9 +292,13 @@ function duplicateGroups($idTD, $acl_id, $pearDB)
  */
 function duplicateContactGroups($idTD, $acl_id, $pearDB)
 {
-    $query = 'INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) '
-        . "SELECT acl_res_id, '{$acl_id}' AS acl_group_id FROM acl_res_group_relations WHERE acl_group_id = '{$idTD}'";
-    $pearDB->query($query);
+    $statement = $pearDB->prepare(
+        'INSERT INTO acl_res_group_relations (acl_res_id, acl_group_id) '
+        . 'SELECT acl_res_id, :acl_id AS acl_group_id FROM acl_res_group_relations WHERE acl_group_id = :idTD'
+    );
+    $statement->bindValue(':acl_id', (int) $acl_id, PDO::PARAM_INT);
+    $statement->bindValue(':idTD', (int) $idTD, PDO::PARAM_INT);
+    $statement->execute();
 }
 
 /**

--- a/centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
@@ -165,8 +165,9 @@ function multipleLCAInDB($lcas = [], $nbrDup = [])
 {
     global $pearDB, $centreon;
 
+    $selectStmt = $pearDB->prepare('SELECT * FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1');
+
     foreach ($lcas as $key => $value) {
-        $selectStmt = $pearDB->prepare('SELECT * FROM `acl_resources` WHERE acl_res_id = :acl_res_id LIMIT 1');
         $selectStmt->bindValue(':acl_res_id', (int) $key, PDO::PARAM_INT);
         $selectStmt->execute();
         $row = $selectStmt->fetch();


### PR DESCRIPTION
## Description

Fixes: [MON-195882](https://centreon.atlassian.net/browse/MON-195882)

Convert SQL queries from string concatenation (with `$db->escape()`) to PDO prepared statements in ACL access list management files to prevent SQL injection vulnerabilities.

This is **part 1 of 6** of SQL queries convertion.

**Changes:**
- Convert all SQL queries in actionsACL, groupsACL, menusACL, and resourcesACL `DB-Func.php` files to use `prepare()`/`bindValue()`/`execute()`
- Hoist `prepare()` calls outside loops for proper statement reuse (enable/disable/delete in actionsACL, duplicate in menusACL)
- Use `unset()` instead of empty string for auto-increment PK columns in duplication functions (menusACL)
- Remove duplicate `bindValue(':group_alias')` in `insertGroup` (groupsACL)

**Note on `htmlentities()`:** The `htmlentities()` calls on values bound to prepared statements are intentionally preserved. Existing data in the database is stored HTML-encoded (the insert/update functions apply `htmlentities()` before writing). Removing it from lookups like `testExistence()` without also changing the insert/update path and migrating stored data would break name matching. This cleanup should be tracked as a separate effort.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

### E2E tests

Run the ACL Cypress test suites:
- `centreon/tests/e2e/features/ACLs/01-acl-access-groups.feature`
- `centreon/tests/e2e/features/ACLs/02-acl-actions-access.feature`
- `centreon/tests/e2e/features/ACLs/03-acl-menus-access.feature`
- `centreon/tests/e2e/features/ACLs/04-acl-resources-access.feature`

### Manual testing

For each ACL type (actions, groups, menus, resources):
- [ ] **Create** a new ACL entry
- [ ] **Duplicate** it (exercises `multiple*InDB` functions with hoisted prepared statements)
- [ ] **Enable/disable** it (exercises hoisted UPDATE/SELECT statements in actionsACL)
- [ ] **Delete** it (exercises hoisted DELETE statements in actionsACL)
- [ ] Verify entries with special characters in names (e.g., `O'Brien`, `<test>`) are handled correctly

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified.
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch.

[MON-195882]: https://centreon.atlassian.net/browse/MON-195882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 19 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Converted concatenated SQL queries to PDO prepared statements across files

**🔧 Refactors**
* Hoisted prepare() calls outside loops to enable statement reuse
* Replaced empty-string primary key handling with unset() during duplication
* Removed duplicate bindValue call in insertGroup to avoid redundant binding
* Removed obsolete PHPStan baseline entry after fixing undefined variable


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103806061?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->