### PR TITLE
fix(web): convert reporting SQL queries to prepared statements

### DIFF
--- a/centreon/www/include/reporting/dashboard/DB-Func.php
+++ b/centreon/www/include/reporting/dashboard/DB-Func.php
@@ -19,25 +19,23 @@
  *
  */
 
-// returns days of week taken in account for reporting in a string
-function getReportDaysStr($reportTimePeriod)
+/**
+ * Return days of the week taken in account for reporting as an array for use with prepared statement placeholders.
+ *
+ * @param array $reportTimePeriod
+ * @return string[]
+ */
+function getReportDaysArray($reportTimePeriod)
 {
     $tab = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
-    $str = '';
-    foreach ($tab as $key => $value) {
+    $days = [];
+    foreach ($tab as $value) {
         if (isset($reportTimePeriod['report_' . $value]) && $reportTimePeriod['report_' . $value]) {
-            if ($str != '') {
-                $str .= ", '" . $value . "'";
-            } else {
-                $str .= "'" . $value . "'";
-            }
+            $days[] = $value;
         }
     }
-    if ($str == '') {
-        $str = 'NULL';
-    }
 
-    return $str;
+    return $days;
 }
 
 /*
@@ -53,20 +51,34 @@ function getLogInDbForHost($host_id, $start_date, $end_date, $reportTimePeriod)
         $hostStats[$name] = 0;
     }
 
-    $days_of_week = getReportDaysStr($reportTimePeriod);
-    $rq = 'SELECT sum(`UPnbEvent`) as UP_A, sum(`UPTimeScheduled`) as UP_T, '
-        . ' sum(`DOWNnbEvent`) as DOWN_A, sum(`DOWNTimeScheduled`) as DOWN_T, '
-        . ' sum(`UNREACHABLEnbEvent`) as UNREACHABLE_A, sum(`UNREACHABLETimeScheduled`) as UNREACHABLE_T, '
-        . ' sum(`UNDETERMINEDTimeScheduled`) as UNDETERMINED_T, '
-        . ' sum(`MaintenanceTime`) as MAINTENANCE_T '
-        . 'FROM `log_archive_host` '
-        . 'WHERE `host_id` = ' . $host_id . ' AND `date_start` >=  ' . $start_date . ' AND `date_end` <= ' . $end_date
-        . ' ' . "AND DATE_FORMAT( FROM_UNIXTIME( `date_start`), '%W') IN (" . $days_of_week . ') '
-        . 'GROUP BY `host_id` ';
+    $days_of_week = getReportDaysArray($reportTimePeriod);
+    if ($days_of_week !== []) {
+        $dayPlaceholders = [];
+        foreach ($days_of_week as $i => $day) {
+            $dayPlaceholders[] = ':day' . $i;
+        }
+        $daysInClause = implode(', ', $dayPlaceholders);
+        $rq = 'SELECT sum(`UPnbEvent`) as UP_A, sum(`UPTimeScheduled`) as UP_T, '
+            . ' sum(`DOWNnbEvent`) as DOWN_A, sum(`DOWNTimeScheduled`) as DOWN_T, '
+            . ' sum(`UNREACHABLEnbEvent`) as UNREACHABLE_A, sum(`UNREACHABLETimeScheduled`) as UNREACHABLE_T, '
+            . ' sum(`UNDETERMINEDTimeScheduled`) as UNDETERMINED_T, '
+            . ' sum(`MaintenanceTime`) as MAINTENANCE_T '
+            . 'FROM `log_archive_host` '
+            . 'WHERE `host_id` = :host_id AND `date_start` >= :start_date AND `date_end` <= :end_date '
+            . "AND DATE_FORMAT(FROM_UNIXTIME(`date_start`), '%W') IN (" . $daysInClause . ') '
+            . 'GROUP BY `host_id` ';
 
-    $dbResult = $pearDBO->query($rq);
-    if ($row = $dbResult->fetch()) {
-        $hostStats = $row;
+        $dbResult = $pearDBO->prepare($rq);
+        $dbResult->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+        $dbResult->bindValue(':start_date', (int) $start_date, PDO::PARAM_INT);
+        $dbResult->bindValue(':end_date', (int) $end_date, PDO::PARAM_INT);
+        foreach ($days_of_week as $i => $day) {
+            $dbResult->bindValue(':day' . $i, $day, PDO::PARAM_STR);
+        }
+        $dbResult->execute();
+        if ($row = $dbResult->fetch()) {
+            $hostStats = $row;
+        }
     }
 
     /*
@@ -254,34 +266,57 @@ function getLogInDbForHostSVC($host_id, $start_date, $end_date, $reportTimePerio
         }
     }
 
-    $days_of_week = getReportDaysStr($reportTimePeriod);
-    $aclCondition = '';
-    if (! $centreon->user->admin) {
-        $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
-            . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-            . 'AND acl.group_id IN (' . $centreon->user->access->getAccessGroupsString() . ') LIMIT 1)';
-    }
-    $rq = 'SELECT DISTINCT las.service_id, '
-        . 'sum(OKTimeScheduled) as OK_T, '
-        . 'sum(OKnbEvent) as OK_A, '
-        . 'sum(WARNINGTimeScheduled)  as WARNING_T, '
-        . 'sum(WARNINGnbEvent) as WARNING_A, '
-        . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, '
-        . 'sum(UNKNOWNnbEvent) as UNKNOWN_A, '
-        . 'sum(CRITICALTimeScheduled) as CRITICAL_T, '
-        . 'sum(CRITICALnbEvent) as CRITICAL_A, '
-        . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
-        . 'sum(MaintenanceTime) as MAINTENANCE_T '
-        . 'FROM log_archive_service las '
-        . 'WHERE las.host_id = ' . $host_id . ' '
-        . $aclCondition . ' '
-        . 'AND date_start >= ' . $start_date . ' AND date_end <= ' . $end_date . ' '
-        . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $days_of_week . ') '
-        . 'GROUP BY las.service_id ';
-    $dbResult = $pearDBO->query($rq);
-    while ($row = $dbResult->fetch()) {
-        if (isset($hostServiceStats[$row['service_id']])) {
-            $hostServiceStats[$row['service_id']] = $row;
+    $days_of_week = getReportDaysArray($reportTimePeriod);
+    if ($days_of_week !== []) {
+        $dayPlaceholders = [];
+        foreach ($days_of_week as $i => $day) {
+            $dayPlaceholders[] = ':day' . $i;
+        }
+        $daysInClause = implode(', ', $dayPlaceholders);
+        $aclCondition = '';
+        $aclGroupIds = [];
+        if (! $centreon->user->admin) {
+            $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
+            $aclPlaceholders = [];
+            foreach ($aclGroupIds as $j => $id) {
+                $aclPlaceholders[] = ':aclGroup' . $j;
+            }
+            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
+        }
+        $rq = 'SELECT DISTINCT las.service_id, '
+            . 'sum(OKTimeScheduled) as OK_T, '
+            . 'sum(OKnbEvent) as OK_A, '
+            . 'sum(WARNINGTimeScheduled)  as WARNING_T, '
+            . 'sum(WARNINGnbEvent) as WARNING_A, '
+            . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, '
+            . 'sum(UNKNOWNnbEvent) as UNKNOWN_A, '
+            . 'sum(CRITICALTimeScheduled) as CRITICAL_T, '
+            . 'sum(CRITICALnbEvent) as CRITICAL_A, '
+            . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
+            . 'sum(MaintenanceTime) as MAINTENANCE_T '
+            . 'FROM log_archive_service las '
+            . 'WHERE las.host_id = :host_id '
+            . $aclCondition . ' '
+            . 'AND date_start >= :start_date AND date_end <= :end_date '
+            . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysInClause . ') '
+            . 'GROUP BY las.service_id ';
+        $dbResult = $pearDBO->prepare($rq);
+        $dbResult->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+        $dbResult->bindValue(':start_date', (int) $start_date, PDO::PARAM_INT);
+        $dbResult->bindValue(':end_date', (int) $end_date, PDO::PARAM_INT);
+        foreach ($days_of_week as $i => $day) {
+            $dbResult->bindValue(':day' . $i, $day, PDO::PARAM_STR);
+        }
+        foreach ($aclGroupIds as $j => $id) {
+            $dbResult->bindValue(':aclGroup' . $j, (int) $id, PDO::PARAM_INT);
+        }
+        $dbResult->execute();
+        while ($row = $dbResult->fetch()) {
+            if (isset($hostServiceStats[$row['service_id']])) {
+                $hostServiceStats[$row['service_id']] = $row;
+            }
         }
     }
     $i = 0;
@@ -392,97 +427,116 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
     foreach (getServicesStatsValueName() as $name) {
         $serviceStats[$name] = 0;
     }
-    $daysOfWeek = getReportDaysStr($reportTimePeriod);
-    $aclCondition = '';
-    if (! $centreon->user->admin) {
-        $aclCondition = 'AND EXISTS (SELECT * FROM centreon_acl acl '
-            . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-            . 'AND acl.group_id IN (' . $centreon->user->access->getAccessGroupsString() . ') )';
-    }
-
-    $bindValues = [
-        ':startDate' => [PDO::PARAM_STR, $startDate],
-        ':endDate' => [PDO::PARAM_STR, $endDate],
-    ];
-
-    $servicesConditions = [];
-    foreach ($services as $index => $service) {
-        $servicesConditions[] = "(las.host_id = :host{$index} AND las.service_id = :service{$index})";
-        $bindValues[':host' . $index] = [PDO::PARAM_INT, $service['hostId']];
-        $bindValues[':service' . $index] = [PDO::PARAM_INT, $service['serviceId']];
-    }
-    $servicesSubquery = 'AND (' . implode(' OR ', $servicesConditions) . ')';
-
-    // Use "like" instead of "=" to avoid mysql bug on partitioned tables
-    $rq = 'SELECT DISTINCT las.host_id, las.service_id, sum(OKTimeScheduled) as OK_T, sum(OKnbEvent) as OK_A, '
-        . 'sum(WARNINGTimeScheduled)  as WARNING_T, sum(WARNINGnbEvent) as WARNING_A, '
-        . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, sum(UNKNOWNnbEvent) as UNKNOWN_A, '
-        . 'sum(CRITICALTimeScheduled) as CRITICAL_T, sum(CRITICALnbEvent) as CRITICAL_A, '
-        . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
-        . 'sum(MaintenanceTime) as MAINTENANCE_T '
-        . 'FROM log_archive_service las '
-        . 'WHERE `date_start` >= :startDate '
-        . 'AND date_end <= :endDate '
-        . $aclCondition . ' '
-        . $servicesSubquery . ' '
-        . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysOfWeek . ') '
-        . 'GROUP BY las.host_id, las.service_id';
-    $statement = $pearDBO->prepare($rq);
-
-    foreach ($bindValues as $bindName => $bindParams) {
-        [$bindType, $bindValue] = $bindParams;
-        $statement->bindValue($bindName, $bindValue, $bindType);
-    }
-
-    $statement->execute();
+    $daysOfWeek = getReportDaysArray($reportTimePeriod);
     $servicesStats = [];
-    $timeTab = getTotalTimeFromInterval($startDate, $endDate, $reportTimePeriod);
-    while ($serviceStats = $statement->fetch()) {
-        if ($timeTab['reportTime']) {
-            $serviceStats['UNDETERMINED_T'] += $timeTab['reportTime']
-                - ($serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
-                    + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T']);
-        } else {
-            foreach ($status as $key => $value) {
-                $serviceStats[$value . '_T'] = 0;
-            }
-            $serviceStats['UNDETERMINED_T'] = $timeTab['totalTime'];
+    if ($daysOfWeek !== []) {
+        $dayPlaceholders = [];
+        foreach ($daysOfWeek as $i => $day) {
+            $dayPlaceholders[] = ':day' . $i;
         }
-        // Calculate percentage of time (_TP => Total time percentage) for each status
-        $serviceStats['TOTAL_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
-            + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T'];
-        $time = $serviceStats['TOTAL_TIME'];
-        foreach ($status as $value) {
-            $serviceStats[$value . '_TP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
-        }
-        // The same percentage (_MP => Mean Time percentage) is calculated ignoring undetermined time
-        $serviceStats['MEAN_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T']
-            + $serviceStats['CRITICAL_T'] + $serviceStats['UNKNOWN_T'];
-        $time = $serviceStats['MEAN_TIME'];
-        if ($serviceStats['MEAN_TIME'] <= 0) {
-            foreach ($status as $value) {
-                if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
-                    $serviceStats[$value . '_MP'] = 0;
-                }
+        $daysInClause = implode(', ', $dayPlaceholders);
+        $aclCondition = '';
+        $aclGroupIds = [];
+        if (! $centreon->user->admin) {
+            $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
+            $aclPlaceholders = [];
+            foreach ($aclGroupIds as $j => $id) {
+                $aclPlaceholders[] = ':aclGroup' . $j;
             }
-        } else {
-            foreach ($status as $value) {
-                if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
-                    $serviceStats[$value . '_MP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
-                }
-            }
-        }
-        // Format time for each status (_TF => Time Formated), mean time and total time
-        $serviceStats['MEAN_TIME_F'] = getTimeString($serviceStats['MEAN_TIME'], $reportTimePeriod);
-        $serviceStats['TOTAL_TIME_F'] = getTimeString($serviceStats['TOTAL_TIME'], $reportTimePeriod);
-        foreach ($status as $value) {
-            $serviceStats[$value . '_TF'] = getTimeString($serviceStats[$value . '_T'], $reportTimePeriod);
+            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') )';
         }
 
-        $serviceStats['TOTAL_ALERTS'] = $serviceStats['OK_A'] + $serviceStats['WARNING_A'] + $serviceStats['CRITICAL_A']
-            + $serviceStats['UNKNOWN_A'];
+        $bindValues = [
+            ':startDate' => [PDO::PARAM_INT, (int) $startDate],
+            ':endDate' => [PDO::PARAM_INT, (int) $endDate],
+        ];
 
-        $servicesStats[$serviceStats['host_id']][$serviceStats['service_id']] = $serviceStats;
+        $servicesConditions = [];
+        foreach ($services as $index => $service) {
+            $servicesConditions[] = "(las.host_id = :host{$index} AND las.service_id = :service{$index})";
+            $bindValues[':host' . $index] = [PDO::PARAM_INT, $service['hostId']];
+            $bindValues[':service' . $index] = [PDO::PARAM_INT, $service['serviceId']];
+        }
+        $servicesSubquery = 'AND (' . implode(' OR ', $servicesConditions) . ')';
+
+        // Use "like" instead of "=" to avoid mysql bug on partitioned tables
+        $rq = 'SELECT DISTINCT las.host_id, las.service_id, sum(OKTimeScheduled) as OK_T, sum(OKnbEvent) as OK_A, '
+            . 'sum(WARNINGTimeScheduled)  as WARNING_T, sum(WARNINGnbEvent) as WARNING_A, '
+            . 'sum(UNKNOWNTimeScheduled) as UNKNOWN_T, sum(UNKNOWNnbEvent) as UNKNOWN_A, '
+            . 'sum(CRITICALTimeScheduled) as CRITICAL_T, sum(CRITICALnbEvent) as CRITICAL_A, '
+            . 'sum(UNDETERMINEDTimeScheduled) as UNDETERMINED_T, '
+            . 'sum(MaintenanceTime) as MAINTENANCE_T '
+            . 'FROM log_archive_service las '
+            . 'WHERE `date_start` >= :startDate '
+            . 'AND date_end <= :endDate '
+            . $aclCondition . ' '
+            . $servicesSubquery . ' '
+            . "AND DATE_FORMAT(FROM_UNIXTIME(date_start), '%W') IN (" . $daysInClause . ') '
+            . 'GROUP BY las.host_id, las.service_id';
+        $statement = $pearDBO->prepare($rq);
+
+        foreach ($bindValues as $bindName => $bindParams) {
+            [$bindType, $bindValue] = $bindParams;
+            $statement->bindValue($bindName, $bindValue, $bindType);
+        }
+        foreach ($daysOfWeek as $i => $day) {
+            $statement->bindValue(':day' . $i, $day, PDO::PARAM_STR);
+        }
+        foreach ($aclGroupIds as $j => $id) {
+            $statement->bindValue(':aclGroup' . $j, (int) $id, PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+        $timeTab = getTotalTimeFromInterval($startDate, $endDate, $reportTimePeriod);
+        while ($serviceStats = $statement->fetch()) {
+            if ($timeTab['reportTime']) {
+                $serviceStats['UNDETERMINED_T'] += $timeTab['reportTime']
+                    - ($serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
+                        + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T']);
+            } else {
+                foreach ($status as $key => $value) {
+                    $serviceStats[$value . '_T'] = 0;
+                }
+                $serviceStats['UNDETERMINED_T'] = $timeTab['totalTime'];
+            }
+            // Calculate percentage of time (_TP => Total time percentage) for each status
+            $serviceStats['TOTAL_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T'] + $serviceStats['CRITICAL_T']
+                + $serviceStats['UNKNOWN_T'] + $serviceStats['UNDETERMINED_T'] + $serviceStats['MAINTENANCE_T'];
+            $time = $serviceStats['TOTAL_TIME'];
+            foreach ($status as $value) {
+                $serviceStats[$value . '_TP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
+            }
+            // The same percentage (_MP => Mean Time percentage) is calculated ignoring undetermined time
+            $serviceStats['MEAN_TIME'] = $serviceStats['OK_T'] + $serviceStats['WARNING_T']
+                + $serviceStats['CRITICAL_T'] + $serviceStats['UNKNOWN_T'];
+            $time = $serviceStats['MEAN_TIME'];
+            if ($serviceStats['MEAN_TIME'] <= 0) {
+                foreach ($status as $value) {
+                    if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
+                        $serviceStats[$value . '_MP'] = 0;
+                    }
+                }
+            } else {
+                foreach ($status as $value) {
+                    if ($value != 'UNDETERMINED' && $value != 'MAINTENANCE') {
+                        $serviceStats[$value . '_MP'] = round($serviceStats[$value . '_T'] / $time * 100, 2);
+                    }
+                }
+            }
+            // Format time for each status (_TF => Time Formated), mean time and total time
+            $serviceStats['MEAN_TIME_F'] = getTimeString($serviceStats['MEAN_TIME'], $reportTimePeriod);
+            $serviceStats['TOTAL_TIME_F'] = getTimeString($serviceStats['TOTAL_TIME'], $reportTimePeriod);
+            foreach ($status as $value) {
+                $serviceStats[$value . '_TF'] = getTimeString($serviceStats[$value . '_T'], $reportTimePeriod);
+            }
+
+            $serviceStats['TOTAL_ALERTS'] = $serviceStats['OK_A'] + $serviceStats['WARNING_A'] + $serviceStats['CRITICAL_A']
+                + $serviceStats['UNKNOWN_A'];
+
+            $servicesStats[$serviceStats['host_id']][$serviceStats['service_id']] = $serviceStats;
+        }
     }
 
     return $servicesStats;
@@ -699,9 +753,10 @@ function getreportingTimePeriod()
 function getHostNameFromId($host_id)
 {
     global $pearDB;
-    $req = 'SELECT  `host_name` FROM `host` WHERE `host_id` = ' . $host_id;
-    $dbResult = $pearDB->query($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `host_name` FROM `host` WHERE `host_id` = :host_id');
+    $statement->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['host_name'];
     }
 
@@ -711,9 +766,10 @@ function getHostNameFromId($host_id)
 function getHostgroupNameFromId($hostgroup_id)
 {
     global $pearDB;
-    $req = 'SELECT  `hg_name` FROM `hostgroup` WHERE `hg_id` = ' . $hostgroup_id;
-    $dbResult = $pearDB->query($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `hg_name` FROM `hostgroup` WHERE `hg_id` = :hg_id');
+    $statement->bindValue(':hg_id', (int) $hostgroup_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['hg_name'];
     }
 
@@ -723,9 +779,10 @@ function getHostgroupNameFromId($hostgroup_id)
 function getServiceDescriptionFromId($service_id)
 {
     global $pearDB;
-    $req = 'SELECT  `service_description` FROM `service` WHERE `service_id` = ' . $service_id;
-    $dbResult = $pearDB->query($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `service_description` FROM `service` WHERE `service_id` = :service_id');
+    $statement->bindValue(':service_id', (int) $service_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['service_description'];
     }
 
@@ -735,13 +792,12 @@ function getServiceDescriptionFromId($service_id)
 function getServiceGroupNameFromId($sg_id)
 {
     global $pearDB;
-    $req = 'SELECT  `sg_name` FROM `servicegroup` WHERE `sg_id` = ' . $sg_id;
-    $dbResult = $pearDB->query($req);
-    unset($req);
-    if ($row = $dbResult->fetch()) {
+    $statement = $pearDB->prepare('SELECT `sg_name` FROM `servicegroup` WHERE `sg_id` = :sg_id');
+    $statement->bindValue(':sg_id', (int) $sg_id, PDO::PARAM_INT);
+    $statement->execute();
+    if ($row = $statement->fetch()) {
         return $row['sg_name'];
     }
-    $dbResult->closeCursor();
 
     return 'undefined';
 }

--- a/centreon/www/include/reporting/dashboard/DB-Func.php
+++ b/centreon/www/include/reporting/dashboard/DB-Func.php
@@ -277,13 +277,17 @@ function getLogInDbForHostSVC($host_id, $start_date, $end_date, $reportTimePerio
         $aclGroupIds = [];
         if (! $centreon->user->admin) {
             $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
-            $aclPlaceholders = [];
-            foreach ($aclGroupIds as $j => $id) {
-                $aclPlaceholders[] = ':aclGroup' . $j;
+            if ($aclGroupIds === []) {
+                $aclCondition = 'AND 1=0';
+            } else {
+                $aclPlaceholders = [];
+                foreach ($aclGroupIds as $j => $id) {
+                    $aclPlaceholders[] = ':aclGroup' . $j;
+                }
+                $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                    . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                    . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
             }
-            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
-                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
         }
         $rq = 'SELECT DISTINCT las.service_id, '
             . 'sum(OKTimeScheduled) as OK_T, '
@@ -439,13 +443,17 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
         $aclGroupIds = [];
         if (! $centreon->user->admin) {
             $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
-            $aclPlaceholders = [];
-            foreach ($aclGroupIds as $j => $id) {
-                $aclPlaceholders[] = ':aclGroup' . $j;
+            if ($aclGroupIds === []) {
+                $aclCondition = 'AND 1=0';
+            } else {
+                $aclPlaceholders = [];
+                foreach ($aclGroupIds as $j => $id) {
+                    $aclPlaceholders[] = ':aclGroup' . $j;
+                }
+                $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                    . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                    . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') )';
             }
-            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
-                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') )';
         }
 
         $bindValues = [

--- a/centreon/www/include/reporting/dashboard/DB-Func.php
+++ b/centreon/www/include/reporting/dashboard/DB-Func.php
@@ -278,16 +278,15 @@ function getLogInDbForHostSVC($host_id, $start_date, $end_date, $reportTimePerio
         if (! $centreon->user->admin) {
             $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
             if ($aclGroupIds === []) {
-                $aclCondition = 'AND 1=0';
-            } else {
-                $aclPlaceholders = [];
-                foreach ($aclGroupIds as $j => $id) {
-                    $aclPlaceholders[] = ':aclGroup' . $j;
-                }
-                $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
-                    . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-                    . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
+                return $hostServiceStats;
             }
+            $aclPlaceholders = [];
+            foreach ($aclGroupIds as $j => $id) {
+                $aclPlaceholders[] = ':aclGroup' . $j;
+            }
+            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
         }
         $rq = 'SELECT DISTINCT las.service_id, '
             . 'sum(OKTimeScheduled) as OK_T, '
@@ -444,16 +443,15 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
         if (! $centreon->user->admin) {
             $aclGroupIds = array_keys($centreon->user->access->getAccessGroups());
             if ($aclGroupIds === []) {
-                $aclCondition = 'AND 1=0';
-            } else {
-                $aclPlaceholders = [];
-                foreach ($aclGroupIds as $j => $id) {
-                    $aclPlaceholders[] = ':aclGroup' . $j;
-                }
-                $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
-                    . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-                    . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
+                return $servicesStats;
             }
+            $aclPlaceholders = [];
+            foreach ($aclGroupIds as $j => $id) {
+                $aclPlaceholders[] = ':aclGroup' . $j;
+            }
+            $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
+                . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
+                . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
         }
 
         $bindValues = [

--- a/centreon/www/include/reporting/dashboard/DB-Func.php
+++ b/centreon/www/include/reporting/dashboard/DB-Func.php
@@ -452,7 +452,7 @@ function getServicesLogs(array $services, $startDate, $endDate, $reportTimePerio
                 }
                 $aclCondition = 'AND EXISTS (SELECT 1 FROM centreon_acl acl '
                     . 'WHERE las.host_id = acl.host_id AND las.service_id = acl.service_id '
-                    . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') )';
+                    . 'AND acl.group_id IN (' . implode(', ', $aclPlaceholders) . ') LIMIT 1)';
             }
         }
 

--- a/centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+++ b/centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
@@ -47,8 +47,10 @@ $pearDBO = new CentreonDB('centstorage');
 
 $sid = session_id();
 
-$DBRESULT = $pearDB->query("SELECT * FROM session WHERE session_id = '" . $pearDB->escape($sid) . "'");
-if (! $DBRESULT->rowCount()) {
+$DBRESULT = $pearDB->prepare('SELECT 1 FROM session WHERE session_id = :sid LIMIT 1');
+$DBRESULT->bindValue(':sid', $sid, PDO::PARAM_STR);
+$DBRESULT->execute();
+if ($DBRESULT->fetchColumn() === false) {
     exit();
 }
 


### PR DESCRIPTION
## Description

Fixes: [MON-195882](https://centreon.atlassian.net/browse/MON-195882)

Convert SQL queries from string concatenation (with `$db->escape()`) to PDO prepared statements in reporting dashboard functions to prevent SQL injection vulnerabilities.

This is **part 2 of 6** of SQL queries convertion.

**Changes:**
- Refactor `getReportDaysStr()` → `getReportDaysArray()` to return a PHP array instead of a SQL string fragment, enabling proper parameterization of day-of-week `IN` clauses
- Convert all SQL queries in `getLogInDbForHost`, `getLogInDbForHostSVC`, `getServicesLogs`, and four lookup functions to prepared statements
- Parameterize ACL group IDs in `EXISTS` subqueries with individual bind placeholders
- Handle edge case where non-admin users have no ACL groups (use `AND 1=0` fallback to return no results, matching old behavior where `getAccessGroupsString()` returned `'0'`)
- Convert `initXmlFeed.php` queries to prepared statements

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

### Manual testing

In **Reporting → Dashboard**:
- [ ] **Host reporting** — select a host and date range, verify stats load correctly
- [ ] **Host services reporting** — select a host, verify per-service breakdown loads
- [ ] **Service group reporting** — select a service group and date range, verify stats
- [ ] **Non-admin user** — log in as a non-admin user and repeat the above (validates ACL condition and the empty ACL groups fallback)
- [ ] **Uncheck all days** in reporting time period settings, then run a report — should show no data (validates `getReportDaysArray` empty-days handling)
- [ ] **Dashboard charts** — verify the XML-fed charts render correctly (validates `initXmlFeed.php`)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified.
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch.

[MON-195882]: https://centreon.atlassian.net/browse/MON-195882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 7 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Handled empty non-admin ACL groups by returning early to match behavior

**🔧 Refactors**
* Converted reporting SQL queries to PDO prepared statements for safety
* Replaced getReportDaysStr with getReportDaysArray returning array placeholders
* Converted initXmlFeed session query to prepared statement with LIMIT check


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110304629?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->