### PR TITLE
fix(backup): add --single-transaction to mysqldump to fix LOCK TABLES error on recent MariaDB versions

### DIFF
--- a/centreon/cron/centreon-backup.pl
+++ b/centreon/cron/centreon-backup.pl
@@ -377,6 +377,7 @@ sub gzippedSqlDump {
     my $mysqldump_pid = eval {
         open3('<&INPUT', \*FROM_MYSQLDUMP, '>&STDERR',
             mysqldump => (
+                '--single-transaction',
                 '-u', $mysql_user,
                 '-p'.$mysql_passwd,
                 '-h', $mysql_host,


### PR DESCRIPTION
## Description

🏷️ `dev-25.10.x` backport for #10034

**Fixes** MON-197815

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added --single-transaction to mysqldump to fix LOCK TABLES error


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104060215?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->