### PR TITLE
fix(dashboard): use configured acknowledgement defaults in resources …

### DIFF
--- a/centreon/packages/ui-context/src/index.ts
+++ b/centreon/packages/ui-context/src/index.ts
@@ -3,7 +3,7 @@ export { default as aclAtom } from './aclAtom';
 export { additionalResourcesAtom } from './additionalResources';
 export { browserLocaleAtom } from './browserLocaleAtom';
 export { default as cloudServicesAtom } from './cloudServicesAtom';
-export { defaultAcl } from './defaults';
+export { defaultAcknowledgement, defaultAcl } from './defaults';
 export { default as downtimeAtom } from './downtimeAtom';
 export {
   federatedModulesAtom,

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/Listing/Actions/Acknowledge/index.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/Listing/Actions/Acknowledge/index.tsx
@@ -1,5 +1,5 @@
 import { useRequest, useSnackbar } from '@centreon/ui';
-import { acknowledgementAtom, userAtom } from '@centreon/ui-context';
+import { userAtom } from '@centreon/ui-context';
 
 import { useFormik } from 'formik';
 import { useAtomValue } from 'jotai';
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { boolean, object, string } from 'yup';
 
+import { acknowledgementLocalAtom } from '../../../atom';
 import { Resource } from '../../models';
 import {
   labelAcknowledgeCommandSent,
@@ -55,7 +56,7 @@ const AcknowledgeForm = ({
   });
 
   const { alias } = useAtomValue(userAtom);
-  const acknowledgement = useAtomValue(acknowledgementAtom);
+  const acknowledgement = useAtomValue(acknowledgementLocalAtom);
 
   const form = useFormik<AcknowledgeFormValues>({
     initialValues: {

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/WidgetContext.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/WidgetContext.tsx
@@ -1,10 +1,11 @@
-import type { Acl, PlatformVersions } from '@centreon/ui-context';
+import type { Acknowledgement, Acl, PlatformVersions } from '@centreon/ui-context';
 
 import { createStore, Provider } from 'jotai';
 import { equals } from 'ramda';
 import { type ReactElement, type ReactNode, useEffect, useMemo } from 'react';
 
 import {
+  acknowledgementLocalAtom,
   aclLocalAtom,
   isOnPublicPageLocalAtom,
   openTicketContextAtom,
@@ -13,6 +14,7 @@ import {
 import type { OpenTicketContext } from './models';
 
 interface WidgetProviderProps {
+  acknowledgement: Acknowledgement;
   acl: Acl;
   children: ReactNode;
   isOnPublicPage: boolean;
@@ -21,6 +23,7 @@ interface WidgetProviderProps {
 }
 
 export const WidgetProvider = ({
+  acknowledgement,
   acl,
   children,
   isOnPublicPage,
@@ -29,13 +32,18 @@ export const WidgetProvider = ({
 }: WidgetProviderProps): ReactElement => {
   const store = useMemo(() => {
     const newStore = createStore();
+    newStore.set(acknowledgementLocalAtom, acknowledgement);
     newStore.set(aclLocalAtom, acl);
     newStore.set(isOnPublicPageLocalAtom, isOnPublicPage);
     newStore.set(platformLocalAtom, platform);
     newStore.set(openTicketContextAtom, openTicketContext);
 
     return newStore;
-  }, [acl, isOnPublicPage, openTicketContext, platform]);
+  }, [acknowledgement, acl, isOnPublicPage, openTicketContext, platform]);
+
+  useEffect(() => {
+    store.set(acknowledgementLocalAtom, acknowledgement);
+  }, [acknowledgement, store]);
 
   useEffect(() => {
     store.set(aclLocalAtom, acl);

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/atom.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/atom.ts
@@ -1,4 +1,9 @@
-import { defaultAcl, type PlatformVersions } from '@centreon/ui-context';
+import {
+  defaultAcknowledgement,
+  defaultAcl,
+  type Acknowledgement,
+  type PlatformVersions
+} from '@centreon/ui-context';
 
 import { atom } from 'jotai';
 
@@ -20,6 +25,7 @@ export const selectedResourcesAtom = atom<Array<Resource>>([]);
  * These are initialized in WidgetProvider with values from global Jotai atoms,
  */
 export const aclLocalAtom = atom(defaultAcl);
+export const acknowledgementLocalAtom = atom<Acknowledgement>(defaultAcknowledgement);
 export const isOnPublicPageLocalAtom = atom(false);
 export const platformLocalAtom = atom<PlatformVersions | null>(null);
 export const openTicketContextAtom = atom<OpenTicketContext>({

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/index.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/index.tsx
@@ -1,4 +1,5 @@
 import {
+  acknowledgementAtom,
   aclAtom,
   isOnPublicPageAtom,
   platformVersionsAtom
@@ -13,6 +14,7 @@ import ResourcesTable from './ResourcesTable';
 import { WidgetProvider } from './WidgetContext';
 
 const Widget = (props: ResourcesTableProps): ReactElement => {
+  const acknowledgement = useAtomValue(acknowledgementAtom);
   const acl = useAtomValue(aclAtom);
   const platform = useAtomValue(platformVersionsAtom);
   const isOnPublicPage = useAtomValue(isOnPublicPageAtom);
@@ -43,6 +45,7 @@ const Widget = (props: ResourcesTableProps): ReactElement => {
 
   return (
     <WidgetProvider
+      acknowledgement={acknowledgement}
       acl={acl}
       isOnPublicPage={isOnPublicPage}
       openTicketContext={openTicketContext}


### PR DESCRIPTION
…table widget

The WidgetProvider in centreon-widget-resourcestable creates an isolated Jotai store for each widget instance. The AcknowledgeForm was reading acknowledgementAtom from this local store, which was never populated with the values fetched from the API at app init — so it always fell back to hardcoded defaults, ignoring whatever was configured in Administration > Parameters > Monitoring.

Fix bridges the global acknowledgementAtom value into the widget's local store via acknowledgementLocalAtom, following the same pattern already used for aclAtom, platformVersionsAtom, and isOnPublicPageAtom.

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
