### PR TITLE
fix(open-tickets): do not use hardcoded database name (EasyVistaRestProvider) (#10223)

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/EasyVistaRest/EasyVistaRestProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/EasyVistaRest/EasyVistaRestProvider.class.php
@@ -128,9 +128,12 @@ class EasyVistaRestProvider extends AbstractProvider
 
         require_once $centreon_path . 'www/modules/centreon-open-tickets/class/centreonDBManager.class.php';
         $db_storage = new CentreonDBManager('centstorage');
+        $configurationDatabase = new CentreonDBManager();
+        $configDbName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
+        $escapedConfigDbName = str_replace('`', '``', $configDbName);
 
         $query = 'SELECT name FROM hostgroups WHERE hostgroup_id IN'
-            . ' (SELECT hostgroup_hg_id FROM centreon.hostgroup_relation WHERE host_host_id IN (' . $listIds . ')'
+            . ' (SELECT hostgroup_hg_id FROM `' . $escapedConfigDbName . '`.hostgroup_relation WHERE host_host_id IN (' . $listIds . ')'
             . ' GROUP BY hostgroup_hg_id HAVING count(hostgroup_hg_id) = :host_count)';
 
         $dbQuery = $db_storage->prepare($query);


### PR DESCRIPTION
🔗 https://centreon.atlassian.net/browse/MON-197915

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced hardcoded 'centreon' DB name with configured database retrieval


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104473904?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->