### PR TITLE
fix loss of ticket id if someone change a custom macro config on host/service while a ticket is opened on said object (#9017)

### DIFF
--- a/centreon-open-tickets/phpstan.legacy.www.baseline.neon
+++ b/centreon-open-tickets/phpstan.legacy.www.baseline.neon
@@ -32,7 +32,7 @@ parameters:
 
 		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) rv must contain 3 or more characters\.$#'
-			count: 33
+			count: 37
 			path: www/modules/centreon-open-tickets/class/automatic.class.php
 
 		-

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -19,6 +19,13 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Common\Domain\Exception\CollectionException;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Domain\Exception\ValueObjectException;
+
 class Automatic
 {
     /** @var Centreon */
@@ -41,6 +48,9 @@ class Automatic
 
     /** @var string */
     protected $uniqId;
+
+    /** @var string */
+    protected $fullMacroName = '';
 
     /** @var array<string, int> */
     protected $registerProviders;
@@ -87,6 +97,24 @@ class Automatic
         $rv = $this->submitTicket($params, $ruleInfo, $contact, [], [$service]);
         $this->doChainRules($rv['chainRuleList'], $params, $contact, [], [$service]);
 
+        $providerClass = $this->getProviderClass($ruleInfo);
+        try {
+            $macroName = $providerClass->getMacroTicketId();
+            $this->setFullMacroName($macroName, 'service');
+            $macroId = $this->getTicketMacroId('service', $service['service_id']);
+            if (! is_null($macroId)) {
+                $this->updateServiceMacro($rv['ticket_id'], $service['service_id'], $macroId);
+            } elseif ($this->isServiceUnique($service['service_id'])) {
+                $this->insertTicketInConfigDB('service', $rv['ticket_id'], $service['service_id']);
+            }
+        } catch (RepositoryException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_BUSINESS_LOG,
+                'Failed to persist ticket macro in config DB for service ticket opening: ' . $e->getMessage(),
+                exception: $e
+            );
+        }
+
         $this->externalServiceCommands($rv['providerClass'], $rv['ticket_id'], $contact, $service);
 
         return ['code' => 0, 'message' => 'Open ticket ' . $rv['ticket_id']];
@@ -107,6 +135,25 @@ class Automatic
         $rv = $this->submitTicket($params, $ruleInfo, $contact, [$host], []);
         $this->doChainRules($rv['chainRuleList'], $params, $contact, [$host], []);
 
+        $providerClass = $this->getProviderClass($ruleInfo);
+        try {
+            $macroName = $providerClass->getMacroTicketId();
+            $this->setFullMacroName($macroName, 'host');
+            $macroId = $this->getTicketMacroId('host', $host['host_id']);
+
+            if (! is_null($macroId)) {
+                $this->updateHostMacro($rv['ticket_id'], $host['host_id'], $macroId);
+            } else {
+                $this->insertTicketInConfigDB('host', $rv['ticket_id'], $host['host_id']);
+            }
+        } catch (RepositoryException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_BUSINESS_LOG,
+                'Failed to persist ticket macro in config DB for host ticket opening: ' . $e->getMessage(),
+                exception: $e
+            );
+        }
+
         $this->externalHostCommands($rv['providerClass'], $rv['ticket_id'], $contact, $host);
 
         return ['code' => 0, 'message' => 'Open ticket ' . $rv['ticket_id']];
@@ -124,6 +171,7 @@ class Automatic
         $host = $this->getHostInformation($params);
         $providerClass = $this->getProviderClass($ruleInfo);
         $macroName = $providerClass->getMacroTicketId();
+        $this->setFullMacroName($macroName, 'host');
 
         $ticketId = $this->getHostTicket($params, $macroName);
 
@@ -137,6 +185,7 @@ class Automatic
             try {
                 $providerClass->closeTicket($closeTicketData);
                 $this->changeMacroHost($macroName, $host);
+                $this->updateHostMacro('', $host['host_id']);
                 $rv = ['code' => 0, 'message' => 'ticket ' . $ticketId . ' has been closed'];
             } catch (Exception $e) {
                 $rv = ['code' => -1, 'message' => $e->getMessage()];
@@ -158,6 +207,7 @@ class Automatic
         $service = $this->getServiceInformation($params);
         $providerClass = $this->getProviderClass($ruleInfo);
         $macroName = $providerClass->getMacroTicketId();
+        $this->setFullMacroName($macroName, 'service');
 
         $ticketId = $this->getServiceTicket($params, $macroName);
 
@@ -172,6 +222,9 @@ class Automatic
             try {
                 $providerClass->closeTicket($closeTicketData);
                 $this->changeMacroService($macroName, $service);
+                if ($this->isServiceUnique($service['service_id'])) {
+                    $this->updateServiceMacro('', $service['service_id']);
+                }
                 $rv = ['code' => 0, 'message' => 'ticket ' . $ticketId . ' has been closed'];
             } catch (Exception $e) {
                 $rv = ['code' => -1, 'message' => $e->getMessage()];
@@ -179,6 +232,327 @@ class Automatic
         }
 
         return $rv;
+    }
+
+    /**
+     * setFullMacroName: set the full ticket_id macro name ($_HOSTXXXXXXX$ or $_SERVICEXXXXXX$)
+     *
+     * @param string $macroName the name of the macro (TICKET_ID)
+     * @param string $type the type of object (service or host)
+     * @return void
+     */
+    protected function setFullMacroName(string $macroName, string $type): void
+    {
+        $this->fullMacroName = $type === 'host' ? '$_HOST' . $macroName . '$' : '$_SERVICE' . $macroName . '$';
+    }
+
+    /**
+     * updateServiceMacro: set the value of the service ticketing macro in the config database
+     *
+     * @param string $ticketId the ticket id
+     * @param int $serviceId the id of the service
+     * @param int|null $macroId the macro id (avoids a redundant SELECT when already known)
+     * @throws RepositoryException
+     * @return void
+     */
+    protected function updateServiceMacro(string $ticketId, int $serviceId, ?int $macroId = null): void
+    {
+        if ($macroId === null) {
+            // check if service has the macro set up
+            $query = <<<'SQL'
+                    SELECT svc_macro_id
+                    FROM on_demand_macro_service
+                    WHERE svc_macro_name = :macro_name AND svc_svc_id = :service_id
+                SQL;
+
+            try {
+                $row = $this->dbCentreon->fetchAssociative($query, QueryParameters::create([
+                    QueryParameter::string('macro_name', $this->fullMacroName),
+                    QueryParameter::int('service_id', $serviceId),
+                ]));
+            } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+                CentreonLog::create()->error(
+                    CentreonLog::TYPE_SQL,
+                    'Error while fetching service macro: ' . $e->getMessage(),
+                    exception: $e
+                );
+
+                throw new RepositoryException('Error while fetching service macro: ' . $e->getMessage(), previous: $e);
+            }
+
+            if (! $row) {
+                return;
+            }
+            $macroId = (int) $row['svc_macro_id'];
+        }
+
+        $query = <<<'SQL'
+                UPDATE on_demand_macro_service
+                SET svc_macro_value = :macro_value
+                WHERE svc_macro_id = :macro_id
+            SQL;
+
+        try {
+            $this->dbCentreon->update($query, QueryParameters::create([
+                QueryParameter::int('macro_id', $macroId),
+                QueryParameter::string('macro_value', $ticketId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while updating service macro: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while updating service macro: ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * updateHostMacro: set the value of the host ticketing macro in the config database
+     *
+     * @param string $ticketId the ticket id
+     * @param int $hostId the host id
+     * @param int|null $macroId the macro id (avoids a redundant SELECT when already known)
+     * @throws RepositoryException
+     * @return void
+     */
+    protected function updateHostMacro(string $ticketId, int $hostId, ?int $macroId = null): void
+    {
+        if ($macroId === null) {
+            $query = <<<'SQL'
+                    SELECT host_macro_id
+                    FROM on_demand_macro_host
+                    WHERE host_macro_name = :macro_name AND host_host_id = :host_id
+                SQL;
+
+            try {
+                $row = $this->dbCentreon->fetchAssociative($query, QueryParameters::create([
+                    QueryParameter::string('macro_name', $this->fullMacroName),
+                    QueryParameter::int('host_id', $hostId),
+                ]));
+            } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+                CentreonLog::create()->error(
+                    CentreonLog::TYPE_SQL,
+                    'Error while fetching host macro: ' . $e->getMessage(),
+                    exception: $e
+                );
+
+                throw new RepositoryException('Error while fetching host macro: ' . $e->getMessage(), previous: $e);
+            }
+
+            if (! $row) {
+                return;
+            }
+            $macroId = (int) $row['host_macro_id'];
+        }
+
+        $query = <<<'SQL'
+                UPDATE on_demand_macro_host
+                SET host_macro_value = :macro_value
+                WHERE host_macro_id = :macro_id
+            SQL;
+
+        try {
+            $this->dbCentreon->update($query, QueryParameters::create([
+                QueryParameter::int('macro_id', $macroId),
+                QueryParameter::string('macro_value', $ticketId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while updating host macro: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while updating host macro: ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * insertTicketInConfigDB: add a new macro entry for the ticket macro in the config db (with the ticket id value)
+     *
+     * @param string $type the object type (host or service)
+     * @param string $ticketId the ticket id
+     * @param int $objectId the id of the object (service id or host id)
+     * @throws RepositoryException
+     * @return void
+     */
+    protected function insertTicketInConfigDB(string $type, string $ticketId, int $objectId): void
+    {
+        try {
+            $macroOrder = $this->getMaxOrder($type, $objectId);
+        } catch (RepositoryException $e) {
+            throw new RepositoryException('Error while fetching macro order before insert: ' . $e->getMessage(), previous: $e);
+        }
+
+        if ($type === 'host') {
+            $query = <<<'SQL'
+                    INSERT INTO on_demand_macro_host (host_macro_name, host_macro_value, is_password, description, host_host_id, macro_order)
+                    VALUES (:macro_name, :ticket_id, NULL, '', :object_id, :macro_order)
+                SQL;
+        } else {
+            $query = <<<'SQL'
+                    INSERT INTO on_demand_macro_service (svc_macro_name, svc_macro_value, is_password, description, svc_svc_id, macro_order)
+                    VALUES (:macro_name, :ticket_id, NULL, '', :object_id, :macro_order)
+                SQL;
+        }
+
+        try {
+            $this->dbCentreon->insert($query, QueryParameters::create([
+                QueryParameter::string('ticket_id', $ticketId),
+                QueryParameter::string('macro_name', $this->fullMacroName),
+                QueryParameter::int('macro_order', $macroOrder),
+                QueryParameter::int('object_id', $objectId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while inserting ticket macro in config DB: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while inserting ticket macro in config DB: ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * getMacroId : returns the id of a macro if it is sets directly on the host or service
+     *
+     * @param string $type the type of object (can be host or service)
+     * @param int $objectId the id of the host or service
+     * @throws RepositoryException
+     * @return int|null the id of the macro if directly linked to the host or service
+     */
+    protected function getTicketMacroId(string $type, int $objectId): ?int
+    {
+        if ($type === 'host') {
+            $query = <<<'SQL'
+                    SELECT host_macro_id AS macro_id
+                    FROM on_demand_macro_host
+                    WHERE host_host_id = :object_id AND host_macro_name = :macro_name
+                SQL;
+        } else {
+            $query = <<<'SQL'
+                    SELECT svc_macro_id AS macro_id
+                    FROM on_demand_macro_service
+                    WHERE svc_svc_id = :object_id AND svc_macro_name = :macro_name
+                SQL;
+        }
+
+        try {
+            $row = $this->dbCentreon->fetchAssociative($query, QueryParameters::create([
+                QueryParameter::int('object_id', $objectId),
+                QueryParameter::string('macro_name', $this->fullMacroName),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while fetching ticket macro id: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while fetching ticket macro id: ' . $e->getMessage(), previous: $e);
+        }
+
+        if ($row) {
+            return (int) $row['macro_id'];
+        }
+
+        return null;
+    }
+
+    /**
+     * getMaxOrder gets the order number for the next custom macro
+     *
+     * @param string $type the type of object (must be host or service)
+     * @param int $objectId the id of the service or the host
+     * @throws RepositoryException
+     * @return int the next available order number
+     */
+    protected function getMaxOrder(string $type, int $objectId): int
+    {
+        if ($type === 'host') {
+            $query = <<<'SQL'
+                    SELECT MAX(macro_order) AS max
+                    FROM on_demand_macro_host
+                    WHERE host_host_id = :object_id
+                SQL;
+        } else {
+            $query = <<<'SQL'
+                    SELECT MAX(macro_order) AS max
+                    FROM on_demand_macro_service
+                    WHERE svc_svc_id = :object_id
+                SQL;
+        }
+
+        try {
+            $row = $this->dbCentreon->fetchAssociative($query, QueryParameters::create([
+                QueryParameter::int('object_id', $objectId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while fetching max macro order: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while fetching max macro order: ' . $e->getMessage(), previous: $e);
+        }
+
+        if ($row) {
+            return is_null($row['max']) ? 0 : (int) $row['max'] + 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * isServiceUnique checks if the service is linked to a single host (not to multiple hosts or to a hostgroup)
+     *
+     * @param int $serviceId the id of the service
+     * @throws RepositoryException
+     * @return bool
+     */
+    protected function isServiceUnique(int $serviceId): bool
+    {
+        $query = <<<'SQL'
+                SELECT count(*) AS duplicated_service
+                FROM (
+                    (
+                        SELECT 1
+                        FROM host_service_relation
+                        WHERE service_service_id = :service_id
+                            AND hostgroup_hg_id IS NOT NULL
+                    ) UNION (
+                        SELECT 1
+                        FROM host_service_relation
+                        WHERE service_service_id = :service_id
+                            AND host_host_id IS NOT NULL
+                        GROUP BY service_service_id HAVING COUNT(service_service_id) > 1
+                    )
+                ) AS relation
+            SQL;
+
+        try {
+            $row = $this->dbCentreon->fetchAssociative($query, QueryParameters::create([
+                QueryParameter::int('service_id', $serviceId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while checking service uniqueness: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while checking service uniqueness: ' . $e->getMessage(), previous: $e);
+        }
+
+        if ($row) {
+            return (int) $row['duplicated_service'] === 0;
+        }
+
+        return true;
     }
 
     /**

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/closeTicket.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/closeTicket.php
@@ -19,7 +19,124 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Common\Domain\Exception\CollectionException;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Domain\Exception\ValueObjectException;
+
+/**
+ * updateHostMacro updates ticket custom macro value to an empty value to fully remove the ticket
+ *
+ * @param string $macroName name of the macro that must be updated
+ * @param int $hostId id of host
+ * @throws RepositoryException
+ * @return void
+ */
+function updateHostMacro(string $macroName, int $hostId): void
+{
+    global $db;
+
+    // check if host has the macro set up
+    $query = <<<'SQL'
+            SELECT host_macro_id
+            FROM on_demand_macro_host
+            WHERE host_macro_name = :macro_name AND host_host_id = :host_id
+        SQL;
+    try {
+        $row = $db->fetchAssociative($query, QueryParameters::create([
+            QueryParameter::string('macro_name', $macroName),
+            QueryParameter::int('host_id', $hostId),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while fetching host macro: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while fetching host macro: ' . $e->getMessage(), previous: $e);
+    }
+
+    if ($row) {
+        $macroId = (int) $row['host_macro_id'];
+        $query = <<<'SQL'
+                UPDATE on_demand_macro_host
+                SET host_macro_value = ''
+                WHERE host_macro_id = :macro_id
+            SQL;
+        try {
+            $db->update($query, QueryParameters::create([
+                QueryParameter::int('macro_id', $macroId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while updating host macro: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while updating host macro: ' . $e->getMessage(), previous: $e);
+        }
+    }
+}
+
+/**
+ * updateServiceMacro updates ticket custom macro value to an empty value to fully remove the ticket
+ *
+ * @param string $macroName name of the macro that must be updated
+ * @param int $serviceId id of service
+ * @throws RepositoryException
+ * @return void
+ */
+function updateServiceMacro(string $macroName, int $serviceId): void
+{
+    global $db;
+
+    // check if service has the macro set up
+    $query = <<<'SQL'
+            SELECT svc_macro_id
+            FROM on_demand_macro_service
+            WHERE svc_macro_name = :macro_name AND svc_svc_id = :service_id
+        SQL;
+    try {
+        $row = $db->fetchAssociative($query, QueryParameters::create([
+            QueryParameter::string('macro_name', $macroName),
+            QueryParameter::int('service_id', $serviceId),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while fetching service macro: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while fetching service macro: ' . $e->getMessage(), previous: $e);
+    }
+
+    if ($row) {
+        $macroId = (int) $row['svc_macro_id'];
+        $query = <<<'SQL'
+                UPDATE on_demand_macro_service
+                SET svc_macro_value = ''
+                WHERE svc_macro_id = :macro_id
+            SQL;
+        try {
+            $db->update($query, QueryParameters::create([
+                QueryParameter::int('macro_id', $macroId),
+            ]));
+        } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_SQL,
+                'Error while updating service macro: ' . $e->getMessage(),
+                exception: $e
+            );
+
+            throw new RepositoryException('Error while updating service macro: ' . $e->getMessage(), previous: $e);
+        }
+    }
+}
 
 $resultat = ['code' => 0, 'msg' => 'ok'];
 
@@ -97,7 +214,7 @@ if (! $centreon_bg->is_admin) {
 }
 
 $query = '(SELECT DISTINCT
-        services.description, hosts.name as host_name, hosts.instance_id, mot.ticket_value, mot.timestamp
+        services.description, services.service_id, hosts.name as host_name, hosts.host_id, hosts.instance_id, mot.ticket_value, mot.timestamp
     FROM services, hosts, mod_open_tickets_link as motl, mod_open_tickets as mot
     WHERE (' . $selected_str . ') AND services.host_id = hosts.host_id';
 if (! $centreon_bg->is_admin) {
@@ -115,7 +232,9 @@ $query .= ' AND motl.host_id = hosts.host_id
     ) UNION ALL (
         SELECT DISTINCT
             NULL as description,
+            NULL as service_id,
             hosts.name as host_name,
+            hosts.host_id,
             hosts.instance_id,
             mot.ticket_value,
             mot.timestamp
@@ -139,7 +258,7 @@ try {
     $dbResult = $db_storage->fetchAllAssociative($query);
 } catch (ConnectionException $e) {
     CentreonLog::create()->error(
-        CentreonLog::TYPE_SQL,
+        CentreonLog::TYPE_BUSINESS_LOG,
         'Error while fetching tickets to close: ' . $e->getMessage(),
         exception: $e
     );
@@ -159,6 +278,8 @@ foreach ($dbResult as $row) {
     $hosts_done[$row['host_name'] . ';' . $row['description']] = 1;
 }
 
+$ownTransaction = false;
+
 try {
     $centreon_provider->closeTicket($tickets);
     require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
@@ -171,6 +292,12 @@ try {
 
     $removed_tickets = [];
     $error_msg = [];
+    $macroName = $centreon_provider->getMacroTicketId();
+
+    $ownTransaction = ! $db->isTransactionActive();
+    if ($ownTransaction) {
+        $db->startTransaction();
+    }
 
     foreach ($problems as $row) {
         // an error in ticket close
@@ -188,10 +315,12 @@ try {
             $removed_tickets[$row['ticket_value']] = 1;
         }
         if (is_null($row['description']) || $row['description'] == '') {
+            $fullMacroName = '$_HOST' . $macroName . '$';
+            updateHostMacro($fullMacroName, $row['host_id']);
             $command = 'CHANGE_CUSTOM_HOST_VAR;%s;%s;%s';
             call_user_func_array(
                 [$external_cmd, $method_external_name],
-                [sprintf($command, $row['host_name'], $centreon_provider->getMacroTicketId(), ''), $row['instance_id']]
+                [sprintf($command, $row['host_name'], $macroName, ''), $row['instance_id']]
             );
             $command = 'REMOVE_HOST_ACKNOWLEDGEMENT;%s';
             call_user_func_array(
@@ -201,10 +330,12 @@ try {
             continue;
         }
 
+        $fullMacroName = '$_SERVICE' . $macroName . '$';
+        updateServiceMacro($fullMacroName, $row['service_id']);
         $command = 'CHANGE_CUSTOM_SVC_VAR;%s;%s;%s;%s';
         call_user_func_array(
             [$external_cmd, $method_external_name],
-            [sprintf($command, $row['host_name'], $row['description'], $centreon_provider->getMacroTicketId(), ''), $row['instance_id']]
+            [sprintf($command, $row['host_name'], $row['description'], $macroName, ''), $row['instance_id']]
         );
         if ($centreon_provider->doAck()) {
             $command = 'REMOVE_SVC_ACKNOWLEDGEMENT;%s;%s';
@@ -216,10 +347,30 @@ try {
     }
 
     $external_cmd->write();
-} catch (Exception $e) {
+    if ($ownTransaction) {
+        $db->commitTransaction();
+    }
+} catch (RepositoryException $e) {
+    CentreonLog::create()->error(
+        CentreonLog::TYPE_BUSINESS_LOG,
+        'Error while closing tickets: ' . $e->getMessage(),
+        exception: $e
+    );
+
+    try {
+        if ($ownTransaction && $db->isTransactionActive()) {
+            $db->rollBackTransaction();
+        }
+    } catch (ConnectionException $rollbackException) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_BUSINESS_LOG,
+            'Failed to roll back transaction while closing tickets: ' . $rollbackException->getMessage(),
+            exception: $rollbackException
+        );
+    }
+
     $resultat['code'] = 1;
     $resultat['msg'] = $e->getMessage();
-    $db->rollback();
 }
 
 $resultat['msg'] = '
@@ -232,7 +383,7 @@ $resultat['msg'] = '
             . join(',', array_keys($removed_tickets)) . '.</td>
     </tr>';
 
-if ($centreon_provider->doCloseTicket() && count($error_msg) > 0) {
+if ($centreon_provider->doCloseTicket() && $error_msg !== []) {
     $resultat['msg'] .= '<tr>
         <td class="FormRowField" style="padding-left:15px; color: red">Issue to close tickets: '
             . join('<br/>', $error_msg) . '.</td>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/actions/submitTicket.php
@@ -19,21 +19,42 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Common\Domain\Exception\CollectionException;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Domain\Exception\ValueObjectException;
+
 function get_contact_information()
 {
     global $db, $centreon_bg;
 
     $result = ['alias' => '', 'email' => '', 'name' => ''];
-    $dbResult = $db->query(
-        "SELECT
-            contact_name as `name`,
-            contact_alias as `alias`,
-            contact_email as email
-        FROM contact
-        WHERE contact_id = '" . $centreon_bg->user_id . "' LIMIT 1"
-    );
-    if (($row = $dbResult->fetch())) {
-        $result = $row;
+    $query = <<<'SQL'
+            SELECT
+                contact_name as `name`,
+                contact_alias as `alias`,
+                contact_email as email
+            FROM contact
+            WHERE contact_id = :contact_id LIMIT 1
+        SQL;
+
+    try {
+        $row = $db->fetchAssociative($query, QueryParameters::create([
+            QueryParameter::int('contact_id', (int) $centreon_bg->user_id),
+        ]));
+        if ($row) {
+            $result = $row;
+        }
+    } catch (ConnectionException|CollectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while fetching contact information: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while fetching contact information: ' . $e->getMessage(), previous: $e);
     }
 
     return $result;
@@ -99,6 +120,243 @@ function do_chain_rules($rule_list, $db_storage, $contact_infos, $selected)
         );
         array_unshift($rule_list, $provider_class->getChainRuleList());
     }
+}
+
+/**
+ * getMacroId : returns the id of a macro if it is sets directly on the host or service
+ *
+ * @param string $type the type of object (can be host or service)
+ * @param string $macroName the name of the macro (usually TICKET_ID)
+ * @param int $objectId the id of the host or service
+ * @throws RepositoryException
+ * @return int|null the id of the macro if directly linked to the host or service
+ */
+function getTicketMacroId(string $type, string $macroName, int $objectId): ?int
+{
+    global $db;
+
+    if ($type === 'host') {
+        $query = <<<'SQL'
+                SELECT host_macro_id AS macro_id
+                FROM on_demand_macro_host
+                WHERE host_host_id = :object_id AND host_macro_name = :macro_name
+            SQL;
+    } else {
+        $query = <<<'SQL'
+                SELECT svc_macro_id AS macro_id
+                FROM on_demand_macro_service
+                WHERE svc_svc_id = :object_id AND svc_macro_name = :macro_name
+            SQL;
+    }
+
+    try {
+        $row = $db->fetchAssociative($query, QueryParameters::create([
+            QueryParameter::int('object_id', $objectId),
+            QueryParameter::string('macro_name', $macroName),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while fetching ticket macro id: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while fetching ticket macro id: ' . $e->getMessage(), previous: $e);
+    }
+
+    if ($row) {
+        return (int) $row['macro_id'];
+    }
+
+    return null;
+}
+
+/**
+ * updateMacroValue when a ticket is created it needs to also be stored in the on_demand_macro_xxx table
+ *
+ * @param string $type the type of object (can be host or service)
+ * @param string $macroValue the value that is going to be updated
+ * @param int $macroId the id of the macro that needs to be updated
+ * @throws RepositoryException
+ * @return void
+ */
+function updateMacroValue(string $type, string $macroValue, int $macroId): void
+{
+    global $db;
+
+    if ($type === 'host') {
+        $query = <<<'SQL'
+                UPDATE on_demand_macro_host
+                SET host_macro_value = :ticket_id
+                WHERE host_macro_id = :macro_id
+            SQL;
+    } else {
+        $query = <<<'SQL'
+                UPDATE on_demand_macro_service
+                SET svc_macro_value = :ticket_id
+                WHERE svc_macro_id = :macro_id
+            SQL;
+    }
+
+    try {
+        $db->update($query, QueryParameters::create([
+            QueryParameter::string('ticket_id', $macroValue),
+            QueryParameter::int('macro_id', $macroId),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while updating macro value: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while updating macro value: ' . $e->getMessage(), previous: $e);
+    }
+}
+
+/**
+ * getMaxOrder gets the order number for the next custom macro
+ *
+ * @param string $type the type of object (must be host or service)
+ * @param int $objectId the id of the service or the host
+ * @throws RepositoryException
+ * @return int the next available order number
+ */
+function getMaxOrder(string $type, int $objectId): int
+{
+    global $db;
+
+    if ($type === 'host') {
+        $query = <<<'SQL'
+                SELECT MAX(macro_order) AS max
+                FROM on_demand_macro_host
+                WHERE host_host_id = :object_id
+            SQL;
+    } else {
+        $query = <<<'SQL'
+                SELECT MAX(macro_order) AS max
+                FROM on_demand_macro_service
+                WHERE svc_svc_id = :object_id
+            SQL;
+    }
+
+    try {
+        $row = $db->fetchAssociative($query, QueryParameters::create([
+            QueryParameter::int('object_id', $objectId),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while fetching max macro order: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while fetching max macro order: ' . $e->getMessage(), previous: $e);
+    }
+
+    if ($row) {
+        return is_null($row['max']) ? 0 : (int) $row['max'] + 1;
+    }
+
+    return 0;
+}
+
+/**
+ * insertNewMacroValue add a new macro on the object (service/host)
+ *
+ * @param string $type the type of object (must be host or service)
+ * @param string $macroName the name of the macro
+ * @param string $macroValue the value of the macro
+ * @param int $objectId the id of the service or the host
+ * @throws RepositoryException
+ * @return void
+ */
+function insertNewMacroValue(string $type, string $macroName, string $macroValue, int $objectId): void
+{
+    global $db;
+    try {
+        $macroOrder = getMaxOrder($type, $objectId);
+    } catch (RepositoryException $e) {
+        throw new RepositoryException('Error while fetching macro order before insert: ' . $e->getMessage(), previous: $e);
+    }
+
+    if ($type === 'host') {
+        $query = <<<'SQL'
+                INSERT INTO on_demand_macro_host (host_macro_name, host_macro_value, is_password, description, host_host_id, macro_order)
+                VALUES (:macro_name, :ticket_id, NULL, '', :object_id, :macro_order)
+            SQL;
+    } else {
+        $query = <<<'SQL'
+                INSERT INTO on_demand_macro_service (svc_macro_name, svc_macro_value, is_password, description, svc_svc_id, macro_order)
+                VALUES (:macro_name, :ticket_id, NULL, '', :object_id, :macro_order)
+            SQL;
+    }
+
+    try {
+        $db->insert($query, QueryParameters::create([
+            QueryParameter::string('ticket_id', $macroValue),
+            QueryParameter::int('object_id', $objectId),
+            QueryParameter::string('macro_name', $macroName),
+            QueryParameter::int('macro_order', $macroOrder),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while inserting new macro value: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while inserting new macro value: ' . $e->getMessage(), previous: $e);
+    }
+}
+
+/**
+ * isServiceUnique checks if the service is linked to a single host (not to multiple hosts or to a hostgroup)
+ *
+ * @param int $serviceId the id of the service
+ * @throws RepositoryException
+ * @return bool
+ */
+function isServiceUnique(int $serviceId): bool
+{
+    global $db;
+    $query = <<<'SQL'
+            SELECT count(*) AS duplicated_service
+            FROM (
+                (
+                    SELECT 1
+                    FROM host_service_relation
+                    WHERE service_service_id = :service_id
+                        AND hostgroup_hg_id IS NOT NULL
+                ) UNION (
+                    SELECT 1
+                    FROM host_service_relation
+                    WHERE service_service_id = :service_id
+                        AND host_host_id IS NOT NULL
+                    GROUP BY service_service_id HAVING COUNT(service_service_id) > 1
+                )
+            ) AS relation
+        SQL;
+
+    try {
+        $row = $db->fetchAssociative($query, QueryParameters::create([
+            QueryParameter::int('service_id', $serviceId),
+        ]));
+    } catch (CollectionException|ConnectionException|ValueObjectException $e) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_SQL,
+            'Error while checking service uniqueness: ' . $e->getMessage(),
+            exception: $e
+        );
+
+        throw new RepositoryException('Error while checking service uniqueness: ' . $e->getMessage(), previous: $e);
+    }
+
+    if ($row) {
+        return (int) $row['duplicated_service'] === 0;
+    }
+
+    return true;
 }
 
 $resultat = ['code' => 0, 'msg' => 'ok'];
@@ -171,6 +429,7 @@ $sticky = ! empty($centreon->optGen['monitoring_ack_sticky']) ? 2 : 1;
 $notify = ! empty($centreon->optGen['monitoring_ack_notify']) ? 1 : 0;
 
 $persistent = ! empty($centreon->optGen['monitoring_ack_persistent']) ? 1 : 0;
+$ownTransaction = false;
 
 try {
     $contact_infos = get_contact_information();
@@ -182,6 +441,7 @@ try {
     );
 
     if ($resultat['result']['ticket_is_ok'] == 1) {
+        $macroName = $centreon_provider->getMacroTicketId();
         do_chain_rules($centreon_provider->getChainRuleList(), $db_storage, $contact_infos, $selected);
 
         require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
@@ -192,7 +452,21 @@ try {
             $method_external_name = 'setProcessCommand';
         }
 
+        $ownTransaction = ! $db->isTransactionActive();
+        if ($ownTransaction) {
+            $db->startTransaction();
+        }
+
         foreach ($selected['host_selected'] as $value) {
+            $fullMacroName = '$_HOST' . $macroName . '$';
+            $macroId = getTicketMacroId('host', $fullMacroName, $value['host_id']);
+
+            if (! is_null($macroId)) {
+                updateMacroValue('host', $resultat['result']['ticket_id'], $macroId);
+            } else {
+                insertNewMacroValue('host', $fullMacroName, $resultat['result']['ticket_id'], $value['host_id']);
+            }
+
             $command = 'CHANGE_CUSTOM_HOST_VAR;%s;%s;%s';
             call_user_func_array(
                 [$external_cmd, $method_external_name],
@@ -200,7 +474,7 @@ try {
                     sprintf(
                         $command,
                         $value['name'],
-                        $centreon_provider->getMacroTicketId(),
+                        $macroName,
                         $resultat['result']['ticket_id']
                     ),
                     $value['instance_id'],
@@ -240,6 +514,18 @@ try {
             }
         }
         foreach ($selected['service_selected'] as $value) {
+            $fullMacroName = '$_SERVICE' . $macroName . '$';
+            $macroId = getTicketMacroId('service', $fullMacroName, $value['service_id']);
+            $isUniqueService = isServiceUnique($value['service_id']);
+
+            if ($isUniqueService) {
+                if (! is_null($macroId)) {
+                    updateMacroValue('service', $resultat['result']['ticket_id'], $macroId);
+                } else {
+                    insertNewMacroValue('service', $fullMacroName, $resultat['result']['ticket_id'], $value['service_id']);
+                }
+            }
+
             $command = 'CHANGE_CUSTOM_SVC_VAR;%s;%s;%s;%s';
             call_user_func_array(
                 [$external_cmd, $method_external_name],
@@ -248,7 +534,7 @@ try {
                         $command,
                         $value['host_name'],
                         $value['description'],
-                        $centreon_provider->getMacroTicketId(),
+                        $macroName,
                         $resultat['result']['ticket_id']
                     ),
                     $value['instance_id'],
@@ -291,10 +577,52 @@ try {
         }
 
         $external_cmd->write();
+        if ($ownTransaction) {
+            $db->commitTransaction();
+        }
     }
 
     $centreon_provider->clearUploadFiles();
-} catch (Exception $e) {
+} catch (RepositoryException $e) {
+    CentreonLog::create()->error(
+        CentreonLog::TYPE_BUSINESS_LOG,
+        'Error while submitting tickets: ' . $e->getMessage(),
+        exception: $e
+    );
+
+    try {
+        if ($ownTransaction && $db->isTransactionActive()) {
+            $db->rollBackTransaction();
+        }
+    } catch (ConnectionException $rollbackException) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_BUSINESS_LOG,
+            'Failed to roll back transaction while submitting tickets: ' . $rollbackException->getMessage(),
+            exception: $rollbackException
+        );
+    }
+
+    $resultat['code'] = 1;
+    $resultat['msg'] = $e->getMessage();
+} catch (Throwable $e) {
+    CentreonLog::create()->error(
+        CentreonLog::TYPE_BUSINESS_LOG,
+        'Unexpected error while submitting tickets: ' . $e->getMessage(),
+        exception: $e
+    );
+
+    try {
+        if ($ownTransaction && $db->isTransactionActive()) {
+            $db->rollBackTransaction();
+        }
+    } catch (ConnectionException $rollbackException) {
+        CentreonLog::create()->error(
+            CentreonLog::TYPE_BUSINESS_LOG,
+            'Failed to roll back transaction while submitting tickets: ' . $rollbackException->getMessage(),
+            exception: $rollbackException
+        );
+    }
+
     $resultat['code'] = 1;
     $resultat['msg'] = $e->getMessage();
 }


### PR DESCRIPTION
dev-24.10.x backport of [MON-192186](https://centreon.atlassian.net/browse/MON-192186)

Ref : [Ticket](https://centreon.atlassian.net/browse/MON-197336)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added helper functions to fetch and update ticket macros

**🐛 Bugfixes**
* Persisted ticket IDs into on_demand_macro tables on ticket creation
* Cleared on_demand_macro values when tickets were closed or changed

**🔧 Refactors**
* Replaced raw SQL with parameterized queries and added error handling


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104497439?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

[MON-192186]: https://centreon.atlassian.net/browse/MON-192186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ