### PR TITLE
feat(i18n): add English .po files for translation overrides

### DIFF
--- a/.github/scripts/translation/make_translation.sh
+++ b/.github/scripts/translation/make_translation.sh
@@ -36,6 +36,7 @@ PROJECTS=(
 # Define language
 LANGS=(
     "de_DE"
+    "en_US"
     "es_ES"
     "fr_FR"
     "pt_BR"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -364,9 +364,6 @@ jobs:
             php bin/centreon-translations.php "$langShortName" "lang/$localefull/LC_MESSAGES/messages.po" "www/locale/$localefull/LC_MESSAGES/messages.ser"
           done
 
-          mkdir -p www/locale/en_US.UTF-8/LC_MESSAGES
-          php bin/centreon-translations.php en lang/fr_FR.UTF-8/LC_MESSAGES/messages.po www/locale/en_US.UTF-8/LC_MESSAGES/messages.ser
-
           if [[ "$(git diff --ignore-matching-lines="POT-Creation-Date" | wc -l)" != "0" ]]; then
             # avoid to always update POT-Creation-Date field
             find -type f -regex '.+\.pot?' -exec sed -i -e 's/"POT-Creation-Date.*$/"POT-Creation-Date: 2025-01-01 00:00+0000\\n"/g' {} \;

--- a/centreon/bin/centreon-translations.php
+++ b/centreon/bin/centreon-translations.php
@@ -120,9 +120,10 @@ function createTranslationFile(
                     $translation .= $matches[2];
                 }
             } elseif (!empty($id) && !empty($translation)) {
-                $englishTranslation[$id] = $id;
-                if (!$isDefaultTranslation) {
-                    // Only if the code of language is not 'en'
+                if ($isDefaultTranslation) {
+                    $englishTranslation[$id] = $translation;
+                } else {
+                    $englishTranslation[$id] = $id;
                     $translations[$id] = $translation;
                 }
                 $id = null;
@@ -134,8 +135,10 @@ function createTranslationFile(
     }
 
     if (!empty($id) && !empty($translation)) {
-        $englishTranslation[$id] = $id;
-        if (!$isDefaultTranslation) {
+        if ($isDefaultTranslation) {
+            $englishTranslation[$id] = $translation;
+        } else {
+            $englishTranslation[$id] = $id;
             $translations[$id] = $translation;
         }
     }

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/help.po
@@ -1,0 +1,5833 @@
+# English translations for Centreon web package.
+# Copyright (C) 2026 Centreon (https://www.centreon.com/)
+# This file is distributed under the same license as the Centreon web package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Centreon web\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-01 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Centreon Team\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"A host or host template inherits properties from its templates, unless the "
+"properties are defined directly on the host or host template itself. A host "
+"or host template can inherit from multiple templates. The properties of the "
+"first template in the list prevail over the properties of the second one, "
+"and so on."
+msgstr ""
+"A host or host template inherits properties from its templates, unless the "
+"properties are defined directly on the host or host template itself. A host "
+"or host template can inherit from multiple templates. The properties of the "
+"first template in the list prevail over the properties of the second one, "
+"and so on."
+
+#: centreon/www/include/configuration/configObject/connector/help.php
+msgid "A short description of the connector."
+msgstr "A short description of the connector."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "ACL action rules that are linked to the access group."
+msgstr "ACL action rules that are linked to the access group."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "ACL groups of user."
+msgstr "ACL groups of user."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "ACL menu rules that are linked to the access group."
+msgstr "ACL menu rules that are linked to the access group."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "ACL resource rules that are linked to the access group."
+msgstr "ACL resource rules that are linked to the access group."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Absolute value for critical level (low threshold)."
+msgstr "Absolute value for critical level (low threshold)."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Absolute value for warning level (low threshold)."
+msgstr "Absolute value for warning level (low threshold)."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Additional Remote Server to which this server will be attached"
+msgstr "Additional Remote Server to which this server will be attached"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Address of the poller"
+msgstr "Address of the poller"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Addresses 1-6 are optional and used to define additional \"addresses\" for "
+"the contact. These addresses can be anything - cell phone numbers, instant "
+"messaging addresses, etc. - the format must be supported by your "
+"notification plugins."
+msgstr ""
+"Addresses 1-6 are optional and used to define additional \"addresses\" for "
+"the contact. These addresses can be anything - cell phone numbers, instant "
+"messaging addresses, etc. - the format must be supported by your "
+"notification plugins."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "Alias of access group."
+msgstr "Alias of access group."
+
+#: centreon/www/include/options/accessLists/menusACL/help.php
+msgid "Alias of menu rule."
+msgstr "Alias of menu rule."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Allow this user to access to Centreon Rest API Realtime with its account."
+msgstr ""
+"Allow this user to access to Centreon Rest API Realtime with its account."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "Allow this user to access to Centreon Rest API with its account."
+msgstr "Allow this user to access to Centreon Rest API with its account."
+
+#: centreon/www/include/Administration/parameters/remote/help.php
+msgid ""
+"Allows to skip the SSL certificate check on the Centreon's central server."
+msgstr ""
+"Allows to skip the SSL certificate check on the Centreon's central server."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows user to delete pollers."
+msgstr "Allows user to delete pollers."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows user to deploy configuration."
+msgstr "Allows user to deploy configuration."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Allows user to generate and export configuration, and restart centreontrapd "
+"process."
+msgstr ""
+"Allows user to generate and export configuration, and restart centreontrapd "
+"process."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on "
+"pollers."
+msgstr ""
+"Allows user to perform “Add”, “Add (advanced)” and “Duplicate” actions on "
+"pollers."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to acknowledge a host."
+msgstr "Allows users to acknowledge a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to acknowledge a service."
+msgstr "Allows users to acknowledge a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to add or delete a comment of a host."
+msgstr "Allows users to add or delete a comment of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to add or delete a comment of a service."
+msgstr "Allows users to add or delete a comment of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable all service checks of a host."
+msgstr "Allows users to enable or disable all service checks of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable checks of a host."
+msgstr "Allows users to enable or disable checks of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable checks of a service."
+msgstr "Allows users to enable or disable checks of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable event handlers."
+msgstr "Allows users to enable or disable event handlers."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable flap detection of a host."
+msgstr "Allows users to enable or disable flap detection of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable flap detection of a service."
+msgstr "Allows users to enable or disable flap detection of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable flap detection."
+msgstr "Allows users to enable or disable flap detection."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable host checks."
+msgstr "Allows users to enable or disable host checks."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable notifications of a host."
+msgstr "Allows users to enable or disable notifications of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable notifications of a service."
+msgstr "Allows users to enable or disable notifications of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable notifications."
+msgstr "Allows users to enable or disable notifications."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable obsessive host checks."
+msgstr "Allows users to enable or disable obsessive host checks."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable obsessive service checks."
+msgstr "Allows users to enable or disable obsessive service checks."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable passive checks of a service."
+msgstr "Allows users to enable or disable passive checks of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable passive host checks."
+msgstr "Allows users to enable or disable passive host checks."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable passive service checks."
+msgstr "Allows users to enable or disable passive service checks."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable performance data processing."
+msgstr "Allows users to enable or disable performance data processing."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable service checks."
+msgstr "Allows users to enable or disable service checks."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to enable or disable service notifications of a host."
+msgstr "Allows users to enable or disable service notifications of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Allows users to enable or disable the event handler processing of a host."
+msgstr ""
+"Allows users to enable or disable the event handler processing of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Allows users to enable or disable the event handler processing of a service."
+msgstr ""
+"Allows users to enable or disable the event handler processing of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Allows users to re-schedule next check of a host by placing its priority to "
+"the top."
+msgstr ""
+"Allows users to re-schedule next check of a host by placing its priority to "
+"the top."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to re-schedule next check of a host."
+msgstr "Allows users to re-schedule next check of a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Allows users to re-schedule next check of a service by placing its priority "
+"to the top."
+msgstr ""
+"Allows users to re-schedule next check of a service by placing its priority "
+"to the top."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to re-schedule next check of a service."
+msgstr "Allows users to re-schedule next check of a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to remove an acknowledgement from a host."
+msgstr "Allows users to remove an acknowledgement from a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to remove an acknowledgement from a service."
+msgstr "Allows users to remove an acknowledgement from a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to restart the monitoring systems."
+msgstr "Allows users to restart the monitoring systems."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to schedule downtime on a host."
+msgstr "Allows users to schedule downtime on a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to schedule downtime on a service."
+msgstr "Allows users to schedule downtime on a service."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to stop the monitoring systems."
+msgstr "Allows users to stop the monitoring systems."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to submit result to a host."
+msgstr "Allows users to submit result to a host."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Allows users to submit result to a service."
+msgstr "Allows users to submit result to a service."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Application directory of Centreon."
+msgstr "Application directory of Centreon."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Authentication can be solely based on OpenId Connect or it can work with "
+"both OpenId Connect and local authentication systems."
+msgstr ""
+"Authentication can be solely based on OpenId Connect or it can work with "
+"both OpenId Connect and local authentication systems."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Authentication can be solely based on SSO or it can work with both SSO and "
+"local authentication systems."
+msgstr ""
+"Authentication can be solely based on SSO or it can work with both SSO and "
+"local authentication systems."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Backup centreon database"
+msgstr "Backup centreon database"
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Backup centreon_storage database"
+msgstr "Backup centreon_storage database"
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid ""
+"Backup configuration files (MySQL, Apache, PHP, SNMP, centreon, centreon-"
+"engine, centreon-broker)"
+msgstr ""
+"Backup configuration files (MySQL, Apache, PHP, SNMP, centreon, centreon-"
+"engine, centreon-broker)"
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"Backup directory to store partition, by default /var/cache/centreon/backup."
+msgstr ""
+"Backup directory to store partition, by default /var/cache/centreon/backup."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Backup retention (in days)"
+msgstr "Backup retention (in days)"
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid ""
+"Backup type for centreon_storage database : mysqldump or LVM snapshot (need "
+"available space on MySQL LVM)"
+msgstr ""
+"Backup type for centreon_storage database : mysqldump or LVM snapshot (need "
+"available space on MySQL LVM)"
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Base value."
+msgstr "Base value."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Broker module used by Centreon."
+msgstr "Broker module used by Centreon."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"By default monitoring engine will assume that all hosts are in UP states "
+"when it starts. You can override the initial state for a host by using this "
+"directive."
+msgstr ""
+"By default monitoring engine will assume that all hosts are in UP states "
+"when it starts. You can override the initial state for a host by using this "
+"directive."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"By default monitoring engine will assume that all services are in OK states "
+"when it starts.You can override the initial state for a service by using "
+"this directive."
+msgstr ""
+"By default monitoring engine will assume that all services are in OK states "
+"when it starts.You can override the initial state for a service by using "
+"this directive."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"By enabling this option, the services linked to the template will be created "
+"independent of the template and attached to this service."
+msgstr ""
+"By enabling this option, the services linked to the template will be created "
+"independent of the template and attached to this service."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "CSS theme."
+msgstr "CSS theme."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Can connect with LDAP without import"
+msgstr "Can connect with LDAP without import"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Category filter for flux in output"
+msgstr "Category filter for flux in output"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid "Central, remote server or poller that will monitor the host."
+msgstr "Central, remote server or poller that will monitor the host."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Centreon Support email: this email is uses in the Centreon footer in order "
+"to have a quick link in order to open an issue to your help desk."
+msgstr ""
+"Centreon Support email: this email is uses in the Centreon footer in order "
+"to have a quick link in order to open an issue to your help desk."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Centreon Web URI."
+msgstr "Centreon Web URI."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Centreontrapd init script to restart process on poller."
+msgstr "Centreontrapd init script to restart process on poller."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"Check this option if your command requires shell features like pipes, "
+"redirections, globbing etc. Note that commands requiring shell are slowing "
+"down the poller server."
+msgstr ""
+"Check this option if your command requires shell features like pipes, "
+"redirections, globbing etc. Note that commands requiring shell are slowing "
+"down the poller server."
+
+#: centreon/www/include/configuration/configObject/traps-mibs/help.php
+msgid ""
+"Choose a local MIB file containing SNMP trap definitions to upload and "
+"import. The file will be parsed with snmpttconvertmib."
+msgstr ""
+"Choose a local MIB file containing SNMP trap definitions to upload and "
+"import. The file will be parsed with snmpttconvertmib."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Choose a service from the list. The service must have been created "
+"beforehand."
+msgstr ""
+"Choose a service from the list. The service must have been created "
+"beforehand."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Choose a service template from the list. The service template must have been "
+"created beforehand."
+msgstr ""
+"Choose a service template from the list. The service template must have been "
+"created beforehand."
+
+#: centreon/www/include/configuration/configObject/traps-mibs/help.php
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Choose a vendor from the list. The vendor must have been created beforehand."
+msgstr ""
+"Choose a vendor from the list. The vendor must have been created beforehand."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Choose the Monitoring Engine server instance this configuration is defined "
+"for."
+msgstr ""
+"Choose the Monitoring Engine server instance this configuration is defined "
+"for."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Choose the matching mode."
+msgstr "Choose the matching mode."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Choose the service state to be submitted to monitoring engine together with "
+"the status message. This simple mode can be used if each trap can be mapped "
+"to exactly 1 monitoring engine status."
+msgstr ""
+"Choose the service state to be submitted to monitoring engine together with "
+"the status message. This simple mode can be used if each trap can be mapped "
+"to exactly 1 monitoring engine status."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid ""
+"Choose the update mode for the below field: incremental adds the selected "
+"values, replacement overwrites the original values."
+msgstr ""
+"Choose the update mode for the below field: incremental adds the selected "
+"values, replacement overwrites the original values."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Choose whether or not a special command should be run by centreontrapd when "
+"this trap was received."
+msgstr ""
+"Choose whether or not a special command should be run by centreontrapd when "
+"this trap was received."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Choose whether or not the associated service should be actively rechecked "
+"after submission of this trap."
+msgstr ""
+"Choose whether or not the associated service should be actively rechecked "
+"after submission of this trap."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Clickable URL displayed in the Notes column of the Resources Status page."
+msgstr ""
+"Clickable URL displayed in the Notes column of the Resources Status page."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Combined with the aggregate_status_updates option, this option determines "
+"the frequency (in seconds!) that Nagios will periodically dump program, "
+"host, and service status data.  If you are not using aggregated status data "
+"updates, this option has no effect. The minimum update interval is 2 seconds."
+msgstr ""
+"Combined with the aggregate_status_updates option, this option determines "
+"the frequency (in seconds!) that Nagios will periodically dump program, "
+"host, and service status data.  If you are not using aggregated status data "
+"updates, this option has no effect. The minimum update interval is 2 seconds."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Command to reload Centreon Broker process"
+msgstr "Command to reload Centreon Broker process"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Command to reload Centreon Engine process"
+msgstr "Command to reload Centreon Engine process"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Command to restart Centreon Engine process"
+msgstr "Command to restart Centreon Engine process"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Command to start Centreon Engine process"
+msgstr "Command to start Centreon Engine process"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Command to stop Centreon Engine process"
+msgstr "Command to stop Centreon Engine process"
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+msgid "Comment regarding this category."
+msgstr "Comment regarding this category."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Comment to describe per example the situation in which this trap will be "
+"send. Additionally the format and the parameters of the trap can be "
+"described."
+msgstr ""
+"Comment to describe per example the situation in which this trap will be "
+"send. Additionally the format and the parameters of the trap can be "
+"described."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid "Comments regarding the command."
+msgstr "Comments regarding the command."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Comments regarding the curve template."
+msgstr "Comments regarding the curve template."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Comments regarding the graph template."
+msgstr "Comments regarding the graph template."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Comments regarding the virtual metric."
+msgstr "Comments regarding the virtual metric."
+
+#: centreon/www/include/options/accessLists/menusACL/help.php
+msgid "Comments regarding this menu rule."
+msgstr "Comments regarding this menu rule."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid "Comments regarding this resource rule."
+msgstr "Comments regarding this resource rule."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid "Compatible with Centreon Broker only."
+msgstr "Compatible with Centreon Broker only."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Connection timeout"
+msgstr "Connection timeout"
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"Connectors are run in background and execute specific commands without the "
+"need to execute a binary, thus enhancing performance. This feature is "
+"available in Centreon Engine (>= 1.3)"
+msgstr ""
+"Connectors are run in background and execute specific commands without the "
+"need to execute a binary, thus enhancing performance. This feature is "
+"available in Centreon Engine (>= 1.3)"
+
+#: centreon/www/include/configuration/configGenerate/help.php
+msgid "Copies the generated files into the scheduler's configuration folder."
+msgstr "Copies the generated files into the scheduler's configuration folder."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Critical threshold."
+msgstr "Critical threshold."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Curve line color."
+msgstr "Curve line color."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Curve thickness."
+msgstr "Curve thickness."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Curve transparency. Used to export the chart."
+msgstr "Curve transparency. Used to export the chart."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Custom Perl code. Will be executed with no change (security issue. Need to "
+"set centreontrapd secure_mode to '1')"
+msgstr ""
+"Custom Perl code. Will be executed with no change (security issue. Need to "
+"set centreontrapd secure_mode to '1')"
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "DEF Type."
+msgstr "DEF Type."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Data source type of the meta service."
+msgstr "Data source type of the meta service."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Database name."
+msgstr "Database name."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Database user."
+msgstr "Database user."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid ""
+"Default contact group applied to new users.<br/>All imported users will join "
+"this contactgroup."
+msgstr ""
+"Default contact group applied to new users.<br/>All imported users will join "
+"this contactgroup."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Default duration of scheduled downtimes."
+msgstr "Default duration of scheduled downtimes."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Default host and contact timezone."
+msgstr "Default host and contact timezone."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Default monitoring engine."
+msgstr "Default monitoring engine."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Default number of displayed elements in listing pages."
+msgstr "Default number of displayed elements in listing pages."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Default number of displayed elements in monitoring consoles."
+msgstr "Default number of displayed elements in monitoring consoles."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Default order in monitoring consoles."
+msgstr "Default order in monitoring consoles."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Default sort in monitoring consoles."
+msgstr "Default sort in monitoring consoles."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"Define a description for this dependency for easier identification and "
+"differentiation."
+msgstr ""
+"Define a description for this dependency for easier identification and "
+"differentiation."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid "Define a longer name or description for the service group here."
+msgstr "Define a longer name or description for the service group here."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"Define a short name for the service group here. The short name will be used "
+"to display the service group in monitoring, views and reporting."
+msgstr ""
+"Define a short name for the service group here. The short name will be used "
+"to display the service group in monitoring, views and reporting."
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid ""
+"Define a short name for this category. It will be displayed with this name "
+"in the ACL configuration."
+msgstr ""
+"Define a short name for this category. It will be displayed with this name "
+"in the ACL configuration."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid "Define a short name for this dependency."
+msgstr "Define a short name for this dependency."
+
+#: centreon/www/include/configuration/configObject/timeperiod/help.php
+msgid "Define a short name to identify the time period."
+msgstr "Define a short name to identify the time period."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define an image that should be associated with this host in the statusmap "
+"CGI in monitoring engine. You can choose a JPEG, PNG, and GIF image. The GD2 "
+"image format is preferred, as other image formats must be converted first "
+"when the statusmap image is generated. The image will look best if it is "
+"40x40 pixels in size."
+msgstr ""
+"Define an image that should be associated with this host in the statusmap "
+"CGI in monitoring engine. You can choose a JPEG, PNG, and GIF image. The GD2 "
+"image format is preferred, as other image formats must be converted first "
+"when the statusmap image is generated. The image will look best if it is "
+"40x40 pixels in size."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define an optional URL that can be used to provide more actions to be "
+"performed on the host. You will see the link to the action URL in the host "
+"details."
+msgstr ""
+"Define an optional URL that can be used to provide more actions to be "
+"performed on the host. You will see the link to the action URL in the host "
+"details."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define an optional URL that can be used to provide more actions to be "
+"performed on the service. You will see the link to the action URL in the "
+"service details."
+msgstr ""
+"Define an optional URL that can be used to provide more actions to be "
+"performed on the service. You will see the link to the action URL in the "
+"service details."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define an optional string that is used in the alternative description of the "
+"icon image."
+msgstr ""
+"Define an optional string that is used in the alternative description of the "
+"icon image."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Define if SSL/TLS must be used to connect to API. It must match Gorgone "
+"httpserver module definition (Default: no)."
+msgstr ""
+"Define if SSL/TLS must be used to connect to API. It must match Gorgone "
+"httpserver module definition (Default: no)."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Define if connection to Gorgone API can be done even if a self signed "
+"certificat is used (Default: yes)."
+msgstr ""
+"Define if connection to Gorgone API can be done even if a self signed "
+"certificat is used (Default: yes)."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Define one or more commands used to notify the contact of a host problem or "
+"recovery. All notification commands are executed when the contact needs to "
+"be notified."
+msgstr ""
+"Define one or more commands used to notify the contact of a host problem or "
+"recovery. All notification commands are executed when the contact needs to "
+"be notified."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Define one or multiple regular expressions to match against the trap message "
+"and map it to the related monitoring engine service state. Use <a "
+"href='http://perldoc.perl.org/perlre.html'>perlre</a> for the format and "
+"place the expression between two slashes."
+msgstr ""
+"Define one or multiple regular expressions to match against the trap message "
+"and map it to the related monitoring engine service state. Use <a "
+"href='http://perldoc.perl.org/perlre.html'>perlre</a> for the format and "
+"place the expression between two slashes."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Define one ore more commands used to notify the contact of a service problem "
+"or recovery. All notification commands are executed when the contact needs "
+"to be notified."
+msgstr ""
+"Define one ore more commands used to notify the contact of a service problem "
+"or recovery. All notification commands are executed when the contact needs "
+"to be notified."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Define the command to execute by centreontrapd's trap handler. The command "
+"must be located in the PATH of the centreontrapd user."
+msgstr ""
+"Define the command to execute by centreontrapd's trap handler. The command "
+"must be located in the PATH of the centreontrapd user."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the coordinates to use when drawing the host in the statusmap CGI. "
+"Coordinates should be given in positive integers, as they correspond to "
+"physical pixels in the generated image. The origin for drawing (0,0) is in "
+"the upper left hand corner of the image and extends in the positive x "
+"direction (to the right) along the top of the image and in the positive y "
+"direction (down) along the left hand side of the image. For reference, the "
+"size of the icons drawn is usually about 40x40 pixels (text takes a little "
+"extra space). The coordinates you specify here are for the upper left hand "
+"corner of the host icon that is drawn. Note: Don't worry about what the "
+"maximum x and y coordinates that you can use are. The CGI will automatically "
+"calculate the maximum dimensions of the image it creates based on the "
+"largest x and y coordinates you specify."
+msgstr ""
+"Define the coordinates to use when drawing the host in the statusmap CGI. "
+"Coordinates should be given in positive integers, as they correspond to "
+"physical pixels in the generated image. The origin for drawing (0,0) is in "
+"the upper left hand corner of the image and extends in the positive x "
+"direction (to the right) along the top of the image and in the positive y "
+"direction (down) along the left hand side of the image. For reference, the "
+"size of the icons drawn is usually about 40x40 pixels (text takes a little "
+"extra space). The coordinates you specify here are for the upper left hand "
+"corner of the host icon that is drawn. Note: Don't worry about what the "
+"maximum x and y coordinates that you can use are. The CGI will automatically "
+"calculate the maximum dimensions of the image it creates based on the "
+"largest x and y coordinates you specify."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the coordinates to use when drawing the host in the statuswrl CGI. "
+"Coordinates can be positive or negative real numbers. The origin for drawing "
+"is (0.0,0.0,0.0). For reference, the size of the host cubes drawn is 0.5 "
+"units on each side (text takes a little more space). The coordinates you "
+"specify here are used as the center of the host cube."
+msgstr ""
+"Define the coordinates to use when drawing the host in the statuswrl CGI. "
+"Coordinates can be positive or negative real numbers. The origin for drawing "
+"is (0.0,0.0,0.0). For reference, the size of the host cubes drawn is 0.5 "
+"units on each side (text takes a little more space). The coordinates you "
+"specify here are used as the center of the host cube."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Define the criteria that determine when the host escalation is used. The "
+"escalation is used only if the host is in one of the states specified in "
+"these options. If no options are specified in a host escalation, the "
+"escalation is considered to be valid during all host states."
+msgstr ""
+"Define the criteria that determine when the host escalation is used. The "
+"escalation is used only if the host is in one of the states specified in "
+"these options. If no options are specified in a host escalation, the "
+"escalation is considered to be valid during all host states."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Define the criteria that determine when the service escalation is used. The "
+"escalation is used only if the service is in one of the states specified in "
+"these options. If no options are specified in a service escalation, the "
+"escalation is considered to be valid during all service states."
+msgstr ""
+"Define the criteria that determine when the service escalation is used. The "
+"escalation is used only if the service is in one of the states specified in "
+"these options. If no options are specified in a service escalation, the "
+"escalation is considered to be valid during all service states."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Define the default language for the user for the centreon front-end here."
+msgstr ""
+"Define the default language for the user for the centreon front-end here."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Define the default page for this user (displayed when they log in). ACLs "
+"must be defined so the user can access the page"
+msgstr ""
+"Define the default page for this user (displayed when they log in). ACLs "
+"must be defined so the user can access the page"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Define the host states for which notifications can be sent out to this "
+"contact. If you specify None as an option, the contact will not receive any "
+"type of host notifications."
+msgstr ""
+"Define the host states for which notifications can be sent out to this "
+"contact. If you specify None as an option, the contact will not receive any "
+"type of host notifications."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the image that should be associated with this host here. This image "
+"will be displayed in the various places. The image will look best if it is "
+"40x40 pixels in size."
+msgstr ""
+"Define the image that should be associated with this host here. This image "
+"will be displayed in the various places. The image will look best if it is "
+"40x40 pixels in size."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the image that should be associated with this service here. This "
+"image will be displayed in the various places. The image will look best if "
+"it is 40x40 pixels in size."
+msgstr ""
+"Define the image that should be associated with this service here. This "
+"image will be displayed in the various places. The image will look best if "
+"it is 40x40 pixels in size."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the number of \"time units\" between regularly scheduled checks of "
+"the host. With the default time unit of 60s, this number will mean multiples "
+"of 1 minute."
+msgstr ""
+"Define the number of \"time units\" between regularly scheduled checks of "
+"the host. With the default time unit of 60s, this number will mean multiples "
+"of 1 minute."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the number of \"time units\" between regularly scheduled checks of "
+"the service. With the default time unit of 60s, this number will mean "
+"multiples of 1 minute. \"Regular\" checks are those that occur when the "
+"service is in an OK state or when the service is in a non-OK state, but has "
+"already been rechecked max_check_attempts number of times. (default value: 5)"
+msgstr ""
+"Define the number of \"time units\" between regularly scheduled checks of "
+"the service. With the default time unit of 60s, this number will mean "
+"multiples of 1 minute. \"Regular\" checks are those that occur when the "
+"service is in an OK state or when the service is in a non-OK state, but has "
+"already been rechecked max_check_attempts number of times. (default value: 5)"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the number of \"time units\" to wait before re-notifying a contact "
+"that this host is still down or unreachable. With the default time unit of "
+"60s, this number will mean multiples of 1 minute. A value of 0 disables re-"
+"notifications of contacts about problems for this host - only one problem "
+"notification will be sent out."
+msgstr ""
+"Define the number of \"time units\" to wait before re-notifying a contact "
+"that this host is still down or unreachable. With the default time unit of "
+"60s, this number will mean multiples of 1 minute. A value of 0 disables re-"
+"notifications of contacts about problems for this host - only one problem "
+"notification will be sent out."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the number of \"time units\" to wait before re-notifying a contact "
+"that this service is still in a warning or critical condition. With the "
+"default time unit of 60s, this number will mean multiples of 1 minute. A "
+"value of 0 disables re-notifications of contacts about problems for this "
+"service - only one problem notification will be sent out. (default value: 30)"
+msgstr ""
+"Define the number of \"time units\" to wait before re-notifying a contact "
+"that this service is still in a warning or critical condition. With the "
+"default time unit of 60s, this number will mean multiples of 1 minute. A "
+"value of 0 disables re-notifications of contacts about problems for this "
+"service - only one problem notification will be sent out. (default value: 30)"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the number of \"time units\" to wait before scheduling a re-check for "
+"this host after a non-UP state was detected. With the default time unit of "
+"60s, this number will mean multiples of 1 minute. Once the host has been "
+"retried max_check_attempts times without a change in its status, it will "
+"revert to being scheduled at its \"normal\" check interval rate."
+msgstr ""
+"Define the number of \"time units\" to wait before scheduling a re-check for "
+"this host after a non-UP state was detected. With the default time unit of "
+"60s, this number will mean multiples of 1 minute. Once the host has been "
+"retried max_check_attempts times without a change in its status, it will "
+"revert to being scheduled at its \"normal\" check interval rate."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the number of \"time units\" to wait before scheduling a re-check for "
+"this service after a non-OK state was detected. With the default time unit "
+"of 60s, this number will mean multiples of 1 minute. Once the service has "
+"been retried max_check_attempts times without a change in its status, it "
+"will revert to being scheduled at its \"normal\" check interval rate. "
+"(default value: 1)"
+msgstr ""
+"Define the number of \"time units\" to wait before scheduling a re-check for "
+"this service after a non-OK state was detected. With the default time unit "
+"of 60s, this number will mean multiples of 1 minute. Once the service has "
+"been retried max_check_attempts times without a change in its status, it "
+"will revert to being scheduled at its \"normal\" check interval rate. "
+"(default value: 1)"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the number of \"time units\" to wait before sending out the first "
+"problem notification when this host enters a non-UP state. With the default "
+"time unit of 60s, this number will mean multiples of 1 minute. If you set "
+"this value to 0, monitoring engine will start sending out notifications "
+"immediately."
+msgstr ""
+"Define the number of \"time units\" to wait before sending out the first "
+"problem notification when this host enters a non-UP state. With the default "
+"time unit of 60s, this number will mean multiples of 1 minute. If you set "
+"this value to 0, monitoring engine will start sending out notifications "
+"immediately."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the number of \"time units\" to wait before sending out the first "
+"problem notification when this service enters a non-OK state. With the "
+"default time unit of 60s, this number will mean multiples of 1 minute. If "
+"you set this value to 0, monitoring engine will start sending out "
+"notifications immediately."
+msgstr ""
+"Define the number of \"time units\" to wait before sending out the first "
+"problem notification when this service enters a non-OK state. With the "
+"default time unit of 60s, this number will mean multiples of 1 minute. If "
+"you set this value to 0, monitoring engine will start sending out "
+"notifications immediately."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the number of \"time units\" to wait before sending out the recovery "
+"notification when this host enters an UP state. With the default time unit "
+"of 60s, this number will mean multiples of 1 minute. If you set this value "
+"to 0, monitoring engine will start sending out notifications immediately."
+msgstr ""
+"Define the number of \"time units\" to wait before sending out the recovery "
+"notification when this host enters an UP state. With the default time unit "
+"of 60s, this number will mean multiples of 1 minute. If you set this value "
+"to 0, monitoring engine will start sending out notifications immediately."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the number of \"time units\" to wait before sending out the recovery "
+"notification when this service enters an OK state. With the default time "
+"unit of 60s, this number will mean multiples of 1 minute. If you set this "
+"value to 0, monitoring engine will start sending out notifications "
+"immediately."
+msgstr ""
+"Define the number of \"time units\" to wait before sending out the recovery "
+"notification when this service enters an OK state. With the default time "
+"unit of 60s, this number will mean multiples of 1 minute. If you set this "
+"value to 0, monitoring engine will start sending out notifications "
+"immediately."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Define the number of minutes between regularly scheduled checks of the meta "
+"service. \"Regular\" checks are those that occur when the service is in an "
+"OK state or when the service is in a non-OK state, but has already been "
+"rechecked max check attempts number of times."
+msgstr ""
+"Define the number of minutes between regularly scheduled checks of the meta "
+"service. \"Regular\" checks are those that occur when the service is in an "
+"OK state or when the service is in a non-OK state, but has already been "
+"rechecked max check attempts number of times."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Define the number of minutes to wait before re-notifying a contact that this "
+"service is still in a non-OK condition. A value of 0 disables re-"
+"notifications of contacts about problems for this service - only one problem "
+"notification will be sent out."
+msgstr ""
+"Define the number of minutes to wait before re-notifying a contact that this "
+"service is still in a non-OK condition. A value of 0 disables re-"
+"notifications of contacts about problems for this service - only one problem "
+"notification will be sent out."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Define the number of minutes to wait before scheduling a re-check for this "
+"service after a non-OK state was detected. Once the service has been retried "
+"max check attempts times without a change in its status, it will revert to "
+"being scheduled at its \"normal\" check interval rate."
+msgstr ""
+"Define the number of minutes to wait before scheduling a re-check for this "
+"service after a non-OK state was detected. Once the service has been retried "
+"max check attempts times without a change in its status, it will revert to "
+"being scheduled at its \"normal\" check interval rate."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Define the number of times that Centreon will retry the service check "
+"command if it returns any state other than an OK state. Setting this value "
+"to 1 will cause Centreon to generate an alert without retrying the service "
+"check again."
+msgstr ""
+"Define the number of times that Centreon will retry the service check "
+"command if it returns any state other than an OK state. Setting this value "
+"to 1 will cause Centreon to generate an alert without retrying the service "
+"check again."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the number of times that monitoring engine will retry the host check "
+"command if it returns any non-OK state. Setting this value to 1 will cause "
+"monitoring engine to generate an alert immediately. Note: If you do not want "
+"to check the status of the host, you must still set this to a minimum value "
+"of 1. To bypass the host check, just leave the check command option blank."
+msgstr ""
+"Define the number of times that monitoring engine will retry the host check "
+"command if it returns any non-OK state. Setting this value to 1 will cause "
+"monitoring engine to generate an alert immediately. Note: If you do not want "
+"to check the status of the host, you must still set this to a minimum value "
+"of 1. To bypass the host check, just leave the check command option blank."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the number of times that monitoring engine will retry the service "
+"check command if it returns any state other than an OK state. Setting this "
+"value to 1 will cause monitoring engine to generate an alert without "
+"retrying the service check again. (default value: 0)"
+msgstr ""
+"Define the number of times that monitoring engine will retry the service "
+"check command if it returns any state other than an OK state. Setting this "
+"value to 1 will cause monitoring engine to generate an alert without "
+"retrying the service check again. (default value: 0)"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "Define the password for the centreon login here."
+msgstr "Define the password for the centreon login here."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Define the poller timezone. If not set, default Centreon timezone is used "
+"(parameters). This timezone is used for hosts which have not configured "
+"timezone."
+msgstr ""
+"Define the poller timezone. If not set, default Centreon timezone is used "
+"(parameters). This timezone is used for hosts which have not configured "
+"timezone."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Define the service states for which notifications can be sent out to this "
+"contact. If you specify None as an option, the contact will not receive any "
+"type of service notifications."
+msgstr ""
+"Define the service states for which notifications can be sent out to this "
+"contact. If you specify None as an option, the contact will not receive any "
+"type of service notifications."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Define the states of the host for which notifications should be sent out. If "
+"you specify None as an option, no host notifications will be sent out. If "
+"you do not specify any notification options, monitoring engine will assume "
+"that you want notifications to be sent out for all possible states."
+msgstr ""
+"Define the states of the host for which notifications should be sent out. If "
+"you specify None as an option, no host notifications will be sent out. If "
+"you do not specify any notification options, monitoring engine will assume "
+"that you want notifications to be sent out for all possible states."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Define the states of the service for which notifications should be sent out. "
+"If you do not specify any notification options, Centreon will assume that "
+"you want notifications to be sent out for all possible states."
+msgstr ""
+"Define the states of the service for which notifications should be sent out. "
+"If you do not specify any notification options, Centreon will assume that "
+"you want notifications to be sent out for all possible states."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Define the states of the service for which notifications should be sent out. "
+"If you specify None as an option, no service notifications will be sent out. "
+"If you do not specify any notification options, monitoring engine will "
+"assume that you want notifications to be sent out for all possible states."
+msgstr ""
+"Define the states of the service for which notifications should be sent out. "
+"If you specify None as an option, no service notifications will be sent out. "
+"If you do not specify any notification options, monitoring engine will "
+"assume that you want notifications to be sent out for all possible states."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"Define the type of the command. The type will be used to show the command "
+"only in the relevant sections."
+msgstr ""
+"Define the type of the command. The type will be used to show the command "
+"only in the relevant sections."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Define which service states \"stalking\" is enabled for."
+msgstr "Define which service states \"stalking\" is enabled for."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Defines the trap execution method"
+msgstr "Defines the trap execution method"
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Description of action rule."
+msgstr "Description of action rule."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid "Description of resource rule."
+msgstr "Description of resource rule."
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid "Description of the downtime"
+msgstr "Description of the downtime"
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid "Description or name used to identify this configuration set."
+msgstr "Description or name used to identify this configuration set."
+
+#: centreon/www/include/options/media/images/help.php
+msgid "Destination directory."
+msgstr "Destination directory."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Directory of log files."
+msgstr "Directory of log files."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Directory where Centreon will export Monitoring Engine object configuration "
+"files to. Monitoring Engine will parse all .cfg files in this directory."
+msgstr ""
+"Directory where Centreon will export Monitoring Engine object configuration "
+"files to. Monitoring Engine will parse all .cfg files in this directory."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Directory where backups will be stored"
+msgstr "Directory where backups will be stored"
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Directory where check plugins are stored."
+msgstr "Directory where check plugins are stored."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Directory where images are stored."
+msgstr "Directory where images are stored."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Display order."
+msgstr "Display order."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Displays Autologin shortcut."
+msgstr "Displays Autologin shortcut."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Displays the legend only, thus hiding the curve."
+msgstr "Displays the legend only, thus hiding the curve."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"Duration of retention regarding comments stored in database. 0 means that no "
+"retention will be applied."
+msgstr ""
+"Duration of retention regarding comments stored in database. 0 means that no "
+"retention will be applied."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"Duration of retention regarding downtimes stored in database. 0 means that "
+"no retention will be applied."
+msgstr ""
+"Duration of retention regarding downtimes stored in database. 0 means that "
+"no retention will be applied."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"Duration of retention regarding performance data stored in database. 0 means "
+"that no retention will be applied."
+msgstr ""
+"Duration of retention regarding performance data stored in database. 0 means "
+"that no retention will be applied."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Enable Backup process"
+msgstr "Enable Backup process"
+
+#: centreon/www/include/Administration/parameters/api/help.php
+msgid ""
+"Enable Centreon Broker statistics collection into the central server in "
+"order to reduce the network load generated by Centcore. Be carefull: broker "
+"statistics will not be available into Home > Broker statistics."
+msgstr ""
+"Enable Centreon Broker statistics collection into the central server in "
+"order to reduce the network load generated by Centcore. Be carefull: broker "
+"statistics will not be available into Home > Broker statistics."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Enable Centreon Broker statistics collection into the central server. Be "
+"careful: if disabled, Broker statistics will not be available into Home > "
+"Broker statistics."
+msgstr ""
+"Enable Centreon Broker statistics collection into the central server. Be "
+"careful: if disabled, Broker statistics will not be available into Home > "
+"Broker statistics."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Enable LDAP authentication"
+msgstr "Enable LDAP authentication"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Enable SSL connection"
+msgstr "Enable SSL connection"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Enable TLS connection"
+msgstr "Enable TLS connection"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Enable TLS encryption."
+msgstr "Enable TLS encryption."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Enable advanced matching mode for cases where a trap relates to multiple "
+"monitoring engine states and the trap message has to be parsed."
+msgstr ""
+"Enable advanced matching mode for cases where a trap relates to multiple "
+"monitoring engine states and the trap message has to be parsed."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Enable login with OpenId Connect."
+msgstr "Enable login with OpenId Connect."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"Enable negotiation option (use only for version of Centren Broker >= 2.5)"
+msgstr ""
+"Enable negotiation option (use only for version of Centren Broker >= 2.5)"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Enable notification form for this user. If you select \"no\" , this contact "
+"will never be generated into configuration files."
+msgstr ""
+"Enable notification form for this user. If you select \"no\" , this contact "
+"will never be generated into configuration files."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Enable or disable active checks (either regularly scheduled or on-demand) of "
+"this host here. By default active host checks are enabled."
+msgstr ""
+"Enable or disable active checks (either regularly scheduled or on-demand) of "
+"this host here. By default active host checks are enabled."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Enable or disable active checks (either regularly scheduled or on-demand) of "
+"this service here. By default active service checks are enabled."
+msgstr ""
+"Enable or disable active checks (either regularly scheduled or on-demand) of "
+"this service here. By default active service checks are enabled."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Enable or disable passive checks here. When disabled submitted states will "
+"be not accepted."
+msgstr ""
+"Enable or disable passive checks here. When disabled submitted states will "
+"be not accepted."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Enable or disable poller"
+msgstr "Enable or disable poller"
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Enable or disable the ACL action rule."
+msgstr "Enable or disable the ACL action rule."
+
+#: centreon/www/include/options/accessLists/menusACL/help.php
+msgid "Enable or disable the ACL menu rule."
+msgstr "Enable or disable the ACL menu rule."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid "Enable or disable the ACL resource rule."
+msgstr "Enable or disable the ACL resource rule."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "Enable or disable the access group."
+msgstr "Enable or disable the access group."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Enable or not configuration messages logging."
+msgstr "Enable or not configuration messages logging."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Enable or not data stream compression."
+msgstr "Enable or not data stream compression."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Enable or not debug messages logging."
+msgstr "Enable or not debug messages logging."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Enable or not error messages logging."
+msgstr "Enable or not error messages logging."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Enable or not informational messages logging."
+msgstr "Enable or not informational messages logging."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Enable the possibility to log pid information in engine log file (option "
+"only for Centreon Engine)"
+msgstr ""
+"Enable the possibility to log pid information in engine log file (option "
+"only for Centreon Engine)"
+
+#: centreon/www/include/Administration/parameters/rrdtool/help.php
+msgid ""
+"Enable the rrdcached for Centreon. This option is valid only with Centreon "
+"Broker"
+msgstr ""
+"Enable the rrdcached for Centreon. This option is valid only with Centreon "
+"Broker"
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid "Enable/Disable logging of all modifications in Centreon"
+msgstr "Enable/Disable logging of all modifications in Centreon"
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Enable/Disable routing definition"
+msgstr "Enable/Disable routing definition"
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Enables Autologin."
+msgstr "Enables Autologin."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables Centcore debug."
+msgstr "Enables Centcore debug."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables Centreontrapd debug."
+msgstr "Enables Centreontrapd debug."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables Centstorage debug."
+msgstr "Enables Centstorage debug."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables LDAP user import debug."
+msgstr "Enables LDAP user import debug."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables Monitoring Engine import debug."
+msgstr "Enables Monitoring Engine import debug."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables RRDTool debug."
+msgstr "Enables RRDTool debug."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables SQL debug."
+msgstr "Enables SQL debug."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Enables area filling."
+msgstr "Enables area filling."
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid "Enables authentication debug."
+msgstr "Enables authentication debug."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Enables auto scale of graph."
+msgstr "Enables auto scale of graph."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Enables graph stacking."
+msgstr "Enables graph stacking."
+
+#: centreon/www/include/options/media/images/help.php
+msgid "Enter a new name for the image."
+msgstr "Enter a new name for the image."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Enter a number that identifies the first notification for which this "
+"escalation is effective. For instance, if you set this value to 3, this "
+"escalation will only be used if the host is down or unreachable long enough "
+"for a third notification to go out."
+msgstr ""
+"Enter a number that identifies the first notification for which this "
+"escalation is effective. For instance, if you set this value to 3, this "
+"escalation will only be used if the host is down or unreachable long enough "
+"for a third notification to go out."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Enter a number that identifies the last notification for which this "
+"escalation is effective. For instance, if you set this value to 5, this "
+"escalation will not be used if more than five notifications are sent out for "
+"the host. Setting this value to 0 means to keep using this escalation entry "
+"forever (no matter how many notifications go out)."
+msgstr ""
+"Enter a number that identifies the last notification for which this "
+"escalation is effective. For instance, if you set this value to 5, this "
+"escalation will not be used if more than five notifications are sent out for "
+"the host. Setting this value to 0 means to keep using this escalation entry "
+"forever (no matter how many notifications go out)."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid "Enter a short name for the escalation to identify it."
+msgstr "Enter a short name for the escalation to identify it."
+
+#: centreon/www/include/options/media/images/help.php
+msgid ""
+"Enter an already existing or a new directory to add the uploads to it. A non-"
+"existent directory name will be created first."
+msgstr ""
+"Enter an already existing or a new directory to add the uploads to it. A non-"
+"existent directory name will be created first."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "Enter the LDAP Distinguished Name (DN) which identifies this user."
+msgstr "Enter the LDAP Distinguished Name (DN) which identifies this user."
+
+#: centreon/www/include/Administration/parameters/remote/help.php
+msgid "Enter the current password of this account."
+msgstr "Enter the current password of this account."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Enter the full numeric object identifier (OID) starting with .1.3.6 "
+"(.iso.org.dod)."
+msgstr ""
+"Enter the full numeric object identifier (OID) starting with .1.3.6 "
+"(.iso.org.dod)."
+
+#: centreon/www/include/Administration/parameters/remote/help.php
+msgid ""
+"Enter the name of an active contact who have the right to 'reach API "
+"configuration' on the Central.This user will be used to call the API from "
+"the Remote to the Central."
+msgstr ""
+"Enter the name of an active contact who have the right to 'reach API "
+"configuration' on the Central.This user will be used to call the API from "
+"the Remote to the Central."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "Enter the password again."
+msgstr "Enter the password again."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Enter the status message to be submitted to monitoring engine. The original "
+"trap message will be placed into the entered string at the position of the "
+"variable $*."
+msgstr ""
+"Enter the status message to be submitted to monitoring engine. The original "
+"trap message will be placed into the entered string at the position of the "
+"variable $*."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Enter the trap name as specified in the MIB file and send by the SNMP master "
+"agent."
+msgstr ""
+"Enter the trap name as specified in the MIB file and send by the SNMP master "
+"agent."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Excluding hosts from the selected host groups will hide them from users."
+msgstr ""
+"Excluding hosts from the selected host groups will hide them from users."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "File for external commands"
+msgstr "File for external commands"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "File where Centreon Broker statistics will be stored"
+msgstr "File where Centreon Broker statistics will be stored"
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "First refresh delay for monitoring."
+msgstr "First refresh delay for monitoring."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "First refresh delay for statistics (top counters)."
+msgstr "First refresh delay for statistics (top counters)."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Fixed."
+msgstr "Fixed."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"For a file logger this is the path to the file. For a standard logger, one "
+"of 'stdout' or 'stderr'."
+msgstr ""
+"For a file logger this is the path to the file. For a standard logger, one "
+"of 'stdout' or 'stderr'."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"For security reasons, to be able to change this user's password, you (the "
+"currently logged-in user) must verify your identity by entering your own "
+"password."
+msgstr ""
+"For security reasons, to be able to change this user's password, you (the "
+"currently logged-in user) must verify your identity by entering your own "
+"password."
+
+#: centreon/www/include/Administration/parameters/remote/help.php
+msgid "Full URL allowing access to the API of the Centreon's central server."
+msgstr "Full URL allowing access to the API of the Centreon's central server."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Full backup period"
+msgstr "Full backup period"
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Function to be applied to calculate the meta service status."
+msgstr "Function to be applied to calculate the meta service status."
+
+#: centreon/www/include/configuration/configGenerateTraps/help.php
+msgid "Generate a light database for traps."
+msgstr "Generate a light database for traps."
+
+#: centreon/www/include/configuration/configGenerate/help.php
+msgid "Generates configuration files and stores them in cache directory."
+msgstr "Generates configuration files and stores them in cache directory."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Geographic coordinates to allow Centreon MAP to plot the resource on a "
+"geographic view. Format: Latitude,Longitude. For example, Paris' coordinates "
+"are 48.51,2.20"
+msgstr ""
+"Geographic coordinates to allow Centreon MAP to plot the resource on a "
+"geographic view. Format: Latitude,Longitude. For example, Paris' coordinates "
+"are 48.51,2.20"
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"Geographical coordinates use by Centreon Map module to position element on "
+"map. Define \"Latitude,Longitude\", for example for Paris coordinates set "
+"\"48.51,2.20\""
+msgstr ""
+"Geographical coordinates use by Centreon Map module to position element on "
+"map. Define \"Latitude,Longitude\", for example for Paris coordinates set "
+"\"48.51,2.20\""
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Gorgone communication protocol (ZMQ or SSH)"
+msgstr "Gorgone communication protocol (ZMQ or SSH)"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Gorgone port of the remote poller (5556 or 22)"
+msgstr "Gorgone port of the remote poller (5556 or 22)"
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Height of grid. Used to export the chart."
+msgstr "Height of grid. Used to export the chart."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Hides curve and legend."
+msgstr "Hides curve and legend."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Host / Service Data Source."
+msgstr "Host / Service Data Source."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid "Host categories linked to the host."
+msgstr "Host categories linked to the host."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Host categories linked to the service."
+msgstr "Host categories linked to the service."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid "Host groups linked to the host."
+msgstr "Host groups linked to the host."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Host groups that will be displayed to users. Hosts that belong to these host "
+"groups will also be visible."
+msgstr ""
+"Host groups that will be displayed to users. Hosts that belong to these host "
+"groups will also be visible."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Host severity level. Can be used to sort alerts in the monitoring menus, "
+"including the Resources Status page."
+msgstr ""
+"Host severity level. Can be used to sort alerts in the monitoring menus, "
+"including the Resources Status page."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Host(s) to which the service is attached"
+msgstr "Host(s) to which the service is attached"
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Hosts that will be displayed to users. Services that belong to these hosts "
+"will also be visible."
+msgstr ""
+"Hosts that will be displayed to users. Services that belong to these hosts "
+"will also be visible."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "How much messages must be logged."
+msgstr "How much messages must be logged."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"I agree to participate to the Centreon Customer Experience Improvement "
+"Program whereby anonymous information about the usage of this server may be "
+"sent to Centreon. This information will solely be used to improve the "
+"software user experience. I will be able to opt-out at anytime. Refer to <a "
+"style=\"text-decoration: underline\" href=\"http://ceip.centreon.com/"
+"\">ceip.centreon.com</a>  for further details."
+msgstr ""
+"I agree to participate to the Centreon Customer Experience Improvement "
+"Program whereby anonymous information about the usage of this server may be "
+"sent to Centreon. This information will solely be used to improve the "
+"software user experience. I will be able to opt-out at anytime. Refer to <a "
+"style=\"text-decoration: underline\" href=\"http://ceip.centreon.com/"
+"\">ceip.centreon.com</a>  for further details."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"IP Address or hostname to communicate with Gorgone API. Should remain "
+"default value (Default: \"127.0.0.1\")."
+msgstr ""
+"IP Address or hostname to communicate with Gorgone API. Should remain "
+"default value (Default: \"127.0.0.1\")."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "IP address or hostname of the database server."
+msgstr "IP address or hostname of the database server."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"IP address or hostname of the host to connect to (leave blank for listening "
+"mode)."
+msgstr ""
+"IP address or hostname of the host to connect to (leave blank for listening "
+"mode)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"IP/DNS of blacklist clients. Use coma as delimiter in case of multiple "
+"clients."
+msgstr ""
+"IP/DNS of blacklist clients. Use coma as delimiter in case of multiple "
+"clients."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"IP/DNS of trusted clients. Use coma as delimiter in case of multiple clients."
+msgstr ""
+"IP/DNS of trusted clients. Use coma as delimiter in case of multiple clients."
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid "Icon for this severity."
+msgstr "Icon for this severity."
+
+#: centreon/www/include/Administration/myAccount/help.php
+msgid ""
+"If checked this option will restore the use of the deprecated pages.This "
+"includes display of the deprecated pages and internal redirection between "
+"pagesIf not checked this option will enable the full use of the new "
+"Monitoring page Resource Status"
+msgstr ""
+"If checked this option will restore the use of the deprecated pages.This "
+"includes display of the deprecated pages and internal redirection between "
+"pagesIf not checked this option will enable the full use of the new "
+"Monitoring page Resource Status"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"If checked, it won't check the validity of the SSL certificate of the Remote "
+"Server."
+msgstr ""
+"If checked, it won't check the validity of the SSL certificate of the Remote "
+"Server."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"If checked, it won't use the proxy configured in 'Administration > "
+"Parameters > Centreon UI' to connect to the Remote Server."
+msgstr ""
+"If checked, it won't use the proxy configured in 'Administration > "
+"Parameters > Centreon UI' to connect to the Remote Server."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"If disabled, the Central server will send configuration and external "
+"commands directly to the poller and will not use the Remote Server as a "
+"proxy."
+msgstr ""
+"If disabled, the Central server will send configuration and external "
+"commands directly to the poller and will not use the Remote Server as a "
+"proxy."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid ""
+"If enabled, a user LDAP synchronization will be performed on login to update "
+"contact's data and calculate new Centreon ACLs."
+msgstr ""
+"If enabled, a user LDAP synchronization will be performed on login to update "
+"contact's data and calculate new Centreon ACLs."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"If this option is enable, the downtimes and acknowledgments will be "
+"displayed on metric chart.<br><b>Warning</b> : This option can slow down the "
+"display of chart."
+msgstr ""
+"If this option is enable, the downtimes and acknowledgments will be "
+"displayed on metric chart.<br><b>Warning</b> : This option can slow down the "
+"display of chart."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"If this option is enabled, the comments will be displayed on the status "
+"chart.<br><b>Warning</b> : This option can slow down the display of the "
+"chart."
+msgstr ""
+"If this option is enabled, the comments will be displayed on the status "
+"chart.<br><b>Warning</b> : This option can slow down the display of the "
+"chart."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"If this option is enabled, use host's notification parameters instead of "
+"service or from  template of service parameters inherited"
+msgstr ""
+"If this option is enabled, use host's notification parameters instead of "
+"service or from  template of service parameters inherited"
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"If you specify a number with an \"s\" appended to it (i.e. 30s), this is the "
+"number of seconds to wait between external command checks. If you leave off "
+"the \"s\", this is the number of \"time units\" to wait between external "
+"command checks. Unless you've changed the interval_length value (as defined "
+"below) from the default value of 60, this number will mean minutes. By "
+"setting this value to -1, Monitoring Engine will check for external commands "
+"as often as possible. Each time Monitoring Engine checks for external "
+"commands it will read and process all commands present in the command file "
+"before continuing on with its other duties."
+msgstr ""
+"If you specify a number with an \"s\" appended to it (i.e. 30s), this is the "
+"number of seconds to wait between external command checks. If you leave off "
+"the \"s\", this is the number of \"time units\" to wait between external "
+"command checks. Unless you've changed the interval_length value (as defined "
+"below) from the default value of 60, this number will mean minutes. By "
+"setting this value to -1, Monitoring Engine will check for external commands "
+"as often as possible. Each time Monitoring Engine checks for external "
+"commands it will read and process all commands present in the command file "
+"before continuing on with its other duties."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"If you've enabled regular expression matching of various object directives "
+"using the use_regexp_matching option, this option will determine when object "
+"directives are treated as regular expressions. If this option is disabled "
+"(the default), directives will only be treated as regular expressions if "
+"they contain *, ?, +, or \\.. If this option is enabled, all appropriate "
+"directives will be treated as regular expression."
+msgstr ""
+"If you've enabled regular expression matching of various object directives "
+"using the use_regexp_matching option, this option will determine when object "
+"directives are treated as regular expressions. If this option is disabled "
+"(the default), directives will only be treated as regular expressions if "
+"they contain *, ?, +, or \\.. If this option is enabled, all appropriate "
+"directives will be treated as regular expression."
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/help.php
+msgid "Ignore ssl certificate."
+msgstr "Ignore ssl certificate."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid "Ignored by Centreon Engine."
+msgstr "Ignored by Centreon Engine."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Illegal characters in external commands. Those characters will be removed "
+"before being processed by Centreon Gorgone."
+msgstr ""
+"Illegal characters in external commands. Those characters will be removed "
+"before being processed by Centreon Gorgone."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Image folders that will be displayed to users. Images that belong to these "
+"folders will be visible."
+msgstr ""
+"Image folders that will be displayed to users. Images that belong to these "
+"folders will be visible."
+
+#: centreon/www/include/options/media/images/help.php
+msgid "Images."
+msgstr "Images."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+#: centreon/www/include/options/accessLists/menusACL/help.php
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid "Implied ACL groups."
+msgstr "Implied ACL groups."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "Implied user groups."
+msgstr "Implied user groups."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "Implied users."
+msgstr "Implied users."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Information note displayed as a tooltip in the Notes column of the Resources "
+"Status page."
+msgstr ""
+"Information note displayed as a tooltip in the Notes column of the Resources "
+"Status page."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Init script for broker daemon."
+msgstr "Init script for broker daemon."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Instead of specifying the parent hosts in the child's parent definition, "
+"it's possible to do it the other way round and specify all child hosts in "
+"the parent's definition."
+msgstr ""
+"Instead of specifying the parent hosts in the child's parent definition, "
+"it's possible to do it the other way round and specify all child hosts in "
+"the parent's definition."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"Interval in seconds before change status of resources from a disconnected "
+"poller"
+msgstr ""
+"Interval in seconds before change status of resources from a disconnected "
+"poller"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Interval in seconds before delete data from deleted pollers."
+msgstr "Interval in seconds before delete data from deleted pollers."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Interval length in seconds."
+msgstr "Interval length in seconds."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Inverted curve (with negative values)."
+msgstr "Inverted curve (with negative values)."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "It is possible to define a specific service for the data source."
+msgstr "It is possible to define a specific service for the data source."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"It should be enabled to control whether or not Centreon Broker\n"
+" should insert performance data in the data_bin table."
+msgstr ""
+"It should be enabled to control whether or not Centreon Broker\n"
+" should insert performance data in the data_bin table."
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/help.php
+msgid "Knowledge wiki url. Exemple: http://wiki/mywiki"
+msgstr "Knowledge wiki url. Exemple: http://wiki/mywiki"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "LDAP groups of user, for informative purpose."
+msgstr "LDAP groups of user, for informative purpose."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid ""
+"Ldap server. Failover will take place if multiple servers are defined.<br/"
+">If TLS is enabled, make sure to configure the certificate requirements on "
+"the ldap.conf file and restart your web server."
+msgstr ""
+"Ldap server. Failover will take place if multiple servers are defined.<br/"
+">If TLS is enabled, make sure to configure the certificate requirements on "
+"the ldap.conf file and restart your web server."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Legend Name."
+msgstr "Legend Name."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Life duration of sessions. The value in minutes cannot be greater than the "
+"session.gc_maxlifetime value set in your php centreon.ini file."
+msgstr ""
+"Life duration of sessions. The value in minutes cannot be greater than the "
+"session.gc_maxlifetime value set in your php centreon.ini file."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"Light databases will be stored in the specified directory. They are used for "
+"synchronizing trap definitions on pollers."
+msgstr ""
+"Light databases will be stored in the specified directory. They are used for "
+"synchronizing trap definitions on pollers."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Link the contact to the contactgroup(s) the user should belong to. This is "
+"an alternative way to specifying the members in contactgroup definitions."
+msgstr ""
+"Link the contact to the contactgroup(s) the user should belong to. This is "
+"an alternative way to specifying the members in contactgroup definitions."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Location (path and filename) where Monitoring Engine should create its main "
+"log file."
+msgstr ""
+"Location (path and filename) where Monitoring Engine should create its main "
+"log file."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Lower limit of grid."
+msgstr "Lower limit of grid."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Macros are used as object-specific variables/properties, which can be "
+"referenced in commands and extended infos. A Macro named TECHCONTACT can be "
+"referenced as $_SERVICETECHCONTACT$."
+msgstr ""
+"Macros are used as object-specific variables/properties, which can be "
+"referenced in commands and extended infos. A Macro named TECHCONTACT can be "
+"referenced as $_SERVICETECHCONTACT$."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Macros are used as object-specific variables/properties, which can be "
+"referenced in commands and extended infos. Example: a macro named MACADDRESS "
+"can be referenced as $_HOSTMACADDRESS$."
+msgstr ""
+"Macros are used as object-specific variables/properties, which can be "
+"referenced in commands and extended infos. Example: a macro named MACADDRESS "
+"can be referenced as $_HOSTMACADDRESS$."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"Mailer binary with complete path. This define the @MAILER@ macro used in "
+"notification commands."
+msgstr ""
+"Mailer binary with complete path. This define the @MAILER@ macro used in "
+"notification commands."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Main poller"
+msgstr "Main poller"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Master Remote Server to which this server will be attached"
+msgstr "Master Remote Server to which this server will be attached"
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Maximum execution time of trap processing. This includes Preexec commands, "
+"submit command and special command"
+msgstr ""
+"Maximum execution time of trap processing. This includes Preexec commands, "
+"submit command and special command"
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Maximum number of hosts to show in the Tactical Overview page."
+msgstr "Maximum number of hosts to show in the Tactical Overview page."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Maximum number of services to show in the Tactical Overview page."
+msgstr "Maximum number of services to show in the Tactical Overview page."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Maximum size in bytes."
+msgstr "Maximum size in bytes."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid "Meta services that will be displayed to users."
+msgstr "Meta services that will be displayed to users."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Metric unit."
+msgstr "Metric unit."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Minimum delay necessary for a trap to be processed after another one"
+msgstr "Minimum delay necessary for a trap to be processed after another one"
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid ""
+"Must be the display name of the metric. Refer to the check plugin for more "
+"information."
+msgstr ""
+"Must be the display name of the metric. Refer to the check plugin for more "
+"information."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid ""
+"MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave empty "
+"to use the default value."
+msgstr ""
+"MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave empty "
+"to use the default value."
+
+#: centreon/www/include/options/accessLists/groupsACL/help.php
+msgid "Name of access group."
+msgstr "Name of access group."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "Name of action rule."
+msgstr "Name of action rule."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Name of configuration"
+msgstr "Name of configuration"
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Name of curve template."
+msgstr "Name of curve template."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Name of graph template."
+msgstr "Name of graph template."
+
+#: centreon/www/include/options/accessLists/menusACL/help.php
+msgid "Name of menu rule."
+msgstr "Name of menu rule."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid "Name of resource rule."
+msgstr "Name of resource rule."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Name of the host or template. The name defined here is used in host group "
+"and service definitions to reference this particular host. It must be unique "
+"and cannot contain white spaces, or special characters like ~!$%^&*\"|'<>?,"
+"()="
+msgstr ""
+"Name of the host or template. The name defined here is used in host group "
+"and service definitions to reference this particular host. It must be unique "
+"and cannot contain white spaces, or special characters like ~!$%^&*\"|'<>?,"
+"()="
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Name of the input or output object that will act as failover."
+msgstr "Name of the input or output object that will act as failover."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Name of the service or template. It cannot contain white spaces, or special "
+"characters like ~!$%^&*\"|'<>?,()=. Each service of an host must have a "
+"unique name. The name of a service template must be unique."
+msgstr ""
+"Name of the service or template. It cannot contain white spaces, or special "
+"characters like ~!$%^&*\"|'<>?,()=. Each service of an host must have a "
+"unique name. The name of a service template must be unique."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Name of virtual metric."
+msgstr "Name of virtual metric."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Name used for identification of this meta service."
+msgstr "Name used for identification of this meta service."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Name used for service in auto-deploy by template."
+msgstr "Name used for service in auto-deploy by template."
+
+#: centreon/www/include/configuration/configObject/connector/help.php
+msgid "Name which will be used for identifying the connector."
+msgstr "Name which will be used for identifying the connector."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Network address. Can be either IP or FQDN. If no DNS service is available, "
+"using a FQDN could raise false alarms."
+msgstr ""
+"Network address. Can be either IP or FQDN. If no DNS service is available, "
+"using a FQDN could raise false alarms."
+
+#: centreon/www/include/Administration/myAccount/help.php
+msgid ""
+"No: You don't consent to share your platform data. Contact Details: You "
+"consent to share your platform data including your alias and email. "
+"Anonymized: You consent to share your platform data, but your alias and "
+"email will be anonymized."
+msgstr ""
+"No: You don't consent to share your platform data. Contact Details: You "
+"consent to share your platform data including your alias and email. "
+"Anonymized: You consent to share your platform data, but your alias and "
+"email will be anonymized."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Notification inheritance for hosts and services. Vertical for the legacy "
+"mode, Close for the first valid object and Cumulative for all valid object."
+msgstr ""
+"Notification inheritance for hosts and services. Vertical for the legacy "
+"mode, Close for the first valid object and Cumulative for all valid object."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Number of line breaks after the legend."
+msgstr "Number of line breaks after the legend."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Number of performance graphs displayed per page."
+msgstr "Number of performance graphs displayed per page."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "On which TCP port is listening the Remote Server?"
+msgstr "On which TCP port is listening the Remote Server?"
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid "Option to enable or disable this downtime"
+msgstr "Option to enable or disable this downtime"
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+#, php-format
+msgid ""
+"Optional format string used for displaying the status of this meta service. "
+"The variable '%d' may be used and will be replaced by the calculated value."
+msgstr ""
+"Optional format string used for displaying the status of this meta service. "
+"The variable '%d' may be used and will be replaced by the calculated value."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"PREEXEC commands are executed after 'routing' and before 'matching', "
+"'actions'"
+msgstr ""
+"PREEXEC commands are executed after 'routing' and before 'matching', "
+"'actions'"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Parent hosts are typically routers, switches, firewalls, etc. that lie "
+"between the monitoring host and a remote hosts. A router, switch, etc. which "
+"is closest to the remote host is considered to be that host\\'s \"parent\". "
+"If this host is on the same network segment as the host doing the monitoring "
+"(without any intermediate routers, etc.) the host is considered to be on the "
+"local network and will not have a parent host. Leave this value blank if the "
+"host does not have a parent host (i.e. it is on the same segment as the "
+"Monitoring Engine host). The order in which you specify parent hosts has no "
+"effect on how things are monitored. Note that notification features based on "
+"host inheritance will not work if the hosts are not monitored by the same "
+"poller."
+msgstr ""
+"Parent hosts are typically routers, switches, firewalls, etc. that lie "
+"between the monitoring host and a remote hosts. A router, switch, etc. which "
+"is closest to the remote host is considered to be that host\\'s \"parent\". "
+"If this host is on the same network segment as the host doing the monitoring "
+"(without any intermediate routers, etc.) the host is considered to be on the "
+"local network and will not have a parent host. Leave this value blank if the "
+"host does not have a parent host (i.e. it is on the same segment as the "
+"Monitoring Engine host). The order in which you specify parent hosts has no "
+"effect on how things are monitored. Note that notification features based on "
+"host inheritance will not work if the hosts are not monitored by the same "
+"poller."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Partial backup period (available on partitioned tables)"
+msgstr "Partial backup period (available on partitioned tables)"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Password for connect to LDAP in read only"
+msgstr "Password for connect to LDAP in read only"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Password of database user."
+msgstr "Password of database user."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Password of the proxy (Only if you use basic authentication)."
+msgstr "Password of the proxy (Only if you use basic authentication)."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Password used to connect to Gorgone API. It must match Gorgone httpserver "
+"module definition (Default: none)."
+msgstr ""
+"Password used to connect to Gorgone API. It must match Gorgone httpserver "
+"module definition (Default: none)."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path of binary of the scheduler"
+msgstr "Path of binary of the scheduler"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path of init script of centreontrapd"
+msgstr "Path of init script of centreontrapd"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path of stats binary of the scheduler"
+msgstr "Path of stats binary of the scheduler"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path of the Centreon Broker log file"
+msgstr "Path of the Centreon Broker log file"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path of the configuration file for Centreon Broker"
+msgstr "Path of the configuration file for Centreon Broker"
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid "Path to RRDTool database for graphs of metrics."
+msgstr "Path to RRDTool database for graphs of metrics."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid "Path to RRDTool database for graphs of monitoring engine stats."
+msgstr "Path to RRDTool database for graphs of monitoring engine stats."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid "Path to RRDTool database for graphs of status."
+msgstr "Path to RRDTool database for graphs of status."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Path to the file."
+msgstr "Path to the file."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path with Centreon Connector binaries"
+msgstr "Path with Centreon Connector binaries"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Path with modules for Centreon Broker"
+msgstr "Path with modules for Centreon Broker"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Perfdata script"
+msgstr "Perfdata script"
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Permits to filter services of host(s). Skip if service_description not "
+"equals to the value set."
+msgstr ""
+"Permits to filter services of host(s). Skip if service_description not "
+"equals to the value set."
+
+#: centreon/www/include/configuration/configGenerateTraps/help.php
+msgid "Poller to interact with."
+msgstr "Poller to interact with."
+
+#: centreon/www/include/Administration/parameters/rrdtool/help.php
+msgid "Port for communicating with rrdcached"
+msgstr "Port for communicating with rrdcached"
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Port of the proxy."
+msgstr "Port of the proxy."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Port on which Gorgone API is listening. It must match Gorgone httpserver "
+"module definition. Should remain default value (Default: \"8085\")."
+msgstr ""
+"Port on which Gorgone API is listening. It must match Gorgone httpserver "
+"module definition. Should remain default value (Default: \"8085\")."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Port on which the DB server listens"
+msgstr "Port on which the DB server listens"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Port to listen on (empty host) or to connect to (with host filled)."
+msgstr "Port to listen on (empty host) or to connect to (with host filled)."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Print total value."
+msgstr "Print total value."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Prints average value."
+msgstr "Prints average value."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Prints last Value."
+msgstr "Prints last Value."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Prints maximum value."
+msgstr "Prints maximum value."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Prints minimum value."
+msgstr "Prints minimum value."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Private key file path when TLS encryption is used."
+msgstr "Private key file path when TLS encryption is used."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"Provided that the user can access the API Tokens menu, this action will "
+"allow them to not only list, create and delete tokens for themselves, but "
+"also manage tokens for other users."
+msgstr ""
+"Provided that the user can access the API Tokens menu, this action will "
+"allow them to not only list, create and delete tokens for themselves, but "
+"also manage tokens for other users."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Public certificate file path when TLS encryption is used."
+msgstr "Public certificate file path when TLS encryption is used."
+
+#: centreon/www/include/configuration/configGenerateTraps/help.php
+msgid "Push database to poller."
+msgstr "Push database to poller."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "RPN (Reverse Polish Notation) Function *."
+msgstr "RPN (Reverse Polish Notation) Function *."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "RRD file directory, for example /var/lib/centreon/metrics"
+msgstr "RRD file directory, for example /var/lib/centreon/metrics"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "RRD file directory, for example /var/lib/centreon/status"
+msgstr "RRD file directory, for example /var/lib/centreon/status"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "RRD storage duration in seconds."
+msgstr "RRD storage duration in seconds."
+
+#: centreon/www/include/Administration/parameters/rrdtool/help.php
+msgid "RRDTOOL binary complete path."
+msgstr "RRDTOOL binary complete path."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid "RRDTool database size (in days)."
+msgstr "RRDTool database size (in days)."
+
+#: centreon/www/include/Administration/parameters/rrdtool/help.php
+msgid "RRDTool version."
+msgstr "RRDTool version."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"Ranges from 0 (no compression) to 9 (best compression). Default is -1 (zlib "
+"compression)"
+msgstr ""
+"Ranges from 0 (no compression) to 9 (best compression). Default is -1 (zlib "
+"compression)"
+
+#: centreon/www/include/configuration/configObject/contactgroup/help.php
+msgid ""
+"Refers to the ACL groups this contact group is linked to. This parameter is "
+"mandatory if you are not an administrator."
+msgstr ""
+"Refers to the ACL groups this contact group is linked to. This parameter is "
+"mandatory if you are not an administrator."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Refresh interval used for statistics (top counters). Minimum value: 10"
+msgstr "Refresh interval used for statistics (top counters). Minimum value: 10"
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Refresh interval used in monitoring consoles. Minimum value: 10"
+msgstr "Refresh interval used in monitoring consoles. Minimum value: 10"
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "Refresh interval used in the Tactical Overview page."
+msgstr "Refresh interval used in the Tactical Overview page."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Refresh interval."
+msgstr "Refresh interval."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Regexp for removing or change some characters in output message (Example: s/"
+"\\|/-/g)."
+msgstr ""
+"Regexp for removing or change some characters in output message (Example: s/"
+"\\|/-/g)."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Remote directory to copy by SCP"
+msgstr "Remote directory to copy by SCP"
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Remote host to copy by SCP"
+msgstr "Remote host to copy by SCP"
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Remote user used by SCP"
+msgstr "Remote user used by SCP"
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid "Resource access rule to which the service group should be linked"
+msgstr "Resource access rule to which the service group should be linked"
+
+#: centreon/www/include/configuration/configGenerate/help.php
+msgid "Restart the scheduler: Restart, Reload or External Command."
+msgstr "Restart the scheduler: Restart, Reload or External Command."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid "Retention duration of logs. 0 means that no retention will be applied."
+msgstr "Retention duration of logs. 0 means that no retention will be applied."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"Retention duration of reporting data. 0 means that no retention will be "
+"applied."
+msgstr ""
+"Retention duration of reporting data. 0 means that no retention will be "
+"applied."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"Retention time for partitioned tables (data_bin, logs, log_archive_host, "
+"log_archive_service), by default 365 days."
+msgstr ""
+"Retention time for partitioned tables (data_bin, logs, log_archive_host, "
+"log_archive_service), by default 365 days."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid "Rounds the value."
+msgstr "Rounds the value."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Routing definition to choose host(s)"
+msgstr "Routing definition to choose host(s)"
+
+#: centreon/www/include/configuration/configGenerate/help.php
+msgid ""
+"Run the commands that are defined in the poller configuration page "
+"(Configuration > Centreon > Poller > Post-Restart command)."
+msgstr ""
+"Run the commands that are defined in the poller configuration page "
+"(Configuration > Centreon > Poller > Post-Restart command)."
+
+#: centreon/www/include/configuration/configGenerate/help.php
+msgid "Runs the scheduler debug mode."
+msgstr "Runs the scheduler debug mode."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"SSH legacy port used by Centreon extensions or tools (see Gorgone "
+"Information for communication port between monitoring servers)"
+msgstr ""
+"SSH legacy port used by Centreon extensions or tools (see Gorgone "
+"Information for communication port between monitoring servers)"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Search size limit"
+msgstr "Search size limit"
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Search string to be used in a SQL LIKE query for service selection."
+msgstr "Search string to be used in a SQL LIKE query for service selection."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Search timeout"
+msgstr "Search timeout"
+
+#: centreon/www/include/options/media/images/help.php
+msgid ""
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg "
+"files. Multiple images can be uploaded together inside archives like zip, "
+"tar, tar.gz or tar.bz2."
+msgstr ""
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg "
+"files. Multiple images can be uploaded together inside archives like zip, "
+"tar, tar.gz or tar.bz2."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select contacts that should be notified whenever there are problems (or "
+"recoveries) with this host. Useful if you want notifications to go to just a "
+"few people and don't want to configure contact groups. You must specify at "
+"least one contact or contact group in each host escalation definition."
+msgstr ""
+"Select contacts that should be notified whenever there are problems (or "
+"recoveries) with this host. Useful if you want notifications to go to just a "
+"few people and don't want to configure contact groups. You must specify at "
+"least one contact or contact group in each host escalation definition."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the contact group(s) that should be notified when the notification is "
+"escalated. You must specify at least one contact group in each escalation "
+"definition."
+msgstr ""
+"Select the contact group(s) that should be notified when the notification is "
+"escalated. You must specify at least one contact group in each escalation "
+"definition."
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+msgid "Select the host templates that this category is linked to."
+msgstr "Select the host templates that this category is linked to."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the host(s) that the escalation should apply to or is associated with."
+msgstr ""
+"Select the host(s) that the escalation should apply to or is associated with."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the hostgroup(s) that the escalation should apply to. The escalation "
+"will apply to all hosts that are members of the specified hostgroup(s)."
+msgstr ""
+"Select the hostgroup(s) that the escalation should apply to. The escalation "
+"will apply to all hosts that are members of the specified hostgroup(s)."
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+msgid "Select the hosts that this category is linked to."
+msgstr "Select the hosts that this category is linked to."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the interval at which notifications should be made while this "
+"escalation is valid. If you specify a value of 0 for the interval, "
+"Monitoring Engine will send the first notification when this escalation "
+"definition is valid, but will then prevent any more problem notifications "
+"from being sent out. Notifications are sent out again until the host or "
+"service recovers. This is useful if you want to stop having notifications "
+"sent out after a certain amount of time. Note: If multiple escalation "
+"entries overlap for one or more notification ranges, the smallest "
+"notification interval from all escalation entries is used."
+msgstr ""
+"Select the interval at which notifications should be made while this "
+"escalation is valid. If you specify a value of 0 for the interval, "
+"Monitoring Engine will send the first notification when this escalation "
+"definition is valid, but will then prevent any more problem notifications "
+"from being sent out. Notifications are sent out again until the host or "
+"service recovers. This is useful if you want to stop having notifications "
+"sent out after a certain amount of time. Note: If multiple escalation "
+"entries overlap for one or more notification ranges, the smallest "
+"notification interval from all escalation entries is used."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the meta service(s) the escalation should apply to or is associated "
+"with."
+msgstr ""
+"Select the meta service(s) the escalation should apply to or is associated "
+"with."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Select the metric to measure for meta service status."
+msgstr "Select the metric to measure for meta service status."
+
+#: centreon/www/include/configuration/configGenerate/help.php
+msgid "Select the poller you would like to interact with."
+msgstr "Select the poller you would like to interact with."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the service group(s) the escalation should apply to or is associated "
+"with. The escalation will apply to all services that are members of the "
+"specified service group(s)."
+msgstr ""
+"Select the service group(s) the escalation should apply to or is associated "
+"with. The escalation will apply to all services that are members of the "
+"specified service group(s)."
+
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid ""
+"Select the service templates this category should be linked to. Every "
+"service based on the selected templates will be automatically linked with "
+"this category."
+msgstr ""
+"Select the service templates this category should be linked to. Every "
+"service based on the selected templates will be automatically linked with "
+"this category."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the service(s) the escalation should apply to or is associated with."
+msgstr ""
+"Select the service(s) the escalation should apply to or is associated with."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"Select the time period during which this escalation is valid. If no time "
+"period is specified, the escalation is considered to be valid during all "
+"times."
+msgstr ""
+"Select the time period during which this escalation is valid. If no time "
+"period is specified, the escalation is considered to be valid during all "
+"times."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Select the timezone, in which the user resides, from the list. The timezones "
+"are listed as time difference to Greenwich Mean Time (GMT) in hours."
+msgstr ""
+"Select the timezone, in which the user resides, from the list. The timezones "
+"are listed as time difference to Greenwich Mean Time (GMT) in hours."
+
+#: centreon/www/include/configuration/configObject/traps-groups/help.php
+msgid "Select traps to be grouped. Execution will be sequential."
+msgstr "Select traps to be grouped. Execution will be sequential."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Selection mode for services to be considered for this meta service. In "
+"service list mode, mark selected services in the options on meta service "
+"list. In SQL matching mode, specify a search string to be used in an SQL "
+"query."
+msgstr ""
+"Selection mode for services to be considered for this meta service. In "
+"service list mode, mark selected services in the options on meta service "
+"list. In SQL matching mode, specify a search string to be used in an SQL "
+"query."
+
+#: centreon/www/include/configuration/configGenerateTraps/help.php
+msgid "Send restart or reload signal to centreontrapd."
+msgstr "Send restart or reload signal to centreontrapd."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Serialization protocol."
+msgstr "Serialization protocol."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Service groups linked to the service."
+msgstr "Service groups linked to the service."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Service groups that will be displayed to users. Services that belong to "
+"these service groups will also be visible."
+msgstr ""
+"Service groups that will be displayed to users. Services that belong to "
+"these service groups will also be visible."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Service severity level. Can be used to sort alerts in the monitoring menus, "
+"including the Resources Status page."
+msgstr ""
+"Service severity level. Can be used to sort alerts in the monitoring menus, "
+"including the Resources Status page."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Set as default graph template."
+msgstr "Set as default graph template."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Set the domain for search the service"
+msgstr "Set the domain for search the service"
+
+#: centreon/www/include/Administration/parameters/debug/help.php
+msgid ""
+"Set the lowest log level: Debug => Info => Notice => Warning => Error => "
+"Critical => Alert => Emergency"
+msgstr ""
+"Set the lowest log level: Debug => Info => Notice => Warning => Error => "
+"Critical => Alert => Emergency"
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Severities are defined in the service category object."
+msgstr "Severities are defined in the service category object."
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid ""
+"Severity level, must be a number. The items displayed will be sorted in "
+"ascending order. Thus the lowest severity is considered than the highest "
+"priority."
+msgstr ""
+"Severity level, must be a number. The items displayed will be sorted in "
+"ascending order. Thus the lowest severity is considered than the highest "
+"priority."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Short description of configuration"
+msgstr "Short description of configuration"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Short description of the poller"
+msgstr "Short description of the poller"
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Skip trap if host or service is in downtime when centreontrapd proceeds. "
+"'History' option is more accurate but needs more powers. The option works "
+"only with centreon-broker AND central mode."
+msgstr ""
+"Skip trap if host or service is in downtime when centreontrapd proceeds. "
+"'History' option is more accurate but needs more powers. The option works "
+"only with centreon-broker AND central mode."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Specify a duration of acknowledgement for this host or host depending to "
+"this template. If you leave it blank, no timeout will be set."
+msgstr ""
+"Specify a duration of acknowledgement for this host or host depending to "
+"this template. If you leave it blank, no timeout will be set."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify a duration of acknowledgement for this service or service depending "
+"to this template. If you leave it blank, no timeout will be set."
+msgstr ""
+"Specify a duration of acknowledgement for this service or service depending "
+"to this template. If you leave it blank, no timeout will be set."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Specify a pager number or an address at a pager gateway here. Any format is "
+"possible as long as it is supported by the notification command."
+msgstr ""
+"Specify a pager number or an address at a pager gateway here. Any format is "
+"possible as long as it is supported by the notification command."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "Specify if the contact is allowed to login into centreon."
+msgstr "Specify if the contact is allowed to login into centreon."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Specify if the user has administrative permissions. Administrators are not "
+"restricted by access control list (ACL) settings."
+msgstr ""
+"Specify if the user has administrative permissions. Administrators are not "
+"restricted by access control list (ACL) settings."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Specify one or more templates of services that should be linked to this "
+"host's template. A host deployed from this host's template will benefit all "
+"services themselves based from services' templates previously linked."
+msgstr ""
+"Specify one or more templates of services that should be linked to this "
+"host's template. A host deployed from this host's template will benefit all "
+"services themselves based from services' templates previously linked."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the command that monitoring engine will run in order to check the "
+"status of the service."
+msgstr ""
+"Specify the command that monitoring engine will run in order to check the "
+"status of the service."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Specify the command that should be used to check if the host is up or down. "
+"Typically, this command would try and ping the host to see if it is "
+"\"alive\". On a non-OK state monitoring engine will assume the host is down. "
+"A blank argument disables active checks for the host status and Monitoring "
+"Engine will always assume the host is up. This is useful if you are "
+"monitoring printers or other devices that are frequently turned off."
+msgstr ""
+"Specify the command that should be used to check if the host is up or down. "
+"Typically, this command would try and ping the host to see if it is "
+"\"alive\". On a non-OK state monitoring engine will assume the host is down. "
+"A blank argument disables active checks for the host status and Monitoring "
+"Engine will always assume the host is up. This is useful if you are "
+"monitoring printers or other devices that are frequently turned off."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Specify the freshness threshold (in seconds) for this host. If you set this "
+"directive to a value of 0, monitoring engine will determine a freshness "
+"threshold to use automatically."
+msgstr ""
+"Specify the freshness threshold (in seconds) for this host. If you set this "
+"directive to a value of 0, monitoring engine will determine a freshness "
+"threshold to use automatically."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the high state change threshold used in flap detection for this "
+"service. A service with a state change rate above or equal to this threshold "
+"is marked as flapping. By setting the value to 0, the program-wide value "
+"will be used."
+msgstr ""
+"Specify the high state change threshold used in flap detection for this "
+"service. A service with a state change rate above or equal to this threshold "
+"is marked as flapping. By setting the value to 0, the program-wide value "
+"will be used."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the hostgroup(s) that this service \"runs\" on or is associated "
+"with. One or more hostgroup(s) may be used instead of, or in addition to, "
+"specifying hosts."
+msgstr ""
+"Specify the hostgroup(s) that this service \"runs\" on or is associated "
+"with. One or more hostgroup(s) may be used instead of, or in addition to, "
+"specifying hosts."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the low state change threshold used in flap detection for this "
+"service. A service with a state change rate below this threshold is marked "
+"normal. By setting the value to 0, the program-wide value will be used."
+msgstr ""
+"Specify the low state change threshold used in flap detection for this "
+"service. A service with a state change rate below this threshold is marked "
+"normal. By setting the value to 0, the program-wide value will be used."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Specify the parameters for the selected check command here."
+msgstr "Specify the parameters for the selected check command here."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Specify the parameters for the selected check command here. The format is: !"
+"ARG1!ARG2!...ARGn"
+msgstr ""
+"Specify the parameters for the selected check command here. The format is: !"
+"ARG1!ARG2!...ARGn"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Specify the primary email address for the contact here. Additional (email) "
+"addresses can be defined under additional information of the contact. "
+"Depending on the notification command used, the email address can be used to "
+"send out email notifications."
+msgstr ""
+"Specify the primary email address for the contact here. Additional (email) "
+"addresses can be defined under additional information of the contact. "
+"Depending on the notification command used, the email address can be used to "
+"send out email notifications."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the relation of known SNMP traps to state changes of this service."
+msgstr ""
+"Specify the relation of known SNMP traps to state changes of this service."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Specify the source for user credentials. Choose between Centreon and LDAP, "
+"whereas LDAP is only available when configured in Administration Options."
+msgstr ""
+"Specify the source for user credentials. Choose between Centreon and LDAP, "
+"whereas LDAP is only available when configured in Administration Options."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the time period during which active checks of this service can be "
+"made."
+msgstr ""
+"Specify the time period during which active checks of this service can be "
+"made."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Specify the time period during which notifications of events for this host "
+"can be sent out to contacts. If a state change occurs during a time which is "
+"not covered by the time period, no notifications will be sent out."
+msgstr ""
+"Specify the time period during which notifications of events for this host "
+"can be sent out to contacts. If a state change occurs during a time which is "
+"not covered by the time period, no notifications will be sent out."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify the time period during which notifications of events for this "
+"service can be sent out to contacts. If a state change occurs during a time "
+"which is not covered by the time period, no notifications will be sent out."
+msgstr ""
+"Specify the time period during which notifications of events for this "
+"service can be sent out to contacts. If a state change occurs during a time "
+"which is not covered by the time period, no notifications will be sent out."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Specify the time period during which the contact can be notified about host "
+"problems or recoveries. You can think of this as an \"on call\" time for "
+"host notifications for the contact."
+msgstr ""
+"Specify the time period during which the contact can be notified about host "
+"problems or recoveries. You can think of this as an \"on call\" time for "
+"host notifications for the contact."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Specify the time period during which the contact can be notified about "
+"service problems or recoveries. You can think of this as an \"on call\" time "
+"for service notifications for the contact."
+msgstr ""
+"Specify the time period during which the contact can be notified about "
+"service problems or recoveries. You can think of this as an \"on call\" time "
+"for service notifications for the contact."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"Specify the time period during which the meta service status is measured."
+msgstr ""
+"Specify the time period during which the meta service status is measured."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify whether or not non-status information about the service is retained "
+"across program restarts. This is only useful if you have enabled state "
+"retention using the retain_state_information directive."
+msgstr ""
+"Specify whether or not non-status information about the service is retained "
+"across program restarts. This is only useful if you have enabled state "
+"retention using the retain_state_information directive."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid "Specify whether or not notifications for this host are enabled."
+msgstr "Specify whether or not notifications for this host are enabled."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid "Specify whether or not notifications for this meta service are enabled."
+msgstr ""
+"Specify whether or not notifications for this meta service are enabled."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "Specify whether or not notifications for this service are enabled."
+msgstr "Specify whether or not notifications for this service are enabled."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify whether or not status-related information about the service is "
+"retained across program restarts. This is only useful if you have enabled "
+"state retention using the retain_state_information directive."
+msgstr ""
+"Specify whether or not status-related information about the service is "
+"retained across program restarts. This is only useful if you have enabled "
+"state retention using the retain_state_information directive."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify whether or not the processing of performance data is enabled for "
+"this service."
+msgstr ""
+"Specify whether or not the processing of performance data is enabled for "
+"this service."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"Specify whether or not the service will inherit host's contacts and "
+"contactgroups (if no contacts or contactgroups are defined for the service)."
+msgstr ""
+"Specify whether or not the service will inherit host's contacts and "
+"contactgroups (if no contacts or contactgroups are defined for the service)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Specify whether this configuration is currently active or not. This way you "
+"can test different configuration sets for one monitoring node."
+msgstr ""
+"Specify whether this configuration is currently active or not. This way you "
+"can test different configuration sets for one monitoring node."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Submit or not the status to the monitoring engine, related to the rules"
+msgstr ""
+"Submit or not the status to the monitoring engine, related to the rules"
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid "Switch the submission of trap results to monitoring engine on or off."
+msgstr "Switch the submission of trap results to monitoring engine on or off."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Switch token_endpoint_auth_method from client_secret_post to "
+"client_secret_basic"
+msgstr ""
+"Switch token_endpoint_auth_method from client_secret_post to "
+"client_secret_basic"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Target DBMS."
+msgstr "Target DBMS."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Template for LDAP attribute"
+msgstr "Template for LDAP attribute"
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Temporary directory used by backup process"
+msgstr "Temporary directory used by backup process"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The LDAP attribute for relation between group and user"
+msgstr "The LDAP attribute for relation between group and user"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+#, php-format
+msgid ""
+"The LDAP search filter for groups<br/>Use %s in filter. The %s will replaced "
+"by group name in autologin or * in contactgroup field"
+msgstr ""
+"The LDAP search filter for groups<br/>Use %s in filter. The %s will replaced "
+"by group name in autologin or * in contactgroup field"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+#, php-format
+msgid ""
+"The LDAP search filter for users<br/>Use %s in filter. The %s will replaced "
+"by login in autologin or * in LDAP import"
+msgstr ""
+"The LDAP search filter for users<br/>Use %s in filter. The %s will replaced "
+"by login in autologin or * in LDAP import"
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"The SNMP community and version specified here can be referenced in the check "
+"command by using the $_HOSTSNMPCOMMUNITY$ and $_HOSTSNMPVERSION$ macros."
+msgstr ""
+"The SNMP community and version specified here can be referenced in the check "
+"command by using the $_HOSTSNMPCOMMUNITY$ and $_HOSTSNMPVERSION$ macros."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"The TCP port used to communicate with rrdcached.\n"
+" This is a global option, go to Administration > Options > RRDTool to modify "
+"it."
+msgstr ""
+"The TCP port used to communicate with rrdcached.\n"
+" This is a global option, go to Administration > Options > RRDTool to modify "
+"it."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"The Unix socket used to communicate with rrdcached.\n"
+" This is a global option, go to Administration > Options > RRDTool to modify "
+"it."
+msgstr ""
+"The Unix socket used to communicate with rrdcached.\n"
+" This is a global option, go to Administration > Options > RRDTool to modify "
+"it."
+
+#: centreon/www/include/Administration/parameters/rrdtool/help.php
+msgid "The absolute path to unix socket for communicating with rrdcached"
+msgstr "The absolute path to unix socket for communicating with rrdcached"
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/help.php
+msgid "The alias is a longer name or description for the vendor/manufacturer."
+msgstr "The alias is a longer name or description for the vendor/manufacturer."
+
+#: centreon/www/include/configuration/configObject/contactgroup/help.php
+msgid ""
+"The alias is a longer name or description used to identify the contact group."
+msgstr ""
+"The alias is a longer name or description used to identify the contact group."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "The alias is a short name used as login name in Centreon."
+msgstr "The alias is a short name used as login name in Centreon."
+
+#: centreon/www/include/configuration/configObject/escalation/help.php
+msgid ""
+"The alias is used to define a longer name or description for the escalation."
+msgstr ""
+"The alias is used to define a longer name or description for the escalation."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid "The alias is used to define a longer name or description for the host."
+msgstr "The alias is used to define a longer name or description for the host."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"The argument description provided here will be displayed instead of the "
+"technical names like ARGn."
+msgstr ""
+"The argument description provided here will be displayed instead of the "
+"technical names like ARGn."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"The argument example defined here will be displayed together with the "
+"command selection and help in providing a hint of how to parametrize the "
+"command for execution."
+msgstr ""
+"The argument example defined here will be displayed together with the "
+"command selection and help in providing a hint of how to parametrize the "
+"command for execution."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The base DN for search groups"
+msgstr "The base DN for search groups"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The base DN for search users"
+msgstr "The base DN for search users"
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"The command line specifies the real command line which is actually executed "
+"by Monitoring engine. Before execution, all valid macros are replaced with "
+"their respective values. To use the dollar sign ($) on the command line, you "
+"have to escape it with another dollar sign ($$). A semicolon (;) is used as "
+"separator for config file comments and must be worked around by setting a "
+"$USER$ macro to a semicolon and then referencing it here in place of the "
+"semicolon. If you want to pass arguments to commands during runtime, you can "
+"use $ARGn$ macros in the command line."
+msgstr ""
+"The command line specifies the real command line which is actually executed "
+"by Monitoring engine. Before execution, all valid macros are replaced with "
+"their respective values. To use the dollar sign ($) on the command line, you "
+"have to escape it with another dollar sign ($$). A semicolon (;) is used as "
+"separator for config file comments and must be worked around by setting a "
+"$USER$ macro to a semicolon and then referencing it here in place of the "
+"semicolon. If you want to pass arguments to commands during runtime, you can "
+"use $ARGn$ macros in the command line."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"The command name is used to identify and display this command in contact, "
+"host and service definitions."
+msgstr ""
+"The command name is used to identify and display this command in contact, "
+"host and service definitions."
+
+#: centreon/www/include/configuration/configObject/connector/help.php
+msgid "The connector binary that centreon-engine will launch."
+msgstr "The connector binary that centreon-engine will launch."
+
+#: centreon/www/include/configuration/configObject/contactgroup/help.php
+msgid ""
+"The contact group name is a short name used to identify the contact group in "
+"other sections."
+msgstr ""
+"The contact group name is a short name used to identify the contact group in "
+"other sections."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid ""
+"The contact template for auto imported user.<br/>This template is applied "
+"for Monitoring Engine contact configuration and ACLs."
+msgstr ""
+"The contact template for auto imported user.<br/>This template is applied "
+"for Monitoring Engine contact configuration and ACLs."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"The event handler command is triggered whenever a change in the state of the "
+"host is detected, i.e. whenever it goes down or recovers."
+msgstr ""
+"The event handler command is triggered whenever a change in the state of the "
+"host is detected, i.e. whenever it goes down or recovers."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"The full name is used to identify the contact in contact group definitions "
+"and in notifications."
+msgstr ""
+"The full name is used to identify the contact in contact group definitions "
+"and in notifications."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The group attribute for user"
+msgstr "The group attribute for user"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The group name<br/>In Centreon : Contact Group Name"
+msgstr "The group name<br/>In Centreon : Contact Group Name"
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"The header variable that will be used as login. i.e: "
+"$_SERVER['HTTP_AUTH_USER']"
+msgstr ""
+"The header variable that will be used as login. i.e: "
+"$_SERVER['HTTP_AUTH_USER']"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"The higher the buffer size is, the best compression.\n"
+" This however increase data streaming latency. Use with caution."
+msgstr ""
+"The higher the buffer size is, the best compression.\n"
+" This however increase data streaming latency. Use with caution."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"The interval between check if some metrics must be rebuild. The default "
+"value is 300s"
+msgstr ""
+"The interval between check if some metrics must be rebuild. The default "
+"value is 300s"
+
+#: centreon/www/include/configuration/configObject/contactgroup/help.php
+msgid ""
+"The linked contacts define a list of contacts that should be included in "
+"this group. This definition is an alternative way to specifying the contact "
+"groups in contact definitions."
+msgstr ""
+"The linked contacts define a list of contacts that should be included in "
+"this group. This definition is an alternative way to specifying the contact "
+"groups in contact definitions."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The login attribute<br/>In Centreon : Alias / Login"
+msgstr "The login attribute<br/>In Centreon : Alias / Login"
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"The macro description provided here will be displayed instead of the "
+"technical name."
+msgstr ""
+"The macro description provided here will be displayed instead of the "
+"technical name."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "The maximum queries per transaction before commit."
+msgstr "The maximum queries per transaction before commit."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "The maximum size of log file."
+msgstr "The maximum size of log file."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid "The monitoring overview will be displayed at the top of all pages."
+msgstr "The monitoring overview will be displayed at the top of all pages."
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"The monitoring poller status overview will be displayed at the top of all "
+"pages."
+msgstr ""
+"The monitoring poller status overview will be displayed at the top of all "
+"pages."
+
+#: centreon/www/include/configuration/configObject/traps-groups/help.php
+msgid "The name is used to identify the group with a short name."
+msgstr "The name is used to identify the group with a short name."
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/help.php
+msgid "The name is used to identify the vendor/manufacturer with a short name."
+msgstr ""
+"The name is used to identify the vendor/manufacturer with a short name."
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid "The name of the recurrent downtime rule."
+msgstr "The name of the recurrent downtime rule."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "The number elements loaded in async select."
+msgstr "The number elements loaded in async select."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"The optional definition of a graph template will be used as default graph "
+"template for this service."
+msgstr ""
+"The optional definition of a graph template will be used as default graph "
+"template for this service."
+
+#: centreon/www/include/configuration/configObject/command/help.php
+msgid ""
+"The optional definition of a graph template will be used as default graph "
+"template, when no other is specified."
+msgstr ""
+"The optional definition of a graph template will be used as default graph "
+"template, when no other is specified."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"The pattern to search for in the username. If i want to remove the domain of "
+"the email: /@.*/"
+msgstr ""
+"The pattern to search for in the username. If i want to remove the domain of "
+"the email: /@.*/"
+
+#: centreon/www/include/options/accessLists/actionsACL/help.php
+msgid ""
+"The poller filter will be available to users in the monitoring consoles."
+msgstr ""
+"The poller filter will be available to users in the monitoring consoles."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "The string to replace."
+msgstr "The string to replace."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "The transaction timeout before running commit."
+msgstr "The transaction timeout before running commit."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The user email<br/>In Centreon : Email"
+msgstr "The user email<br/>In Centreon : Email"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The user firstname<br/>In Centreon : givenname"
+msgstr "The user firstname<br/>In Centreon : givenname"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The user lastname<br/>In Centreon : sn"
+msgstr "The user lastname<br/>In Centreon : sn"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The user name<br/>In Centreon : Full Name"
+msgstr "The user name<br/>In Centreon : Full Name"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "The user pager<br/>In Centreon : Pager"
+msgstr "The user pager<br/>In Centreon : Pager"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid ""
+"The version protocol for connect to LDAP<br/>Use version 3 for Active "
+"Directory"
+msgstr ""
+"The version protocol for connect to LDAP<br/>Use version 3 for Active "
+"Directory"
+
+#: centreon/www/include/configuration/configObject/timeperiod/help.php
+msgid ""
+"The weekday directives are comma-delimited lists of time ranges that are "
+"\"valid\" times for a particular day of the week. Each time range is in the "
+"form of HH:MM-HH:MM, where hours are specified on a 24 hour clock. For "
+"example, 00:15-24:00 means 12:15am in the morning for this day until 12:00am "
+"midnight (a 23 hour, 45 minute total time range). If you wish to exclude an "
+"entire day from the timeperiod, simply do not include it in the timeperiod "
+"definition."
+msgstr ""
+"The weekday directives are comma-delimited lists of time ranges that are "
+"\"valid\" times for a particular day of the week. Each time range is in the "
+"form of HH:MM-HH:MM, where hours are specified on a 24 hour clock. For "
+"example, 00:15-24:00 means 12:15am in the morning for this day until 12:00am "
+"midnight (a 23 hour, 45 minute total time range). If you wish to exclude an "
+"entire day from the timeperiod, simply do not include it in the timeperiod "
+"definition."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "This allows the retention to work even if the socket is listening"
+msgstr "This allows the retention to work even if the socket is listening"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "This can be used to disable graph update and therefore reduce I/O"
+msgstr "This can be used to disable graph update and therefore reduce I/O"
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive determines whether or not checks for the service will be "
+"\"obsessed\" over. When enabled the obsess over service command will be "
+"executed after every check of this service."
+msgstr ""
+"This directive determines whether or not checks for the service will be "
+"\"obsessed\" over. When enabled the obsess over service command will be "
+"executed after every check of this service."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive determines whether or not checks for this host will be "
+"\"obsessed\" over. When enabled the obsess over host command will be "
+"executed after every check of this host."
+msgstr ""
+"This directive determines whether or not checks for this host will be "
+"\"obsessed\" over. When enabled the obsess over host command will be "
+"executed after every check of this host."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive determines which host states \"stalking\" is enabled for."
+msgstr ""
+"This directive determines which host states \"stalking\" is enabled for."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive indicates whether or not the dependency inherits dependencies "
+"of the host that is being depended upon (also referred to as the master "
+"host). In other words, if the master host is dependent upon other hosts and "
+"any one of those dependencies fail, this dependency will also fail."
+msgstr ""
+"This directive indicates whether or not the dependency inherits dependencies "
+"of the host that is being depended upon (also referred to as the master "
+"host). In other words, if the master host is dependent upon other hosts and "
+"any one of those dependencies fail, this dependency will also fail."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to define an alternate name that should be displayed "
+"in the web interface for this host. If not specified, this defaults to the "
+"value you specify as host name."
+msgstr ""
+"This directive is used to define an alternate name that should be displayed "
+"in the web interface for this host. If not specified, this defaults to the "
+"value you specify as host name."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to define an alternate name that should be displayed "
+"in the web interface for this service. If not specified, this defaults to "
+"the value you specify as service description."
+msgstr ""
+"This directive is used to define an alternate name that should be displayed "
+"in the web interface for this service. If not specified, this defaults to "
+"the value you specify as service description."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This directive is used to define an optional URL that can be used to provide "
+"more actions to be performed on the service group. Any valid URL can be "
+"used. If you plan on using relative paths, the base path will be the same as "
+"what is used to access the CGIs (i.e. /cgi-bin/nagios/)."
+msgstr ""
+"This directive is used to define an optional URL that can be used to provide "
+"more actions to be performed on the service group. Any valid URL can be "
+"used. If you plan on using relative paths, the base path will be the same as "
+"what is used to access the CGIs (i.e. /cgi-bin/nagios/)."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This directive is used to define an optional URL that can be used to provide "
+"more information about the service group. Any valid URL can be used. If you "
+"plan on using relative paths, the base path will be the same as what is used "
+"to access the CGIs (i.e. /cgi-bin/nagios/). This can be very useful if you "
+"want to make detailed information on the service group, emergency contact "
+"methods, etc. available to other support staff."
+msgstr ""
+"This directive is used to define an optional URL that can be used to provide "
+"more information about the service group. Any valid URL can be used. If you "
+"plan on using relative paths, the base path will be the same as what is used "
+"to access the CGIs (i.e. /cgi-bin/nagios/). This can be very useful if you "
+"want to make detailed information on the service group, emergency contact "
+"methods, etc. available to other support staff."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This directive is used to define an optional string of notes pertaining to "
+"the service group. If you specify a note here, you will see it in the "
+"extended information CGI (when you are viewing information about the "
+"specified service group)."
+msgstr ""
+"This directive is used to define an optional string of notes pertaining to "
+"the service group. If you specify a note here, you will see it in the "
+"extended information CGI (when you are viewing information about the "
+"specified service group)."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to define the criteria that determine when "
+"notifications for the dependent host should not be sent out. If the master "
+"host is in one of the failure states we specify, notifications for the "
+"dependent host will not be sent to contacts. If you specify None as an "
+"option, the notification dependency will never fail and notifications for "
+"the dependent host will always be sent out."
+msgstr ""
+"This directive is used to define the criteria that determine when "
+"notifications for the dependent host should not be sent out. If the master "
+"host is in one of the failure states we specify, notifications for the "
+"dependent host will not be sent to contacts. If you specify None as an "
+"option, the notification dependency will never fail and notifications for "
+"the dependent host will always be sent out."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to denote whether the service is \"volatile\". A "
+"volatile service resets its state to OK with every query. Services are "
+"normally not volatile."
+msgstr ""
+"This directive is used to denote whether the service is \"volatile\". A "
+"volatile service resets its state to OK with every query. Services are "
+"normally not volatile."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine what host states the flap detection "
+"logic will use for this host."
+msgstr ""
+"This directive is used to determine what host states the flap detection "
+"logic will use for this host."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to determine what service states the flap detection "
+"logic will use for this service."
+msgstr ""
+"This directive is used to determine what service states the flap detection "
+"logic will use for this service."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine whether or not flap detection is enabled "
+"for this host."
+msgstr ""
+"This directive is used to determine whether or not flap detection is enabled "
+"for this host."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to determine whether or not flap detection is enabled "
+"for this service. A service is marked as flapping when frequent state "
+"changes occur."
+msgstr ""
+"This directive is used to determine whether or not flap detection is enabled "
+"for this service. A service is marked as flapping when frequent state "
+"changes occur."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine whether or not freshness checks are "
+"enabled for this host. When enabled monitoring engine will trigger an active "
+"check when last passive result is older than the value defined in the "
+"threshold. By default freshness checks are enabled."
+msgstr ""
+"This directive is used to determine whether or not freshness checks are "
+"enabled for this host. When enabled monitoring engine will trigger an active "
+"check when last passive result is older than the value defined in the "
+"threshold. By default freshness checks are enabled."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to determine whether or not freshness checks are "
+"enabled for this service. When enabled monitoring engine will trigger an "
+"active check when last passive result is older than the value defined in the "
+"threshold. By default freshness checks are enabled."
+msgstr ""
+"This directive is used to determine whether or not freshness checks are "
+"enabled for this service. When enabled monitoring engine will trigger an "
+"active check when last passive result is older than the value defined in the "
+"threshold. By default freshness checks are enabled."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"This directive is used to determine whether or not non-status information "
+"about the contact is retained across program restarts. This is only useful "
+"if you have enabled state retention using the retain_state_information "
+"directive."
+msgstr ""
+"This directive is used to determine whether or not non-status information "
+"about the contact is retained across program restarts. This is only useful "
+"if you have enabled state retention using the retain_state_information "
+"directive."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine whether or not non-status information "
+"about the host is retained across program restarts. This is only useful if "
+"you have enabled state retention using the retain_state_information "
+"directive."
+msgstr ""
+"This directive is used to determine whether or not non-status information "
+"about the host is retained across program restarts. This is only useful if "
+"you have enabled state retention using the retain_state_information "
+"directive."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"This directive is used to determine whether or not status-related "
+"information about the contact is retained across program restarts. This is "
+"only useful if you have enabled state retention using the "
+"retain_state_information directive."
+msgstr ""
+"This directive is used to determine whether or not status-related "
+"information about the contact is retained across program restarts. This is "
+"only useful if you have enabled state retention using the "
+"retain_state_information directive."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine whether or not status-related "
+"information about the host is retained across program restarts. This is only "
+"useful if you have enabled the global state retention option."
+msgstr ""
+"This directive is used to determine whether or not status-related "
+"information about the host is retained across program restarts. This is only "
+"useful if you have enabled the global state retention option."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"This directive is used to determine whether or not the contact can submit "
+"external commands to monitoring engine from the CGIs."
+msgstr ""
+"This directive is used to determine whether or not the contact can submit "
+"external commands to monitoring engine from the CGIs."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"This directive is used to determine whether or not the contact will receive "
+"notifications about host problems and recoveries."
+msgstr ""
+"This directive is used to determine whether or not the contact will receive "
+"notifications about host problems and recoveries."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"This directive is used to determine whether or not the contact will receive "
+"notifications about service problems and recoveries."
+msgstr ""
+"This directive is used to determine whether or not the contact will receive "
+"notifications about service problems and recoveries."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine whether or not the event handler for "
+"this host is enabled."
+msgstr ""
+"This directive is used to determine whether or not the event handler for "
+"this host is enabled."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to determine whether or not the event handler for "
+"this service is enabled."
+msgstr ""
+"This directive is used to determine whether or not the event handler for "
+"this service is enabled."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to determine whether or not the processing of "
+"performance data is enabled for this host."
+msgstr ""
+"This directive is used to determine whether or not the processing of "
+"performance data is enabled for this host."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+msgid "This directive is used to identify the dependent host(s)."
+msgstr "This directive is used to identify the dependent host(s)."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the dependent host."
+msgstr ""
+"This directive is used to identify the description of the dependent host."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the dependent meta "
+"service."
+msgstr ""
+"This directive is used to identify the description of the dependent meta "
+"service."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the dependent service "
+"group."
+msgstr ""
+"This directive is used to identify the description of the dependent service "
+"group."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the dependent service."
+msgstr ""
+"This directive is used to identify the description of the dependent service."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the meta service that "
+"is being depended upon (also referred to as the master meta service)."
+msgstr ""
+"This directive is used to identify the description of the meta service that "
+"is being depended upon (also referred to as the master meta service)."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the service group that "
+"is being depended upon (also referred to as the master service group)."
+msgstr ""
+"This directive is used to identify the description of the service group that "
+"is being depended upon (also referred to as the master service group)."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the description of the service that is "
+"being depended upon (also referred to as the master service)."
+msgstr ""
+"This directive is used to identify the description of the service that is "
+"being depended upon (also referred to as the master service)."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the host(s) that the dependent service "
+"\"runs\" on or is associated with. Leaving this directive blank can be used "
+"to create \"same host\" dependencies."
+msgstr ""
+"This directive is used to identify the host(s) that the dependent service "
+"\"runs\" on or is associated with. Leaving this directive blank can be used "
+"to create \"same host\" dependencies."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the host(s) that the service that is "
+"being depended upon (also referred to as the master service) \"runs\" on or "
+"is associated with."
+msgstr ""
+"This directive is used to identify the host(s) that the service that is "
+"being depended upon (also referred to as the master service) \"runs\" on or "
+"is associated with."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+msgid ""
+"This directive is used to identify the short name(s) of the dependent "
+"hostgroup(s). The dependent_hostgroup_name may be used instead of, or in "
+"addition to, the dependent_host_name directive."
+msgstr ""
+"This directive is used to identify the short name(s) of the dependent "
+"hostgroup(s). The dependent_hostgroup_name may be used instead of, or in "
+"addition to, the dependent_host_name directive."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+msgid ""
+"This directive is used to identify the short name(s) of the host(s) that is "
+"being depended upon (also referred to as the master host)."
+msgstr ""
+"This directive is used to identify the short name(s) of the host(s) that is "
+"being depended upon (also referred to as the master host)."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+msgid ""
+"This directive is used to identify the short name(s) of the hostgroup(s) "
+"that is being depended upon (also referred to as the master host). The "
+"hostgroup_name may be used instead of, or in addition to, the host_name "
+"directive."
+msgstr ""
+"This directive is used to identify the short name(s) of the hostgroup(s) "
+"that is being depended upon (also referred to as the master host). The "
+"hostgroup_name may be used instead of, or in addition to, the host_name "
+"directive."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to identify the short name(s) of the hostgroup(s) "
+"that the service that is being depended upon (also referred to as the master "
+"service) \"runs\" on or is associated with. Multiple hostgroups should be "
+"separated by commas. The hostgroup_name may be used instead of, or in "
+"addition to, the host_name directive."
+msgstr ""
+"This directive is used to identify the short name(s) of the hostgroup(s) "
+"that the service that is being depended upon (also referred to as the master "
+"service) \"runs\" on or is associated with. Multiple hostgroups should be "
+"separated by commas. The hostgroup_name may be used instead of, or in "
+"addition to, the host_name directive."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This directive is used to specify an event broker module that should by "
+"loaded by Monitoring Engine at startup. Use multiple directives if you want "
+"to load more than one module. Arguments that should be passed to the module "
+"at startup are separated from the module path by a space."
+msgstr ""
+"This directive is used to specify an event broker module that should by "
+"loaded by Monitoring Engine at startup. Use multiple directives if you want "
+"to load more than one module. Arguments that should be passed to the module "
+"at startup are separated from the module path by a space."
+
+#: centreon/www/include/configuration/configObject/timeperiod/help.php
+msgid ""
+"This directive is used to specify other timeperiod definitions whose time "
+"ranges should be excluded from this timeperiod."
+msgstr ""
+"This directive is used to specify other timeperiod definitions whose time "
+"ranges should be excluded from this timeperiod."
+
+#: centreon/www/include/configuration/configObject/timeperiod/help.php
+msgid ""
+"This directive is used to specify other timeperiod used as a timeperiod "
+"model."
+msgstr ""
+"This directive is used to specify other timeperiod used as a timeperiod "
+"model."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to specify the command that should be run whenever a "
+"change in the state of the service is detected (i.e. whenever it changes to "
+"non-OK or recovers)."
+msgstr ""
+"This directive is used to specify the command that should be run whenever a "
+"change in the state of the service is detected (i.e. whenever it changes to "
+"non-OK or recovers)."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to specify the criteria that determine when the "
+"dependent host should not be actively checked. If the master host is in one "
+"of the failure states we specify, the dependent host will not be actively "
+"checked. If you specify None as an option, the execution dependency will "
+"never fail and the dependent host will always be actively checked (if other "
+"conditions allow for it to be)."
+msgstr ""
+"This directive is used to specify the criteria that determine when the "
+"dependent host should not be actively checked. If the master host is in one "
+"of the failure states we specify, the dependent host will not be actively "
+"checked. If you specify None as an option, the execution dependency will "
+"never fail and the dependent host will always be actively checked (if other "
+"conditions allow for it to be)."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This directive is used to specify the freshness threshold (in seconds) for "
+"this service. If you set this directive to a value of 0, monitoring engine "
+"will determine a freshness threshold to use automatically."
+msgstr ""
+"This directive is used to specify the freshness threshold (in seconds) for "
+"this service. If you set this directive to a value of 0, monitoring engine "
+"will determine a freshness threshold to use automatically."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to specify the high state change threshold used in "
+"flap detection for this host. If you set this directive to a value of 0, the "
+"program-wide value will be used."
+msgstr ""
+"This directive is used to specify the high state change threshold used in "
+"flap detection for this host. If you set this directive to a value of 0, the "
+"program-wide value will be used."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to specify the low state change threshold used in "
+"flap detection for this host. If you set this directive to a value of 0, the "
+"program-wide value will be used."
+msgstr ""
+"This directive is used to specify the low state change threshold used in "
+"flap detection for this host. If you set this directive to a value of 0, the "
+"program-wide value will be used."
+
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to specify the short name (s) of the hostgroup(s) "
+"that the dependent service \"runs\" on or is associated with. The "
+"dependent_hostgroup may be used instead of, or in addition to, the "
+"dependent_host directive."
+msgstr ""
+"This directive is used to specify the short name (s) of the hostgroup(s) "
+"that the dependent service \"runs\" on or is associated with. The "
+"dependent_hostgroup may be used instead of, or in addition to, the "
+"dependent_host directive."
+
+#: centreon/www/include/configuration/configObject/host_dependency/help.php
+#: centreon/www/include/configuration/configObject/service_dependency/help.php
+msgid ""
+"This directive is used to specify the short name of the time period during "
+"which this dependency is valid. If this directive is not specified, the "
+"dependency is considered to be valid during all times."
+msgstr ""
+"This directive is used to specify the short name of the time period during "
+"which this dependency is valid. If this directive is not specified, the "
+"dependency is considered to be valid during all times."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This directive is used to specify the time period during which active checks "
+"of this host can be executed."
+msgstr ""
+"This directive is used to specify the time period during which active checks "
+"of this host can be executed."
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid ""
+"This field give the possibility to configure the frequency of this downtime."
+msgstr ""
+"This field give the possibility to configure the frequency of this downtime."
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid ""
+"This field give you the possibility to select all hostgroups and all hosts "
+"contained into the selected hostgroups implied by this downtime"
+msgstr ""
+"This field give you the possibility to select all hostgroups and all hosts "
+"contained into the selected hostgroups implied by this downtime"
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid ""
+"This field give you the possibility to select all hosts implied by this "
+"downtime"
+msgstr ""
+"This field give you the possibility to select all hosts implied by this "
+"downtime"
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid ""
+"This field give you the possibility to select all servicegroups and all "
+"services contained into the servicegroups implied by this downtime"
+msgstr ""
+"This field give you the possibility to select all servicegroups and all "
+"services contained into the servicegroups implied by this downtime"
+
+#: centreon/www/include/monitoring/recurrentDowntime/help.php
+msgid ""
+"This field give you the possibility to select all services implied by this "
+"downtime"
+msgstr ""
+"This field give you the possibility to select all services implied by this "
+"downtime"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid ""
+"This field is used to specify the interval, in hours, between two LDAP data "
+"synchronization. By default 1 hour."
+msgstr ""
+"This field is used to specify the interval, in hours, between two LDAP data "
+"synchronization. By default 1 hour."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This field should be filled only if filtering option is enabled. You can "
+"define the list of macros that should be sent to Centreon Broker."
+msgstr ""
+"This field should be filled only if filtering option is enabled. You can "
+"define the list of macros that should be sent to Centreon Broker."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This is a list of contact groups that should be notified whenever there are "
+"problems (or recoveries) with this host. You must specify at least one "
+"contact or contact group in each host definition."
+msgstr ""
+"This is a list of contact groups that should be notified whenever there are "
+"problems (or recoveries) with this host. You must specify at least one "
+"contact or contact group in each host definition."
+
+#: centreon/www/include/configuration/configObject/meta_service/help.php
+msgid ""
+"This is a list of contact groups that should be notified whenever there are "
+"problems (or recoveries) with this service."
+msgstr ""
+"This is a list of contact groups that should be notified whenever there are "
+"problems (or recoveries) with this service."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This is a list of contact groups that should be notified whenever there are "
+"problems (or recoveries) with this service. You must specify at least one "
+"contact or contact group in each service definition."
+msgstr ""
+"This is a list of contact groups that should be notified whenever there are "
+"problems (or recoveries) with this service. You must specify at least one "
+"contact or contact group in each service definition."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This is a list of contacts that should be notified whenever there are "
+"problems (or recoveries) with this host. Useful if you want notifications to "
+"go to just a few people and don't want to configure contact groups. You must "
+"specify at least one contact or contact group in each host definition (or "
+"indirectly through its template)."
+msgstr ""
+"This is a list of contacts that should be notified whenever there are "
+"problems (or recoveries) with this host. Useful if you want notifications to "
+"go to just a few people and don't want to configure contact groups. You must "
+"specify at least one contact or contact group in each host definition (or "
+"indirectly through its template)."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This is a list of contacts that should be notified whenever there are "
+"problems (or recoveries) with this service. Useful if you want notifications "
+"to go to just a few people and don't want to configure contact groups. You "
+"must specify at least one contact or contact group in each service "
+"definition (or indirectly through its template)."
+msgstr ""
+"This is a list of contacts that should be notified whenever there are "
+"problems (or recoveries) with this service. Useful if you want notifications "
+"to go to just a few people and don't want to configure contact groups. You "
+"must specify at least one contact or contact group in each service "
+"definition (or indirectly through its template)."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This is a list of host group-bound services that should be included in this "
+"service group."
+msgstr ""
+"This is a list of host group-bound services that should be included in this "
+"service group."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This is a list of host-bound services that should be included in this "
+"service group."
+msgstr ""
+"This is a list of host-bound services that should be included in this "
+"service group."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This is a list of service templates that should be included in this service "
+"group. Service template needs to be associated with a host template in order "
+"to show up here."
+msgstr ""
+"This is a list of service templates that should be included in this service "
+"group. Service template needs to be associated with a host template in order "
+"to show up here."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is an advanced feature. This option determines how many buffer slots "
+"Monitoring Engine will reserve for caching external commands that have been "
+"read from the external command file by a worker thread, but have not yet "
+"been processed by the main thread of the Monitoring Engine daemon. This "
+"option essentially determines how many commands can be buffered. For "
+"installations where you process a large number of passive checks (e.g. "
+"distributed setups), you may need to increase this number. You should "
+"consider using MRTG to graph Monitoring Engine' usage of external command "
+"buffers."
+msgstr ""
+"This is an advanced feature. This option determines how many buffer slots "
+"Monitoring Engine will reserve for caching external commands that have been "
+"read from the external command file by a worker thread, but have not yet "
+"been processed by the main thread of the Monitoring Engine daemon. This "
+"option essentially determines how many commands can be buffered. For "
+"installations where you process a large number of passive checks (e.g. "
+"distributed setups), you may need to increase this number. You should "
+"consider using MRTG to graph Monitoring Engine' usage of external command "
+"buffers."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This is required so that you can access your host after creation. Some "
+"selected resource groups may contain filter, thus still preventing you from "
+"seeing the new host. In this case, make sure to link your Host to a Host "
+"Category."
+msgstr ""
+"This is required so that you can access your host after creation. Some "
+"selected resource groups may contain filter, thus still preventing you from "
+"seeing the new host. In this case, make sure to link your Host to a Host "
+"Category."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the email address for the administrator of the local machine (i.e. "
+"the one that Monitoring Engine is running on). This value can be used in "
+"notification commands by using the $ADMINEMAIL$ macro."
+msgstr ""
+"This is the email address for the administrator of the local machine (i.e. "
+"the one that Monitoring Engine is running on). This value can be used in "
+"notification commands by using the $ADMINEMAIL$ macro."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the file that Monitoring Engine uses to store the current status, "
+"comment, and downtime information. This file is deleted every time "
+"Monitoring Engine stops and recreated when it starts."
+msgstr ""
+"This is the file that Monitoring Engine uses to store the current status, "
+"comment, and downtime information. This file is deleted every time "
+"Monitoring Engine stops and recreated when it starts."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the file that Monitoring Engine will check for external commands to "
+"process. Centreon writes commands to this file. The external command file is "
+"implemented as a named pipe (FIFO), which is created when Monitoring Engine "
+"starts and removed when it shuts down. If the file exists when Monitoring "
+"Engine starts, the Monitoring Engine process will terminate with an error "
+"message."
+msgstr ""
+"This is the file that Monitoring Engine will check for external commands to "
+"process. Centreon writes commands to this file. The external command file is "
+"implemented as a named pipe (FIFO), which is created when Monitoring Engine "
+"starts and removed when it shuts down. If the file exists when Monitoring "
+"Engine starts, the Monitoring Engine process will terminate with an error "
+"message."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the file that Monitoring Engine will use for storing status, "
+"downtime, and comment information before it shuts down. When Monitoring "
+"Engine is restarted it will use the information stored in this file for "
+"setting the initial states of services and hosts before it starts monitoring "
+"anything. In order to make Monitoring Engine retain state information "
+"between program restarts, you must enable the retain_state_information "
+"option."
+msgstr ""
+"This is the file that Monitoring Engine will use for storing status, "
+"downtime, and comment information before it shuts down. When Monitoring "
+"Engine is restarted it will use the information stored in this file for "
+"setting the initial states of services and hosts before it starts monitoring "
+"anything. In order to make Monitoring Engine retain state information "
+"between program restarts, you must enable the retain_state_information "
+"option."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the maximum number of seconds that Monitoring Engine will allow "
+"event handlers to be run. If an event handler exceeds this time limit it "
+"will be killed and a warning will be logged. This option is meant to be used "
+"as a last ditch mechanism to kill off commands which are misbehaving and not "
+"exiting in a timely manner. It should be set to something high (like 60 "
+"seconds or more), so that each event handler command normally finishes "
+"executing within this time limit. If an event handler runs longer than this "
+"limit, Monitoring Engine will kill it off thinking it is a runaway processes."
+msgstr ""
+"This is the maximum number of seconds that Monitoring Engine will allow "
+"event handlers to be run. If an event handler exceeds this time limit it "
+"will be killed and a warning will be logged. This option is meant to be used "
+"as a last ditch mechanism to kill off commands which are misbehaving and not "
+"exiting in a timely manner. It should be set to something high (like 60 "
+"seconds or more), so that each event handler command normally finishes "
+"executing within this time limit. If an event handler runs longer than this "
+"limit, Monitoring Engine will kill it off thinking it is a runaway processes."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the maximum number of seconds that Monitoring Engine will allow host "
+"checks to run. If checks exceed this limit, they are killed and a CRITICAL "
+"state is returned and the host will be assumed to be DOWN. A timeout error "
+"will also be logged. This option is meant to be used as a last ditch "
+"mechanism to kill off plugins which are misbehaving and not exiting in a "
+"timely manner. It should be set to something high (like 60 seconds or more), "
+"so that each host check normally finishes executing within this time limit. "
+"If a host check runs longer than this limit, Monitoring Engine will kill it "
+"off thinking it is a runaway processes."
+msgstr ""
+"This is the maximum number of seconds that Monitoring Engine will allow host "
+"checks to run. If checks exceed this limit, they are killed and a CRITICAL "
+"state is returned and the host will be assumed to be DOWN. A timeout error "
+"will also be logged. This option is meant to be used as a last ditch "
+"mechanism to kill off plugins which are misbehaving and not exiting in a "
+"timely manner. It should be set to something high (like 60 seconds or more), "
+"so that each host check normally finishes executing within this time limit. "
+"If a host check runs longer than this limit, Monitoring Engine will kill it "
+"off thinking it is a runaway processes."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the maximum number of seconds that Monitoring Engine will allow "
+"notification commands to be run. If a notification command exceeds this time "
+"limit it will be killed and a warning will be logged. This option is meant "
+"to be used as a last ditch mechanism to kill off commands which are "
+"misbehaving and not exiting in a timely manner. It should be set to "
+"something high (like 60 seconds or more), so that each notification command "
+"finishes executing within this time limit. If a notification command runs "
+"longer than this limit, Monitoring Engine will kill it off thinking it is a "
+"runaway processes."
+msgstr ""
+"This is the maximum number of seconds that Monitoring Engine will allow "
+"notification commands to be run. If a notification command exceeds this time "
+"limit it will be killed and a warning will be logged. This option is meant "
+"to be used as a last ditch mechanism to kill off commands which are "
+"misbehaving and not exiting in a timely manner. It should be set to "
+"something high (like 60 seconds or more), so that each notification command "
+"finishes executing within this time limit. If a notification command runs "
+"longer than this limit, Monitoring Engine will kill it off thinking it is a "
+"runaway processes."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the maximum number of seconds that the monitoring engine will allow "
+"service checks to run. If checks exceed this limit, they are killed and an "
+"UNKNOWN state is returned. A timeout error will also be logged. This option "
+"is meant to be used as a last ditch mechanism to kill off plugins which are "
+"misbehaving and not exiting in a timely manner. It should be set to "
+"something high (like 60 seconds or more), so that each service check "
+"normally finishes executing within this time limit. If a service check runs "
+"longer than this limit, the monitoring engine will kill it off, thinking it "
+"is a runaway process."
+msgstr ""
+"This is the maximum number of seconds that the monitoring engine will allow "
+"service checks to run. If checks exceed this limit, they are killed and an "
+"UNKNOWN state is returned. A timeout error will also be logged. This option "
+"is meant to be used as a last ditch mechanism to kill off plugins which are "
+"misbehaving and not exiting in a timely manner. It should be set to "
+"something high (like 60 seconds or more), so that each service check "
+"normally finishes executing within this time limit. If a service check runs "
+"longer than this limit, the monitoring engine will kill it off, thinking it "
+"is a runaway process."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"This is the number of seconds per \"unit interval\" used for timing in the "
+"scheduling queue, re-notifications, etc. \"Units intervals\" are used in the "
+"object configuration file to determine how often to run a service check, how "
+"often to re-notify a contact, etc. The default value for this is set to 60, "
+"which means that a \"unit value\" of 1 in the object configuration file will "
+"mean 60 seconds (1 minute)."
+msgstr ""
+"This is the number of seconds per \"unit interval\" used for timing in the "
+"scheduling queue, re-notifications, etc. \"Units intervals\" are used in the "
+"object configuration file to determine how often to run a service check, how "
+"often to re-notify a contact, etc. The default value for this is set to 60, "
+"which means that a \"unit value\" of 1 in the object configuration file will "
+"mean 60 seconds (1 minute)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the number of seconds that Monitoring Engine will sleep before "
+"checking to see if the next service or host check in the scheduling queue "
+"should be executed. Note that Monitoring Engine will only sleep after it "
+"\"catches up\" with queued service checks that have fallen behind."
+msgstr ""
+"This is the number of seconds that Monitoring Engine will sleep before "
+"checking to see if the next service or host check in the scheduling queue "
+"should be executed. Note that Monitoring Engine will only sleep after it "
+"\"catches up\" with queued service checks that have fallen behind."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This is the pager number (or pager email gateway) for the administrator of "
+"the local machine (i.e. the one that Monitoring Engine is running on). The "
+"pager number/address can be used in notification commands by using the "
+"$ADMINPAGER$ macro."
+msgstr ""
+"This is the pager number (or pager email gateway) for the administrator of "
+"the local machine (i.e. the one that Monitoring Engine is running on). The "
+"pager number/address can be used in notification commands by using the "
+"$ADMINPAGER$ macro."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This is where you specify the name of the template object that you want to "
+"inherit properties/variables from. Inherited properties doesn't need to be "
+"specified again. \"Local\" object variables always take precedence over "
+"variables defined in the template object. Objects can inherit properties/"
+"variables from multiple levels of template objects. When defining multiple "
+"sources, the first template specified takes precedence over the later one, "
+"in the case where a property is defined in both."
+msgstr ""
+"This is where you specify the name of the template object that you want to "
+"inherit properties/variables from. Inherited properties doesn't need to be "
+"specified again. \"Local\" object variables always take precedence over "
+"variables defined in the template object. Objects can inherit properties/"
+"variables from multiple levels of template objects. When defining multiple "
+"sources, the first template specified takes precedence over the later one, "
+"in the case where a property is defined in both."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to control how host checks are initially \"spread "
+"out\" in the event queue. Enter \"s\" for using a \"smart\" delay "
+"calculation (the default), which will cause Monitoring Engine to calculate "
+"an average check interval and spread initial checks of all hosts out over "
+"that interval, thereby helping to eliminate CPU load spikes. Using no delay "
+"(\"n\") is generally not recommended, as it will cause all host checks to be "
+"scheduled for execution at the same time. This means that you will generally "
+"have large CPU spikes when the hosts are all executed in parallel. Use a "
+"\"d\" for a \"dumb\" delay of 1 second between host checks or supply a fixed "
+"value of x.xx seconds for the inter-check delay."
+msgstr ""
+"This option allows you to control how host checks are initially \"spread "
+"out\" in the event queue. Enter \"s\" for using a \"smart\" delay "
+"calculation (the default), which will cause Monitoring Engine to calculate "
+"an average check interval and spread initial checks of all hosts out over "
+"that interval, thereby helping to eliminate CPU load spikes. Using no delay "
+"(\"n\") is generally not recommended, as it will cause all host checks to be "
+"scheduled for execution at the same time. This means that you will generally "
+"have large CPU spikes when the hosts are all executed in parallel. Use a "
+"\"d\" for a \"dumb\" delay of 1 second between host checks or supply a fixed "
+"value of x.xx seconds for the inter-check delay."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to control how service checks are initially \"spread "
+"out\" in the event queue. Enter \"s\" for using a \"smart\" delay "
+"calculation (the default), which will cause Monitoring Engine to calculate "
+"an average check interval and spread initial checks of all services out over "
+"that interval, thereby helping to eliminate CPU load spikes. Using no delay "
+"(\"n\") is generally not recommended, as it will cause all service checks to "
+"be scheduled for execution at the same time. This means that you will "
+"generally have large CPU spikes when the services are all executed in "
+"parallel. Use a \"d\" for a \"dumb\" delay of 1 second between service "
+"checks or supply a fixed value of x.xx seconds for the inter-check delay."
+msgstr ""
+"This option allows you to control how service checks are initially \"spread "
+"out\" in the event queue. Enter \"s\" for using a \"smart\" delay "
+"calculation (the default), which will cause Monitoring Engine to calculate "
+"an average check interval and spread initial checks of all services out over "
+"that interval, thereby helping to eliminate CPU load spikes. Using no delay "
+"(\"n\") is generally not recommended, as it will cause all service checks to "
+"be scheduled for execution at the same time. This means that you will "
+"generally have large CPU spikes when the services are all executed in "
+"parallel. Use a \"d\" for a \"dumb\" delay of 1 second between service "
+"checks or supply a fixed value of x.xx seconds for the inter-check delay."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to control the frequency in seconds of check result "
+"\"reaper\" events. \"Reaper\" events process the results from host and "
+"service checks that have finished executing. These events constitute the "
+"core of the monitoring logic in Monitoring Engine."
+msgstr ""
+"This option allows you to control the frequency in seconds of check result "
+"\"reaper\" events. \"Reaper\" events process the results from host and "
+"service checks that have finished executing. These events constitute the "
+"core of the monitoring logic in Monitoring Engine."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to enable or disable checks for orphaned hoste "
+"checks. Orphaned host checks are checks which have been executed and have "
+"been removed from the event queue, but have not had any results reported in "
+"a long time. Since no results have come back in for the host, it is not "
+"rescheduled in the event queue. This can cause host checks to stop being "
+"executed. Normally it is very rare for this to happen - it might happen if "
+"an external user or process killed off the process that was being used to "
+"execute a host check. If this option is enabled and Monitoring Engine finds "
+"that results for a particular host check have not come back, it will log an "
+"error message and reschedule the host check. This option is enabled by "
+"default."
+msgstr ""
+"This option allows you to enable or disable checks for orphaned hoste "
+"checks. Orphaned host checks are checks which have been executed and have "
+"been removed from the event queue, but have not had any results reported in "
+"a long time. Since no results have come back in for the host, it is not "
+"rescheduled in the event queue. This can cause host checks to stop being "
+"executed. Normally it is very rare for this to happen - it might happen if "
+"an external user or process killed off the process that was being used to "
+"execute a host check. If this option is enabled and Monitoring Engine finds "
+"that results for a particular host check have not come back, it will log an "
+"error message and reschedule the host check. This option is enabled by "
+"default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to enable or disable checks for orphaned service "
+"checks. Orphaned service checks are checks which have been executed and have "
+"been removed from the event queue, but have not had any results reported in "
+"a long time. Since no results have come back in for the service, it is not "
+"rescheduled in the event queue. This can cause service checks to stop being "
+"executed. Normally it is very rare for this to happen - it might happen if "
+"an external user or process killed off the process that was being used to "
+"execute a service check. If this option is enabled and Monitoring Engine "
+"finds that results for a particular service check have not come back, it "
+"will log an error message and reschedule the service check. This option is "
+"enabled by default."
+msgstr ""
+"This option allows you to enable or disable checks for orphaned service "
+"checks. Orphaned service checks are checks which have been executed and have "
+"been removed from the event queue, but have not had any results reported in "
+"a long time. Since no results have come back in for the service, it is not "
+"rescheduled in the event queue. This can cause service checks to stop being "
+"executed. Normally it is very rare for this to happen - it might happen if "
+"an external user or process killed off the process that was being used to "
+"execute a service check. If this option is enabled and Monitoring Engine "
+"finds that results for a particular service check have not come back, it "
+"will log an error message and reschedule the service check. This option is "
+"enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to specify a host event handler command that is to be "
+"run for every host state change. The global event handler is executed "
+"immediately prior to the event handler that you have optionally specified in "
+"each host definition. The maximum amount of time that this command can run "
+"is controlled by the event_handler_timeout option."
+msgstr ""
+"This option allows you to specify a host event handler command that is to be "
+"run for every host state change. The global event handler is executed "
+"immediately prior to the event handler that you have optionally specified in "
+"each host definition. The maximum amount of time that this command can run "
+"is controlled by the event_handler_timeout option."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to specify a service event handler command that is to "
+"be run for every service state change. The global event handler is executed "
+"immediately prior to the event handler that you have optionally specified in "
+"each service definition. The maximum amount of time that this command can "
+"run is controlled by the event_handler_timeout option."
+msgstr ""
+"This option allows you to specify a service event handler command that is to "
+"be run for every service state change. The global event handler is executed "
+"immediately prior to the event handler that you have optionally specified in "
+"each service definition. The maximum amount of time that this command can "
+"run is controlled by the event_handler_timeout option."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to specify illegal characters that cannot be used in "
+"host names, service descriptions, or names of other object types. Monitoring "
+"Engine will allow you to use most characters in object definitions, but I "
+"recommend not using the characters set by default. Doing may give you "
+"problems in the web interface, notification commands, etc."
+msgstr ""
+"This option allows you to specify illegal characters that cannot be used in "
+"host names, service descriptions, or names of other object types. Monitoring "
+"Engine will allow you to use most characters in object definitions, but I "
+"recommend not using the characters set by default. Doing may give you "
+"problems in the web interface, notification commands, etc."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to specify illegal characters that should be stripped "
+"from macros before being used in notifications, event handlers, and other "
+"commands. This DOES NOT affect macros used in service or host check "
+"commands. Some of these characters are interpreted by the shell (i.e. the "
+"backtick) and can lead to security problems."
+msgstr ""
+"This option allows you to specify illegal characters that should be stripped "
+"from macros before being used in notifications, event handlers, and other "
+"commands. This DOES NOT affect macros used in service or host check "
+"commands. Some of these characters are interpreted by the shell (i.e. the "
+"backtick) and can lead to security problems."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to specify the maximum number of service checks that "
+"can be run in parallel at any given time. Specifying a value of 1 for this "
+"variable essentially prevents any service checks from being run in parallel. "
+"Specifying a value of 0 (the default) does not place any restrictions on the "
+"number of concurrent checks. You'll have to modify this value based on the "
+"system resources you have available on the machine that runs Monitoring "
+"Engine, as it directly affects the maximum load that will be imposed on the "
+"system (processor utilization, memory, etc.)."
+msgstr ""
+"This option allows you to specify the maximum number of service checks that "
+"can be run in parallel at any given time. Specifying a value of 1 for this "
+"variable essentially prevents any service checks from being run in parallel. "
+"Specifying a value of 0 (the default) does not place any restrictions on the "
+"number of concurrent checks. You'll have to modify this value based on the "
+"system resources you have available on the machine that runs Monitoring "
+"Engine, as it directly affects the maximum load that will be imposed on the "
+"system (processor utilization, memory, etc.)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option allows you to specify what kind of date/time format Monitoring "
+"Engine should use in the web interface and date/time macros."
+msgstr ""
+"This option allows you to specify what kind of date/time format Monitoring "
+"Engine should use in the web interface and date/time macros."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"This option can be used to avoid search performance issues in Resource "
+"status, when dealing with large amounts of data.\n"
+"Limited search: Free text search will be performed only on the following "
+"fields: host name, alias and address, and service description. Use if you "
+"have a large amount of data.\n"
+"Full search: Free text search will also be performed on the \"information\" "
+"field. This is appropriate only if you have a small amount of data, as it "
+"affects performance."
+msgstr ""
+"This option can be used to avoid search performance issues in Resource "
+"status, when dealing with large amounts of data.\n"
+"Limited search: Free text search will be performed only on the following "
+"fields: host name, alias and address, and service description. Use if you "
+"have a large amount of data.\n"
+"Full search: Free text search will also be performed on the \"information\" "
+"field. This is appropriate only if you have a small amount of data, as it "
+"affects performance."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option controls what (if any) data gets sent to the event broker and, "
+"in turn, to any loaded event broker module. Centreon relies heavily on the "
+"broker and needs this value to be set as -1."
+msgstr ""
+"This option controls what (if any) data gets sent to the event broker and, "
+"in turn, to any loaded event broker module. Centreon relies heavily on the "
+"broker and needs this value to be set as -1."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines how much debugging information Monitoring Engine "
+"should write to the debug_file. By default the verbosity is set to level 1."
+msgstr ""
+"This option determines how much debugging information Monitoring Engine "
+"should write to the debug_file. By default the verbosity is set to level 1."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines how often Monitoring Engine will attempt to "
+"automatically reschedule checks. This option only has an effect if the "
+"auto_reschedule_checks option is enabled. Default is 30 seconds."
+msgstr ""
+"This option determines how often Monitoring Engine will attempt to "
+"automatically reschedule checks. This option only has an effect if the "
+"auto_reschedule_checks option is enabled. Default is 30 seconds."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines how service checks are interleaved. Interleaving "
+"allows for a more even distribution of service checks, reduced load on "
+"remote hosts, and faster overall detection of host problems. By default this "
+"value is set to s (smart) for automatic calculation of the interleave "
+"factor. Don't change unless you have a specific reason to change it. Setting "
+"this value to a number greater than or equal to 1 specifies the interleave "
+"factor to use. A value of 1 is equivalent to not interleaving the service "
+"checks."
+msgstr ""
+"This option determines how service checks are interleaved. Interleaving "
+"allows for a more even distribution of service checks, reduced load on "
+"remote hosts, and faster overall detection of host problems. By default this "
+"value is set to s (smart) for automatic calculation of the interleave "
+"factor. Don't change unless you have a specific reason to change it. Setting "
+"this value to a number greater than or equal to 1 specifies the interleave "
+"factor to use. A value of 1 is equivalent to not interleaving the service "
+"checks."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the \"window\" of time that Monitoring Engine will "
+"look at when automatically rescheduling checks. Only host and service checks "
+"that occur in the next X seconds (determined by this variable) will be "
+"rescheduled. This option only has an effect if the auto_reschedule_checks "
+"option is enabled. Default is 180 seconds (3 minutes)."
+msgstr ""
+"This option determines the \"window\" of time that Monitoring Engine will "
+"look at when automatically rescheduling checks. Only host and service checks "
+"that occur in the next X seconds (determined by this variable) will be "
+"rescheduled. This option only has an effect if the auto_reschedule_checks "
+"option is enabled. Default is 180 seconds (3 minutes)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the maximum amount of time (in seconds) that the "
+"state of a previous host check is considered current. Cached host states "
+"(from host checks that were performed more recently than the time specified "
+"by this value) can improve host check performance immensely. Too high of a "
+"value for this option may result in (temporarily) inaccurate host states, "
+"while a low value may result in a performance hit for host checks. Use a "
+"value of 0 if you want to disable host check caching."
+msgstr ""
+"This option determines the maximum amount of time (in seconds) that the "
+"state of a previous host check is considered current. Cached host states "
+"(from host checks that were performed more recently than the time specified "
+"by this value) can improve host check performance immensely. Too high of a "
+"value for this option may result in (temporarily) inaccurate host states, "
+"while a low value may result in a performance hit for host checks. Use a "
+"value of 0 if you want to disable host check caching."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the maximum amount of time (in seconds) that the "
+"state of a previous service check is considered current. Cached service "
+"states (from service checks that were performed more recently than the time "
+"specified by this value) can improve service check performance when a lot of "
+"service dependencies are used. Too high of a value for this option may "
+"result in inaccuracies in the service dependency logic. Use a value of 0 if "
+"you want to disable service check caching."
+msgstr ""
+"This option determines the maximum amount of time (in seconds) that the "
+"state of a previous service check is considered current. Cached service "
+"states (from service checks that were performed more recently than the time "
+"specified by this value) can improve service check performance when a lot of "
+"service dependencies are used. Too high of a value for this option may "
+"result in inaccuracies in the service dependency logic. Use a value of 0 if "
+"you want to disable service check caching."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the maximum number of minutes from when Monitoring "
+"Engine starts that all hosts (that are scheduled to be regularly checked) "
+"are checked. This option will automatically adjust the host inter-check "
+"delay method (if necessary) to ensure that the initial checks of all hosts "
+"occur within the timeframe you specify. In general, this option will not "
+"have an effect on host check scheduling if scheduling information is being "
+"retained using the use_retained_scheduling_info option. Default value is 30 "
+"(minutes)."
+msgstr ""
+"This option determines the maximum number of minutes from when Monitoring "
+"Engine starts that all hosts (that are scheduled to be regularly checked) "
+"are checked. This option will automatically adjust the host inter-check "
+"delay method (if necessary) to ensure that the initial checks of all hosts "
+"occur within the timeframe you specify. In general, this option will not "
+"have an effect on host check scheduling if scheduling information is being "
+"retained using the use_retained_scheduling_info option. Default value is 30 "
+"(minutes)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the maximum number of minutes from when Monitoring "
+"Engine starts until all services (that are scheduled to be regularly "
+"checked) are checked. This option will automatically adjust the service "
+"inter-check delay method (if necessary) to ensure that the initial checks of "
+"all services occur within the timeframe you specify. In general, this option "
+"will not have an effect on service check scheduling if scheduling "
+"information is being retained using the use_retained_scheduling_info option. "
+"Default value in centengine is 5 (minutes) but it should be raised to 30 if "
+"the poller monitors more than 5000 services to avoid load issues."
+msgstr ""
+"This option determines the maximum number of minutes from when Monitoring "
+"Engine starts until all services (that are scheduled to be regularly "
+"checked) are checked. This option will automatically adjust the service "
+"inter-check delay method (if necessary) to ensure that the initial checks of "
+"all services occur within the timeframe you specify. In general, this option "
+"will not have an effect on service check scheduling if scheduling "
+"information is being retained using the use_retained_scheduling_info option. "
+"Default value in centengine is 5 (minutes) but it should be raised to 30 if "
+"the poller monitors more than 5000 services to avoid load issues."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the maximum size (in bytes) of the debug file. If the "
+"file grows larger than this size, it will be renamed with a .old extension. "
+"If a file already exists with a .old extension it will automatically be "
+"deleted. This helps ensure your disk space usage doesn't get out of control "
+"when debugging Monitoring Engine."
+msgstr ""
+"This option determines the maximum size (in bytes) of the debug file. If the "
+"file grows larger than this size, it will be renamed with a .old extension. "
+"If a file already exists with a .old extension it will automatically be "
+"deleted. This helps ensure your disk space usage doesn't get out of control "
+"when debugging Monitoring Engine."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines the number of seconds Monitoring Engine will add to "
+"any host or services freshness threshold it automatically calculates (e.g. "
+"those not specified explicitly by the user)."
+msgstr ""
+"This option determines the number of seconds Monitoring Engine will add to "
+"any host or services freshness threshold it automatically calculates (e.g. "
+"those not specified explicitly by the user)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines what type of information Monitoring Engine should "
+"write to the debug_file."
+msgstr ""
+"This option determines what type of information Monitoring Engine should "
+"write to the debug_file."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines where Monitoring Engine should write debugging "
+"information. What (if any) information is written is determined by the "
+"debug_level and debug_verbosity options. You can have Monitoring Engine "
+"automaticaly rotate the debug file when it reaches a certain size by using "
+"the max_debug_file_size option."
+msgstr ""
+"This option determines where Monitoring Engine should write debugging "
+"information. What (if any) information is written is determined by the "
+"debug_level and debug_verbosity options. You can have Monitoring Engine "
+"automaticaly rotate the debug file when it reaches a certain size by using "
+"the max_debug_file_size option."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether messages are logged to the syslog facility on "
+"your local host."
+msgstr ""
+"This option determines whether messages are logged to the syslog facility on "
+"your local host."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will accept passive "
+"host checks when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not accept any passive host checks. Note: If you have "
+"state retention enabled, Monitoring Engine will ignore this setting when it "
+"(re)starts and use the last known setting for this option (as stored in the "
+"state retention file), unless you disable the use_retained_program_state "
+"option. If you want to change this option when state retention is active "
+"(and the use_retained_program_state is enabled), you'll have to use the "
+"appropriate external command or change it via the web interface. Option is "
+"enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will accept passive "
+"host checks when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not accept any passive host checks. Note: If you have "
+"state retention enabled, Monitoring Engine will ignore this setting when it "
+"(re)starts and use the last known setting for this option (as stored in the "
+"state retention file), unless you disable the use_retained_program_state "
+"option. If you want to change this option when state retention is active "
+"(and the use_retained_program_state is enabled), you'll have to use the "
+"appropriate external command or change it via the web interface. Option is "
+"enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will accept passive "
+"service checks when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not accept any passive service checks. Note: If you "
+"have state retention enabled, Monitoring Engine will ignore this setting "
+"when it (re)starts and use the last known setting for this option (as stored "
+"in the state retention file), unless you disable the "
+"use_retained_program_state option. If you want to change this option when "
+"state retention is active (and the use_retained_program_state is enabled), "
+"you'll have to use the appropriate external command or change it via the web "
+"interface. Option is enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will accept passive "
+"service checks when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not accept any passive service checks. Note: If you "
+"have state retention enabled, Monitoring Engine will ignore this setting "
+"when it (re)starts and use the last known setting for this option (as stored "
+"in the state retention file), unless you disable the "
+"use_retained_program_state option. If you want to change this option when "
+"state retention is active (and the use_retained_program_state is enabled), "
+"you'll have to use the appropriate external command or change it via the web "
+"interface. Option is enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will attempt to "
+"automatically reschedule active host and service checks to \"smooth\" them "
+"out over time. This can help to balance the load on the monitoring server, "
+"as it will attempt to keep the time between consecutive checks consistent, "
+"at the expense of executing checks on a more rigid schedule.<br><b>Warning:</"
+"b> this is an experimental feature and may be removed in future versions. "
+"Enabling this option can degrade performance - rather than increase it - if "
+"used improperly!"
+msgstr ""
+"This option determines whether or not Monitoring Engine will attempt to "
+"automatically reschedule active host and service checks to \"smooth\" them "
+"out over time. This can help to balance the load on the monitoring server, "
+"as it will attempt to keep the time between consecutive checks consistent, "
+"at the expense of executing checks on a more rigid schedule.<br><b>Warning:</"
+"b> this is an experimental feature and may be removed in future versions. "
+"Enabling this option can degrade performance - rather than increase it - if "
+"used improperly!"
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will check the "
+"command file for commands that should be executed. This option must be "
+"enabled if you plan on using Centreon to issue commands via the web "
+"interface."
+msgstr ""
+"This option determines whether or not Monitoring Engine will check the "
+"command file for commands that should be executed. This option must be "
+"enabled if you plan on using Centreon to issue commands via the web "
+"interface."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will execute host "
+"checks when it initially (re)starts. If this option is disabled, Monitoring "
+"Engine will not actively execute any host checks and will remain in a sort "
+"of \"sleep\" mode (it can still accept passive checks unless you've disabled "
+"them). This option is most often used when configuring backup monitoring "
+"servers, as described in the documentation on redundancy, or when setting up "
+"a distributed monitoring environment. Note: If you have state retention "
+"enabled, Monitoring Engine will ignore this setting when it (re)starts and "
+"use the last known setting for this option (as stored in the state retention "
+"file), unless you disable the use_retained_program_state option. If you want "
+"to change this option when state retention is active (and the "
+"use_retained_program_state is enabled), you'll have to use the appropriate "
+"external command or change it via the web interface. Host checks are enabled "
+"by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will execute host "
+"checks when it initially (re)starts. If this option is disabled, Monitoring "
+"Engine will not actively execute any host checks and will remain in a sort "
+"of \"sleep\" mode (it can still accept passive checks unless you've disabled "
+"them). This option is most often used when configuring backup monitoring "
+"servers, as described in the documentation on redundancy, or when setting up "
+"a distributed monitoring environment. Note: If you have state retention "
+"enabled, Monitoring Engine will ignore this setting when it (re)starts and "
+"use the last known setting for this option (as stored in the state retention "
+"file), unless you disable the use_retained_program_state option. If you want "
+"to change this option when state retention is active (and the "
+"use_retained_program_state is enabled), you'll have to use the appropriate "
+"external command or change it via the web interface. Host checks are enabled "
+"by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will execute "
+"predictive checks of hosts that are being depended upon (as defined in host "
+"dependencies) for a particular host when it changes state. Predictive checks "
+"help ensure that the dependency logic is as accurate as possible. This "
+"option is enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will execute "
+"predictive checks of hosts that are being depended upon (as defined in host "
+"dependencies) for a particular host when it changes state. Predictive checks "
+"help ensure that the dependency logic is as accurate as possible. This "
+"option is enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will execute "
+"predictive checks of services that are being depended upon (as defined in "
+"service dependencies) for a particular service when it changes state. "
+"Predictive checks help ensure that the dependency logic is as accurate as "
+"possible. More information on how predictive checks work can be found here. "
+"This option is enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will execute "
+"predictive checks of services that are being depended upon (as defined in "
+"service dependencies) for a particular service when it changes state. "
+"Predictive checks help ensure that the dependency logic is as accurate as "
+"possible. More information on how predictive checks work can be found here. "
+"This option is enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will execute service "
+"checks when it initially (re)starts. If this option is disabled, Monitoring "
+"Engine will not actively execute any service checks and will remain in a "
+"sort of \"sleep\" mode (it can still accept passive checks unless you've "
+"disabled them). This option is most often used when configuring backup "
+"monitoring servers, as described in the documentation on redundancy, or when "
+"setting up a distributed monitoring environment. Note: If you have state "
+"retention enabled, Monitoring Engine will ignore this setting when it "
+"(re)starts and use the last known setting for this option (as stored in the "
+"state retention file), unless you disable the use_retained_program_state "
+"option. If you want to change this option when state retention is active "
+"(and the use_retained_program_state is enabled), you'll have to use the "
+"appropriate external command or change it via the web interface. Service "
+"checks are enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will execute service "
+"checks when it initially (re)starts. If this option is disabled, Monitoring "
+"Engine will not actively execute any service checks and will remain in a "
+"sort of \"sleep\" mode (it can still accept passive checks unless you've "
+"disabled them). This option is most often used when configuring backup "
+"monitoring servers, as described in the documentation on redundancy, or when "
+"setting up a distributed monitoring environment. Note: If you have state "
+"retention enabled, Monitoring Engine will ignore this setting when it "
+"(re)starts and use the last known setting for this option (as stored in the "
+"state retention file), unless you disable the use_retained_program_state "
+"option. If you want to change this option when state retention is active "
+"(and the use_retained_program_state is enabled), you'll have to use the "
+"appropriate external command or change it via the web interface. Service "
+"checks are enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will log external "
+"commands that it receives from the external command file. This option is "
+"enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will log external "
+"commands that it receives from the external command file. This option is "
+"enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will log passive "
+"host and service checks that it receives from the external command file. "
+"This option is enabled by default. If you are setting up a distributed "
+"monitoring environment or plan on handling a large number of passive checks "
+"on a regular basis, you may wish to disable this option so your log file "
+"doesn't get too large."
+msgstr ""
+"This option determines whether or not Monitoring Engine will log passive "
+"host and service checks that it receives from the external command file. "
+"This option is enabled by default. If you are setting up a distributed "
+"monitoring environment or plan on handling a large number of passive checks "
+"on a regular basis, you may wish to disable this option so your log file "
+"doesn't get too large."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will periodically "
+"check the \"freshness\" of host checks. Enabling this option is useful for "
+"helping to ensure that passive host checks are received in a timely manner. "
+"If the check results is found to be not fresh, Monitoring Engine will force "
+"an active check of the host or service by executing the command specified by "
+"in the host or service definition. This option is enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will periodically "
+"check the \"freshness\" of host checks. Enabling this option is useful for "
+"helping to ensure that passive host checks are received in a timely manner. "
+"If the check results is found to be not fresh, Monitoring Engine will force "
+"an active check of the host or service by executing the command specified by "
+"in the host or service definition. This option is enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will periodically "
+"check the \"freshness\" of service checks. Enabling this option is useful "
+"for helping to ensure that passive service checks are received in a timely "
+"manner. If the check results is found to be not fresh, Monitoring Engine "
+"will force an active check of the host or service by executing the command "
+"specified by in the host or service definition. This option is enabled by "
+"default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will periodically "
+"check the \"freshness\" of service checks. Enabling this option is useful "
+"for helping to ensure that passive service checks are received in a timely "
+"manner. If the check results is found to be not fresh, Monitoring Engine "
+"will force an active check of the host or service by executing the command "
+"specified by in the host or service definition. This option is enabled by "
+"default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will retain state "
+"information for hosts and services between program restarts. If you enable "
+"this option, you should supply a value for the state_retention_file "
+"variable. When enabled, Monitoring Engine will save all state information "
+"for hosts and service before it shuts down (or restarts) and will read in "
+"previously saved state information when it starts up again. Option is "
+"enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will retain state "
+"information for hosts and services between program restarts. If you enable "
+"this option, you should supply a value for the state_retention_file "
+"variable. When enabled, Monitoring Engine will save all state information "
+"for hosts and service before it shuts down (or restarts) and will read in "
+"previously saved state information when it starts up again. Option is "
+"enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will run event "
+"handlers when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not run any host or service event handlers. Note: If "
+"you have state retention enabled, Monitoring Engine will ignore this setting "
+"when it (re)starts and use the last known setting for this option (as stored "
+"in the state retention file), unless you disable the "
+"use_retained_program_state option. If you want to change this option when "
+"state retention is active (and the use_retained_program_state is enabled), "
+"you'll have to use the appropriate external command or change it via the web "
+"interface. Option is enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will run event "
+"handlers when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not run any host or service event handlers. Note: If "
+"you have state retention enabled, Monitoring Engine will ignore this setting "
+"when it (re)starts and use the last known setting for this option (as stored "
+"in the state retention file), unless you disable the "
+"use_retained_program_state option. If you want to change this option when "
+"state retention is active (and the use_retained_program_state is enabled), "
+"you'll have to use the appropriate external command or change it via the web "
+"interface. Option is enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will send out "
+"notifications when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not send out notifications for any host or service. "
+"Note: If you have state retention enabled, Monitoring Engine will ignore "
+"this setting when it (re)starts and use the last known setting for this "
+"option (as stored in the state retention file), unless you disable the "
+"use_retained_program_state option. If you want to change this option when "
+"state retention is active (and the use_retained_program_state is enabled), "
+"you'll have to use the appropriate external command or change it via the web "
+"interface. Notifications are enabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will send out "
+"notifications when it initially (re)starts. If this option is disabled, "
+"Monitoring Engine will not send out notifications for any host or service. "
+"Note: If you have state retention enabled, Monitoring Engine will ignore "
+"this setting when it (re)starts and use the last known setting for this "
+"option (as stored in the state retention file), unless you disable the "
+"use_retained_program_state option. If you want to change this option when "
+"state retention is active (and the use_retained_program_state is enabled), "
+"you'll have to use the appropriate external command or change it via the web "
+"interface. Notifications are enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will treat passive "
+"host checks as HARD states or SOFT states. By default, a passive host check "
+"result will put a host into a HARD state type. This option is disabled by "
+"default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will treat passive "
+"host checks as HARD states or SOFT states. By default, a passive host check "
+"result will put a host into a HARD state type. This option is disabled by "
+"default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will try and detect "
+"hosts and services that are \"flapping\". Flapping occurs when a host or "
+"service changes between states too frequently, resulting in a barrage of "
+"notifications being sent out. When Monitoring Engine detects that a host or "
+"service is flapping, it will temporarily suppress notifications for that "
+"host/service until it stops flapping. Flap detection is very experimental at "
+"this point, so use this feature with caution! More information on how flap "
+"detection and handling works can be found here. Note: If you have state "
+"retention enabled, Monitoring Engine will ignore this setting when it "
+"(re)starts and use the last known setting for this option (as stored in the "
+"state retention file), unless you disable the use_retained_program_state "
+"option. This option is disabled by default."
+msgstr ""
+"This option determines whether or not Monitoring Engine will try and detect "
+"hosts and services that are \"flapping\". Flapping occurs when a host or "
+"service changes between states too frequently, resulting in a barrage of "
+"notifications being sent out. When Monitoring Engine detects that a host or "
+"service is flapping, it will temporarily suppress notifications for that "
+"host/service until it stops flapping. Flap detection is very experimental at "
+"this point, so use this feature with caution! More information on how flap "
+"detection and handling works can be found here. Note: If you have state "
+"retention enabled, Monitoring Engine will ignore this setting when it "
+"(re)starts and use the last known setting for this option (as stored in the "
+"state retention file), unless you disable the use_retained_program_state "
+"option. This option is disabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not Monitoring Engine will use soft state "
+"information when checking host and service dependencies. Normally Monitoring "
+"Engine will only use the latest hard host or service state when checking "
+"dependencies. If you want it to use the latest state (regardless of whether "
+"its a soft or hard state type), enable this option."
+msgstr ""
+"This option determines whether or not Monitoring Engine will use soft state "
+"information when checking host and service dependencies. Normally Monitoring "
+"Engine will only use the latest hard host or service state when checking "
+"dependencies. If you want it to use the latest state (regardless of whether "
+"its a soft or hard state type), enable this option."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not host check retries are logged. Logging "
+"host check retries is mostly useful when attempting to debug Monitoring "
+"Engine or test out host event handlers."
+msgstr ""
+"This option determines whether or not host check retries are logged. Logging "
+"host check retries is mostly useful when attempting to debug Monitoring "
+"Engine or test out host event handlers."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not notification messages are logged. If "
+"you have a lot of contacts or regular service failures your log file will "
+"grow relatively quickly. Use this option to keep contact notifications from "
+"being logged."
+msgstr ""
+"This option determines whether or not notification messages are logged. If "
+"you have a lot of contacts or regular service failures your log file will "
+"grow relatively quickly. Use this option to keep contact notifications from "
+"being logged."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not service and host event handlers are "
+"logged. Event handlers are optional commands that can be run whenever a "
+"service or hosts changes state. Logging event handlers is most useful when "
+"debugging Monitoring Engine or first trying out your event handler scripts."
+msgstr ""
+"This option determines whether or not service and host event handlers are "
+"logged. Event handlers are optional commands that can be run whenever a "
+"service or hosts changes state. Logging event handlers is most useful when "
+"debugging Monitoring Engine or first trying out your event handler scripts."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not service check retries are logged. "
+"Service check retries occur when a service check results in a non-OK state, "
+"but you have configured Monitoring Engine to retry the service more than "
+"once before responding to the error. Services in this situation are "
+"considered to be in \"soft\" states. Logging service check retries is mostly "
+"useful when attempting to debug Monitoring Engine or test out service event "
+"handlers."
+msgstr ""
+"This option determines whether or not service check retries are logged. "
+"Service check retries occur when a service check results in a non-OK state, "
+"but you have configured Monitoring Engine to retry the service more than "
+"once before responding to the error. Services in this situation are "
+"considered to be in \"soft\" states. Logging service check retries is mostly "
+"useful when attempting to debug Monitoring Engine or test out service event "
+"handlers."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not the Monitoring Engine daemon will make "
+"all standard macros available as environment variables to your check, "
+"notification, event hander, etc. commands. In large Monitoring Engine "
+"installations this can be problematic because it takes additional memory and "
+"(more importantly) CPU to compute the values of all macros and make them "
+"available to the environment. This option is enabled by default."
+msgstr ""
+"This option determines whether or not the Monitoring Engine daemon will make "
+"all standard macros available as environment variables to your check, "
+"notification, event hander, etc. commands. In large Monitoring Engine "
+"installations this can be problematic because it takes additional memory and "
+"(more importantly) CPU to compute the values of all macros and make them "
+"available to the environment. This option is enabled by default."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option determines whether or not various directives in your object "
+"definitions will be processed as regular expressions. More information on "
+"how this works can be found in Monitoring Engine section on object tricks. "
+"This option is disabled by default."
+msgstr ""
+"This option determines whether or not various directives in your object "
+"definitions will be processed as regular expressions. More information on "
+"how this works can be found in Monitoring Engine section on object tricks. "
+"This option is disabled by default."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"This option enable a strict mode for the management of parent links between "
+"hosts on different pollers. Some hosts can have a parent link between them "
+"even if they are not monitored by the same poller. Select yes if you want to "
+"block the UI in order to oblige user to let host with a declared relation on "
+"the same poller. if you select No, during the generation process, relation "
+"will be broken and not generated but kept with Centreon Broker Correlation "
+"module."
+msgstr ""
+"This option enable a strict mode for the management of parent links between "
+"hosts on different pollers. Some hosts can have a parent link between them "
+"even if they are not monitored by the same poller. Select yes if you want to "
+"block the UI in order to oblige user to let host with a declared relation on "
+"the same poller. if you select No, during the generation process, relation "
+"will be broken and not generated but kept with Centreon Broker Correlation "
+"module."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option is used to set the high threshold for detection of host "
+"flapping. For more information read the Monitoring Engine section about "
+"flapping."
+msgstr ""
+"This option is used to set the high threshold for detection of host "
+"flapping. For more information read the Monitoring Engine section about "
+"flapping."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option is used to set the high threshold for detection of service "
+"flapping. For more information read the Monitoring Engine section about "
+"flapping."
+msgstr ""
+"This option is used to set the high threshold for detection of service "
+"flapping. For more information read the Monitoring Engine section about "
+"flapping."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option is used to set the low threshold for detection of host flapping. "
+"For more information read the Monitoring Engine section about flapping."
+msgstr ""
+"This option is used to set the low threshold for detection of host flapping. "
+"For more information read the Monitoring Engine section about flapping."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option is used to set the low threshold for detection of service "
+"flapping. For more information read the Monitoring Engine section about "
+"flapping."
+msgstr ""
+"This option is used to set the low threshold for detection of service "
+"flapping. For more information read the Monitoring Engine section about "
+"flapping."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This option will disable all service checks if the host is not in an UP "
+"state. While desirable in some\n"
+"    environments, enabling this value can distort report values as the "
+"expected quantity of checks will not have been\n"
+"    performed."
+msgstr ""
+"This option will disable all service checks if the host is not in an UP "
+"state. While desirable in some\n"
+"    environments, enabling this value can distort report values as the "
+"expected quantity of checks will not have been\n"
+"    performed."
+
+#: centreon/www/include/configuration/configObject/contactgroup/help.php
+msgid ""
+"This optional directive can be used to include contacts from other \"sub\" "
+"contact groups in this contact group. Specify a list of other contact groups "
+"whose members should be included in this group."
+msgstr ""
+"This optional directive can be used to include contacts from other \"sub\" "
+"contact groups in this contact group. Specify a list of other contact groups "
+"whose members should be included in this group."
+
+#: centreon/www/include/configuration/configObject/servicegroup/help.php
+msgid ""
+"This optional directive can be used to include services from other \"sub\" "
+"service groups in this service group."
+msgstr ""
+"This optional directive can be used to include services from other \"sub\" "
+"service groups in this service group."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This options is an advanced configuration of engine that enables or not the "
+"filtering of macros sent to broker.If you don't understand the purpose of "
+"enabling this option, please do not enable it."
+msgstr ""
+"This options is an advanced configuration of engine that enables or not the "
+"filtering of macros sent to broker.If you don't understand the purpose of "
+"enabling this option, please do not enable it."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"This parameters are passed to the event handler commands in the same way "
+"check command parameters are handled. The format is: !ARG1!ARG2!...ARGn"
+msgstr ""
+"This parameters are passed to the event handler commands in the same way "
+"check command parameters are handled. The format is: !ARG1!ARG2!...ARGn"
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This setting determines how often (in minutes) that Monitoring Engine will "
+"automatically save retention data during normal operation. If you set this "
+"value to 0, Monitoring Engine will not save retention data at regular "
+"intervals, but it will still save retention data before shutting down or "
+"restarting. If you have disabled state retention (with the "
+"retain_state_information option), this option has no effect."
+msgstr ""
+"This setting determines how often (in minutes) that Monitoring Engine will "
+"automatically save retention data during normal operation. If you set this "
+"value to 0, Monitoring Engine will not save retention data at regular "
+"intervals, but it will still save retention data before shutting down or "
+"restarting. If you have disabled state retention (with the "
+"retain_state_information option), this option has no effect."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This setting determines how often (in seconds) Monitoring Engine will "
+"periodically check the \"freshness\" of host check results. If you have "
+"disabled host freshness checking (with the check_host_freshness option), "
+"this option has no effect."
+msgstr ""
+"This setting determines how often (in seconds) Monitoring Engine will "
+"periodically check the \"freshness\" of host check results. If you have "
+"disabled host freshness checking (with the check_host_freshness option), "
+"this option has no effect."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This setting determines how often (in seconds) Monitoring Engine will "
+"periodically check the \"freshness\" of service check results. If you have "
+"disabled service freshness checking (with the check_service_freshness "
+"option), this option has no effect."
+msgstr ""
+"This setting determines how often (in seconds) Monitoring Engine will "
+"periodically check the \"freshness\" of service check results. If you have "
+"disabled service freshness checking (with the check_service_freshness "
+"option), this option has no effect."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This setting determines whether or not Monitoring Engine will retain "
+"scheduling info (next check times) for hosts and services when it restarts. "
+"If you are adding a large number (or percentage) of hosts and services, I "
+"would recommend disabling this option when you first restart Monitoring "
+"Engine, as it can adversely skew the spread of initial checks. Otherwise you "
+"will probably want to leave it enabled."
+msgstr ""
+"This setting determines whether or not Monitoring Engine will retain "
+"scheduling info (next check times) for hosts and services when it restarts. "
+"If you are adding a large number (or percentage) of hosts and services, I "
+"would recommend disabling this option when you first restart Monitoring "
+"Engine, as it can adversely skew the spread of initial checks. Otherwise you "
+"will probably want to leave it enabled."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"This setting determines whether or not Monitoring Engine will set various "
+"program-wide state variables based on the values saved in the retention "
+"file. Some of these program-wide state variables that are normally saved "
+"across program restarts if state retention is enabled include the "
+"enable_notifications, enable_flap_detection, enable_event_handlers, "
+"execute_service_checks, and accept_passive_service_checks options. If you do "
+"not have state retention enabled, this option has no effect. This option is "
+"enabled by default."
+msgstr ""
+"This setting determines whether or not Monitoring Engine will set various "
+"program-wide state variables based on the values saved in the retention "
+"file. Some of these program-wide state variables that are normally saved "
+"across program restarts if state retention is enabled include the "
+"enable_notifications, enable_flap_detection, enable_event_handlers, "
+"execute_service_checks, and accept_passive_service_checks options. If you do "
+"not have state retention enabled, this option has no effect. This option is "
+"enabled by default."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"This setting determines whether the host and its services must be monitored "
+"or not."
+msgstr ""
+"This setting determines whether the host and its services must be monitored "
+"or not."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "This setting determines whether the service must be monitored or not."
+msgstr "This setting determines whether the service must be monitored or not."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"Those commands can be executed at the end of the file generation generation/"
+"restart process. Do not specify macros in the commands, for they will not be "
+"replaced. Make sure to have sufficient rights for the Apache user to run "
+"these commands."
+msgstr ""
+"Those commands can be executed at the end of the file generation generation/"
+"restart process. Do not specify macros in the commands, for they will not be "
+"replaced. Make sure to have sufficient rights for the Apache user to run "
+"these commands."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Time in seconds to wait before launching failover."
+msgstr "Time in seconds to wait before launching failover."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"Time in seconds to wait between each connection attempt (Default value: 30s)."
+msgstr ""
+"Time in seconds to wait between each connection attempt (Default value: 30s)."
+
+#: centreon/www/include/configuration/configNagios/help.php
+msgid ""
+"Time interval in seconds between two heartbeat events. This event is the one "
+"responsible of the 'Last Update' column update in the Pollers listing. Value "
+"must be between 5 and 600. Default value is 30."
+msgstr ""
+"Time interval in seconds between two heartbeat events. This event is the one "
+"responsible of the 'Last Update' column update in the Pollers listing. Value "
+"must be between 5 and 600. Default value is 30."
+
+#: centreon/www/include/Administration/parameters/api/help.php
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid "Timeout value in seconds. Used to make actions calls timeout."
+msgstr "Timeout value in seconds. Used to make actions calls timeout."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"Timezone corresponding to the host's location. This will impact how the "
+"check period is applied to it."
+msgstr ""
+"Timezone corresponding to the host's location. This will impact how the "
+"check period is applied to it."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid "To fill"
+msgstr "To fill"
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid ""
+"Token used for autologin. Refer to the Centreon documentation to know more "
+"about its usage."
+msgstr ""
+"Token used for autologin. Refer to the Centreon documentation to know more "
+"about its usage."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Trusted CA's certificate."
+msgstr "Trusted CA's certificate."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "URL of the proxy."
+msgstr "URL of the proxy."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Upper limit of grid."
+msgstr "Upper limit of grid."
+
+#: centreon/www/include/Administration/parameters/backup/help.php
+msgid "Use SCP to copy backup on remote host"
+msgstr "Use SCP to copy backup on remote host"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Use the DNS service for get LDAP host"
+msgstr "Use the DNS service for get LDAP host"
+
+#: centreon/www/include/configuration/configObject/timeperiod/help.php
+msgid ""
+"Use the alias as a longer name or description to identify the time period."
+msgstr ""
+"Use the alias as a longer name or description to identify the time period."
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid "Use this field for a longer description of this category."
+msgstr "Use this field for a longer description of this category."
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/help.php
+msgid ""
+"Use this for an optional description or comments about the vendor/"
+"manufacturer."
+msgstr ""
+"Use this for an optional description or comments about the vendor/"
+"manufacturer."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Used for identifying the poller"
+msgstr "Used for identifying the poller"
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "User DN for connect to LDAP in read only"
+msgstr "User DN for connect to LDAP in read only"
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "User of the proxy (Only if you use basic authentication)."
+msgstr "User of the proxy (Only if you use basic authentication)."
+
+#: centreon/www/include/Administration/parameters/gorgone/help.php
+msgid ""
+"Username used to connect to Gorgone API. It must match Gorgone httpserver "
+"module definition (Default: none)."
+msgstr ""
+"Username used to connect to Gorgone API. It must match Gorgone httpserver "
+"module definition (Default: none)."
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid "Usually cpus/2."
+msgstr "Usually cpus/2."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Vertical Label (Y-axis)."
+msgstr "Vertical Label (Y-axis)."
+
+#: centreon/www/include/views/virtualMetrics/help.php
+msgid "Warning threshold."
+msgstr "Warning threshold."
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid ""
+"What kind of method is needed to reach the Remote Server, HTTP or HTTPS?"
+msgstr ""
+"What kind of method is needed to reach the Remote Server, HTTP or HTTPS?"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"When enabled,\n"
+" the broker engine will check whether or not the replication is up to date "
+"before attempting to update data."
+msgstr ""
+"When enabled,\n"
+" the broker engine will check whether or not the replication is up to date "
+"before attempting to update data."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "When enabled, \"Host Down\" notification messages will be displayed."
+msgstr "When enabled, \"Host Down\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"When enabled, \"Host Unreachable\" notification messages will be displayed."
+msgstr ""
+"When enabled, \"Host Unreachable\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "When enabled, \"Host Up\" notification messages will be displayed."
+msgstr "When enabled, \"Host Up\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"When enabled, \"Service Critical\" notification messages will be displayed."
+msgstr ""
+"When enabled, \"Service Critical\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "When enabled, \"Service OK\" notification messages will be displayed."
+msgstr "When enabled, \"Service OK\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"When enabled, \"Service Unknown\" notification messages will be displayed."
+msgstr ""
+"When enabled, \"Service Unknown\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"When enabled, \"Service Warning\" notification messages will be displayed."
+msgstr ""
+"When enabled, \"Service Warning\" notification messages will be displayed."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"When enabled, notification messages are displayed when new alerts arise in "
+"the monitoring consoles."
+msgstr ""
+"When enabled, notification messages are displayed when new alerts arise in "
+"the monitoring consoles."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"When enabled, the contact definition will not override the definitions on "
+"template levels, it will be appended instead."
+msgstr ""
+"When enabled, the contact definition will not override the definitions on "
+"template levels, it will be appended instead."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+msgid ""
+"When enabled, the contact group definition will not override the definitions "
+"on template levels, it will be appended instead."
+msgstr ""
+"When enabled, the contact group definition will not override the definitions "
+"on template levels, it will be appended instead."
+
+#: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"When enabled, the contactgroup definition will not override the definitions "
+"on template levels, it will be appended instead."
+msgstr ""
+"When enabled, the contactgroup definition will not override the definitions "
+"on template levels, it will be appended instead."
+
+#: centreon/www/include/views/componentTemplates/help.php
+msgid ""
+"When filling property is enable, the area color displayed in Centreon is the "
+"curve line color with transparency.For exported graphs, the area color is "
+"defined with those fields."
+msgstr ""
+"When filling property is enable, the area color displayed in Centreon is the "
+"curve line color with transparency.For exported graphs, the area color is "
+"defined with those fields."
+
+#: centreon/www/include/configuration/configObject/service/help.php
+msgid ""
+"When one of these host template is applied to a host, a service will be "
+"created based on the current template."
+msgstr ""
+"When one of these host template is applied to a host, a service will be "
+"created based on the current template."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Whether SSO authentication is enabled. SSO feature have only to be enabled "
+"in a secured and dedicated environment for SSO. Direct access to Centreon UI "
+"from users have to be disabled."
+msgstr ""
+"Whether SSO authentication is enabled. SSO feature have only to be enabled "
+"in a secured and dedicated environment for SSO. Direct access to Centreon UI "
+"from users have to be disabled."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Whether execution interval will be applied to identical OIDs or identical "
+"OIDs and hosts"
+msgstr ""
+"Whether execution interval will be applied to identical OIDs or identical "
+"OIDs and hosts"
+
+#: centreon/www/include/configuration/configCentreonBroker/help.php
+msgid ""
+"Whether or not Broker should create entries in the index_data table.\n"
+" This process should be done by Centreon and this option should only be "
+"enabled by advanced \n"
+" users knowing what they're doing"
+msgstr ""
+"Whether or not Broker should create entries in the index_data table.\n"
+" This process should be done by Centreon and this option should only be "
+"enabled by advanced \n"
+" users knowing what they're doing"
+
+#: centreon/www/include/configuration/configObject/connector/help.php
+msgid "Whether or not the connector is enabled."
+msgstr "Whether or not the connector is enabled."
+
+#: centreon/www/include/Administration/parameters/ldap/help.php
+msgid "Whether or not the password should be stored in database"
+msgstr "Whether or not the password should be stored in database"
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid "Whether or not this category is enabled."
+msgstr "Whether or not this category is enabled."
+
+#: centreon/www/include/configuration/configObject/traps/help.php
+msgid ""
+"Whether or not traps will be inserted into database. Disabled by default"
+msgstr ""
+"Whether or not traps will be inserted into database. Disabled by default"
+
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Whether the poller is local"
+msgstr "Whether the poller is local"
+
+#: centreon/www/include/configuration/configObject/host_categories/help.php
+#: centreon/www/include/configuration/configObject/service_categories/help.php
+msgid ""
+"Whether this category is a severity. Severities appear on the monitoring "
+"consoles."
+msgstr ""
+"Whether this category is a severity. Severities appear on the monitoring "
+"consoles."
+
+#: centreon/www/include/views/graphTemplates/help.php
+msgid "Width of grid. Used to export the chart."
+msgstr "Width of grid. Used to export the chart."
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/help.php
+msgid "Wiki account password."
+msgstr "Wiki account password."
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/help.php
+msgid "Wiki account with delete right."
+msgstr "Wiki account with delete right."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Will only display hosts that belong to these host categories. When blank, no "
+"filter is applied."
+msgstr ""
+"Will only display hosts that belong to these host categories. When blank, no "
+"filter is applied."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Will only display resources that are monitored by these pollers. When blank, "
+"no filter is applied."
+msgstr ""
+"Will only display resources that are monitored by these pollers. When blank, "
+"no filter is applied."
+
+#: centreon/www/include/options/accessLists/resourcesACL/help.php
+msgid ""
+"Will only display services that belong to these service categories. When "
+"blank, no filter is applied."
+msgstr ""
+"Will only display services that belong to these service categories. When "
+"blank, no filter is applied."
+
+#: centreon/www/include/configuration/configObject/timeperiod/help.php
+msgid ""
+"You can specify several different types of exceptions to the standard "
+"rotating weekday schedule. Exceptions can take a number of different forms "
+"including single days of a specific or generic month, single weekdays in a "
+"month, or single calendar dates. You can also specify a range of days/dates "
+"and even specify skip intervals to obtain functionality described by \"every "
+"3 days between these dates\". Weekdays and different types of exceptions all "
+"have different levels of precedence, so it is important to understand how "
+"they can affect each other."
+msgstr ""
+"You can specify several different types of exceptions to the standard "
+"rotating weekday schedule. Exceptions can take a number of different forms "
+"including single days of a specific or generic month, single weekdays in a "
+"month, or single calendar dates. You can also specify a range of days/dates "
+"and even specify skip intervals to obtain functionality described by \"every "
+"3 days between these dates\". Weekdays and different types of exceptions all "
+"have different levels of precedence, so it is important to understand how "
+"they can affect each other."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect Authorization endpoint (for example /auth)."
+msgstr "Your OpenId Connect Authorization endpoint (for example /auth)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect End Session endpoint (for example /logout)."
+msgstr "Your OpenId Connect End Session endpoint (for example /logout)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Your OpenId Connect Introspection Token endpoint (for example /token/"
+"introspect)."
+msgstr ""
+"Your OpenId Connect Introspection Token endpoint (for example /token/"
+"introspect)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect Scope (for example openid)."
+msgstr "Your OpenId Connect Scope (for example openid)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect Token endpoint (for example /token)."
+msgstr "Your OpenId Connect Token endpoint (for example /token)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect User Information endpoint (for example /userinfo)."
+msgstr "Your OpenId Connect User Information endpoint (for example /userinfo)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Your OpenId Connect base Url (for example http://IP:8080/auth/realms/master/"
+"protocol/openid-connect)."
+msgstr ""
+"Your OpenId Connect base Url (for example http://IP:8080/auth/realms/master/"
+"protocol/openid-connect)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect client ID."
+msgstr "Your OpenId Connect client ID."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid "Your OpenId Connect client secret."
+msgstr "Your OpenId Connect client secret."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Your OpenId Connect login claim value (if empty preferred_username will be "
+"used)."
+msgstr ""
+"Your OpenId Connect login claim value (if empty preferred_username will be "
+"used)."
+
+#: centreon/www/include/Administration/parameters/general/help.php
+msgid ""
+"Your OpenId Connect redirect url (this server, {scheme}, {hostname} and "
+"{port} can be used for substitions, default is {scheme}://{hostname}:{port}/"
+"your_centreon_path/index.php if left empty)."
+msgstr ""
+"Your OpenId Connect redirect url (this server, {scheme}, {hostname} and "
+"{port} can be used for substitions, default is {scheme}://{hostname}:{port}/"
+"your_centreon_path/index.php if left empty)."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "[Acknowledge services attached to hosts] option is enabled by default."
+msgstr "[Acknowledge services attached to hosts] option is enabled by default."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "[Force Active Checks] option is enabled by default."
+msgstr "[Force Active Checks] option is enabled by default."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "[Notify] option is enabled by default."
+msgstr "[Notify] option is enabled by default."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "[Persistent] option is enabled by default."
+msgstr "[Persistent] option is enabled by default."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid ""
+"[Set downtimes on services attached to hosts] option is enbaled by default."
+msgstr ""
+"[Set downtimes on services attached to hosts] option is enbaled by default."
+
+#: centreon/www/include/Administration/parameters/engine/help.php
+msgid "[Sticky] option is enabled by default."
+msgstr "[Sticky] option is enabled by default."
+
+#: centreon/www/include/Administration/parameters/centstorage/help.php
+msgid ""
+"number of partitions created in advance to prevent issues, by default 10 "
+"days."
+msgstr ""
+"number of partitions created in advance to prevent issues, by default 10 "
+"days."

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/help.po
@@ -63,10 +63,6 @@ msgstr "Absolute value for warning level (low threshold)."
 msgid "Additional Remote Server to which this server will be attached"
 msgstr "Additional Remote Server to which this server will be attached"
 
-#: centreon/www/include/configuration/configServers/help.php
-msgid "Address of the poller"
-msgstr "Address of the poller"
-
 #: centreon/www/include/configuration/configObject/contact/help.php
 msgid ""
 "Addresses 1-6 are optional and used to define additional \"addresses\" for "
@@ -1753,6 +1749,10 @@ msgstr ""
 "IP Address or hostname to communicate with Gorgone API. Should remain "
 "default value (Default: \"127.0.0.1\")."
 
+#: centreon/www/include/configuration/configServers/help.php
+msgid "IP address of the poller"
+msgstr ""
+
 #: centreon/www/include/configuration/configCentreonBroker/help.php
 msgid "IP address or hostname of the database server."
 msgstr "IP address or hostname of the database server."
@@ -2129,12 +2129,8 @@ msgstr ""
 "information."
 
 #: centreon/www/include/Administration/parameters/backup/help.php
-msgid ""
-"MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave empty "
-"to use the default value."
+msgid "MySQL configuration file path (i.e. /etc/my.cnf.d/centreon.cnf)"
 msgstr ""
-"MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave empty "
-"to use the default value."
 
 #: centreon/www/include/options/accessLists/groupsACL/help.php
 msgid "Name of access group."
@@ -5831,3 +5827,15 @@ msgid ""
 msgstr ""
 "number of partitions created in advance to prevent issues, by default 10 "
 "days."
+
+#: unknown
+msgid "Address of the poller"
+msgstr "Address of the poller"
+
+#: unknown
+msgid ""
+"MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave "
+"empty to use the default value."
+msgstr ""
+"MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave "
+"empty to use the default value."

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/help.po
@@ -63,6 +63,10 @@ msgstr "Absolute value for warning level (low threshold)."
 msgid "Additional Remote Server to which this server will be attached"
 msgstr "Additional Remote Server to which this server will be attached"
 
+#: centreon/www/include/configuration/configServers/help.php
+msgid "Address of the poller"
+msgstr "Address of the poller"
+
 #: centreon/www/include/configuration/configObject/contact/help.php
 msgid ""
 "Addresses 1-6 are optional and used to define additional \"addresses\" for "
@@ -548,6 +552,10 @@ msgstr ""
 "send. Additionally the format and the parameters of the trap can be "
 "described."
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid "Comments on this host group."
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/command/help.php
 msgid "Comments regarding the command."
 msgstr "Comments regarding the command."
@@ -710,6 +718,15 @@ msgstr "Define a short name for this dependency."
 msgid "Define a short name to identify the time period."
 msgstr "Define a short name to identify the time period."
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"Define an image that should be associated with this host group in the "
+"statusmap CGI in monitoring engine. You can choose a JPEG, PNG, and GIF "
+"image. The GD2 image format is preferred, as other image formats must be "
+"converted first when the statusmap image is generated. The image will look "
+"best if it is 40x40 pixels in size."
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/host/help.php
 msgid ""
 "Define an image that should be associated with this host in the statusmap "
@@ -723,6 +740,13 @@ msgstr ""
 "image format is preferred, as other image formats must be converted first "
 "when the statusmap image is generated. The image will look best if it is "
 "40x40 pixels in size."
+
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"Define an optional URL that can be used to provide more actions to be "
+"performed on the host group. You will see the link to the action URL in the "
+"host group details."
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/host/help.php
 msgid ""
@@ -744,7 +768,20 @@ msgstr ""
 "performed on the service. You will see the link to the action URL in the "
 "service details."
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"Define an optional URL that can be used to provide more information about "
+"the host group. Any valid URL can be used. This can be very useful if you "
+"want to make detailed information on the host group, emergency contact "
+"methods, etc. available to other support staff."
+msgstr ""
+
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid "Define an optional string of notes pertaining to the host group."
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
 #: centreon/www/include/configuration/configObject/service/help.php
 msgid ""
 "Define an optional string that is used in the alternative description of the "
@@ -898,6 +935,13 @@ msgstr ""
 "Define the host states for which notifications can be sent out to this "
 "contact. If you specify None as an option, the contact will not receive any "
 "type of host notifications."
+
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"Define the image that should be associated with this host group here. This "
+"image will be displayed in the various places. The image will look best if "
+"it is 40x40 pixels in size."
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/host/help.php
 msgid ""
@@ -1640,6 +1684,13 @@ msgstr "Generate a light database for traps."
 msgid "Generates configuration files and stores them in cache directory."
 msgstr "Generates configuration files and stores them in cache directory."
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"Geographic coordinates to allow Centreon MAP to plot the host group on a "
+"geographic view. Format: Latitude,Longitude. For example, Paris' coordinates "
+"are 48.51,2.20"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/host/help.php
 #: centreon/www/include/configuration/configObject/service/help.php
 msgid ""
@@ -1713,6 +1764,10 @@ msgstr ""
 msgid "Host(s) to which the service is attached"
 msgstr "Host(s) to which the service is attached"
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid "Hosts belonging to the group"
+msgstr ""
+
 #: centreon/www/include/options/accessLists/resourcesACL/help.php
 msgid ""
 "Hosts that will be displayed to users. Services that belong to these hosts "
@@ -1748,10 +1803,6 @@ msgid ""
 msgstr ""
 "IP Address or hostname to communicate with Gorgone API. Should remain "
 "default value (Default: \"127.0.0.1\")."
-
-#: centreon/www/include/configuration/configServers/help.php
-msgid "IP address of the poller"
-msgstr ""
 
 #: centreon/www/include/configuration/configCentreonBroker/help.php
 msgid "IP address or hostname of the database server."
@@ -1912,14 +1963,6 @@ msgid ""
 msgstr ""
 "Illegal characters in external commands. Those characters will be removed "
 "before being processed by Centreon Gorgone."
-
-#: centreon/www/include/options/accessLists/resourcesACL/help.php
-msgid ""
-"Image folders that will be displayed to users. Images that belong to these "
-"folders will be visible."
-msgstr ""
-"Image folders that will be displayed to users. Images that belong to these "
-"folders will be visible."
 
 #: centreon/www/include/options/media/images/help.php
 msgid "Images."
@@ -2159,6 +2202,12 @@ msgstr "Name of menu rule."
 #: centreon/www/include/options/accessLists/resourcesACL/help.php
 msgid "Name of resource rule."
 msgstr "Name of resource rule."
+
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"Name of the host group. It must be unique and cannot contain white spaces, "
+"or special characters like ~!$%^&*\"|'<>?,()=."
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/host/help.php
 msgid ""
@@ -2451,6 +2500,12 @@ msgstr "RRD file directory, for example /var/lib/centreon/metrics"
 msgid "RRD file directory, for example /var/lib/centreon/status"
 msgstr "RRD file directory, for example /var/lib/centreon/status"
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"RRD retention duration of all the services that are in this host group. If "
+"service is in multiple host groups, the highest retention value will be used."
+msgstr ""
+
 #: centreon/www/include/configuration/configCentreonBroker/help.php
 msgid "RRD storage duration in seconds."
 msgstr "RRD storage duration in seconds."
@@ -2518,6 +2573,10 @@ msgstr "Remote host to copy by SCP"
 #: centreon/www/include/Administration/parameters/backup/help.php
 msgid "Remote user used by SCP"
 msgstr "Remote user used by SCP"
+
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid "Resource access rule to which the host group should be linked"
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/servicegroup/help.php
 msgid "Resource access rule to which the service group should be linked"
@@ -2589,13 +2648,10 @@ msgstr "Search timeout"
 
 #: centreon/www/include/options/media/images/help.php
 msgid ""
-"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg "
-"files. Multiple images can be uploaded together inside archives like zip, "
-"tar, tar.gz or tar.bz2."
+"Select a local file to upload. You can upload jpg, png, gif and gd2 files. "
+"Multiple images can be uploaded together inside archives like zip, tar, "
+"tar.gz or tar.bz2."
 msgstr ""
-"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg "
-"files. Multiple images can be uploaded together inside archives like zip, "
-"tar, tar.gz or tar.bz2."
 
 #: centreon/www/include/configuration/configObject/escalation/help.php
 msgid ""
@@ -3130,6 +3186,7 @@ msgstr ""
 "by login in autologin or * in LDAP import"
 
 #: centreon/www/include/configuration/configObject/host/help.php
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
 msgid ""
 "The SNMP community and version specified here can be referenced in the check "
 "command by using the $_HOSTSNMPCOMMUNITY$ and $_HOSTSNMPVERSION$ macros."
@@ -3557,6 +3614,13 @@ msgstr ""
 "the service group. If you specify a note here, you will see it in the "
 "extended information CGI (when you are viewing information about the "
 "specified service group)."
+
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"This directive is used to define is a longer name or description used to "
+"identify the host group.It is provided in order to allow you to more easily "
+"identify a particular host group."
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/host_dependency/help.php
 #: centreon/www/include/configuration/configObject/service_dependency/help.php
@@ -5267,6 +5331,12 @@ msgstr ""
 "contact groups in this contact group. Specify a list of other contact groups "
 "whose members should be included in this group."
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid ""
+"This optional directive can be used to include hosts from other host groups "
+"in this host group."
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/servicegroup/help.php
 msgid ""
 "This optional directive can be used to include services from other \"sub\" "
@@ -5676,6 +5746,10 @@ msgstr ""
 "Whether this category is a severity. Severities appear on the monitoring "
 "consoles."
 
+#: centreon/www/include/configuration/configObject/hostgroup/help.php
+msgid "Whether this host group is enabled."
+msgstr ""
+
 #: centreon/www/include/views/graphTemplates/help.php
 msgid "Width of grid. Used to export the chart."
 msgstr "Width of grid. Used to export the chart."
@@ -5829,8 +5903,12 @@ msgstr ""
 "days."
 
 #: unknown
-msgid "Address of the poller"
-msgstr "Address of the poller"
+msgid ""
+"Image folders that will be displayed to users. Images that belong to "
+"these folders will be visible."
+msgstr ""
+"Image folders that will be displayed to users. Images that belong to "
+"these folders will be visible."
 
 #: unknown
 msgid ""
@@ -5839,3 +5917,13 @@ msgid ""
 msgstr ""
 "MySQL configuration file path (e.g. /etc/my.cnf.d/centreon.cnf); leave "
 "empty to use the default value."
+
+#: unknown
+msgid ""
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg "
+"files. Multiple images can be uploaded together inside archives like zip, "
+"tar, tar.gz or tar.bz2."
+msgstr ""
+"Select a local file to upload. You can upload jpg, png, gif, gd2 and svg "
+"files. Multiple images can be uploaded together inside archives like zip, "
+"tar, tar.gz or tar.bz2."

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1,0 +1,19990 @@
+# English translations for Centreon web package.
+# Copyright (C) 2026 Centreon (https://www.centreon.com/)
+# This file is distributed under the same license as the Centreon web package.
+# Automatically generated, 2026.
+#
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/centreon_broker_translation.php
+msgid ""
+msgstr ""
+"Project-Id-Version: Centreon web\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-01 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Centreon Team\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: centreon/www/install/smarty_translate.php
+msgid " + Add a new entry"
+msgstr " + Add a new entry"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid " Required fields"
+msgstr " Required fields"
+
+#: centreon/www/install/smarty_translate.php
+msgid " Table is not partitioned "
+msgstr " Table is not partitioned "
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid " The timezone used is configured on your user settings"
+msgstr " The timezone used is configured on your user settings"
+
+#: centreon/www/install/step_upgrade/step3.php
+msgid " to "
+msgstr " to "
+
+#: centreon/www/install/react_translation.php
+#, php-format
+msgid "%s is not valid."
+msgstr "%s is not valid."
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+#, php-format
+msgid "'%d' is not a valid command type"
+msgstr "'%d' is not a valid command type"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+#, php-format
+msgid "'%s' does not exist with ID(s) '%s'"
+msgstr "'%s' does not exist with ID(s) '%s'"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "'%s' must contain at least one element"
+msgstr "'%s' must contain at least one element"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+#, php-format
+msgid "'%s' service name already exists for host ID %d"
+msgstr "'%s' service name already exists for host ID %d"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "*The timezone used is configured on your user settings"
+msgstr "*The timezone used is configured on your user settings"
+
+#: centreon/www/install/front_translate.php
+msgid "/*+&"
+msgstr "/*+&"
+
+#: centreon/www/install/front_translate.php
+msgid "0-9"
+msgstr "0-9"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "1 Column"
+msgstr "1 Column"
+
+#: centreon/www/install/front_translate.php
+msgid "1 day"
+msgstr "1 day"
+
+#: centreon/www/install/smarty_translate.php
+msgid "1 minute"
+msgstr "1 minute"
+
+#: centreon/www/install/front_translate.php
+msgid "12 hours"
+msgstr "12 hours"
+
+#: centreon/www/install/smarty_translate.php
+msgid "15 minutes"
+msgstr "15 minutes"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "2 Columns"
+msgstr "2 Columns"
+
+#: centreon/www/install/front_translate.php
+msgid "24 hours"
+msgstr "24 hours"
+
+#: centreon/www/install/front_translate.php
+msgid "24h/24h - 7/7 days"
+msgstr "24h/24h - 7/7 days"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "24x7"
+msgstr "24x7"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "3 Columns"
+msgstr "3 Columns"
+
+#: centreon/www/install/smarty_translate.php
+msgid "30 minutes"
+msgstr "30 minutes"
+
+#: centreon/www/install/front_translate.php
+msgid "31 days"
+msgstr "31 days"
+
+#: centreon/www/install/smarty_translate.php
+msgid "5 minutes"
+msgstr "5 minutes"
+
+#: centreon/www/install/front_translate.php
+msgid "7 days"
+msgstr "7 days"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid ""
+"<b><i>Help :</i></b> Select hosts and hostgroups that can be seen by "
+"associated users. You also have the possibility to exclude host(s) from "
+"selected hostgroup(s)."
+msgstr ""
+"<b><i>Help :</i></b> Select hosts and hostgroups that can be seen by "
+"associated users. You also have the possibility to exclude host(s) from "
+"selected hostgroup(s)."
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid ""
+"<b><i>Help :</i></b> Select image folders that can be seen by associated "
+"users."
+msgstr ""
+"<b><i>Help :</i></b> Select image folders that can be seen by associated "
+"users."
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid ""
+"<b><i>Help :</i></b> Select meta services that can be seen by associated "
+"users."
+msgstr ""
+"<b><i>Help :</i></b> Select meta services that can be seen by associated "
+"users."
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid ""
+"<b><i>Help :</i></b> Select services that can be seen by associated users."
+msgstr ""
+"<b><i>Help :</i></b> Select services that can be seen by associated users."
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid ""
+"<b><i>Help :</i></b> Select the filter(s) you want to apply to the resource "
+"definition for a more restrictive view."
+msgstr ""
+"<b><i>Help :</i></b> Select the filter(s) you want to apply to the resource "
+"definition for a more restrictive view."
+
+#: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+msgid "<br><b>Centreon : </b>A reload signal has been sent to "
+msgstr "<br><b>Centreon : </b>A reload signal has been sent to "
+
+#: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+msgid "<br><b>Centreon : </b>A restart signal has been sent to "
+msgstr "<br><b>Centreon : </b>A restart signal has been sent to "
+
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+msgid "<br><b>Centreon : </b>All configuration will be send to "
+msgstr "<br><b>Centreon : </b>All configuration will be send to "
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid ""
+"<br><i><b><font color=\"#B22222\">Notes </font>:</b></i><br>- Do not mix "
+"metrics of different sources.<br>- Only aggregation functions work in VDEF "
+"rpn expressions."
+msgstr ""
+"<br><i><b><font color=\"#B22222\">Notes </font>:</b></i><br>- Do not mix "
+"metrics of different sources.<br>- Only aggregation functions work in VDEF "
+"rpn expressions."
+
+#: centreon/www/install/step_upgrade/step4.php
+msgid "<p>Currently upgrading... please do not interrupt this process.</p>"
+msgstr "<p>Currently upgrading... please do not interrupt this process.</p>"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "A '%s': '%s'@'%s' is already saved"
+msgstr "A '%s': '%s'@'%s' is already saved"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid ""
+"A host or host template can have several templates. See help for more "
+"details."
+msgstr ""
+"A host or host template can have several templates. See help for more "
+"details."
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "A macro is malformated."
+msgstr "A macro is malformated."
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "A platform using the name : '%s' or address : '%s' already exists"
+msgstr "A platform using the name : '%s' or address : '%s' already exists"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid ""
+"A poller/agent configuration is already associated with poller ID(s) '%s'"
+msgstr ""
+"A poller/agent configuration is already associated with poller ID(s) '%s'"
+
+#: centreon/www/install/front_translate.php
+msgid "A-Z"
+msgstr "A-Z"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "ACKNOWLEDGED"
+msgstr "ACKNOWLEDGED"
+
+#: centreon/www/install/menu_translation.php
+msgid "ACL"
+msgstr "ACL"
+
+#: centreon/www/install/smarty_translate.php
+msgid "ACL Actions"
+msgstr "ACL Actions"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "ACL Definition"
+msgstr "ACL Definition"
+
+#: centreon/www/install/smarty_translate.php
+msgid "ACL Group"
+msgstr "ACL Group"
+
+#: centreon/www/install/smarty_translate.php
+msgid "ACL Menu"
+msgstr "ACL Menu"
+
+#: centreon/www/install/smarty_translate.php
+msgid "ACL Resource"
+msgstr "ACL Resource"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "ACL Resource Groups"
+msgstr "ACL Resource Groups"
+
+#: centreon/www/include/options/accessLists/resourcesACL/DB-Func.php
+msgid "ACL Resource name can't be empty"
+msgstr "ACL Resource name can't be empty"
+
+#: centreon/www/install/front_translate.php
+msgid "ACL access group"
+msgstr "ACL access group"
+
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+msgid "ACL reloaded"
+msgstr "ACL reloaded"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+msgid "ADD"
+msgstr "ADD"
+
+#: centreon/www/install/smarty_translate.php
+msgid "API Access Configuration"
+msgstr "API Access Configuration"
+
+#: centreon/www/install/smarty_translate.php
+msgid "API Options"
+msgstr "API Options"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+msgid "API calling the Central returned a Client exception"
+msgstr "API calling the Central returned a Client exception"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+msgid "API calling the Central returned a Redirection exception"
+msgstr "API calling the Central returned a Redirection exception"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
+msgid "API calling the Central returned a Server exception"
+msgstr "API calling the Central returned a Server exception"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Aborted."
+msgstr "Aborted."
+
+#: centreon/www/install/menu_translation.php
+msgid "About"
+msgstr "About"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "Access"
+msgstr "Access"
+
+#: centreon/www/install/menu_translation.php
+msgid "Access Groups"
+msgstr "Access Groups"
+
+#: centreon/www/install/menu_translation.php
+msgid "Access List"
+msgstr "Access List"
+
+#: centreon/www/install/front_translate.php
+msgid "Access group"
+msgstr "Access group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Access groups"
+msgstr "Access groups"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Access list groups"
+msgstr "Access list groups"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Access list name"
+msgstr "Access list name"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Access lists"
+msgstr "Access lists"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Accessible Pages"
+msgstr "Accessible Pages"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Acknowledge"
+msgstr "Acknowledge"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Acknowledge Host Problem"
+msgstr "Acknowledge Host Problem"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Acknowledge Service Problem"
+msgstr "Acknowledge Service Problem"
+
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+msgid "Acknowledge a Service"
+msgstr "Acknowledge a Service"
+
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Acknowledge a host"
+msgstr "Acknowledge a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Acknowledge a service"
+msgstr "Acknowledge a service"
+
+#: centreon/www/install/front_translate.php
+msgid "Acknowledge command sent"
+msgstr "Acknowledge command sent"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Acknowledge problem"
+msgstr "Acknowledge problem"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+msgid "Acknowledge problems"
+msgstr "Acknowledge problems"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+msgid "Acknowledge selected problems"
+msgstr "Acknowledge selected problems"
+
+#: centreon/www/install/front_translate.php
+msgid "Acknowledge services attached to host"
+msgstr "Acknowledge services attached to host"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+msgid "Acknowledge services attached to hosts"
+msgstr "Acknowledge services attached to hosts"
+
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Acknowledge services of hosts"
+msgstr "Acknowledge services of hosts"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Acknowledged"
+msgstr "Acknowledged"
+
+#: centreon/www/install/front_translate.php
+msgid "Acknowledged by"
+msgstr "Acknowledged by"
+
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+#, php-format
+msgid "Acknowledged by %s"
+msgstr "Acknowledged by %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Acknowledgement"
+msgstr "Acknowledgement"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+msgid "Acknowledgement already cancelled for this host"
+msgstr "Acknowledgement already cancelled for this host"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+msgid "Acknowledgement already cancelled for this meta service"
+msgstr "Acknowledgement already cancelled for this meta service"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+msgid "Acknowledgement already cancelled for this service"
+msgstr "Acknowledgement already cancelled for this service"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Acknowledgement timeout"
+msgstr "Acknowledgement timeout"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/install/front_translate.php
+msgid "Action"
+msgstr "Action"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Action 1 : Submit result to Monitoring Engine"
+msgstr "Action 1 : Submit result to Monitoring Engine"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Action 2 : Force rescheduling of service check"
+msgstr "Action 2 : Force rescheduling of service check"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Action 3 : Execute a Command"
+msgstr "Action 3 : Execute a Command"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Action Name"
+msgstr "Action Name"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Action URL"
+msgstr "Action URL"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Action access list link"
+msgstr "Action access list link"
+
+#: centreon/src/Centreon/Infrastructure/ActionLog/ActionLogRepositoryRDB.php
+msgid "Action log id can not be null"
+msgstr "Action log id can not be null"
+
+#: centreon/src/Centreon/Domain/ActionLog/ActionLogService.php
+msgid "Action log id cannot be null"
+msgstr "Action log id cannot be null"
+
+#: centreon/www/install/front_translate.php
+msgid "Action not permitted"
+msgstr "Action not permitted"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "Action not permitted for output of type '%s'"
+msgstr "Action not permitted for output of type '%s'"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Actions"
+msgstr "Actions"
+
+#: centreon/www/install/menu_translation.php
+msgid "Actions Access"
+msgstr "Actions Access"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Actions access"
+msgstr "Actions access"
+
+#: centreon/www/install/front_translate.php
+msgid "Activation"
+msgstr "Activation"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+msgid "Active"
+msgstr "Active"
+
+#: centreon/www/install/front_translate.php
+msgid "Active / Inactive"
+msgstr "Active / Inactive"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Active Checks"
+msgstr "Active Checks"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Active Checks Enabled"
+msgstr "Active Checks Enabled"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Active Directory"
+msgstr "Active Directory"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Active Directory :"
+msgstr "Active Directory :"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Actual"
+msgstr "Actual"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Actual End"
+msgstr "Actual End"
+
+#: centreon/www/class/centreonConfigCentreonBroker.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+msgid "Add"
+msgstr "Add"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Add (advanced)"
+msgstr "Add (advanced)"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Add Comment for this host"
+msgstr "Add Comment for this host"
+
+#: centreon/www/install/front_translate.php
+msgid "Add Contact..."
+msgstr "Add Contact..."
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Add Data Processing"
+msgstr "Add Data Processing"
+
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+msgid "Add Group"
+msgstr "Add Group"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Add Image(s)"
+msgstr "Add Image(s)"
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+msgid "Add Vendor"
+msgstr "Add Vendor"
+
+#: centreon/www/install/menu_translation.php
+msgid "Add View"
+msgstr "Add View"
+
+#: centreon/www/install/menu_translation.php
+msgid "Add Widget"
+msgstr "Add Widget"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Add a Centreon Poller"
+msgstr "Add a Centreon Poller"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Add a Centreon Remote Server"
+msgstr "Add a Centreon Remote Server"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Add a Centreon-Broker Configuration"
+msgstr "Add a Centreon-Broker Configuration"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Add a Command"
+msgstr "Add a Command"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Add a Connector"
+msgstr "Add a Connector"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "Add a Contact Group"
+msgstr "Add a Contact Group"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Add a Data Source Template"
+msgstr "Add a Data Source Template"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Add a Dependency"
+msgstr "Add a Dependency"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Add a Graph Template"
+msgstr "Add a Graph Template"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Add a Group"
+msgstr "Add a Group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Add a Host"
+msgstr "Add a Host"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Add a Host Extended Info"
+msgstr "Add a Host Extended Info"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Add a Host Template"
+msgstr "Add a Host Template"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "Add a Meta Service"
+msgstr "Add a Meta Service"
+
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+msgid "Add a Meta Service indicator"
+msgstr "Add a Meta Service indicator"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Add a Monitoring Engine Configuration File"
+msgstr "Add a Monitoring Engine Configuration File"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Add a Service"
+msgstr "Add a Service"
+
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "Add a Service Category"
+msgstr "Add a Service Category"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Add a Service Group"
+msgstr "Add a Service Group"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Add a Service Template Model"
+msgstr "Add a Service Template Model"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Add a Time Period"
+msgstr "Add a Time Period"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Add a Trap definition"
+msgstr "Add a Trap definition"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Add a User"
+msgstr "Add a User"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Add a User Template"
+msgstr "Add a User Template"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Add a Virtual Metric"
+msgstr "Add a Virtual Metric"
+
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/front_translate.php
+msgid "Add a comment"
+msgstr "Add a comment"
+
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+msgid "Add a comment for Host"
+msgstr "Add a comment for Host"
+
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+msgid "Add a comment for Service"
+msgstr "Add a comment for Service"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Add a comment for this service"
+msgstr "Add a comment for this service"
+
+#: centreon/www/install/front_translate.php
+msgid "Add a contact"
+msgstr "Add a contact"
+
+#: centreon/www/install/front_translate.php
+msgid "Add a contact group"
+msgstr "Add a contact group"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Add a downtime"
+msgstr "Add a downtime"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Add a global macro"
+msgstr "Add a global macro"
+
+#: centreon/www/install/front_translate.php
+msgid "Add a host"
+msgstr "Add a host"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "Add a host category"
+msgstr "Add a host category"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Add a new macro"
+msgstr "Add a new macro"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Add a poller"
+msgstr "Add a poller"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Add a template"
+msgstr "Add a template"
+
+#: centreon/www/install/front_translate.php
+msgid "Add a token"
+msgstr "Add a token"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Add a widget"
+msgstr "Add a widget"
+
+#: centreon/www/install/front_translate.php
+msgid "Add additional configurations"
+msgstr "Add additional configurations"
+
+#: centreon/www/install/front_translate.php
+msgid "Add advanced server configuration"
+msgstr "Add advanced server configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Add agent configuration"
+msgstr "Add agent configuration"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Add an ACL"
+msgstr "Add an ACL"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Add an Action"
+msgstr "Add an Action"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Add an Escalation"
+msgstr "Add an Escalation"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Add an Extended Info"
+msgstr "Add an Extended Info"
+
+#: centreon/www/install/front_translate.php
+msgid "Add an additional configuration"
+msgstr "Add an additional configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Add an advanced configuration"
+msgstr "Add an advanced configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Add at least 1 contact"
+msgstr "Add at least 1 contact"
+
+#: centreon/www/install/front_translate.php
+msgid "Add columns"
+msgstr "Add columns"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Add comment"
+msgstr "Add comment"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Add downtime"
+msgstr "Add downtime"
+
+#: centreon/www/install/front_translate.php
+msgid "Add filter"
+msgstr "Add filter"
+
+#: centreon/www/install/front_translate.php
+msgid "Add host group"
+msgstr "Add host group"
+
+#: centreon/www/install/steps/process/installConfigurationDb.php
+msgid ""
+"Add innodb_file_per_table=1 in my.cnf file under the [mysqld] section and "
+"restart MySQL Server."
+msgstr ""
+"Add innodb_file_per_table=1 in my.cnf file under the [mysqld] section and "
+"restart MySQL Server."
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Add macros"
+msgstr "Add macros"
+
+#: centreon/www/install/front_translate.php
+msgid "Add metric"
+msgstr "Add metric"
+
+#: centreon/www/install/front_translate.php
+msgid "Add new agent configuration"
+msgstr "Add new agent configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Add new dataset"
+msgstr "Add new dataset"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Add new entry"
+msgstr "Add new entry"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Add new period"
+msgstr "Add new period"
+
+#: centreon/www/install/front_translate.php
+msgid "Add parameter"
+msgstr "Add parameter"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Add relations"
+msgstr "Add relations"
+
+#: centreon/www/install/front_translate.php
+msgid "Add resource datasets"
+msgstr "Add resource datasets"
+
+#: centreon/www/install/react_translation.php
+msgid "Add server with wizard"
+msgstr "Add server with wizard"
+
+#: centreon/www/install/front_translate.php
+msgid "Add to favorites"
+msgstr "Add to favorites"
+
+#: centreon/www/install/front_translate.php
+msgid "Add vCenter/ESX"
+msgstr "Add vCenter/ESX"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Add view"
+msgstr "Add view"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Add widget"
+msgstr "Add widget"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+msgid "Add with wizard"
+msgstr "Add with wizard"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Add/Delete a comment for a host"
+msgstr "Add/Delete a comment for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Add/Delete a comment for a service"
+msgstr "Add/Delete a comment for a service"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/install/front_translate.php
+msgid "Added"
+msgstr "Added"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Additional Addresses"
+msgstr "Additional Addresses"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Additional Configurations"
+msgstr "Additional Configurations"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Additional Information"
+msgstr "Additional Information"
+
+#: centreon/www/install/front_translate.php
+msgid "Additional configuration created"
+msgstr "Additional configuration created"
+
+#: centreon/www/install/front_translate.php
+msgid "Additional configuration deleted"
+msgstr "Additional configuration deleted"
+
+#: centreon/www/install/front_translate.php
+msgid "Additional configuration duplicated"
+msgstr "Additional configuration duplicated"
+
+#: centreon/www/install/front_translate.php
+msgid "Additional configuration updated"
+msgstr "Additional configuration updated"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Additional freshness latency"
+msgstr "Additional freshness latency"
+
+#: centreon/www/install/front_translate.php
+msgid "Additional information"
+msgstr "Additional information"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Address"
+msgstr "Address"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address1"
+msgstr "Address1"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address2"
+msgstr "Address2"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address3"
+msgstr "Address3"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address4"
+msgstr "Address4"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address5"
+msgstr "Address5"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address6"
+msgstr "Address6"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/install/front_translate.php
+msgid "Admin"
+msgstr "Admin"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step5.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/smarty_translate.php
+msgid "Admin information"
+msgstr "Admin information"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/install/menu_translation.php
+msgid "Administration"
+msgstr "Administration"
+
+#: centreon/www/install/menu_translation.php
+msgid "Administrator"
+msgstr "Administrator"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Administrator Email Address"
+msgstr "Administrator Email Address"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Administrator Pager"
+msgstr "Administrator Pager"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Advanced"
+msgstr "Advanced"
+
+#: centreon/www/install/menu_translation.php
+msgid "Advanced Logs"
+msgstr "Advanced Logs"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Advanced matching behavior"
+msgstr "Advanced matching behavior"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Advanced matching mode"
+msgstr "Advanced matching mode"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Advanced matching rules"
+msgstr "Advanced matching rules"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Advanced options"
+msgstr "Advanced options"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Advanced settings"
+msgstr "Advanced settings"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Advanced: reverse Centreon Broker communication flow"
+msgstr "Advanced: reverse Centreon Broker communication flow"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "After"
+msgstr "After"
+
+#: centreon/www/install/front_translate.php
+msgid "Agent"
+msgstr "Agent"
+
+#: centreon/www/install/front_translate.php
+msgid "Agent configuration created"
+msgstr "Agent configuration created"
+
+#: centreon/www/install/front_translate.php
+msgid "Agent configuration updated"
+msgstr "Agent configuration updated"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Agent configurations"
+msgstr "Agent configurations"
+
+#: centreon/www/install/front_translate.php
+msgid "Agent type"
+msgstr "Agent type"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Aggregation frequency"
+msgstr "Aggregation frequency"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "Alert"
+msgstr "Alert"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Alerts"
+msgstr "Alerts"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/install/front_translate.php
+msgid "Alias"
+msgstr "Alias"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "Alias / Login"
+msgstr "Alias / Login"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Alias already exists"
+msgstr "Alias already exists"
+
+#: centreon/www/class/centreonLogAction.class.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "All"
+msgstr "All"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "All Comments for this service"
+msgstr "All Comments for this service"
+
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+msgid "All Hostgroups"
+msgstr "All Hostgroups"
+
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+msgid "All Hosts"
+msgstr "All Hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "All KPIs on this Business Activity are working fine."
+msgstr "All KPIs on this Business Activity are working fine."
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "All Pollers"
+msgstr "All Pollers"
+
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+msgid "All Servicegroups"
+msgstr "All Servicegroups"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "All Services"
+msgstr "All Services"
+
+#: centreon/www/install/front_translate.php
+msgid "All alerts"
+msgstr "All alerts"
+
+#: centreon/www/install/front_translate.php
+msgid "All business views"
+msgstr "All business views"
+
+#: centreon/www/install/front_translate.php
+msgid "All business views selected"
+msgstr "All business views selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All checks are disabled"
+msgstr "All checks are disabled"
+
+#: centreon/www/install/front_translate.php
+msgid "All columns"
+msgstr "All columns"
+
+#: centreon/www/install/front_translate.php
+msgid "All contact groups"
+msgstr "All contact groups"
+
+#: centreon/www/install/front_translate.php
+msgid "All contact groups selected"
+msgstr "All contact groups selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All contacts"
+msgstr "All contacts"
+
+#: centreon/www/install/front_translate.php
+msgid "All contacts selected"
+msgstr "All contacts selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All host groups"
+msgstr "All host groups"
+
+#: centreon/www/install/front_translate.php
+msgid "All host groups selected"
+msgstr "All host groups selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All hosts"
+msgstr "All hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "All hosts selected"
+msgstr "All hosts selected"
+
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/install/front_translate.php
+msgid "All image folders"
+msgstr "All image folders"
+
+#: centreon/www/install/front_translate.php
+msgid "All image folders selected"
+msgstr "All image folders selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All metrics on this service are working fine."
+msgstr "All metrics on this service are working fine."
+
+#: centreon/www/install/front_translate.php
+msgid "All pages"
+msgstr "All pages"
+
+#: centreon/www/install/react_translation.php
+msgid "All pollers"
+msgstr "All pollers"
+
+#: centreon/www/install/front_translate.php
+msgid "All pollers:"
+msgstr "All pollers:"
+
+#: centreon/www/install/front_translate.php
+msgid "All resources"
+msgstr "All resources"
+
+#: centreon/www/install/front_translate.php
+msgid "All resources selected"
+msgstr "All resources selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All service groups"
+msgstr "All service groups"
+
+#: centreon/www/install/front_translate.php
+msgid "All service groups selected"
+msgstr "All service groups selected"
+
+#: centreon/www/install/front_translate.php
+msgid "All services on this host are working fine."
+msgstr "All services on this host are working fine."
+
+#: centreon/www/include/options/session/connected_user.php
+msgid ""
+"All this contact sessions will be closed. Are you sure you want to request a "
+"synchronization at the next login of this Contact ?"
+msgstr ""
+"All this contact sessions will be closed. Are you sure you want to request a "
+"synchronization at the next login of this Contact ?"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid "Allow self signed certificate"
+msgstr "Allow self signed certificate"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Allows you to add free text to your dashboards (section titles, information, "
+"etc.)."
+msgstr ""
+"Allows you to add free text to your dashboards (section titles, information, "
+"etc.)."
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Already exists"
+msgstr "Already exists"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid ""
+"Already requested, please wait the CRON execution or for the user to login"
+msgstr ""
+"Already requested, please wait the CRON execution or for the user to login"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Alt icon"
+msgstr "Alt icon"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Alternative domain for ldap"
+msgstr "Alternative domain for ldap"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#, php-format
+msgid ""
+"An additional configuration of type '%s' is already associated with poller "
+"ID(s) '%s'"
+msgstr ""
+"An additional configuration of type '%s' is already associated with poller "
+"ID(s) '%s'"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"An agent is a piece of software you install on the host you want to monitor, "
+"that executes the checks."
+msgstr ""
+"An agent is a piece of software you install on the host you want to monitor, "
+"that executes the checks."
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "An error occured while decoding Identity Provider ID Token"
+msgstr "An error occured while decoding Identity Provider ID Token"
+
+#: centreon/src/CentreonModule/Infrastructure/Source/ModuleException.php
+#, php-format
+msgid "An error occured while retrieving details of module \"%s\""
+msgstr "An error occured while retrieving details of module \"%s\""
+
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+msgid "An error occurred"
+msgstr "An error occurred"
+
+#: centreon/www/install/front_translate.php
+msgid "An error occurred during authentication"
+msgstr "An error occurred during authentication"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+msgid "An error occurred when applying post update actions"
+msgstr "An error occurred when applying post update actions"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+#, php-format
+msgid "An error occurred when applying the update %s (%s)"
+msgstr "An error occurred when applying the update %s (%s)"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+#, php-format
+msgid "An error occurred when applying the update (%s)"
+msgstr "An error occurred when applying the update (%s)"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+msgid "An error occurred when retrieving available updates"
+msgstr "An error occurred when retrieving available updates"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+msgid "An error occurred when retrieving the current version"
+msgstr "An error occurred when retrieving the current version"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+msgid "An error occurred when writing engine context configuration"
+msgstr "An error occurred when writing engine context configuration"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "An error occurred while creating the file '%s'"
+msgstr "An error occurred while creating the file '%s'"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "An error occurred while deleting the file '%s'"
+msgstr "An error occurred while deleting the file '%s'"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+msgid "An error occurred while deleting the platform"
+msgstr "An error occurred while deleting the platform"
+
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+msgid "An error occurred while disabling the central menus"
+msgstr "An error occurred while disabling the central menus"
+
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+msgid "An error occurred while enabling the central menus"
+msgstr "An error occurred while enabling the central menus"
+
+#: centreon/www/class/centreonCustomView.class.php
+msgid "An error occurred while retrieving groups linked to ViewId on database"
+msgstr "An error occurred while retrieving groups linked to ViewId on database"
+
+#: centreon/src/Core/Notification/Application/UseCase/FindNotifications/FindNotifications.php
+msgid "An error occurred while retrieving the notifications listing"
+msgstr "An error occurred while retrieving the notifications listing"
+
+#: centreon/www/class/centreonCustomView.class.php
+msgid "An error occurred while retrieving users linked to ViewId on database"
+msgstr "An error occurred while retrieving users linked to ViewId on database"
+
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+msgid "An error occurred while searching any remote children"
+msgstr "An error occurred while searching any remote children"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+msgid "An error occurred while updating the platform"
+msgstr "An error occurred while updating the platform"
+
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+msgid "An error occurred while updating the platform topology"
+msgstr "An error occurred while updating the platform topology"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "An integer with a minimum value of 1 is required"
+msgstr "An integer with a minimum value of 1 is required"
+
+#: centreon/www/install/front_translate.php
+msgid "And many others..."
+msgstr "And many others..."
+
+#: centreon/www/install/front_translate.php
+msgid "Anomaly detection"
+msgstr "Anomaly detection"
+
+#: centreon/www/api/class/centreon_home_customview.class.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Apply"
+msgstr "Apply"
+
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Apply Period"
+msgstr "Apply Period"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Apply configurations"
+msgstr "Apply configurations"
+
+#: centreon/www/install/front_translate.php
+msgid "Apply only first role"
+msgstr "Apply only first role"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Apply period"
+msgstr "Apply period"
+
+#: centreon/www/install/front_translate.php
+msgid "Apply resource access rules to the host group"
+msgstr "Apply resource access rules to the host group"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Archives"
+msgstr "Archives"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Are you sure you want to change the size of the envelope? The new envelope "
+"size will be applied immediately."
+msgstr ""
+"Are you sure you want to change the size of the envelope? The new envelope "
+"size will be applied immediately."
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+msgid "Are you sure you want to detach the service ?"
+msgstr "Are you sure you want to detach the service ?"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Area"
+msgstr "Area"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Area color"
+msgstr "Area color"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Args"
+msgstr "Args"
+
+#: centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+msgid "Argument"
+msgstr "Argument"
+
+#: centreon/www/include/configuration/configObject/command/formArguments.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Argument Descriptions"
+msgstr "Argument Descriptions"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Argument Example"
+msgstr "Argument Example"
+
+#: centreon/www/include/configuration/configObject/command/formArguments.php
+msgid "Arguments"
+msgstr "Arguments"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "Ascending"
+msgstr "Ascending"
+
+#: centreon/www/include/configuration/configResources/listResources.php
+msgid "Associated pollers"
+msgstr "Associated pollers"
+
+#: centreon/www/install/front_translate.php
+msgid "At least one authorization relation is required"
+msgstr "At least one authorization relation is required"
+
+#: centreon/www/install/front_translate.php
+msgid "At least one column must be selected"
+msgstr "At least one column must be selected"
+
+#: centreon/www/install/front_translate.php
+msgid "At least one connection mode must be enabled."
+msgstr "At least one connection mode must be enabled."
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "At least one contact or contactgroup should be linked to the rule"
+msgstr "At least one contact or contactgroup should be linked to the rule"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"At least one illegal character in '%s' was found in platform's name: '%s'"
+msgstr ""
+"At least one illegal character in '%s' was found in platform's name: '%s'"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"At least one non RFC compliant character was found in platform's hostname: "
+"'%s'"
+msgstr ""
+"At least one non RFC compliant character was found in platform's hostname: "
+"'%s'"
+
+#: centreon/www/install/front_translate.php
+msgid "At least one of the two following fields must be filled"
+msgstr "At least one of the two following fields must be filled"
+
+#: centreon/www/install/front_translate.php
+msgid "At least one poller is required"
+msgstr "At least one poller is required"
+
+#: centreon/www/install/front_translate.php
+msgid "At least one vCenter is required"
+msgstr "At least one vCenter is required"
+
+#: centreon/www/install/front_translate.php
+msgid "At least three columns must be selected"
+msgstr "At least three columns must be selected"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Attach additional Remote Servers"
+msgstr "Attach additional Remote Servers"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Attach poller to a master remote server"
+msgstr "Attach poller to a master remote server"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Attach poller to additional remote servers"
+msgstr "Attach poller to additional remote servers"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Attach to Master Remote Server"
+msgstr "Attach to Master Remote Server"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Attempt"
+msgstr "Attempt"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Audit log activation"
+msgstr "Audit log activation"
+
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Authentication"
+msgstr "Authentication"
+
+#: centreon/src/App/Security/Infrastructure/Security/TokenAuthenticator.php
+#: centreon/src/Security/TokenAPIAuthenticator.php
+msgid "Authentication Required"
+msgstr "Authentication Required"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Authentication Source"
+msgstr "Authentication Source"
+
+#: centreon/www/install/menu_translation.php
+msgid "Authentication Tokens"
+msgstr "Authentication Tokens"
+
+#: centreon/www/install/front_translate.php
+msgid "Authentication conditions"
+msgstr "Authentication conditions"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Authentication debug"
+msgstr "Authentication debug"
+
+#: centreon/www/install/front_translate.php
+msgid "Authentication denied"
+msgstr "Authentication denied"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
+#: centreon/www/include/Administration/myAccount/DB-Func.php
+#: centreon/www/include/configuration/configObject/contact/DB-Func.php
+msgid "Authentication failed"
+msgstr "Authentication failed"
+
+#: centreon/www/install/front_translate.php
+msgid "Authentication mode"
+msgstr "Authentication mode"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Authentication properties"
+msgstr "Authentication properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Authentication token copied to the clipboard"
+msgstr "Authentication token copied to the clipboard"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Authentication token expired"
+msgstr "Authentication token expired"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Authentication token not found"
+msgstr "Authentication token not found"
+
+#: centreon/www/install/front_translate.php
+msgid "Authentication tokens"
+msgstr "Authentication tokens"
+
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Author"
+msgstr "Author"
+
+#: centreon/www/install/front_translate.php
+msgid "Authorization endpoint"
+msgstr "Authorization endpoint"
+
+#: centreon/www/install/front_translate.php
+msgid "Authorization key"
+msgstr "Authorization key"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Authorization token (optional)"
+msgstr "Authorization token (optional)"
+
+#: centreon/www/install/front_translate.php
+msgid "Authorization value"
+msgstr "Authorization value"
+
+#: centreon/www/install/front_translate.php
+msgid "Authorizations"
+msgstr "Authorizations"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Authorizations information"
+msgstr "Authorizations information"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
+msgid "Authorized conditions not found in provider conditions"
+msgstr "Authorized conditions not found in provider conditions"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Authors"
+msgstr "Authors"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Auto"
+msgstr "Auto"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Auto Rescheduling"
+msgstr "Auto Rescheduling"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/install/front_translate.php
+msgid "Auto import users"
+msgstr "Auto import users"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Auto-Rescheduling Interval"
+msgstr "Auto-Rescheduling Interval"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Auto-Rescheduling Option"
+msgstr "Auto-Rescheduling Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Auto-Rescheduling Window"
+msgstr "Auto-Rescheduling Window"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Auto: Default value defined for the corresponding curve template (Monitoring "
+"> Performances > Curves)."
+msgstr ""
+"Auto: Default value defined for the corresponding curve template (Monitoring "
+"> Performances > Curves)."
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Autologin Key"
+msgstr "Autologin Key"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Automatic State Retention Update Interval"
+msgstr "Automatic State Retention Update Interval"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Autorized contacts"
+msgstr "Autorized contacts"
+
+#: centreon/www/install/menu_translation.php
+msgid "Availability"
+msgstr "Availability"
+
+#: centreon/www/class/centreonConfigCentreonBroker.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/install/front_translate.php
+msgid "Available"
+msgstr "Available"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Average"
+msgstr "Average"
+
+#: centreon/www/install/front_translate.php
+msgid "Avg"
+msgstr "Avg"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Axes"
+msgstr "Axes"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "BBDO version"
+msgstr "BBDO version"
+
+#: centreon/www/include/core/header/htmlHeader.php
+#: centreon/www/install/smarty_translate.php
+msgid "Back"
+msgstr "Back"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Background color"
+msgstr "Background color"
+
+#: centreon/www/install/menu_translation.php
+msgid "Backup"
+msgstr "Backup"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup configuration files"
+msgstr "Backup configuration files"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup database centreon"
+msgstr "Backup database centreon"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup database centreon_storage"
+msgstr "Backup database centreon_storage"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup directory"
+msgstr "Backup directory"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Backup directory for partitioning"
+msgstr "Backup directory for partitioning"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup enabled"
+msgstr "Backup enabled"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Backup properties"
+msgstr "Backup properties"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup retention"
+msgstr "Backup retention"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Backup type"
+msgstr "Backup type"
+
+#: centreon/www/install/front_translate.php
+msgid "Backward"
+msgstr "Backward"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Bad Format: start color by #"
+msgstr "Bad Format: start color by #"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Bad OID Format"
+msgstr "Bad OID Format"
+
+#: centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+msgid "Bad SQL request"
+msgstr "Bad SQL request"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Bad Session ID"
+msgstr "Bad Session ID"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+msgid "Bad host ID"
+msgstr "Bad host ID"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#, php-format
+msgid "Bad ldap filter: missing %s pattern. Check user or group filter"
+msgstr "Bad ldap filter: missing %s pattern. Check user or group filter"
+
+#: centreon/www/include/options/media/images/syncDir.php
+msgid "Bad picture alias detected :"
+msgstr "Bad picture alias detected :"
+
+#: centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+msgid "Bad search operator"
+msgstr "Bad search operator"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Bad service ID"
+msgstr "Bad service ID"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Bar"
+msgstr "Bar"
+
+#: centreon/www/install/front_translate.php
+msgid "Bar chart"
+msgstr "Bar chart"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Bar opacity"
+msgstr "Bar opacity"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Bar radius"
+msgstr "Bar radius"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+msgid "Base"
+msgstr "Base"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Base 10"
+msgstr "Base 10"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Base 2"
+msgstr "Base 2"
+
+#: centreon/www/install/front_translate.php
+msgid "Base URL"
+msgstr "Base URL"
+
+#: centreon/www/install/front_translate.php
+msgid "Base color"
+msgstr "Base color"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Basic Settings"
+msgstr "Basic Settings"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Basic information"
+msgstr "Basic information"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Before"
+msgstr "Before"
+
+#: centreon/www/install/front_translate.php
+msgid "Before last year"
+msgstr "Before last year"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+msgid "Begin date"
+msgstr "Begin date"
+
+#: centreon/www/install/front_translate.php
+msgid "Better"
+msgstr "Better"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Bind password"
+msgstr "Bind password"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Bind user"
+msgstr "Bind user"
+
+#: centreon/www/install/front_translate.php
+msgid "Blacklist client addresses"
+msgstr "Blacklist client addresses"
+
+#: centreon/www/install/front_translate.php
+msgid "Blocking duration must be less than or equal to 7 days"
+msgstr "Blocking duration must be less than or equal to 7 days"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Both"
+msgstr "Both"
+
+#: centreon/www/install/front_translate.php
+msgid "Both identity provider and Centreon UI"
+msgstr "Both identity provider and Centreon UI"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Bottom"
+msgstr "Bottom"
+
+#: centreon/www/install/front_translate.php
+msgid "Breadcrumb copied"
+msgstr "Breadcrumb copied"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Broker Module"
+msgstr "Broker Module"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Broker Module Configuration File"
+msgstr "Broker Module Configuration File"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Broker Module Options"
+msgstr "Broker Module Options"
+
+#: centreon/www/install/menu_translation.php
+msgid "Broker Statistics"
+msgstr "Broker Statistics"
+
+#: centreon/www/install/menu_translation.php
+msgid "Broker configuration"
+msgstr "Broker configuration"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "Broker configuration #%d not found"
+msgstr "Broker configuration #%d not found"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Broker events"
+msgstr "Broker events"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step4.php
+msgid "Broker module information"
+msgstr "Broker module information"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Buffering timeout"
+msgstr "Buffering timeout"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid "Build full URI (SCHEME://IP:PORT/PATH)."
+msgstr "Build full URI (SCHEME://IP:PORT/PATH)."
+
+#: centreon/www/install/front_translate.php
+msgid "Business Activity"
+msgstr "Business Activity"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Business Activity Diagram"
+msgstr "Business Activity Diagram"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Business Activity availability"
+msgstr "Business Activity availability"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Business Activity availability history"
+msgstr "Business Activity availability history"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Business Activity status timeline"
+msgstr "Business Activity status timeline"
+
+#: centreon/www/install/front_translate.php
+msgid "Business View"
+msgstr "Business View"
+
+#: centreon/www/install/front_translate.php
+msgid "Business Views"
+msgstr "Business Views"
+
+#: centreon/www/install/front_translate.php
+msgid "Business Views events"
+msgstr "Business Views events"
+
+#: centreon/www/install/front_translate.php
+msgid "Business view"
+msgstr "Business view"
+
+#: centreon/www/install/step_upgrade/step4.php
+msgid ""
+"But do not edit the SQL files unless you know what you are doing.Refresh "
+"this page when the problem is fixed."
+msgstr ""
+"But do not edit the SQL files unless you know what you are doing.Refresh "
+"this page when the problem is fixed."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Button 1"
+msgstr "Button 1"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Button 2"
+msgstr "Button 2"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Button 3"
+msgstr "Button 3"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Button 4"
+msgstr "Button 4"
+
+#: centreon/www/install/front_translate.php
+msgid "By"
+msgstr "By"
+
+#: centreon/www/install/menu_translation.php
+msgid "By Host"
+msgstr "By Host"
+
+#: centreon/www/install/menu_translation.php
+msgid "By Host Group"
+msgstr "By Host Group"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "By OID"
+msgstr "By OID"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "By OID and Host"
+msgstr "By OID and Host"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "By OID, Host and Service"
+msgstr "By OID, Host and Service"
+
+#: centreon/www/install/menu_translation.php
+msgid "By Service Group"
+msgstr "By Service Group"
+
+#: centreon/www/install/menu_translation.php
+msgid "By Status"
+msgstr "By Status"
+
+#: centreon/www/install/front_translate.php
+msgid "By agent"
+msgstr "By agent"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"By default, the data of Business Views is aggregated monthly over the past "
+"12 months (if available)."
+msgstr ""
+"By default, the data of Business Views is aggregated monthly over the past "
+"12 months (if available)."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"By executing this script, your platform will be in a locked mode and you "
+"will not be able to do <strong>anything</strong> during the migration "
+"process (example: deploying your configuration, updating administration "
+"parameters, etc...)."
+msgstr ""
+"By executing this script, your platform will be in a locked mode and you "
+"will not be able to do <strong>anything</strong> during the migration "
+"process (example: deploying your configuration, updating administration "
+"parameters, etc...)."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "By name"
+msgstr "By name"
+
+#: centreon/www/install/front_translate.php
+msgid "By poller"
+msgstr "By poller"
+
+#: centreon/www/install/front_translate.php
+msgid "CA (.crt, .cert, .cer)"
+msgstr "CA (.crt, .cert, .cer)"
+
+#: centreon/www/install/front_translate.php
+msgid "CA Common Name (CN)"
+msgstr "CA Common Name (CN)"
+
+#: centreon/www/install/front_translate.php
+msgid "CMA authentication token(s)"
+msgstr "CMA authentication token(s)"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "CRITICAL"
+msgstr "CRITICAL"
+
+#: centreon/www/install/front_translate.php
+msgid "CSV"
+msgstr "CSV"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Cache"
+msgstr "Cache"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Cache directory"
+msgstr "Cache directory"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Cached Check"
+msgstr "Cached Check"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Cached Host Check"
+msgstr "Cached Host Check"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Cached Service Check"
+msgstr "Cached Service Check"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+msgid "Calculation Type"
+msgstr "Calculation Type"
+
+#: centreon/www/install/front_translate.php
+msgid "Calculation method"
+msgstr "Calculation method"
+
+#: centreon/src/Centreon/Domain/MetaServiceConfiguration/Model/MetaServiceConfiguration.php
+#: centreon/tests/php/Centreon/Domain/MetaServiceConfiguration/Model/MetaServiceConfigurationTest.php
+#, php-format
+msgid "Calculation method provided not supported (%s)"
+msgstr "Calculation method provided not supported (%s)"
+
+#: centreon/www/install/front_translate.php
+msgid "Calculation type"
+msgstr "Calculation type"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Calculations based on time period"
+msgstr "Calculations based on time period"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Can't Use This Virtual Metric '"
+msgstr "Can't Use This Virtual Metric '"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "Can't be equal to 0"
+msgstr "Can't be equal to 0"
+
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "Can't execute binary"
+msgstr "Can't execute binary"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid ""
+"Can't resolve username from login claim using configured regular expression"
+msgstr ""
+"Can't resolve username from login claim using configured regular expression"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Can't write in directory"
+msgstr "Can't write in directory"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Cancel"
+msgstr "Cancel"
+
+#: centreon/www/install/front_translate.php
+msgid "Cancel notification creation"
+msgstr "Cancel notification creation"
+
+#: centreon/www/install/front_translate.php
+msgid "Cancel notification update"
+msgstr "Cancel notification update"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Cancelled"
+msgstr "Cancelled"
+
+#: centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
+#, php-format
+msgid "Cannot build uri to unknown tab : %s"
+msgstr "Cannot build uri to unknown tab : %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Cannot enter fullscreen mode"
+msgstr "Cannot enter fullscreen mode"
+
+#: centreon/www/install/steps/process/insertBaseConf.php
+msgid "Cannot get Centreon version"
+msgstr "Cannot get Centreon version"
+
+#: centreon/www/install/steps/process/insertBaseConf.php
+msgid "Cannot get timezone information"
+msgstr "Cannot get timezone information"
+
+#: centreon/www/install/front_translate.php
+msgid "Cannot load module"
+msgstr "Cannot load module"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Cannot open statistics file"
+msgstr "Cannot open statistics file"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "Cannot register the '%s' platform : '%s'@'%s' behind a '%s' platform"
+msgstr "Cannot register the '%s' platform : '%s'@'%s' behind a '%s' platform"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+msgid "Cannot retrieve the current version"
+msgstr "Cannot retrieve the current version"
+
+#: centreon/src/Core/Platform/Infrastructure/Validator/RequirementValidators/DatabaseRequirementException.php
+msgid "Cannot retrieve the database version information"
+msgstr "Cannot retrieve the database version information"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
+msgid "Cannot set parent id to a central server"
+msgstr "Cannot set parent id to a central server"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
+msgid "Cannot use parent address on a Central server type"
+msgstr "Cannot use parent address on a Central server type"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Categories"
+msgstr "Categories"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Centcore commands"
+msgstr "Centcore commands"
+
+#: centreon/src/Centreon/Infrastructure/Engine/EngineRepositoryFile.php
+#, php-format
+msgid "Centcore directory %s does not exist"
+msgstr "Centcore directory %s does not exist"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Central"
+msgstr "Central"
+
+#: centreon/src/Centreon/Domain/Repository/CfgCentreonBrokerRepository.php
+msgid "Central broker config id not found"
+msgstr "Central broker config id not found"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/Exception/PlatformInformationException.php
+msgid ""
+"Central platform's API data is not consistent. Please check the 'Remote "
+"Access' form."
+msgstr ""
+"Central platform's API data is not consistent. Please check the 'Remote "
+"Access' form."
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid "Central's API URI"
+msgstr "Central's API URI"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid "Central's API credentials"
+msgstr "Central's API credentials"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"Central's credentials are missing on: '%s'@'%s'. Please check the Remote "
+"Access form"
+msgstr ""
+"Central's credentials are missing on: '%s'@'%s'. Please check the Remote "
+"Access form"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"Central's path is missing on: '%s'@'%s'. Please check the Remote Access form"
+msgstr ""
+"Central's path is missing on: '%s'@'%s'. Please check the Remote Access form"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"Central's protocol port is missing on: '%s'@'%s'. Please check the Remote "
+"Access form"
+msgstr ""
+"Central's protocol port is missing on: '%s'@'%s'. Please check the Remote "
+"Access form"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"Central's protocol scheme is missing on: '%s'@'%s'. Please check the Remote "
+"Access form"
+msgstr ""
+"Central's protocol scheme is missing on: '%s'@'%s'. Please check the Remote "
+"Access form"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
+msgid "Central's response => Code : "
+msgstr "Central's response => Code : "
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/front_translate.php
+msgid "Centreon"
+msgstr "Centreon"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Centreon Authentication"
+msgstr "Centreon Authentication"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/smarty_translate.php
+msgid "Centreon Broker"
+msgstr "Centreon Broker"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Centreon Broker configuration"
+msgstr "Centreon Broker configuration"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Broker configuration path"
+msgstr "Centreon Broker configuration path"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Broker logs path"
+msgstr "Centreon Broker logs path"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Broker modules path"
+msgstr "Centreon Broker modules path"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Broker reload command"
+msgstr "Centreon Broker reload command"
+
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+#, php-format
+msgid ""
+"Centreon Broker's configuration directory '%s' does not exist and could not\n"
+"                                             be created for monitoring "
+"engine '%s'. Please check its path or create it"
+msgstr ""
+"Centreon Broker's configuration directory '%s' does not exist and could not\n"
+"                                             be created for monitoring "
+"engine '%s'. Please check its path or create it"
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+#, php-format
+msgid ""
+"Centreon Broker's configuration directory '%s' does not exist and could not "
+"be created for monitoring engine '%s'. Please check it's path or create it"
+msgstr ""
+"Centreon Broker's configuration directory '%s' does not exist and could not "
+"be created for monitoring engine '%s'. Please check it's path or create it"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Centreon Central address, as seen by this server"
+msgstr "Centreon Central address, as seen by this server"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Connector"
+msgstr "Centreon Connector"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Connector path"
+msgstr "Centreon Connector path"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Centreon Databases Statistics"
+msgstr "Centreon Databases Statistics"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Centreon Gorgone debug"
+msgstr "Centreon Gorgone debug"
+
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/index.php
+msgid "Centreon Installation"
+msgstr "Centreon Installation"
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon Logo"
+msgstr "Centreon Logo"
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon Monitoring Agent"
+msgstr "Centreon Monitoring Agent"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Centreon Storage Path"
+msgstr "Centreon Storage Path"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Centreon Support Email"
+msgstr "Centreon Support Email"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreon Trap Collector"
+msgstr "Centreon Trap Collector"
+
+#: centreon/www/install/menu_translation.php
+msgid "Centreon UI"
+msgstr "Centreon UI"
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon UI only"
+msgstr "Centreon UI only"
+
+#: centreon/www/install/step_upgrade/step1.php
+msgid "Centreon Upgrade"
+msgstr "Centreon Upgrade"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Centreon Web Folder on Remote"
+msgstr "Centreon Web Folder on Remote"
+
+#: centreon/src/EventSubscriber/UpdateEventSubscriber.php
+msgid "Centreon database schema does not seem to be installed."
+msgstr "Centreon database schema does not seem to be installed."
+
+#: centreon/src/EventSubscriber/UpdateEventSubscriber.php
+#, php-format
+msgid "Centreon database schema version is \"%s\" (\"%s\" required)."
+msgstr "Centreon database schema version is \"%s\" (\"%s\" required)."
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Centreon information"
+msgstr "Centreon information"
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon is loading..."
+msgstr "Centreon is loading..."
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon wallpaper"
+msgstr "Centreon wallpaper"
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon website"
+msgstr "Centreon website"
+
+#: centreon/www/install/front_translate.php
+msgid "Centreon's Github"
+msgstr "Centreon's Github"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Centreon-Broker "
+msgstr "Centreon-Broker "
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Centreontrapd debug"
+msgstr "Centreontrapd debug"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Centreontrapd init script path"
+msgstr "Centreontrapd init script path"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Certificate Common Name (optional)"
+msgstr "Certificate Common Name (optional)"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Certificate path"
+msgstr "Certificate path"
+
+#: centreon/www/install/front_translate.php
+msgid "Change end date"
+msgstr "Change end date"
+
+#: centreon/www/install/front_translate.php
+msgid "Change end time"
+msgstr "Change end time"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Change my settings"
+msgstr "Change my settings"
+
+#: centreon/www/install/front_translate.php
+msgid "Change start date"
+msgstr "Change start date"
+
+#: centreon/www/install/front_translate.php
+msgid "Change start time"
+msgstr "Change start time"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Changed"
+msgstr "Changed"
+
+#: centreon/www/install/front_translate.php
+msgid "Changes to the envelope size will be applied immediately"
+msgstr "Changes to the envelope size will be applied immediately"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid ""
+"Changing the type of an existing poller/agent configuration is not allowed"
+msgstr ""
+"Changing the type of an existing poller/agent configuration is not allowed"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid ""
+"Changing type of an existing additional connector configuration is not "
+"allowed"
+msgstr ""
+"Changing type of an existing additional connector configuration is not "
+"allowed"
+
+#: centreon/www/install/front_translate.php
+msgid "Channels"
+msgstr "Channels"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Chart"
+msgstr "Chart"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Chart Filters"
+msgstr "Chart Filters"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Chart options"
+msgstr "Chart options"
+
+#: centreon/www/install/menu_translation.php
+msgid "Chart periods"
+msgstr "Chart periods"
+
+#: centreon/www/install/menu_translation.php
+msgid "Chart split"
+msgstr "Chart split"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/install/front_translate.php
+msgid "Check"
+msgstr "Check"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Check Command"
+msgstr "Check Command"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Check Downtime"
+msgstr "Check Downtime"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Check Duration"
+msgstr "Check Duration"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Check Freshness"
+msgstr "Check Freshness"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Check Options"
+msgstr "Check Options"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Check Period"
+msgstr "Check Period"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Check Result Reaper Frequency"
+msgstr "Check Result Reaper Frequency"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostCommandException.php
+#, php-format
+msgid "Check command of host id %d not found"
+msgstr "Check command of host id %d not found"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/Exception/ServiceCommandException.php
+#, php-format
+msgid "Check command of service id %d not found"
+msgstr "Check command of service id %d not found"
+
+#: centreon/www/install/front_translate.php
+msgid "Check command sent !"
+msgstr "Check command sent !"
+
+#: centreon/www/install/front_translate.php
+msgid "Check command sent ! Please refresh the listing to update the data."
+msgstr "Check command sent ! Please refresh the listing to update the data."
+
+#: centreon/www/install/front_translate.php
+msgid "Check command sent!"
+msgstr "Check command sent!"
+
+#: centreon/www/install/front_translate.php
+msgid "Check duration"
+msgstr "Check duration"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Check information"
+msgstr "Check information"
+
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+msgid "Check output"
+msgstr "Check output"
+
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+msgid "Check result"
+msgstr "Check result"
+
+#: centreon/www/install/front_translate.php
+msgid "Check selected resources even outside configured check period"
+msgstr "Check selected resources even outside configured check period"
+
+#: centreon/www/install/front_translate.php
+msgid "Check selected resources only within configured check period"
+msgstr "Check selected resources only within configured check period"
+
+#: centreon/www/install/front_translate.php
+msgid "Check this resource even outside configured check period"
+msgstr "Check this resource even outside configured check period"
+
+#: centreon/www/install/front_translate.php
+msgid "Check this resource only within configured check period"
+msgstr "Check this resource only within configured check period"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
+msgid "Checks"
+msgstr "Checks"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Checks Enabled"
+msgstr "Checks Enabled"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Checks for this service"
+msgstr "Checks for this service"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Child Hosts"
+msgstr "Child Hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Choose a duration between 1 hour and 1 week"
+msgstr "Choose a duration between 1 hour and 1 week"
+
+#: centreon/www/install/front_translate.php
+msgid "Choose a duration between 7 days and 12 months"
+msgstr "Choose a duration between 7 days and 12 months"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Choose a server type"
+msgstr "Choose a server type"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Choose a service if you want a specific curve for it."
+msgstr "Choose a service if you want a specific curve for it."
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Choose a service if you want a specific virtual metric for it."
+msgstr "Choose a service if you want a specific virtual metric for it."
+
+#: centreon/www/install/front_translate.php
+msgid "Choose a value between 1 and 10"
+msgstr "Choose a value between 1 and 10"
+
+#: centreon/www/install/front_translate.php
+msgid "Choose at least 1 resource"
+msgstr "Choose at least 1 resource"
+
+#: centreon/www/install/front_translate.php
+msgid "Choose at least 1 service group"
+msgstr "Choose at least 1 service group"
+
+#: centreon/www/install/front_translate.php
+msgid "Choose at least one contact or contact group"
+msgstr "Choose at least one contact or contact group"
+
+#: centreon/www/install/front_translate.php
+msgid "Choose letter cases"
+msgstr "Choose letter cases"
+
+#: centreon/www/include/eventLogs/viewLog.php
+msgid "Choose the source"
+msgstr "Choose the source"
+
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Choose the source to graph"
+msgstr "Choose the source to graph"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Circular Definition"
+msgstr "Circular Definition"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Circular inheritance not allowed"
+msgstr "Circular inheritance not allowed"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
+#, php-format
+msgid "Class %s has to implement %s to be DataRepresenter"
+msgstr "Class %s has to implement %s to be DataRepresenter"
+
+#: centreon/src/Centreon/Infrastructure/Serializer/Exception/SerializerException.php
+#, php-format
+msgid "Class %s not found"
+msgstr "Class %s not found"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Classification"
+msgstr "Classification"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Cleanup check interval"
+msgstr "Cleanup check interval"
+
+#: centreon/www/install/front_translate.php
+msgid "Clear"
+msgstr "Clear"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Clear arguments"
+msgstr "Clear arguments"
+
+#: centreon/www/install/front_translate.php
+msgid "Clear filter"
+msgstr "Clear filter"
+
+#: centreon/www/install/front_translate.php
+msgid "Click here for details"
+msgstr "Click here for details"
+
+#: centreon/www/install/front_translate.php
+msgid "Client ID"
+msgstr "Client ID"
+
+#: centreon/www/install/front_translate.php
+msgid "Client addresses"
+msgstr "Client addresses"
+
+#: centreon/www/install/front_translate.php
+msgid "Client secret"
+msgstr "Client secret"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Clock"
+msgstr "Clock"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Clock / Timer"
+msgstr "Clock / Timer"
+
+#: centreon/www/include/configuration/configObject/command/formArguments.php
+#: centreon/www/include/configuration/configObject/command/formMacros.php
+#: centreon/www/include/options/media/images/syncDir.php
+#: centreon/www/install/front_translate.php
+msgid "Close"
+msgstr "Close"
+
+#: centreon/www/install/front_translate.php
+msgid "Close a ticket"
+msgstr "Close a ticket"
+
+#: centreon/www/install/front_translate.php
+msgid "Close edit modal"
+msgstr "Close edit modal"
+
+#: centreon/www/install/front_translate.php
+msgid "Close the panel"
+msgstr "Close the panel"
+
+#: centreon/www/install/front_translate.php
+msgid "Close ticket"
+msgstr "Close ticket"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Closest Value"
+msgstr "Closest Value"
+
+#: centreon/www/install/front_translate.php
+msgid "Collapse"
+msgstr "Collapse"
+
+#: centreon/www/install/front_translate.php
+msgid "Collapse information panel"
+msgstr "Collapse information panel"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Color line mode"
+msgstr "Color line mode"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Colors"
+msgstr "Colors"
+
+#: centreon/www/install/front_translate.php
+msgid "Columns"
+msgstr "Columns"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Command"
+msgstr "Command"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Command Line"
+msgstr "Command Line"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Command Name"
+msgstr "Command Name"
+
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+msgid "Command Options"
+msgstr "Command Options"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Command Type"
+msgstr "Command Type"
+
+#: centreon/www/install/front_translate.php
+msgid "Command copied"
+msgstr "Command copied"
+
+#: centreon/www/install/front_translate.php
+msgid "Command copied to clipboard"
+msgstr "Command copied to clipboard"
+
+#: centreon/www/include/monitoring/external_cmd/functions.php
+msgid "Command execution problem"
+msgstr "Command execution problem"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Command file"
+msgstr "Command file"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Command inheritance"
+msgstr "Command inheritance"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Command sent"
+msgstr "Command sent"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
+msgid "Commands"
+msgstr "Commands"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Commands definitions can contain Macros but they have to be valid."
+msgstr "Commands definitions can contain Macros but they have to be valid."
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Commands in buffer"
+msgstr "Commands in buffer"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Comment"
+msgstr "Comment"
+
+#: centreon/www/install/front_translate.php
+msgid "Comment added"
+msgstr "Comment added"
+
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "Comment is required"
+msgstr "Comment is required"
+
+#: centreon/www/include/monitoring/comments/AddComment.php
+msgid "Comment type"
+msgstr "Comment type"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Comments"
+msgstr "Comments"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Common Options"
+msgstr "Common Options"
+
+#: centreon/www/install/front_translate.php
+msgid "Common properties"
+msgstr "Common properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Compact"
+msgstr "Compact"
+
+#: centreon/www/install/front_translate.php
+msgid "Compact time period"
+msgstr "Compact time period"
+
+#: centreon/www/install/front_translate.php
+msgid "Comparison rule for the requested authentication context"
+msgstr "Comparison rule for the requested authentication context"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Compression"
+msgstr "Compression"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Compression (zlib)"
+msgstr "Compression (zlib)"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Compression buffer size"
+msgstr "Compression buffer size"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Compression level"
+msgstr "Compression level"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Compulsory Address"
+msgstr "Compulsory Address"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Compulsory Alias"
+msgstr "Compulsory Alias"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Compulsory Command"
+msgstr "Compulsory Command"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Compulsory Command Line"
+msgstr "Compulsory Command Line"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Compulsory Description"
+msgstr "Compulsory Description"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+msgid "Compulsory Field"
+msgstr "Compulsory Field"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Compulsory Groups"
+msgstr "Compulsory Groups"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Compulsory Instance"
+msgstr "Compulsory Instance"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Compulsory Name"
+msgstr "Compulsory Name"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Compulsory Option"
+msgstr "Compulsory Option"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Compulsory Period"
+msgstr "Compulsory Period"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Compulsory Poller"
+msgstr "Compulsory Poller"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Compulsory alias"
+msgstr "Compulsory alias"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "Compulsory field"
+msgstr "Compulsory field"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Compulsory image name"
+msgstr "Compulsory image name"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Compulsory name"
+msgstr "Compulsory name"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Condensed"
+msgstr "Condensed"
+
+#: centreon/www/install/front_translate.php
+msgid "Condition value"
+msgstr "Condition value"
+
+#: centreon/www/install/front_translate.php
+msgid "Conditions attribute path"
+msgstr "Conditions attribute path"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Conf Changed"
+msgstr "Conf Changed"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Config file name"
+msgstr "Config file name"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Config information"
+msgstr "Config information"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Configuration"
+msgstr "Configuration"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Configuration Files Export"
+msgstr "Configuration Files Export"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Configuration Files Options"
+msgstr "Configuration Files Options"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Configuration Name"
+msgstr "Configuration Name"
+
+#: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
+msgid "Configuration command cannot be splitted by macros"
+msgstr "Configuration command cannot be splitted by macros"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Configuration database"
+msgstr "Configuration database"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Configuration database name"
+msgstr "Configuration database name"
+
+#: centreon/www/install/front_translate.php
+msgid "Configuration exported and reloaded"
+msgstr "Configuration exported and reloaded"
+
+#: centreon/www/install/step_upgrade/step1.php
+msgid "Configuration file not found."
+msgstr "Configuration file not found."
+
+#: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
+msgid "Configuration has changed"
+msgstr "Configuration has changed"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Configuration messages"
+msgstr "Configuration messages"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Configuration name"
+msgstr "Configuration name"
+
+#: centreon/www/install/front_translate.php
+msgid "Configuration provider"
+msgstr "Configuration provider"
+
+#: centreon/www/install/front_translate.php
+msgid "Configure"
+msgstr "Configure"
+
+#: centreon/www/install/front_translate.php
+msgid "Configure a server"
+msgstr "Configure a server"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Configure host"
+msgstr "Configure host"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#, php-format
+msgid "Configure host %s"
+msgstr "Configure host %s"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Configure pollers"
+msgstr "Configure pollers"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Configure service"
+msgstr "Configure service"
+
+#: centreon/www/install/front_translate.php
+msgid "Confirm"
+msgstr "Confirm"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Confirm Password"
+msgstr "Confirm Password"
+
+#: centreon/www/install/front_translate.php
+msgid "Confirm notification creation"
+msgstr "Confirm notification creation"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Confirm password"
+msgstr "Confirm password"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Confirm user password"
+msgstr "Confirm user password"
+
+#: centreon/www/install/step_upgrade/step5.php
+#, php-format
+msgid ""
+"Congratulations, you have successfully upgraded to Centreon version <b>%s</"
+"b>."
+msgstr ""
+"Congratulations, you have successfully upgraded to Centreon version <b>%s</"
+"b>."
+
+#: centreon/www/install/front_translate.php
+msgid "Connect"
+msgstr "Connect"
+
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+msgid "Connected users"
+msgstr "Connected users"
+
+#: centreon/www/api/class/centreon_proxy.class.php
+msgid "Connection Successful"
+msgstr "Connection Successful"
+
+#: centreon/www/class/centreonDB.class.php
+msgid "Connection failed, please contact your administrator"
+msgstr "Connection failed, please contact your administrator"
+
+#: centreon/www/install/front_translate.php
+msgid "Connection initiated"
+msgstr "Connection initiated"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Connection port"
+msgstr "Connection port"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Connector Description"
+msgstr "Connector Description"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Connector Name"
+msgstr "Connector Name"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Connector Status"
+msgstr "Connector Status"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/install/menu_translation.php
+msgid "Connectors"
+msgstr "Connectors"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Console"
+msgstr "Console"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Contact"
+msgstr "Contact"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "Contact Group Name"
+msgstr "Contact Group Name"
+
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Contact Groups"
+msgstr "Contact Groups"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Contact Name"
+msgstr "Contact Name"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Contact additive inheritance"
+msgstr "Contact additive inheritance"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Contact already exists"
+msgstr "Contact already exists"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Contact group"
+msgstr "Contact group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Contact group additive inheritance"
+msgstr "Contact group additive inheritance"
+
+#: centreon/www/install/front_translate.php
+msgid "Contact groups"
+msgstr "Contact groups"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Contact groups notified for this host"
+msgstr "Contact groups notified for this host"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Contact groups notified for this service"
+msgstr "Contact groups notified for this service"
+
+#: centreon/src/Core/Command/Infrastructure/Command/Exception/CommandMigrationCommandException.php
+#: centreon/src/Core/Media/Infrastructure/Command/Exception/MediaMigrationCommandException.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Contact not found"
+msgstr "Contact not found"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Contact template"
+msgstr "Contact template"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Contact template used"
+msgstr "Contact template used"
+
+#: centreon/www/install/front_translate.php
+msgid "Contact your Centreon administrator or update the following file"
+msgstr "Contact your Centreon administrator or update the following file"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid ""
+"Contactgroups exists. If you try to use a LDAP contactgroup, please verified "
+"if a Centreon contactgroup has the same name."
+msgstr ""
+"Contactgroups exists. If you try to use a LDAP contactgroup, please verified "
+"if a Centreon contactgroup has the same name."
+
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/install/front_translate.php
+msgid "Contacts"
+msgstr "Contacts"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Contacts & Contact groups method calculation"
+msgstr "Contacts & Contact groups method calculation"
+
+#: centreon/www/install/menu_translation.php
+msgid "Contacts / Users"
+msgstr "Contacts / Users"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Contacts notified for this host"
+msgstr "Contacts notified for this host"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Contacts notified for this service"
+msgstr "Contacts notified for this service"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "Contacts with the 'Reach Centreon Front-end' option enabled"
+msgstr "Contacts with the 'Reach Centreon Front-end' option enabled"
+
+#: centreon/www/install/front_translate.php
+msgid "Contacts/Contact groups"
+msgstr "Contacts/Contact groups"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+msgid "Content is not a valid JSON string"
+msgstr "Content is not a valid JSON string"
+
+#: centreon/www/install/front_translate.php
+msgid "Contributors"
+msgstr "Contributors"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Convert Trap information"
+msgstr "Convert Trap information"
+
+#: centreon/www/include/options/media/images/syncDir.php
+msgid "Convert gd2 -> png :"
+msgstr "Convert gd2 -> png :"
+
+#: centreon/www/install/front_translate.php
+msgid "Copy"
+msgstr "Copy"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Copy autologin link"
+msgstr "Copy autologin link"
+
+#: centreon/www/install/front_translate.php
+msgid "Copy breadcrumb"
+msgstr "Copy breadcrumb"
+
+#: centreon/www/install/front_translate.php
+msgid "Copy link"
+msgstr "Copy link"
+
+#: centreon/www/install/front_translate.php
+msgid "Copy the link to this resource"
+msgstr "Copy the link to this resource"
+
+#: centreon/www/install/front_translate.php
+msgid "Copy/paste x.509 certificate"
+msgstr "Copy/paste x.509 certificate"
+
+#: centreon/www/api/class/centreon_proxy.class.php
+msgid "Could not establish connection to Centreon IMP servers ("
+msgstr "Could not establish connection to Centreon IMP servers ("
+
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+#, php-format
+msgid ""
+"Could not find configuration directory '%s' for monitoring engine '%s'.\n"
+"                                 Please check its path or create it"
+msgstr ""
+"Could not find configuration directory '%s' for monitoring engine '%s'.\n"
+"                                 Please check its path or create it"
+
+#: centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+#: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+msgid "Could not write into centcore.cmd. Please check file permissions."
+msgstr "Could not write into centcore.cmd. Please check file permissions."
+
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+#, php-format
+msgid ""
+"Could not write to Centreon Broker's configuration file '%s' for monitoring\n"
+"                                             engine '%s'. Please add writing "
+"permissions for the webserver's user"
+msgstr ""
+"Could not write to Centreon Broker's configuration file '%s' for monitoring\n"
+"                                             engine '%s'. Please add writing "
+"permissions for the webserver's user"
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+#, php-format
+msgid ""
+"Could not write to Centreon Broker's configuration file '%s' for monitoring "
+"engine '%s'. Please add writing permissions for the webserver's user"
+msgstr ""
+"Could not write to Centreon Broker's configuration file '%s' for monitoring "
+"engine '%s'. Please add writing permissions for the webserver's user"
+
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+#, php-format
+msgid ""
+"Could not write to file '%s' for monitoring engine '%s'. Please add writing\n"
+"                                     permissions for the webserver's user"
+msgstr ""
+"Could not write to file '%s' for monitoring engine '%s'. Please add writing\n"
+"                                     permissions for the webserver's user"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Countdown"
+msgstr "Countdown"
+
+#: centreon/www/install/front_translate.php
+msgid "Create"
+msgstr "Create"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Create Services linked to the Template too"
+msgstr "Create Services linked to the Template too"
+
+#: centreon/www/install/front_translate.php
+msgid "Create a dashboard"
+msgstr "Create a dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Create a new resource access rule"
+msgstr "Create a new resource access rule"
+
+#: centreon/www/install/front_translate.php
+msgid "Create a notification rule"
+msgstr "Create a notification rule"
+
+#: centreon/www/install/front_translate.php
+msgid "Create a ticket"
+msgstr "Create a ticket"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Create a view"
+msgstr "Create a view"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Create and edit pollers"
+msgstr "Create and edit pollers"
+
+#: centreon/www/install/front_translate.php
+msgid "Create authentication token"
+msgstr "Create authentication token"
+
+#: centreon/www/install/front_translate.php
+msgid "Create dashboard"
+msgstr "Create dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Create new CMA token"
+msgstr "Create new CMA token"
+
+#: centreon/www/install/front_translate.php
+msgid "Create new Poller"
+msgstr "Create new Poller"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Create new Remote Server"
+msgstr "Create new Remote Server"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Create new view "
+msgstr "Create new view "
+
+#: centreon/www/install/front_translate.php
+msgid "Create notification for the first time"
+msgstr "Create notification for the first time"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Create wiki page"
+msgstr "Create wiki page"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Creating Export Task"
+msgstr "Creating Export Task"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Creating database user"
+msgstr "Creating database user"
+
+#: centreon/www/install/front_translate.php
+msgid "Creation date"
+msgstr "Creation date"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Creation time"
+msgstr "Creation time"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Creator"
+msgstr "Creator"
+
+#: centreon/www/install/front_translate.php
+msgid "Criterias"
+msgstr "Criterias"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Critical"
+msgstr "Critical"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Critical Area color"
+msgstr "Critical Area color"
+
+#: centreon/www/install/front_translate.php
+msgid "Critical KPIs"
+msgstr "Critical KPIs"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+msgid "Critical Level"
+msgstr "Critical Level"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Critical Threshold"
+msgstr "Critical Threshold"
+
+#: centreon/www/install/react_translation.php
+msgid "Critical services"
+msgstr "Critical services"
+
+#: centreon/www/install/front_translate.php
+msgid "Critical status services"
+msgstr "Critical status services"
+
+#: centreon/www/install/front_translate.php
+msgid "Critical threshold"
+msgstr "Critical threshold"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Criticality"
+msgstr "Criticality"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Cumulative inheritance"
+msgstr "Cumulative inheritance"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+msgid "Current Attempt"
+msgstr "Current Attempt"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Current Notification Number"
+msgstr "Current Notification Number"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Current State Duration"
+msgstr "Current State Duration"
+
+#: centreon/www/install/front_translate.php
+msgid "Current notification number"
+msgstr "Current notification number"
+
+#: centreon/www/install/front_translate.php
+msgid "Current page only"
+msgstr "Current page only"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/install/front_translate.php
+msgid "Current password"
+msgstr "Current password"
+
+#: centreon/www/install/front_translate.php
+msgid "Current status duration"
+msgstr "Current status duration"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"Currently installing database and generating cache... please do not "
+"interrupt this process."
+msgstr ""
+"Currently installing database and generating cache... please do not "
+"interrupt this process."
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/smarty_translate.php
+msgid "Curve"
+msgstr "Curve"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Curve type"
+msgstr "Curve type"
+
+#: centreon/www/install/menu_translation.php
+msgid "Curves"
+msgstr "Curves"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Custom"
+msgstr "Custom"
+
+#: centreon/www/install/menu_translation.php
+msgid "Custom Views"
+msgstr "Custom Views"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Custom boundaries apply to the percentage."
+msgstr "Custom boundaries apply to the percentage."
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Custom code"
+msgstr "Custom code"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Custom macros"
+msgstr "Custom macros"
+
+#: centreon/www/install/front_translate.php
+msgid "Custom refresh interval"
+msgstr "Custom refresh interval"
+
+#: centreon/www/install/front_translate.php
+msgid "Custom value"
+msgstr "Custom value"
+
+#: centreon/www/install/front_translate.php
+msgid "Customize"
+msgstr "Customize"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "DB host"
+msgstr "DB host"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "DB name"
+msgstr "DB name"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "DB password"
+msgstr "DB password"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "DB port"
+msgstr "DB port"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "DB type"
+msgstr "DB type"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "DB user"
+msgstr "DB user"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+msgid "DEF Type"
+msgstr "DEF Type"
+
+#: centreon/www/install/front_translate.php
+msgid "DNS/IP"
+msgstr "DNS/IP"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "DOWN"
+msgstr "DOWN"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Daily"
+msgstr "Daily"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Dash width"
+msgstr "Dash width"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Dashboard Integration Properties"
+msgstr "Dashboard Integration Properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Dashboard created"
+msgstr "Dashboard created"
+
+#: centreon/www/install/front_translate.php
+msgid "Dashboard deleted"
+msgstr "Dashboard deleted"
+
+#: centreon/www/install/front_translate.php
+msgid "Dashboard duplicated"
+msgstr "Dashboard duplicated"
+
+#: centreon/www/install/front_translate.php
+msgid "Dashboard global interval"
+msgstr "Dashboard global interval"
+
+#: centreon/www/install/front_translate.php
+msgid "Dashboard updated"
+msgstr "Dashboard updated"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Dashboards"
+msgstr "Dashboards"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Dashes"
+msgstr "Dashes"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
+msgid "Data"
+msgstr "Data"
+
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+msgid "Data Count"
+msgstr "Data Count"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/smarty_translate.php
+msgid "Data Processing"
+msgstr "Data Processing"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Data Source Name"
+msgstr "Data Source Name"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/install/smarty_translate.php
+msgid "Data Source Type"
+msgstr "Data Source Type"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Data Source already in use for this Host/Service"
+msgstr "Data Source already in use for this Host/Service"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Data Sources"
+msgstr "Data Sources"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Data free"
+msgstr "Data free"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Data is aggregated daily for graphs presenting hosts."
+msgstr "Data is aggregated daily for graphs presenting hosts."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host categories."
+msgstr ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host categories."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host groups."
+msgstr ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host groups."
+
+#: centreon/www/install/smarty_translate.php
+msgid "Data size"
+msgstr "Data size"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Data source type"
+msgstr "Data source type"
+
+#: centreon/src/Centreon/Domain/MetaServiceConfiguration/Model/MetaServiceConfiguration.php
+#: centreon/tests/php/Centreon/Domain/MetaServiceConfiguration/Model/MetaServiceConfigurationTest.php
+#, php-format
+msgid "Data source type provided not supported (%s)"
+msgstr "Data source type provided not supported (%s)"
+
+#: centreon/www/install/front_translate.php
+msgid "Database"
+msgstr "Database"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Database Engine"
+msgstr "Database Engine"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Database Host Address (default: localhost)"
+msgstr "Database Host Address (default: localhost)"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Database Options"
+msgstr "Database Options"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Database Port (default: 3306)"
+msgstr "Database Port (default: 3306)"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Database generation"
+msgstr "Database generation"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step6.php
+#: centreon/www/install/smarty_translate.php
+msgid "Database information"
+msgstr "Database information"
+
+#: centreon/www/install/front_translate.php
+msgid "Database issue"
+msgstr "Database issue"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Database password"
+msgstr "Database password"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Database user name"
+msgstr "Database user name"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Database user password"
+msgstr "Database user password"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Database username"
+msgstr "Database username"
+
+#: centreon/www/install/menu_translation.php
+msgid "Databases"
+msgstr "Databases"
+
+#: centreon/www/install/front_translate.php
+msgid "Dataset selection"
+msgstr "Dataset selection"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/smarty_translate.php
+msgid "Date"
+msgstr "Date"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Date Format"
+msgstr "Date Format"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Date format"
+msgstr "Date format"
+
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/install/front_translate.php
+msgid "Day"
+msgstr "Day"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/front_translate.php
+msgid "Days"
+msgstr "Days"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
+msgid "Debug"
+msgstr "Debug"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Debug Configuration"
+msgstr "Debug Configuration"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Debug Level"
+msgstr "Debug Level"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Debug Properties"
+msgstr "Debug Properties"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Debug Verbosity"
+msgstr "Debug Verbosity"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Debug file (Directory + File)"
+msgstr "Debug file (Directory + File)"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Debug file Maximum Size"
+msgstr "Debug file Maximum Size"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Debug level"
+msgstr "Debug level"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Debug messages"
+msgstr "Debug messages"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/install/front_translate.php
+msgid "Default"
+msgstr "Default"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Default Centreon Graph Template"
+msgstr "Default Centreon Graph Template"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Default Language"
+msgstr "Default Language"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Default Severity"
+msgstr "Default Severity"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Default Status"
+msgstr "Default Status"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Default acknowledgement settings"
+msgstr "Default acknowledgement settings"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Default contactgroup"
+msgstr "Default contactgroup"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Default downtime settings"
+msgstr "Default downtime settings"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Default page"
+msgstr "Default page"
+
+#: centreon/www/install/front_translate.php
+msgid "Define OpenID Connect configuration"
+msgstr "Define OpenID Connect configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Define SAML configuration"
+msgstr "Define SAML configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Define Web SSO Configuration"
+msgstr "Define Web SSO Configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Define authorized conditions values"
+msgstr "Define authorized conditions values"
+
+#: centreon/www/install/front_translate.php
+msgid "Define relations between roles and ACL access groups"
+msgstr "Define relations between roles and ACL access groups"
+
+#: centreon/www/install/front_translate.php
+msgid "Define the password security policy"
+msgstr "Define the password security policy"
+
+#: centreon/www/install/front_translate.php
+msgid "Define the relation between authorization value and access group"
+msgstr "Define the relation between authorization value and access group"
+
+#: centreon/www/install/front_translate.php
+msgid "Define the relation between groups and contact groups"
+msgstr "Define the relation between groups and contact groups"
+
+#: centreon/www/install/front_translate.php
+msgid "Define the relation between roles and ACL access groups"
+msgstr "Define the relation between roles and ACL access groups"
+
+#: centreon/www/install/front_translate.php
+msgid "Define your endpoint"
+msgstr "Define your endpoint"
+
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Delete"
+msgstr "Delete"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Delete Problem Acknowledgement"
+msgstr "Delete Problem Acknowledgement"
+
+#: centreon/www/install/menu_translation.php
+msgid "Delete View"
+msgstr "Delete View"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete additional configuration"
+msgstr "Delete additional configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete agent configuration"
+msgstr "Delete agent configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete dashboard"
+msgstr "Delete dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete filter?"
+msgstr "Delete filter?"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Delete graphs"
+msgstr "Delete graphs"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete multiple resource access rules"
+msgstr "Delete multiple resource access rules"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete notification rule?"
+msgstr "Delete notification rule?"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete poller"
+msgstr "Delete poller"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Delete pollers"
+msgstr "Delete pollers"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete rule"
+msgstr "Delete rule"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete rules"
+msgstr "Delete rules"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete the relation"
+msgstr "Delete the relation"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete token"
+msgstr "Delete token"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete user"
+msgstr "Delete user"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Delete view"
+msgstr "Delete view"
+
+#: centreon/www/install/front_translate.php
+msgid "Delete widget"
+msgstr "Delete widget"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Delete wiki page"
+msgstr "Delete wiki page"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Deleted"
+msgstr "Deleted"
+
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"Deleting this view might impact other users. Are you sure you want to do it?"
+msgstr ""
+"Deleting this view might impact other users. Are you sure you want to do it?"
+
+#: centreon/www/include/home/customViews/index.php
+msgid ""
+"Deleting this widget might impact users with whom you are sharing this view. "
+"Are you sure you want to do it?"
+msgstr ""
+"Deleting this widget might impact users with whom you are sharing this view. "
+"Are you sure you want to do it?"
+
+#: centreon/www/install/menu_translation.php
+msgid "Dependencies"
+msgstr "Dependencies"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step2.php
+#: centreon/www/install/step_upgrade/step2.php
+msgid "Dependency check up"
+msgstr "Dependency check up"
+
+#: centreon/www/include/configuration/configObject/host_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+msgid "Dependency description can't be empty"
+msgstr "Dependency description can't be empty"
+
+#: centreon/www/include/configuration/configObject/host_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+msgid "Dependency name can't be empty"
+msgstr "Dependency name can't be empty"
+
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+msgid "Dependent Host Groups Name"
+msgstr "Dependent Host Groups Name"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+msgid "Dependent Host Names"
+msgstr "Dependent Host Names"
+
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+msgid "Dependent Hosts"
+msgstr "Dependent Hosts"
+
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+msgid "Dependent Meta Service Names"
+msgstr "Dependent Meta Service Names"
+
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Dependent Servicegroups"
+msgstr "Dependent Servicegroups"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+msgid "Dependent Services"
+msgstr "Dependent Services"
+
+#: centreon/www/include/configuration/configObject/host/listHost.php
+msgid "Deploy Service"
+msgstr "Deploy Service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Deploy configuration"
+msgstr "Deploy configuration"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "Descending"
+msgstr "Descending"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Describe arguments"
+msgstr "Describe arguments"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Describe macros"
+msgstr "Describe macros"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/install/front_translate.php
+msgid "Description"
+msgstr "Description"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+msgid "Destination Directory"
+msgstr "Destination Directory"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+msgid "Destination directory"
+msgstr "Destination directory"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+msgid "Detach"
+msgstr "Detach"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+msgid "Detach host group services"
+msgstr "Detach host group services"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Detailed Graph"
+msgstr "Detailed Graph"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/install/front_translate.php
+msgid "Details"
+msgstr "Details"
+
+#: centreon/www/include/common/common-Func.php
+msgid "Detection by browser"
+msgstr "Detection by browser"
+
+#: centreon/www/install/front_translate.php
+msgid "Developed by"
+msgstr "Developed by"
+
+#: centreon/www/install/front_translate.php
+msgid "Developers"
+msgstr "Developers"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/include/options/media/images/listImg.php
+msgid "Directory"
+msgstr "Directory"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Directory + Mailer Binary"
+msgstr "Directory + Mailer Binary"
+
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "Directory + RRDTOOL Binary"
+msgstr "Directory + RRDTOOL Binary"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+msgid "Directory name"
+msgstr "Directory name"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Directory of light database for traps"
+msgstr "Directory of light database for traps"
+
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/install/front_translate.php
+msgid "Disable"
+msgstr "Disable"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Disable Active Checks"
+msgstr "Disable Active Checks"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Disable Event Handler"
+msgstr "Disable Event Handler"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Disable Flap Detection"
+msgstr "Disable Flap Detection"
+
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+msgid "Disable Host Check"
+msgstr "Disable Host Check"
+
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+msgid "Disable Host Notification"
+msgstr "Disable Host Notification"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Disable Host Notifications"
+msgstr "Disable Host Notifications"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Disable Obsess Over Host"
+msgstr "Disable Obsess Over Host"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Disable Obsess Over Service"
+msgstr "Disable Obsess Over Service"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Disable Passive Checks"
+msgstr "Disable Passive Checks"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Disable Service Checks When Host Down"
+msgstr "Disable Service Checks When Host Down"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Disable Service Notifications"
+msgstr "Disable Service Notifications"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Disable all service checks on this host"
+msgstr "Disable all service checks on this host"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Disable all service notifications on this host"
+msgstr "Disable all service notifications on this host"
+
+#: centreon/www/install/front_translate.php
+msgid "Disable autorefresh"
+msgstr "Disable autorefresh"
+
+#: centreon/www/install/front_translate.php
+msgid "Disable token"
+msgstr "Disable token"
+
+#: centreon/www/install/front_translate.php
+msgid "Disable verify peer"
+msgstr "Disable verify peer"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+msgid "Disabled"
+msgstr "Disabled"
+
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+msgid "Disabled Hosts"
+msgstr "Disabled Hosts"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/install/front_translate.php
+msgid "Disabled hosts"
+msgstr "Disabled hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Disacknowledge"
+msgstr "Disacknowledge"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Disacknowledge a service"
+msgstr "Disacknowledge a service"
+
+#: centreon/www/install/front_translate.php
+msgid "Disacknowledge services attached to hosts"
+msgstr "Disacknowledge services attached to hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Disacknowledgement command sent"
+msgstr "Disacknowledgement command sent"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Disaknowledge a host"
+msgstr "Disaknowledge a host"
+
+#: centreon/www/install/front_translate.php
+msgid "Discard"
+msgstr "Discard"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "Disconnect user"
+msgstr "Disconnect user"
+
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/install/menu_translation.php
+msgid "Discovery"
+msgstr "Discovery"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Display"
+msgstr "Display"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Display "
+msgstr "Display "
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Display Autologin shortcut"
+msgstr "Display Autologin shortcut"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Display Chart"
+msgstr "Display Chart"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Display Finished Downtimes"
+msgstr "Display Finished Downtimes"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Display Only The Legend"
+msgstr "Display Only The Legend"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Display Optional Modifier"
+msgstr "Display Optional Modifier"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Display Poller Listing"
+msgstr "Display Poller Listing"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Display Recurring Downtimes"
+msgstr "Display Recurring Downtimes"
+
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Display Status"
+msgstr "Display Status"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Display Top Counter"
+msgstr "Display Top Counter"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Display Top Counter pollers statistics"
+msgstr "Display Top Counter pollers statistics"
+
+#: centreon/www/include/configuration/configObject/host/listHost.php
+msgid "Display all Services for this host"
+msgstr "Display all Services for this host"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Display anyway"
+msgstr "Display anyway"
+
+#: centreon/www/install/front_translate.php
+msgid "Display as"
+msgstr "Display as"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display availability and performance as"
+msgstr "Display availability and performance as"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display availability as"
+msgstr "Display availability as"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display average as"
+msgstr "Display average as"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Display comment on chart"
+msgstr "Display comment on chart"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display curve points"
+msgstr "Display curve points"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Display details"
+msgstr "Display details"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Display downtime and acknowledgment on chart"
+msgstr "Display downtime and acknowledgment on chart"
+
+#: centreon/www/install/front_translate.php
+msgid "Display events"
+msgstr "Display events"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Display executed command by monitoring engine"
+msgstr "Display executed command by monitoring engine"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display mode"
+msgstr "Display mode"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Display multiple periods"
+msgstr "Display multiple periods"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Display properties"
+msgstr "Display properties"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display resources"
+msgstr "Display resources"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display resources with these status types"
+msgstr "Display resources with these status types"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display resources with this state"
+msgstr "Display resources with this state"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display resources with this status"
+msgstr "Display resources with this status"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display resources with this type"
+msgstr "Display resources with this type"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display resources with this unit"
+msgstr "Display resources with this unit"
+
+#: centreon/www/install/front_translate.php
+msgid "Display the complete graph"
+msgstr "Display the complete graph"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display the diagram with this status"
+msgstr "Display the diagram with this status"
+
+#: centreon/www/install/front_translate.php
+msgid "Display the password"
+msgstr "Display the password"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display ticket creation buttons"
+msgstr "Display ticket creation buttons"
+
+#: centreon/www/install/front_translate.php
+msgid "Display up to"
+msgstr "Display up to"
+
+#: centreon/www/install/front_translate.php
+msgid "Display view:"
+msgstr "Display view:"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display with this resource type"
+msgstr "Display with this resource type"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Display with this view"
+msgstr "Display with this view"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays a detailed view of the current status for selected resources as a "
+"chart."
+msgstr ""
+"Displays a detailed view of the current status for selected resources as a "
+"chart."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays a list of storage with saturation foreseen, current usage, days "
+"until saturation, and evolution of usage since the past day."
+msgstr ""
+"Displays a list of storage with saturation foreseen, current usage, days "
+"until saturation, and evolution of usage since the past day."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays a status overview for selected resources, grouped by hosts or by "
+"services."
+msgstr ""
+"Displays a status overview for selected resources, grouped by hosts or by "
+"services."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Displays a web page"
+msgstr "Displays a web page"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays availability and alerts of a Business Activity for a given period."
+msgstr ""
+"Displays availability and alerts of a Business Activity for a given period."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Displays availability, performance and alerts for a Business Activity"
+msgstr "Displays availability, performance and alerts for a Business Activity"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Displays data on resource status and events, centralized in a table."
+msgstr "Displays data on resource status and events, centralized in a table."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays graphically a business activity hierarchy of KPIs and lets you "
+"navigate through it."
+msgstr ""
+"Displays graphically a business activity hierarchy of KPIs and lets you "
+"navigate through it."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Displays metrics for a given time period."
+msgstr "Displays metrics for a given time period."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays the availability history of hosts, host categories or hostgroups."
+msgstr ""
+"Displays the availability history of hosts, host categories or hostgroups."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays the distribution of current statuses on a Business Activity, as a "
+"chronological timeline for a given time period."
+msgstr ""
+"Displays the distribution of current statuses on a Business Activity, as a "
+"chronological timeline for a given time period."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays the distribution of current statuses on selected groups of "
+"resources, as a table."
+msgstr ""
+"Displays the distribution of current statuses on selected groups of "
+"resources, as a table."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays the future evolution of a metric as a trend curve, based on its "
+"recent average data."
+msgstr ""
+"Displays the future evolution of a metric as a trend curve, based on its "
+"recent average data."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Displays the time according to the selected time zone, or a timer."
+msgstr "Displays the time according to the selected time zone, or a timer."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Displays the top or bottom x hosts, for a selected metric."
+msgstr "Displays the top or bottom x hosts, for a selected metric."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Displays the value of a single metric as a text, a gauge or a bar chart."
+msgstr ""
+"Displays the value of a single metric as a text, a gauge or a bar chart."
+
+#: centreon/www/install/smarty_translate.php
+msgid "Dissociate"
+msgstr "Dissociate"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Dissociate this view ?"
+msgstr "Dissociate this view ?"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Do not check SSL certificate validation"
+msgstr "Do not check SSL certificate validation"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Do not use configured proxy to connect to this server"
+msgstr "Do not use configured proxy to connect to this server"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Do not use proxy defined in global configuration"
+msgstr "Do not use proxy defined in global configuration"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Do you confirm the cancellation ?"
+msgstr "Do you confirm the cancellation ?"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid ""
+"Do you confirm the change of the RRD data source type ? If yes, you must "
+"rebuild the RRD Database"
+msgstr ""
+"Do you confirm the change of the RRD data source type ? If yes, you must "
+"rebuild the RRD Database"
+
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/Administration/parameters/ldap/listFunction.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+msgid "Do you confirm the deletion ?"
+msgstr "Do you confirm the deletion ?"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+msgid "Do you confirm the duplication ?"
+msgstr "Do you confirm the duplication ?"
+
+#: centreon/www/include/configuration/configObject/timeperiod/timeperiod_JS.php
+msgid "Do you confirm this deletion?"
+msgstr "Do you confirm this deletion?"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "Do you really want to unblock this user?"
+msgstr "Do you really want to unblock this user?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to leave this page?"
+msgstr "Do you want to leave this page?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to quit the form without saving the changes?"
+msgstr "Do you want to quit the form without saving the changes?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to quit without saving the changes?"
+msgstr "Do you want to quit without saving the changes?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to reset the form?"
+msgstr "Do you want to reset the form?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to save the changes?"
+msgstr "Do you want to save the changes?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to switch to classic mode?"
+msgstr "Do you want to switch to classic mode?"
+
+#: centreon/www/install/front_translate.php
+msgid "Do you want to switch to regex mode?"
+msgstr "Do you want to switch to regex mode?"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Documentation"
+msgstr "Documentation"
+
+#: centreon/www/install/front_translate.php
+msgid "Done"
+msgstr "Done"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Donut chart"
+msgstr "Donut chart"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Dots"
+msgstr "Dots"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/install/front_translate.php
+msgid "Down"
+msgstr "Down"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Down Alert"
+msgstr "Down Alert"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Down Mean Time"
+msgstr "Down Mean Time"
+
+#: centreon/www/install/front_translate.php
+msgid "Down status hosts"
+msgstr "Down status hosts"
+
+#: centreon/src/Core/Metric/Application/Exception/MetricException.php
+msgid "Downloading the performance metrics is not allowed"
+msgstr "Downloading the performance metrics is not allowed"
+
+#: centreon/www/install/front_translate.php
+msgid "Downtime"
+msgstr "Downtime"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Downtime Configuration"
+msgstr "Downtime Configuration"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Downtime Scheduled"
+msgstr "Downtime Scheduled"
+
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+#, php-format
+msgid "Downtime already cancelled for this %s"
+msgstr "Downtime already cancelled for this %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Downtime command sent"
+msgstr "Downtime command sent"
+
+#: centreon/www/install/front_translate.php
+msgid "Downtime duration"
+msgstr "Downtime duration"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+msgid "Downtime internal id can not be null"
+msgstr "Downtime internal id can not be null"
+
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+msgid "Downtime not found"
+msgstr "Downtime not found"
+
+#: centreon/www/install/front_translate.php
+msgid "Downtime set by"
+msgstr "Downtime set by"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+#, php-format
+msgid "Downtime set by %s"
+msgstr "Downtime set by %s"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Downtime type"
+msgstr "Downtime type"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
+msgid "Downtimes"
+msgstr "Downtimes"
+
+#: centreon/www/install/front_translate.php
+msgid "Drag handle"
+msgstr "Drag handle"
+
+#: centreon/www/install/front_translate.php
+msgid "Drop or"
+msgstr "Drop or"
+
+#: centreon/www/install/front_translate.php
+msgid "Drop or select a file"
+msgstr "Drop or select a file"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Dump"
+msgstr "Dump"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+msgid "Duplicate"
+msgstr "Duplicate"
+
+#: centreon/www/install/front_translate.php
+msgid "Duplicate connector configuration"
+msgstr "Duplicate connector configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Duplicate dashboard"
+msgstr "Duplicate dashboard"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "Duplicates not allowed for property '%s'"
+msgstr "Duplicates not allowed for property '%s'"
+
+#: centreon/www/install/front_translate.php
+msgid "Duplications"
+msgstr "Duplications"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Duration"
+msgstr "Duration"
+
+#: centreon/www/install/front_translate.php
+msgid "E-mail"
+msgstr "E-mail"
+
+#: centreon/www/install/menu_translation.php
+msgid "Edit View"
+msgstr "Edit View"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Edit a view"
+msgstr "Edit a view"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit anomaly detection data"
+msgstr "Edit anomaly detection data"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit connector configuration"
+msgstr "Edit connector configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit dashboard"
+msgstr "Edit dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit link"
+msgstr "Edit link"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit modal"
+msgstr "Edit modal"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit name"
+msgstr "Edit name"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit password"
+msgstr "Edit password"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Edit profile"
+msgstr "Edit profile"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit properties"
+msgstr "Edit properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit resource access rule"
+msgstr "Edit resource access rule"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Edit view"
+msgstr "Edit view"
+
+#: centreon/www/install/front_translate.php
+msgid "Edit widget"
+msgstr "Edit widget"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"Edit wiki\n"
+"                    page"
+msgstr ""
+"Edit wiki\n"
+"                    page"
+
+#: centreon/www/install/front_translate.php
+msgid "Editor"
+msgstr "Editor"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/install/smarty_translate.php
+msgid "Email"
+msgstr "Email"
+
+#: centreon/www/install/front_translate.php
+msgid "Email attribute"
+msgstr "Email attribute"
+
+#: centreon/www/install/front_translate.php
+msgid "Email attribute path"
+msgstr "Email attribute path"
+
+#: centreon/www/install/front_translate.php
+msgid "Email template for the notification message"
+msgstr "Email template for the notification message"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Empty Line After This Legend"
+msgstr "Empty Line After This Legend"
+
+#: centreon/www/include/options/media/images/listImg.php
+msgid "Empty directory"
+msgstr "Empty directory"
+
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/install/front_translate.php
+msgid "Enable"
+msgstr "Enable"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Enable Active Checks"
+msgstr "Enable Active Checks"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Enable Autologin"
+msgstr "Enable Autologin"
+
+#: centreon/www/include/Administration/parameters/api/api.php
+msgid "Enable Broker Statistics Collection"
+msgstr "Enable Broker Statistics Collection"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+msgid "Enable Broker statistics collection"
+msgstr "Enable Broker statistics collection"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Enable Event Handler"
+msgstr "Enable Event Handler"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Enable Flap Detection"
+msgstr "Enable Flap Detection"
+
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+msgid "Enable Host Check"
+msgstr "Enable Host Check"
+
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+msgid "Enable Host Notification"
+msgstr "Enable Host Notification"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Enable Host Notifications"
+msgstr "Enable Host Notifications"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Enable LDAP authentication"
+msgstr "Enable LDAP authentication"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Enable LDAP synchronization on login"
+msgstr "Enable LDAP synchronization on login"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Enable Notifications"
+msgstr "Enable Notifications"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Enable Obsess Over Host"
+msgstr "Enable Obsess Over Host"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Enable Obsess Over Service"
+msgstr "Enable Obsess Over Service"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable OpenID Connect authentication"
+msgstr "Enable OpenID Connect authentication"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Enable Passive Checks"
+msgstr "Enable Passive Checks"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Enable RRDCached"
+msgstr "Enable RRDCached"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable SAMLv2 authentication"
+msgstr "Enable SAMLv2 authentication"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Enable Service Notifications"
+msgstr "Enable Service Notifications"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Enable TLS encryption"
+msgstr "Enable TLS encryption"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Enable Timezone management"
+msgstr "Enable Timezone management"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable Web SSO authentication"
+msgstr "Enable Web SSO authentication"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Enable all service checks on this host"
+msgstr "Enable all service checks on this host"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Enable all service notifications on this host"
+msgstr "Enable all service notifications on this host"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable auto import"
+msgstr "Enable auto import"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable automatic management"
+msgstr "Enable automatic management"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable autorefresh"
+msgstr "Enable autorefresh"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable conditions on identity provider"
+msgstr "Enable conditions on identity provider"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Enable environment macros"
+msgstr "Enable environment macros"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Enable logging pid information"
+msgstr "Enable logging pid information"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Enable macro filtering"
+msgstr "Enable macro filtering"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Enable negotiation"
+msgstr "Enable negotiation"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable requested authentication context"
+msgstr "Enable requested authentication context"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Enable retention"
+msgstr "Enable retention"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Enable routing"
+msgstr "Enable routing"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Enable shell"
+msgstr "Enable shell"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Enable ticket creation for hosts"
+msgstr "Enable ticket creation for hosts"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Enable ticket creation for services"
+msgstr "Enable ticket creation for services"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Enable ticket management"
+msgstr "Enable ticket management"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable token"
+msgstr "Enable token"
+
+#: centreon/www/install/front_translate.php
+msgid "Enable/Disable"
+msgstr "Enable/Disable"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Checks for a host"
+msgstr "Enable/Disable Checks for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Checks for a service"
+msgstr "Enable/Disable Checks for a service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Checks services of a host"
+msgstr "Enable/Disable Checks services of a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Event Handler for a host"
+msgstr "Enable/Disable Event Handler for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Event Handler for a service"
+msgstr "Enable/Disable Event Handler for a service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Event Handlers"
+msgstr "Enable/Disable Event Handlers"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Flap Detection"
+msgstr "Enable/Disable Flap Detection"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Flap Detection for a host"
+msgstr "Enable/Disable Flap Detection for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Flap Detection of a service"
+msgstr "Enable/Disable Flap Detection of a service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Notifications for a host"
+msgstr "Enable/Disable Notifications for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Notifications for a service"
+msgstr "Enable/Disable Notifications for a service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Notifications services of a host"
+msgstr "Enable/Disable Notifications services of a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Obsessive host checks"
+msgstr "Enable/Disable Obsessive host checks"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Obsessive service checks"
+msgstr "Enable/Disable Obsessive service checks"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable Performance Data"
+msgstr "Enable/Disable Performance Data"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Enable/Disable audit logs"
+msgstr "Enable/Disable audit logs"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable host checks"
+msgstr "Enable/Disable host checks"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable notifications"
+msgstr "Enable/Disable notifications"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable passive checks of a service"
+msgstr "Enable/Disable passive checks of a service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable passive host checks"
+msgstr "Enable/Disable passive host checks"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable passive service checks"
+msgstr "Enable/Disable passive service checks"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Enable/Disable service checks"
+msgstr "Enable/Disable service checks"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Enable/disable resource"
+msgstr "Enable/disable resource"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+msgid "Enabled"
+msgstr "Enabled"
+
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+msgid "Enabled Hosts"
+msgstr "Enabled Hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Enabled hosts"
+msgstr "Enabled hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Encryption level"
+msgstr "Encryption level"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "End"
+msgstr "End"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/install/smarty_translate.php
+msgid "End Time"
+msgstr "End Time"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/install/front_translate.php
+msgid "End date"
+msgstr "End date"
+
+#: centreon/www/install/front_translate.php
+msgid "End session endpoint"
+msgstr "End session endpoint"
+
+#: centreon/www/install/front_translate.php
+msgid "End time"
+msgstr "End time"
+
+#: centreon/www/install/front_translate.php
+msgid "Ends at"
+msgstr "Ends at"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Engine Directories"
+msgstr "Engine Directories"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Engine Name"
+msgstr "Engine Name"
+
+#: centreon/www/install/menu_translation.php
+msgid "Engine Statistics"
+msgstr "Engine Statistics"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Engine Status"
+msgstr "Engine Status"
+
+#: centreon/www/install/menu_translation.php
+msgid "Engine configuration"
+msgstr "Engine configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Enter Regex"
+msgstr "Enter Regex"
+
+#: centreon/www/install/front_translate.php
+msgid "Enter regex mode"
+msgstr "Enter regex mode"
+
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Entry Time"
+msgstr "Entry Time"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Entry time"
+msgstr "Entry time"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Error"
+msgstr "Error"
+
+#: centreon/www/include/configuration/configObject/host/DB-Func.php
+msgid "Error during creation (json encoding). See logs for more detail"
+msgstr "Error during creation (json encoding). See logs for more detail"
+
+#: centreon/src/Centreon/Infrastructure/Engine/EngineRepositoryFile.php
+#, php-format
+msgid "Error during creation of the CentCore command file (%s)"
+msgstr "Error during creation of the CentCore command file (%s)"
+
+#: centreon/www/include/configuration/configObject/host/DB-Func.php
+msgid ""
+"Error during update. See logs for more detail or contact your administrator."
+msgstr ""
+"Error during update. See logs for more detail or contact your administrator."
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+msgid "Error from Central's register API"
+msgstr "Error from Central's register API"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Error in getting stats filename"
+msgstr "Error in getting stats filename"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Error in hour definition"
+msgstr "Error in hour definition"
+
+#: centreon/src/Core/Application/Configuration/User/Exception/UserException.php
+msgid "Error in reading the themes available to the user"
+msgstr "Error in reading the themes available to the user"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Error messages"
+msgstr "Error messages"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+#, php-format
+msgid "Error on adding a host (Reason: %s)"
+msgstr "Error on adding a host (Reason: %s)"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+#, php-format
+msgid "Error on monitoring server #%d: %s"
+msgstr "Error on monitoring server #%d: %s"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostMacroServiceException.php
+#, php-format
+msgid "Error on reading host macros (Reason: %s)"
+msgstr "Error on reading host macros (Reason: %s)"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/Exception/ServiceConfigurationServiceException.php
+#, php-format
+msgid "Error on removing services from the host #%d"
+msgstr "Error on removing services from the host #%d"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+#, php-format
+msgid "Error on removing services from the host #%d (Reason: %s)"
+msgstr "Error on removing services from the host #%d (Reason: %s)"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+msgid "Error on retrieving monitoring servers"
+msgstr "Error on retrieving monitoring servers"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+#, php-format
+msgid "Error on updating a host (Reason: %s)"
+msgstr "Error on updating a host (Reason: %s)"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostMacroServiceException.php
+#, php-format
+msgid "Error on updating a host macro (Reason: %s)"
+msgstr "Error on updating a host macro (Reason: %s)"
+
+#: centreon/src/Core/Application/Configuration/User/Exception/UserException.php
+#, php-format
+msgid "Error on updating an user"
+msgstr "Error on updating an user"
+
+#: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
+#, php-format
+msgid "Error uploading file '%s'"
+msgstr "Error uploading file '%s'"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostCategoryException.php
+msgid "Error when adding a host category"
+msgstr "Error when adding a host category"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
+msgid "Error when adding a host groups"
+msgstr "Error when adding a host groups"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostMacroServiceException.php
+msgid "Error when adding a host macro"
+msgstr "Error when adding a host macro"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "Error when adding a notification configuration"
+msgstr "Error when adding a notification configuration"
+
+#: centreon/src/Centreon/Domain/ActionLog/ActionLogService.php
+msgid "Error when adding an entry in the action log"
+msgstr "Error when adding an entry in the action log"
+
+#: centreon/src/Centreon/Domain/ActionLog/ActionLogService.php
+#, php-format
+msgid "Error when adding details for the action log %d"
+msgstr "Error when adding details for the action log %d"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+#, php-format
+msgid "Error when adding filter %s"
+msgstr "Error when adding filter %s"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "Error when adding in topology the platform : '%s'@'%s'"
+msgstr "Error when adding in topology the platform : '%s'@'%s'"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+#, php-format
+msgid "Error when adding services to the host %d"
+msgstr "Error when adding services to the host %d"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+msgid "Error when adding the time period"
+msgstr "Error when adding the time period"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+#, php-format
+msgid "Error when changing host status (%d to %s)"
+msgstr "Error when changing host status (%d to %s)"
+
+#: centreon/src/Centreon/Domain/Gorgone/GorgoneService.php
+msgid "Error when connecting to the Gorgone server"
+msgstr "Error when connecting to the Gorgone server"
+
+#: centreon/src/Centreon/Application/Controller/FilterController.php
+#: centreon/src/Centreon/Application/Controller/PlatformController.php
+#: centreon/src/Centreon/Application/Controller/PlatformTopologyController.php
+msgid "Error when decoding sent data"
+msgstr "Error when decoding sent data"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+#, php-format
+msgid "Error when deleting filter %s"
+msgstr "Error when deleting filter %s"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+#, php-format
+msgid "Error when deleting the time period %d"
+msgstr "Error when deleting the time period %d"
+
+#: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
+msgid "Error when initializing the api uri"
+msgstr "Error when initializing the api uri"
+
+#: centreon/src/Centreon/Domain/Option/OptionService.php
+msgid "Error when retrieving selected options"
+msgstr "Error when retrieving selected options"
+
+#: centreon/src/Core/Platform/Infrastructure/Validator/RequirementValidators/DatabaseRequirementException.php
+msgid "Error when retrieving the database version"
+msgstr "Error when retrieving the database version"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+#, php-format
+msgid "Error when searching filter id %d"
+msgstr "Error when searching filter id %d"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+msgid "Error when searching filters"
+msgstr "Error when searching filters"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
+#, php-format
+msgid "Error when searching for a monitoring server %s"
+msgstr "Error when searching for a monitoring server %s"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Error when searching for already used host names"
+msgstr "Error when searching for already used host names"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+msgid "Error when searching for host and related service templates"
+msgstr "Error when searching for host and related service templates"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostCategoryException.php
+msgid "Error when searching for host categories"
+msgstr "Error when searching for host categories"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
+msgid "Error when searching for host groups"
+msgstr "Error when searching for host groups"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostSeverityException.php
+msgid "Error when searching for host severities"
+msgstr "Error when searching for host severities"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Error when searching for host templates"
+msgstr "Error when searching for host templates"
+
+#: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+msgid "Error when searching for hosts"
+msgstr "Error when searching for hosts"
+
+#: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+msgid "Error when searching for meta services"
+msgstr "Error when searching for meta services"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/RealTimeMonitoringServerException.php
+msgid "Error when searching for real time monitoring servers"
+msgstr "Error when searching for real time monitoring servers"
+
+#: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+msgid "Error when searching for services"
+msgstr "Error when searching for services"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+msgid "Error when searching for services by host"
+msgstr "Error when searching for services by host"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#, php-format
+msgid "Error when searching for the Engine configuration (%s)"
+msgstr "Error when searching for the Engine configuration (%s)"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+msgid "Error when searching for the central engine configuration"
+msgstr "Error when searching for the central engine configuration"
+
+#: centreon/src/Centreon/Domain/Engine/Exception/EngineConfigurationException.php
+#, php-format
+msgid "Error when searching for the engine configuration (%s)"
+msgstr "Error when searching for the engine configuration (%s)"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+#, php-format
+msgid "Error when searching for the host category #%d"
+msgstr "Error when searching for the host category #%d"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostCategoryException.php
+#, php-format
+msgid "Error when searching for the host category (%s)"
+msgstr "Error when searching for the host category (%s)"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
+#, php-format
+msgid "Error when searching for the host group (%s)"
+msgstr "Error when searching for the host group (%s)"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+#, php-format
+msgid "Error when searching for the host severity #%d"
+msgstr "Error when searching for the host severity #%d"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostSeverityException.php
+#, php-format
+msgid "Error when searching for the host severity (%s)"
+msgstr "Error when searching for the host severity (%s)"
+
+#: centreon/src/Centreon/Domain/Monitoring/MetaService/Exception/MetaServiceMetricException.php
+#, php-format
+msgid "Error when searching for the meta service (%d) metrics"
+msgstr "Error when searching for the meta service (%d) metrics"
+
+#: centreon/src/Centreon/Domain/MetaServiceConfiguration/Exception/MetaServiceConfigurationException.php
+#, php-format
+msgid "Error when searching for the meta service configuration (%s)"
+msgstr "Error when searching for the meta service configuration (%s)"
+
+#: centreon/src/Centreon/Domain/MetaServiceConfiguration/Exception/MetaServiceConfigurationException.php
+#, php-format
+msgid "Error when searching for the meta services configurations"
+msgstr "Error when searching for the meta services configurations"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+#, php-format
+msgid "Error when searching for the time period %d"
+msgstr "Error when searching for the time period %d"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+msgid "Error when searching for time periods"
+msgstr "Error when searching for time periods"
+
+#: centreon/src/Centreon/Domain/Monitoring/HostGroup/HostGroupService.php
+msgid "Error when searching hostgroups"
+msgstr "Error when searching hostgroups"
+
+#: centreon/src/Centreon/Domain/Monitoring/ServiceGroup/ServiceGroupService.php
+msgid "Error when searching servicegroups"
+msgstr "Error when searching servicegroups"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+#, php-format
+msgid "Error when updating filter %s"
+msgstr "Error when updating filter %s"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+#, php-format
+msgid "Error when updating the time period %d"
+msgstr "Error when updating the time period %d"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+msgid "Error while adding a Broker input/output"
+msgstr "Error while adding a Broker input/output"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while adding a dashboard"
+msgstr "Error while adding a dashboard"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while adding a host"
+msgstr "Error while adding a host"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while adding a host group"
+msgstr "Error while adding a host group"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "Error while adding a host template"
+msgstr "Error while adding a host template"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "Error while adding a media"
+msgstr "Error while adding a media"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while adding a poller/agent configuration"
+msgstr "Error while adding a poller/agent configuration"
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "Error while adding a resource access rule"
+msgstr "Error while adding a resource access rule"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "Error while adding a service group"
+msgstr "Error while adding a service group"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "Error while adding a token"
+msgstr "Error while adding a token"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid "Error while adding an additional configuration"
+msgstr "Error while adding an additional configuration"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Error while adding authentication token"
+msgstr "Error while adding authentication token"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+msgid "Error while adding the command"
+msgstr "Error while adding the command"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "Error while adding the service"
+msgstr "Error while adding the service"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "Error while adding the service template"
+msgstr "Error while adding the service template"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while creating contact"
+msgstr "Error while creating contact"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Error while creating host category"
+msgstr "Error while creating host category"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "Error while creating host severity"
+msgstr "Error while creating host severity"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while creating service category"
+msgstr "Error while creating service category"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Error while creating service severity"
+msgstr "Error while creating service severity"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while deleting a dashboard"
+msgstr "Error while deleting a dashboard"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while deleting a host group"
+msgstr "Error while deleting a host group"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "Error while deleting a host template"
+msgstr "Error while deleting a host template"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "Error while deleting a notification configuration"
+msgstr "Error while deleting a notification configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while deleting a poller/agent configuration"
+msgstr "Error while deleting a poller/agent configuration"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "Error while deleting a service group"
+msgstr "Error while deleting a service group"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "Error while deleting a token"
+msgstr "Error while deleting a token"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid "Error while deleting an additional configuration"
+msgstr "Error while deleting an additional configuration"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Error while deleting expired token"
+msgstr "Error while deleting expired token"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Error while deleting host category"
+msgstr "Error while deleting host category"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "Error while deleting host severity"
+msgstr "Error while deleting host severity"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while deleting service category"
+msgstr "Error while deleting service category"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Error while deleting service severity"
+msgstr "Error while deleting service severity"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Error while deleting session"
+msgstr "Error while deleting session"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while deleting the host"
+msgstr "Error while deleting the host"
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "Error while deleting the resource access rule"
+msgstr "Error while deleting the resource access rule"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "Error while deleting the service"
+msgstr "Error while deleting the service"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "Error while deleting the service template"
+msgstr "Error while deleting the service template"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while duplicating a host group"
+msgstr "Error while duplicating a host group"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Error while editing service severity"
+msgstr "Error while editing service severity"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while enabling/disabling host groups"
+msgstr "Error while enabling/disabling host groups"
+
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+msgid "Error while fetching ACL topologies"
+msgstr "Error while fetching ACL topologies"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Error while importing LDAP contact"
+msgstr "Error while importing LDAP contact"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while linking a dashboard to its thumbnail"
+msgstr "Error while linking a dashboard to its thumbnail"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while linking host categories to a host"
+msgstr "Error while linking host categories to a host"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "Error while linking host categories to a host template"
+msgstr "Error while linking host categories to a host template"
+
+#: centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+#, php-format
+msgid "Error while linking template %s to host (id: %d)"
+msgstr "Error while linking template %s to host (id: %d)"
+
+#: centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+#, php-format
+msgid "Error while linking template (id: %d) to host (id: %d)"
+msgstr "Error while linking template (id: %d) to host (id: %d)"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "Error while listing notification resources"
+msgstr "Error while listing notification resources"
+
+#: centreon/src/Core/Platform/Application/Repository/UpdateLockerException.php
+msgid "Error while locking the update process"
+msgstr "Error while locking the update process"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "Error while partially updating a host template"
+msgstr "Error while partially updating a host template"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "Error while partially updating a notification configuration"
+msgstr "Error while partially updating a notification configuration"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "Error while partially updating the token"
+msgstr "Error while partially updating the token"
+
+#: centreon/www/include/configuration/configObject/contact/contact.php
+msgid "Error while processing contacts"
+msgstr "Error while processing contacts"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Local/Repository/ConfigurationException.php
+msgid "Error while reading local provider configuration"
+msgstr "Error while reading local provider configuration"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Error while refresh token"
+msgstr "Error while refresh token"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while retrieving ACL groups for contact form"
+msgstr "Error while retrieving ACL groups for contact form"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while retrieving LDAP auth information"
+msgstr "Error while retrieving LDAP auth information"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+msgid "Error while retrieving a command"
+msgstr "Error while retrieving a command"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while retrieving a dashboard"
+msgstr "Error while retrieving a dashboard"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while retrieving a host"
+msgstr "Error while retrieving a host"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Error while retrieving a host category"
+msgstr "Error while retrieving a host category"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while retrieving a host group"
+msgstr "Error while retrieving a host group"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "Error while retrieving a host template"
+msgstr "Error while retrieving a host template"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "Error while retrieving a notification configuration"
+msgstr "Error while retrieving a notification configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while retrieving a poller/agent configuration"
+msgstr "Error while retrieving a poller/agent configuration"
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "Error while retrieving a resource access rule"
+msgstr "Error while retrieving a resource access rule"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "Error while retrieving a service"
+msgstr "Error while retrieving a service"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "Error while retrieving a service template"
+msgstr "Error while retrieving a service template"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "Error while retrieving a token"
+msgstr "Error while retrieving a token"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid "Error while retrieving an additional configuration"
+msgstr "Error while retrieving an additional configuration"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid ""
+"Error while retrieving contact groups allowed to receive a dashboard share"
+msgstr ""
+"Error while retrieving contact groups allowed to receive a dashboard share"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while retrieving contact information for contact form"
+msgstr "Error while retrieving contact information for contact form"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while retrieving contact templates"
+msgstr "Error while retrieving contact templates"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while retrieving contacts allowed to receive a dashboard share"
+msgstr "Error while retrieving contacts allowed to receive a dashboard share"
+
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+msgid "Error while retrieving host dependencies"
+msgstr "Error while retrieving host dependencies"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "Error while retrieving host severity"
+msgstr "Error while retrieving host severity"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while retrieving host statuses distribution"
+msgstr "Error while retrieving host statuses distribution"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while retrieving multiple poller/agent configurations"
+msgstr "Error while retrieving multiple poller/agent configurations"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while retrieving newly created dashboard"
+msgstr "Error while retrieving newly created dashboard"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while retrieving newly created host group"
+msgstr "Error while retrieving newly created host group"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "Error while retrieving newly created service group"
+msgstr "Error while retrieving newly created service group"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while retrieving recently created service category"
+msgstr "Error while retrieving recently created service category"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Error while retrieving recently created service severity"
+msgstr "Error while retrieving recently created service severity"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while retrieving remote server information"
+msgstr "Error while retrieving remote server information"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "Error while retrieving service statuses distribution"
+msgstr "Error while retrieving service statuses distribution"
+
+#: centreon/src/Core/Resources/Application/Exception/ResourceException.php
+msgid "Error while retrieving the number of hosts by status"
+msgstr "Error while retrieving the number of hosts by status"
+
+#: centreon/src/Core/Resources/Application/Exception/ResourceException.php
+msgid "Error while retrieving the number of services by status"
+msgstr "Error while retrieving the number of services by status"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while retrieving topologies for contact form"
+msgstr "Error while retrieving topologies for contact form"
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "Error while search resource access rules"
+msgstr "Error while search resource access rules"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+#: centreon/src/Security/Domain/Authentication/Exceptions/AuthenticationTokenException.php
+msgid "Error while searching authentication tokens"
+msgstr "Error while searching authentication tokens"
+
+#: centreon/src/Centreon/Domain/Contact/Exception/ContactServiceException.php
+msgid "Error while searching contact"
+msgstr "Error while searching contact"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid "Error while searching for additional configurations"
+msgstr "Error while searching for additional configurations"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+msgid "Error while searching for commands"
+msgstr "Error while searching for commands"
+
+#: centreon/src/Core/Connector/Application/Exception/ConnectorException.php
+msgid "Error while searching for connectors"
+msgstr "Error while searching for connectors"
+
+#: centreon/src/Core/Contact/Application/Exception/ContactTemplateException.php
+msgid "Error while searching for contact templates"
+msgstr "Error while searching for contact templates"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while searching for dashboards"
+msgstr "Error while searching for dashboards"
+
+#: centreon/src/Core/GraphTemplate/Application/Exception/GraphTemplateException.php
+msgid "Error while searching for graph templates"
+msgstr "Error while searching for graph templates"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Error while searching for host categories"
+msgstr "Error while searching for host categories"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while searching for host configurations"
+msgstr "Error while searching for host configurations"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while searching for host groups"
+msgstr "Error while searching for host groups"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "Error while searching for host severities"
+msgstr "Error while searching for host severities"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "Error while searching for host templates"
+msgstr "Error while searching for host templates"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "Error while searching for media"
+msgstr "Error while searching for media"
+
+#: centreon/src/Core/Resources/Application/Exception/ResourceException.php
+msgid "Error while searching for resources"
+msgstr "Error while searching for resources"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while searching for service categories"
+msgstr "Error while searching for service categories"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "Error while searching for service groups"
+msgstr "Error while searching for service groups"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Error while searching for service severities"
+msgstr "Error while searching for service severities"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "Error while searching for service templates"
+msgstr "Error while searching for service templates"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "Error while searching for services"
+msgstr "Error while searching for services"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Error while searching for the command of host"
+msgstr "Error while searching for the command of host"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+msgid "Error while searching for the command of service"
+msgstr "Error while searching for the command of service"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Error while searching for the host"
+msgstr "Error while searching for the host"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Error while searching for the host macros"
+msgstr "Error while searching for the host macros"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+#, php-format
+msgid "Error while searching for the host template %d"
+msgstr "Error while searching for the host template %d"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Error while searching for the number of host"
+msgstr "Error while searching for the number of host"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+msgid "Error while searching for the service"
+msgstr "Error while searching for the service"
+
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+msgid "Error while searching for the service macros"
+msgstr "Error while searching for the service macros"
+
+#: centreon/src/Core/Application/Configuration/User/Exception/UserException.php
+#: centreon/src/Core/User/Application/Exception/UserException.php
+msgid "Error while searching for the user"
+msgstr "Error while searching for the user"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "Error while searching for tokens"
+msgstr "Error while searching for tokens"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while searching for user favorite dashboards"
+msgstr "Error while searching for user favorite dashboards"
+
+#: centreon/src/Core/User/Application/Exception/UserException.php
+msgid "Error while searching for users"
+msgstr "Error while searching for users"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Error while searching host categories in real time context"
+msgstr "Error while searching host categories in real time context"
+
+#: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
+#, php-format
+msgid "Error while searching provider configuration: '%s'"
+msgstr "Error while searching provider configuration: '%s'"
+
+#: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
+msgid "Error while searching providers configurations"
+msgstr "Error while searching providers configurations"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while searching service categories in real time context"
+msgstr "Error while searching service categories in real time context"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid ""
+"Error while trying to update a widget which belongs to another dashboard"
+msgstr ""
+"Error while trying to update a widget which belongs to another dashboard"
+
+#: centreon/src/Core/Platform/Application/Repository/UpdateLockerException.php
+msgid "Error while unlocking the update process"
+msgstr "Error while unlocking the update process"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+msgid "Error while updating a Broker input/output"
+msgstr "Error while updating a Broker input/output"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while updating a dashboard"
+msgstr "Error while updating a dashboard"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Error while updating a host"
+msgstr "Error while updating a host"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "Error while updating a host group"
+msgstr "Error while updating a host group"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "Error while updating a media"
+msgstr "Error while updating a media"
+
+#: centreon/src/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotification.php
+msgid "Error while updating a notification configuration"
+msgstr "Error while updating a notification configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while updating a poller/agent configuration"
+msgstr "Error while updating a poller/agent configuration"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "Error while updating a service"
+msgstr "Error while updating a service"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "Error while updating a service template"
+msgstr "Error while updating a service template"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid "Error while updating an additional configuration"
+msgstr "Error while updating an additional configuration"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Error while updating authentication tokens"
+msgstr "Error while updating authentication tokens"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while updating contact"
+msgstr "Error while updating contact"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Error while updating contact (massive change)"
+msgstr "Error while updating contact (massive change)"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "Error while updating host severity"
+msgstr "Error while updating host severity"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while updating the dashboard share"
+msgstr "Error while updating the dashboard share"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Error while updating the host category"
+msgstr "Error while updating the host category"
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "Error while updating the resource access rule"
+msgstr "Error while updating the resource access rule"
+
+#: centreon/www/include/eventLogs/viewLog.php
+msgid "Errors"
+msgstr "Errors"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Escalated Hosts"
+msgstr "Escalated Hosts"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Escalated Services"
+msgstr "Escalated Services"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Escalation"
+msgstr "Escalation"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Escalation Name"
+msgstr "Escalation Name"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Escalation Period"
+msgstr "Escalation Period"
+
+#: centreon/www/install/menu_translation.php
+msgid "Escalations"
+msgstr "Escalations"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/front_translate.php
+msgid "Event"
+msgstr "Event"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Event Handler"
+msgstr "Event Handler"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Event Handler Enabled"
+msgstr "Event Handler Enabled"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Event Handler Logging Option"
+msgstr "Event Handler Logging Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Event Handler Option"
+msgstr "Event Handler Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Event Handler Timeout"
+msgstr "Event Handler Timeout"
+
+#: centreon/www/install/menu_translation.php
+msgid "Event Logs"
+msgstr "Event Logs"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Event Type"
+msgstr "Event Type"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Event broker directive"
+msgstr "Event broker directive"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Event broker information"
+msgstr "Event broker information"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Event processing speed"
+msgstr "Event processing speed"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Event queue max size"
+msgstr "Event queue max size"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Event queues maximum total size"
+msgstr "Event queues maximum total size"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Events"
+msgstr "Events"
+
+#: centreon/www/install/front_translate.php
+msgid "Everything is OK"
+msgstr "Everything is OK"
+
+#: centreon/www/install/step_upgrade/step3.php
+msgid "Everything is ready !"
+msgstr "Everything is ready !"
+
+#: centreon/www/install/front_translate.php
+msgid "Exact"
+msgstr "Exact"
+
+#: centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+msgid "Example"
+msgstr "Example"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Exception List"
+msgstr "Exception List"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Exceptions"
+msgstr "Exceptions"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Exclude hosts from selected host groups"
+msgstr "Exclude hosts from selected host groups"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Excluded Timerange"
+msgstr "Excluded Timerange"
+
+#: centreon/www/install/front_translate.php
+msgid "Excluded users"
+msgstr "Excluded users"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Execute special command"
+msgstr "Execute special command"
+
+#: centreon/www/install/front_translate.php
+msgid "Execute this script as root on the central."
+msgstr "Execute this script as root on the central."
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Executed Check Command Line"
+msgstr "Executed Check Command Line"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/configuration/configGenerate/xml/postcommand.php
+msgid "Executing command"
+msgstr "Executing command"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Execution Failure Criteria"
+msgstr "Execution Failure Criteria"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Execution Time"
+msgstr "Execution Time"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Execution interval"
+msgstr "Execution interval"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Execution method"
+msgstr "Execution method"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Execution type"
+msgstr "Execution type"
+
+#: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
+msgid "Execution was too long and reached timeout"
+msgstr "Execution was too long and reached timeout"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Existing directory"
+msgstr "Existing directory"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Existing or new directory"
+msgstr "Existing or new directory"
+
+#: centreon/www/install/front_translate.php
+msgid "Exit"
+msgstr "Exit"
+
+#: centreon/www/install/front_translate.php
+msgid "Exit edition mode"
+msgstr "Exit edition mode"
+
+#: centreon/www/install/front_translate.php
+msgid "Exit regex mode"
+msgstr "Exit regex mode"
+
+#: centreon/www/install/front_translate.php
+msgid "Exit {{dashboardName}}"
+msgstr "Exit {{dashboardName}}"
+
+#: centreon/www/install/front_translate.php
+msgid "Expand"
+msgstr "Expand"
+
+#: centreon/www/install/front_translate.php
+msgid "Expand information panel"
+msgstr "Expand information panel"
+
+#: centreon/www/install/front_translate.php
+msgid "Expiration date"
+msgstr "Expiration date"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/install/front_translate.php
+msgid "Export"
+msgstr "Export"
+
+#: centreon/www/install/front_translate.php
+msgid "Export & reload"
+msgstr "Export & reload"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Export CSV"
+msgstr "Export CSV"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/install/smarty_translate.php
+msgid "Export Options"
+msgstr "Export Options"
+
+#: centreon/www/install/front_translate.php
+msgid "Export and reload the configuration?"
+msgstr "Export and reload the configuration?"
+
+#: centreon/www/install/front_translate.php
+msgid "Export as"
+msgstr "Export as"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Export configuration"
+msgstr "Export configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Export generation timeout"
+msgstr "Export generation timeout"
+
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesLog.php
+msgid "Export in CSV format"
+msgstr "Export in CSV format"
+
+#: centreon/www/install/front_translate.php
+msgid "Export processing in progress"
+msgstr "Export processing in progress"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Export processing might take some time. The real time data displayed at the "
+"output may have changed since the start of processing."
+msgstr ""
+"Export processing might take some time. The real time data displayed at the "
+"output may have changed since the start of processing."
+
+#: centreon/www/install/front_translate.php
+msgid "Export to CSV"
+msgstr "Export to CSV"
+
+#: centreon/www/install/front_translate.php
+msgid "Export to png"
+msgstr "Export to png"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Export will be processed but will not include all rows. You can still filter "
+"your resources to reduce the number of rows."
+msgstr ""
+"Export will be processed but will not include all rows. You can still filter "
+"your resources to reduce the number of rows."
+
+#: centreon/www/install/front_translate.php
+msgid "Exporting and reloading the configuration. Please wait..."
+msgstr "Exporting and reloading the configuration. Please wait..."
+
+#: centreon/www/install/front_translate.php
+msgid "Expression in"
+msgstr "Expression in"
+
+#: centreon/www/install/front_translate.php
+msgid "Extended"
+msgstr "Extended"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Extended Info"
+msgstr "Extended Info"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Extended Settings"
+msgstr "Extended Settings"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Extended Status Information"
+msgstr "Extended Status Information"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Extended information"
+msgstr "Extended information"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Extended status information"
+msgstr "Extended status information"
+
+#: centreon/www/install/front_translate.php
+msgid "Extension not allowed"
+msgstr "Extension not allowed"
+
+#: centreon/www/install/menu_translation.php
+msgid "Extensions"
+msgstr "Extensions"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External Command Buffer Slots"
+msgstr "External Command Buffer Slots"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External Command Check Interval"
+msgstr "External Command Check Interval"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External Command Check Option"
+msgstr "External Command Check Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External Command File"
+msgstr "External Command File"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External Command Logging Option"
+msgstr "External Command Logging Option"
+
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "External Command successfully submitted... Exiting window..."
+msgstr "External Command successfully submitted... Exiting window..."
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External Commands"
+msgstr "External Commands"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "External commands"
+msgstr "External commands"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
+msgid "FQDN / Address"
+msgstr "FQDN / Address"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to copy breadcrumb"
+msgstr "Failed to copy breadcrumb"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to copy command"
+msgstr "Failed to copy command"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to copy link"
+msgstr "Failed to copy link"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to create the dashboard"
+msgstr "Failed to create the dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete"
+msgstr "Failed to delete"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete the dashboard"
+msgstr "Failed to delete the dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete the notification"
+msgstr "Failed to delete the notification"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete the notifications"
+msgstr "Failed to delete the notifications"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete the resource access rule"
+msgstr "Failed to delete the resource access rule"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete the selected notifications"
+msgstr "Failed to delete the selected notifications"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to delete the selected resource access rules"
+msgstr "Failed to delete the selected resource access rules"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to disable"
+msgstr "Failed to disable"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to duplicate"
+msgstr "Failed to duplicate"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to duplicate the dashboard"
+msgstr "Failed to duplicate the dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to duplicate the notification"
+msgstr "Failed to duplicate the notification"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to duplicate the resource access rule"
+msgstr "Failed to duplicate the resource access rule"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to enable"
+msgstr "Failed to enable"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Failed to execute command"
+msgstr "Failed to execute command"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to export and reload the configuration"
+msgstr "Failed to export and reload the configuration"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+#, php-format
+msgid "Failed to get the auth token from Central : '%s''"
+msgstr "Failed to get the auth token from Central : '%s''"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to save OpenID Connect configuration"
+msgstr "Failed to save OpenID Connect configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to save SAML configuration"
+msgstr "Failed to save SAML configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to save Web SSO configuration"
+msgstr "Failed to save Web SSO configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to save password security policy"
+msgstr "Failed to save password security policy"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to save shares"
+msgstr "Failed to save shares"
+
+#: centreon/www/install/front_translate.php
+msgid "Failed to update the dashboard"
+msgstr "Failed to update the dashboard"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Failover name"
+msgstr "Failover name"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Features flipping"
+msgstr "Features flipping"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Field Name"
+msgstr "Field Name"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Field Value"
+msgstr "Field Value"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
+msgid "File"
+msgstr "File"
+
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+msgid "File (.mib)"
+msgstr "File (.mib)"
+
+#: centreon/www/install/smarty_translate.php
+msgid "File Path"
+msgstr "File Path"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "File extension not authorized"
+msgstr "File extension not authorized"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "File for Centreon Broker statistics"
+msgstr "File for Centreon Broker statistics"
+
+#: centreon/www/install/steps/functions.php
+msgid "File not found"
+msgstr "File not found"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "File path"
+msgstr "File path"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "File path or format '%s' (%s) is invalid"
+msgstr "File path or format '%s' (%s) is invalid"
+
+#: centreon/www/install/front_translate.php
+msgid "File too big"
+msgstr "File too big"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Files"
+msgstr "Files"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Fill opacity"
+msgstr "Fill opacity"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+msgid "Filling"
+msgstr "Filling"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/install/front_translate.php
+msgid "Filter"
+msgstr "Filter"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Filter Examples"
+msgstr "Filter Examples"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+msgid "Filter already exists"
+msgstr "Filter already exists"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Filter by Host"
+msgstr "Filter by Host"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Filter by Hostgroup"
+msgstr "Filter by Hostgroup"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Filter by Servicegroup"
+msgstr "Filter by Servicegroup"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Filter category"
+msgstr "Filter category"
+
+#: centreon/www/install/front_translate.php
+msgid "Filter created"
+msgstr "Filter created"
+
+#: centreon/www/install/front_translate.php
+msgid "Filter deleted"
+msgstr "Filter deleted"
+
+#: centreon/src/Centreon/Application/Controller/FilterController.php
+#, php-format
+msgid "Filter id %d not found"
+msgstr "Filter id %d not found"
+
+#: centreon/src/Centreon/Domain/Filter/FilterService.php
+msgid "Filter name already used"
+msgstr "Filter name already used"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Filter on event categories"
+msgstr "Filter on event categories"
+
+#: centreon/www/install/front_translate.php
+msgid "Filter options"
+msgstr "Filter options"
+
+#: centreon/www/install/front_translate.php
+msgid "Filter saved"
+msgstr "Filter saved"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Filter services"
+msgstr "Filter services"
+
+#: centreon/www/install/front_translate.php
+msgid "Filter updated"
+msgstr "Filter updated"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Filters"
+msgstr "Filters"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Finalizing Setup"
+msgstr "Finalizing Setup"
+
+#: centreon/www/install/front_translate.php
+msgid "Find explanations and examples"
+msgstr "Find explanations and examples"
+
+#: centreon/www/install/front_translate.php
+msgid "Finish the setup"
+msgstr "Finish the setup"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "First Notification"
+msgstr "First Notification"
+
+#: centreon/www/install/smarty_translate.php
+msgid "First name"
+msgstr "First name"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "First notification delay"
+msgstr "First notification delay"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+msgid "First of month"
+msgstr "First of month"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
+msgid "First page"
+msgstr "First page"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Fixed"
+msgstr "Fixed"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Flap Detection"
+msgstr "Flap Detection"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Flap Detection Enabled"
+msgstr "Flap Detection Enabled"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Flap Detection Option"
+msgstr "Flap Detection Option"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Flapping"
+msgstr "Flapping"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Flapping Options"
+msgstr "Flapping Options"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Flapping options"
+msgstr "Flapping options"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Flexible"
+msgstr "Flexible"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Folders"
+msgstr "Folders"
+
+#: centreon/src/CentreonModule/Infrastructure/Source/ModuleException.php
+#, php-format
+msgid "Following modules need to be removed first: %s"
+msgstr "Following modules need to be removed first: %s"
+
+#: centreon/www/install/step_upgrade/step3.php
+msgid "For further details on changes, please find the complete changelog on "
+msgstr "For further details on changes, please find the complete changelog on "
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"For security reasons, the token can only be displayed once. Remember to "
+"store it well."
+msgstr ""
+"For security reasons, the token can only be displayed once. Remember to "
+"store it well."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"For some connectors, you must define on the poller the credentials required "
+"to access the monitored hosts. You can do it easily from here."
+msgstr ""
+"For some connectors, you must define on the poller the credentials required "
+"to access the monitored hosts. You can do it easily from here."
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Force Active Checks"
+msgstr "Force Active Checks"
+
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+msgid "Force active check"
+msgstr "Force active check"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Force active checks"
+msgstr "Force active checks"
+
+#: centreon/www/install/front_translate.php
+msgid "Forced check"
+msgstr "Forced check"
+
+#: centreon/www/install/front_translate.php
+msgid "Forced check command sent !"
+msgstr "Forced check command sent !"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Forced check command sent ! Please refresh the listing to update the data."
+msgstr ""
+"Forced check command sent ! Please refresh the listing to update the data."
+
+#: centreon/www/install/front_translate.php
+msgid "Forced check command sent!"
+msgstr "Forced check command sent!"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Forecast based on past X days"
+msgstr "Forecast based on past X days"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/media/images/formDirectory.php
+msgid "Form"
+msgstr "Form"
+
+#: centreon/www/install/front_translate.php
+msgid "Forward"
+msgstr "Forward"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Forward provisioning"
+msgstr "Forward provisioning"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+msgid "Fourth of month"
+msgstr "Fourth of month"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Free text search behavior"
+msgstr "Free text search behavior"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Free text search behavior can be configured in the Administration > "
+"Parameters > Centreon UI page."
+msgstr ""
+"Free text search behavior can be configured in the Administration > "
+"Parameters > Centreon UI page."
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Freshness"
+msgstr "Freshness"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Freshness Control options"
+msgstr "Freshness Control options"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Freshness Threshold"
+msgstr "Freshness Threshold"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Friday"
+msgstr "Friday"
+
+#: centreon/www/class/centreonWidget/Params/Date.class.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "From"
+msgstr "From"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "Full Name"
+msgstr "Full Name"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Full backup"
+msgstr "Full backup"
+
+#: centreon/www/install/front_translate.php
+msgid "Full name attribute"
+msgstr "Full name attribute"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Full search"
+msgstr "Full search"
+
+#: centreon/www/install/front_translate.php
+msgid "Fullname attribute path"
+msgstr "Fullname attribute path"
+
+#: centreon/www/install/front_translate.php
+msgid "Fullscreen (F)"
+msgstr "Fullscreen (F)"
+
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+msgid "Function"
+msgstr "Function"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Function enter/exit information"
+msgstr "Function enter/exit information"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Functions"
+msgstr "Functions"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "GMT is activated on your system. Exceptions will not be generated."
+msgstr "GMT is activated on your system. Exceptions will not be generated."
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Gauge"
+msgstr "Gauge"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "General"
+msgstr "General"
+
+#: centreon/www/api/class/centreon_home_customview.class.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/home/customViews/formLoad.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/smarty_translate.php
+msgid "General Information"
+msgstr "General Information"
+
+#: centreon/www/install/smarty_translate.php
+msgid "General Options"
+msgstr "General Options"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/install/front_translate.php
+msgid "General information"
+msgstr "General information"
+
+#: centreon/www/install/smarty_translate.php
+msgid "General informations"
+msgstr "General informations"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/install/menu_translation.php
+msgid "Generate"
+msgstr "Generate"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Generate Configuration Files"
+msgstr "Generate Configuration Files"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Generate SNMP Trap configuration"
+msgstr "Generate SNMP Trap configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Generate token"
+msgstr "Generate token"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Generate trap database "
+msgstr "Generate trap database "
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Generating Export Files"
+msgstr "Generating Export Files"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Generating application cache"
+msgstr "Generating application cache"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Generating files"
+msgstr "Generating files"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+#, php-format
+msgid "Generation error on monitoring server #%d: %s"
+msgstr "Generation error on monitoring server #%d: %s"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Generic data (example)"
+msgstr "Generic data (example)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Generic data for single metric (example)"
+msgstr "Generic data for single metric (example)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Generic input (example)"
+msgstr "Generic input (example)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Generic text"
+msgstr "Generic text"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Generic text (example)"
+msgstr "Generic text (example)"
+
+#: centreon/www/install/front_translate.php
+msgid "Generic widgets"
+msgstr "Generic widgets"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Geo coordinates"
+msgstr "Geo coordinates"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Geographic coordinates"
+msgstr "Geographic coordinates"
+
+#: centreon/www/install/front_translate.php
+msgid "Geographic coordinates for MAP"
+msgstr "Geographic coordinates for MAP"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Global Functionalities Access"
+msgstr "Global Functionalities Access"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Global Host Event Handler"
+msgstr "Global Host Event Handler"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Global Monitoring Engine Actions (External Process Commands)"
+msgstr "Global Monitoring Engine Actions (External Process Commands)"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Global Service Event Handler"
+msgstr "Global Service Event Handler"
+
+#: centreon/www/install/menu_translation.php
+msgid "Global macros"
+msgstr "Global macros"
+
+#: centreon/www/install/front_translate.php
+msgid "Global refresh interval"
+msgstr "Global refresh interval"
+
+#: centreon/www/install/front_translate.php
+msgid "Go to performance page"
+msgstr "Go to performance page"
+
+#: centreon/www/install/front_translate.php
+msgid "Good"
+msgstr "Good"
+
+#: centreon/www/install/menu_translation.php
+msgid "Gorgone"
+msgstr "Gorgone"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Gorgone Information"
+msgstr "Gorgone Information"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Gorgone connection port"
+msgstr "Gorgone connection port"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Gorgone connection protocol"
+msgstr "Gorgone connection protocol"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Gorgone properties"
+msgstr "Gorgone properties"
+
+#: centreon/www/class/centreonGraph.class.php
+#: centreon/www/class/centreonGraphNg.class.php
+#: centreon/www/install/front_translate.php
+msgid "Graph"
+msgstr "Graph"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Graph Choice"
+msgstr "Graph Choice"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Graph Period"
+msgstr "Graph Period"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Graph Template"
+msgstr "Graph Template"
+
+#: centreon/www/install/front_translate.php
+msgid "Graph options"
+msgstr "Graph options"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Graph per page for Performances"
+msgstr "Graph per page for Performances"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Graph style"
+msgstr "Graph style"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/install/smarty_translate.php
+msgid "Graph template"
+msgstr "Graph template"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Graphs"
+msgstr "Graphs"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Grid"
+msgstr "Grid"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Gridline type"
+msgstr "Gridline type"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Group"
+msgstr "Group"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Group Information"
+msgstr "Group Information"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Group Ldap"
+msgstr "Group Ldap"
+
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Group Name"
+msgstr "Group Name"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Group Relations"
+msgstr "Group Relations"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Group attribute"
+msgstr "Group attribute"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Group filter"
+msgstr "Group filter"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Group member attribute"
+msgstr "Group member attribute"
+
+#: centreon/www/install/front_translate.php
+msgid "Group members"
+msgstr "Group members"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Group monitoring"
+msgstr "Group monitoring"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Group name"
+msgstr "Group name"
+
+#: centreon/www/install/front_translate.php
+msgid "Group value"
+msgstr "Group value"
+
+#: centreon/www/install/front_translate.php
+msgid "Groups"
+msgstr "Groups"
+
+#: centreon/www/install/front_translate.php
+msgid "Groups attribute path"
+msgstr "Groups attribute path"
+
+#: centreon/www/install/front_translate.php
+msgid "Groups mapping"
+msgstr "Groups mapping"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "HARD"
+msgstr "HARD"
+
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "HTTP Action Link"
+msgstr "HTTP Action Link"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "HTTP Link"
+msgstr "HTTP Link"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "HTTP Method"
+msgstr "HTTP Method"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "HTTP Port"
+msgstr "HTTP Port"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Hard"
+msgstr "Hard"
+
+#: centreon/www/include/eventLogs/viewLog.php
+msgid "Hard Only"
+msgstr "Hard Only"
+
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Hard State Duration"
+msgstr "Hard State Duration"
+
+#: centreon/www/install/front_translate.php
+msgid "Health"
+msgstr "Health"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Heartbeat Interval"
+msgstr "Heartbeat Interval"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Height"
+msgstr "Height"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/core/footer/footerPart.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Help"
+msgstr "Help"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/smarty_translate.php
+msgid "Hidden"
+msgstr "Hidden"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Hidden Graph And Legend"
+msgstr "Hidden Graph And Legend"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Hide"
+msgstr "Hide"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Hide graphs of selected Services"
+msgstr "Hide graphs of selected Services"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Hide services with Down host"
+msgstr "Hide services with Down host"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Hide services with Unreachable host"
+msgstr "Hide services with Unreachable host"
+
+#: centreon/www/install/front_translate.php
+msgid "Hide the password"
+msgstr "Hide the password"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "High Flap Threshold"
+msgstr "High Flap Threshold"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "High Host Flap Threshold"
+msgstr "High Host Flap Threshold"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "High Service Flap Threshold"
+msgstr "High Service Flap Threshold"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Highly detailed information"
+msgstr "Highly detailed information"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "History"
+msgstr "History"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "History Options"
+msgstr "History Options"
+
+#: centreon/www/install/menu_translation.php
+msgid "Home"
+msgstr "Home"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Horizontal bar chart"
+msgstr "Horizontal bar chart"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configKnowledge/search.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Host"
+msgstr "Host"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+#, php-format
+msgid "Host #%d not found"
+msgstr "Host #%d not found"
+
+#: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+#: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+#: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
+#, php-format
+msgid "Host %d not found"
+msgstr "Host %d not found"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Host / Service Required"
+msgstr "Host / Service Required"
+
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Host Acknowledgement"
+msgstr "Host Acknowledgement"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "Host Categories"
+msgstr "Host Categories"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Host Categories Relations"
+msgstr "Host Categories Relations"
+
+#: centreon/www/install/front_translate.php
+msgid "Host Category"
+msgstr "Host Category"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Host Category Filter"
+msgstr "Host Category Filter"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Check Execution Option"
+msgstr "Host Check Execution Option"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Host Check Execution Time"
+msgstr "Host Check Execution Time"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Check Options"
+msgstr "Host Check Options"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Host Check Properties"
+msgstr "Host Check Properties"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Check Scheduling Options"
+msgstr "Host Check Scheduling Options"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Check Timeout"
+msgstr "Host Check Timeout"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Host Commands"
+msgstr "Host Commands"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Host Configuration"
+msgstr "Host Configuration"
+
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Host Downtime"
+msgstr "Host Downtime"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Host Extended Infos"
+msgstr "Host Extended Infos"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Freshness Check Interval"
+msgstr "Host Freshness Check Interval"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Freshness Check Option"
+msgstr "Host Freshness Check Option"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroupJS.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/install/front_translate.php
+msgid "Host Group"
+msgstr "Host Group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/menu_translation.php
+msgid "Host Groups"
+msgstr "Host Groups"
+
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+msgid "Host Groups Name"
+msgstr "Host Groups Name"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Host Groups Shared"
+msgstr "Host Groups Shared"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "Host ID #%d is invalid"
+msgstr "Host ID #%d is invalid"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Host Information"
+msgstr "Host Information"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Inter-Check Delay Method"
+msgstr "Host Inter-Check Delay Method"
+
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/install/smarty_translate.php
+msgid "Host Name"
+msgstr "Host Name"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+msgid "Host Names"
+msgstr "Host Names"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Host Notification Commands"
+msgstr "Host Notification Commands"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Host Notification Options"
+msgstr "Host Notification Options"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "Host Notification Period"
+msgstr "Host Notification Period"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+msgid "Host Problems"
+msgstr "Host Problems"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Host Resources"
+msgstr "Host Resources"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host Retry Logging Option"
+msgstr "Host Retry Logging Option"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Host Shortcuts"
+msgstr "Host Shortcuts"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Host Status"
+msgstr "Host Status"
+
+#: centreon/www/include/configuration/configKnowledge/search.php
+msgid "Host Template"
+msgstr "Host Template"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/menu_translation.php
+msgid "Host Templates"
+msgstr "Host Templates"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+msgid "Host Uses"
+msgstr "Host Uses"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Host address"
+msgstr "Host address"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+msgid "Host and service id can not be null at the same time"
+msgstr "Host and service id can not be null at the same time"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Host basic information"
+msgstr "Host basic information"
+
+#: centreon/www/install/front_translate.php
+msgid "Host category"
+msgstr "Host category"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostCategoryException.php
+#, php-format
+msgid "Host category (%s) not found"
+msgstr "Host category (%s) not found"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "Host category name already exists"
+msgstr "Host category name already exists"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Host check latency"
+msgstr "Host check latency"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Host check options"
+msgstr "Host check options"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Host commands and shortcuts"
+msgstr "Host commands and shortcuts"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Host dependency"
+msgstr "Host dependency"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Host escalations"
+msgstr "Host escalations"
+
+#: centreon/www/install/front_translate.php
+msgid "Host group"
+msgstr "Host group"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
+#, php-format
+msgid "Host group (%s) not found"
+msgstr "Host group (%s) not found"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Host groups"
+msgstr "Host groups"
+
+#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+#, php-format
+msgid "Host id %d not found"
+msgstr "Host id %d not found"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+#: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
+msgid "Host id cannot be null"
+msgstr "Host id cannot be null"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Host inheritance to services"
+msgstr "Host inheritance to services"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Host is currently on downtime"
+msgstr "Host is currently on downtime"
+
+#: centreon/www/widgets/host-monitoring/src/index.php
+msgid "Host is flapping"
+msgstr "Host is flapping"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+msgid "Host links (host template links)"
+msgstr "Host links (host template links)"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Host list"
+msgstr "Host list"
+
+#: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#, php-format
+msgid "Host meta for meta %d not found"
+msgstr "Host meta for meta %d not found"
+
+#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+#, php-format
+msgid "Host meta for meta service %d not found"
+msgstr "Host meta for meta service %d not found"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/smarty_translate.php
+msgid "Host name"
+msgstr "Host name"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+msgid "Host name already exists"
+msgstr "Host name already exists"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+msgid "Host name can not be empty"
+msgstr "Host name can not be empty"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#, php-format
+msgid "Host name can not be empty for host (id: %d)"
+msgstr "Host name can not be empty for host (id: %d)"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+msgid "Host name cannot be empty"
+msgstr "Host name cannot be empty"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+msgid "Host name cannot be null"
+msgstr "Host name cannot be null"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Host name is already in use"
+msgstr "Host name is already in use"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#, php-format
+msgid "Host name of service (id: %d) can not be empty"
+msgstr "Host name of service (id: %d) can not be empty"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "Host name should not start with '_Module_'"
+msgstr "Host name should not start with '_Module_'"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+#: centreon/www/api/class/centreon_monitoring_externalcmd.class.php
+msgid "Host not found"
+msgstr "Host not found"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Host notifications"
+msgstr "Host notifications"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Host severities"
+msgstr "Host severities"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/install/front_translate.php
+msgid "Host severity"
+msgstr "Host severity"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostSeverityException.php
+#, php-format
+msgid "Host severity (%s) not found"
+msgstr "Host severity (%s) not found"
+
+#: centreon/www/install/front_translate.php
+msgid "Host severity level"
+msgstr "Host severity level"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "Host severity name already exists"
+msgstr "Host severity name already exists"
+
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+msgid "Host state"
+msgstr "Host state"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Host status"
+msgstr "Host status"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Host template"
+msgstr "Host template"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#, php-format
+msgid "Host template #%d is locked (edition and deletion not allowed)"
+msgstr "Host template #%d is locked (edition and deletion not allowed)"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#, php-format
+msgid "Host template #%d not found"
+msgstr "Host template #%d not found"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid ""
+"Host template required in service group association is not linked to service "
+"template"
+msgstr ""
+"Host template required in service group association is not linked to service "
+"template"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Host to connect to"
+msgstr "Host to connect to"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Host/service check information"
+msgstr "Host/service check information"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Acknowledge"
+msgstr "Host: Acknowledge"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Disable Host Check"
+msgstr "Host: Disable Host Check"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Disable Host Notification"
+msgstr "Host: Disable Host Notification"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Enable Host Check"
+msgstr "Host: Enable Host Check"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Enable Host Notification"
+msgstr "Host: Enable Host Notification"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Remove Acknowledgement"
+msgstr "Host: Remove Acknowledgement"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Host: Set Downtime"
+msgstr "Host: Set Downtime"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+msgid "HostGroup"
+msgstr "HostGroup"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "HostGroup or Host Required"
+msgstr "HostGroup or Host Required"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+msgid "HostGroups"
+msgstr "HostGroups"
+
+#: centreon/www/include/configuration/configKnowledge/search.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Hostgroup"
+msgstr "Hostgroup"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Hostgroup Relations"
+msgstr "Hostgroup Relations"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Hostgroup availability history"
+msgstr "Hostgroup availability history"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Hostgroup dependency"
+msgstr "Hostgroup dependency"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Hostgroup inheritance to services"
+msgstr "Hostgroup inheritance to services"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Hostgroups"
+msgstr "Hostgroups"
+
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHGJS.php
+msgid "Hostgroups / Hosts"
+msgstr "Hostgroups / Hosts"
+
+#: centreon/www/install/menu_translation.php
+msgid "Hostgroups Summary"
+msgstr "Hostgroups Summary"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/widgets/global-health/src/global_health.php
+msgid "Hosts"
+msgstr "Hosts"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Hosts : Acknowledge"
+msgstr "Hosts : Acknowledge"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Hosts : Disable Check"
+msgstr "Hosts : Disable Check"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Hosts : Disable Notification"
+msgstr "Hosts : Disable Notification"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Hosts : Disacknowledge"
+msgstr "Hosts : Disacknowledge"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Hosts : Enable Check"
+msgstr "Hosts : Enable Check"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Hosts : Enable Notification"
+msgstr "Hosts : Enable Notification"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Hosts : Schedule immediate check"
+msgstr "Hosts : Schedule immediate check"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Hosts : Schedule immediate check (Forced)"
+msgstr "Hosts : Schedule immediate check (Forced)"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Hosts : Set Downtime"
+msgstr "Hosts : Set Downtime"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Hosts Actions Access"
+msgstr "Hosts Actions Access"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Hosts Actively Checked"
+msgstr "Hosts Actively Checked"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Hosts Escalation Options"
+msgstr "Hosts Escalation Options"
+
+#: centreon/www/include/monitoring/status/HostGroups/hostGroupJS.php
+msgid "Hosts Status"
+msgstr "Hosts Status"
+
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+msgid "Hosts Templates"
+msgstr "Hosts Templates"
+
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+msgid "Hosts group state"
+msgstr "Hosts group state"
+
+#: centreon/www/install/front_translate.php
+msgid "Hosts will not be affected because you don't have sufficient permission"
+msgstr ""
+"Hosts will not be affected because you don't have sufficient permission"
+
+#: centreon/www/install/front_translate.php
+msgid "Hour"
+msgstr "Hour"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
+msgid "Hours"
+msgstr "Hours"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Hover on timeline to see more information"
+msgstr "Hover on timeline to see more information"
+
+#: centreon/www/install/front_translate.php
+msgid "Human readable"
+msgstr "Human readable"
+
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "IP"
+msgstr "IP"
+
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+#: centreon/www/include/options/session/connected_user.php
+msgid "IP Address"
+msgstr "IP Address"
+
+#: centreon/www/include/configuration/configObject/host/listHost.php
+msgid "IP Address / DNS"
+msgstr "IP Address / DNS"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+msgid "IP address or hostname"
+msgstr "IP address or hostname"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/front_translate.php
+msgid "Icon"
+msgstr "Icon"
+
+#: centreon/src/Centreon/Domain/Configuration/Icon/IconException.php
+#, php-format
+msgid "Icon #%d does not exist"
+msgstr "Icon #%d does not exist"
+
+#: centreon/www/install/front_translate.php
+msgid "Identity provider"
+msgstr "Identity provider"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"If checked, a notification is sent to the contacts linked to the object to "
+"warn that the incident on the resource has been acknowledged"
+msgstr ""
+"If checked, a notification is sent to the contacts linked to the object to "
+"warn that the incident on the resource has been acknowledged"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "If match, disable submit"
+msgstr "If match, disable submit"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "If no match, disable submit"
+msgstr "If no match, disable submit"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "If no match, submit default status"
+msgstr "If no match, submit default status"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"If the agent is not allowed to connect to the poller for security reasons "
+"(e.g. when the poller is in a DMZ), you can use a poller-initiated "
+"connection."
+msgstr ""
+"If the agent is not allowed to connect to the poller for security reasons "
+"(e.g. when the poller is in a DMZ), you can use a poller-initiated "
+"connection."
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid ""
+"If the contact is connected, all his instances will be closed. Are you sure "
+"you want to request a data synchronization at the next login of this "
+"Contact ?"
+msgstr ""
+"If the contact is connected, all his instances will be closed. Are you sure "
+"you want to request a data synchronization at the next login of this "
+"Contact ?"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"If ticket management is enabled, only the “by service” view is available."
+msgstr ""
+"If ticket management is enabled, only the “by service” view is available."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"If we consider the following example in the JSON received from the "
+"authorization endpoint, a relation is defined between the value"
+msgstr ""
+"If we consider the following example in the JSON received from the "
+"authorization endpoint, a relation is defined between the value"
+
+#: centreon/www/install/front_translate.php
+msgid "If you click on Discard, your changes will not be saved."
+msgstr "If you click on Discard, your changes will not be saved."
+
+#: centreon/www/install/front_translate.php
+msgid "If you leave the edition mode, your changes will not be saved."
+msgstr "If you leave the edition mode, your changes will not be saved."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"If you leave without saving your dashboard, changes will be permanently lost."
+msgstr ""
+"If you leave without saving your dashboard, changes will be permanently lost."
+
+#: centreon/www/install/front_translate.php
+msgid "If you leave {{dashboardName}}, your changes will not be saved."
+msgstr "If you leave {{dashboardName}}, your changes will not be saved."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"If you want to display the graph with host categories and hosts, you must "
+"select only one hostgroup."
+msgstr ""
+"If you want to display the graph with host categories and hosts, you must "
+"select only one hostgroup."
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+msgid "Ignore ssl certificate"
+msgstr "Ignore ssl certificate"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Illegal Macro Output Characters"
+msgstr "Illegal Macro Output Characters"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Illegal Object Name Characters"
+msgstr "Illegal Object Name Characters"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+msgid "Illegal characters for Gorgone commands"
+msgstr "Illegal characters for Gorgone commands"
+
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/include/options/media/images/listImg.php
+msgid "Image"
+msgstr "Image"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Image Name"
+msgstr "Image Name"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Image Type"
+msgstr "Image Type"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/front_translate.php
+msgid "Image folders"
+msgstr "Image folders"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Image or archive"
+msgstr "Image or archive"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/install/menu_translation.php
+msgid "Images"
+msgstr "Images"
+
+#: centreon/www/install/front_translate.php
+msgid "Impact applied when:"
+msgstr "Impact applied when:"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Impacted Resources"
+msgstr "Impacted Resources"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Implied Contact Groups"
+msgstr "Implied Contact Groups"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Implied Contacts"
+msgstr "Implied Contacts"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Implied Server"
+msgstr "Implied Server"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+msgid "Import"
+msgstr "Import"
+
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+msgid "Import SNMP traps from MIB file"
+msgstr "Import SNMP traps from MIB file"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Import from LDAP servers"
+msgstr "Import from LDAP servers"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Import users manually"
+msgstr "Import users manually"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Impossible to change server due to parentship with other hosts"
+msgstr "Impossible to change server due to parentship with other hosts"
+
+#: centreon/src/Core/Contact/Application/Exception/ContactGroupException.php
+msgid "Impossible to get contact groups from data storage"
+msgstr "Impossible to get contact groups from data storage"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "Impossible to validate, one or more field is incorrect"
+msgstr "Impossible to validate, one or more field is incorrect"
+
+#: centreon/www/install/smarty_translate.php
+msgid "In Downtime"
+msgstr "In Downtime"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "In Scheduled Downtime?"
+msgstr "In Scheduled Downtime?"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "In downtime"
+msgstr "In downtime"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Include all hostgroups"
+msgstr "Include all hostgroups"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Include all hosts"
+msgstr "Include all hosts"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Include all image folders"
+msgstr "Include all image folders"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Include all servicegroups"
+msgstr "Include all servicegroups"
+
+#: centreon/www/install/front_translate.php
+msgid "Include services for these hosts"
+msgstr "Include services for these hosts"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Included Timerange"
+msgstr "Included Timerange"
+
+#: centreon/www/install/front_translate.php
+msgid "Includes {{count}} resources"
+msgstr "Includes {{count}} resources"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Incorrect LDAP filter syntax"
+msgstr "Incorrect LDAP filter syntax"
+
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+msgid "Incorrect Resource Type"
+msgstr "Incorrect Resource Type"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
+#, php-format
+msgid "Incorrect Resource type: %s"
+msgstr "Incorrect Resource type: %s"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Incremental"
+msgstr "Incremental"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Index size"
+msgstr "Index size"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Info"
+msgstr "Info"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/install/front_translate.php
+msgid "Information"
+msgstr "Information"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Informational messages"
+msgstr "Informational messages"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Informations"
+msgstr "Informations"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Inherit only contacts/contacts group from host"
+msgstr "Inherit only contacts/contacts group from host"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Input"
+msgstr "Input"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Input accepted events type"
+msgstr "Input accepted events type"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Input treatment options"
+msgstr "Input treatment options"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "Input/Output #%d not found for Broker configuration #%d"
+msgstr "Input/Output #%d not found for Broker configuration #%d"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+msgid "Inputs"
+msgstr "Inputs"
+
+#: centreon/www/install/front_translate.php
+msgid "Insecure TLS"
+msgstr "Insecure TLS"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Insert in index data"
+msgstr "Insert in index data"
+
+#: centreon/www/install/front_translate.php
+msgid "Insert link"
+msgstr "Insert link"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Insert trap's information into database"
+msgstr "Insert trap's information into database"
+
+#: centreon/www/install/front_translate.php
+msgid "Install"
+msgstr "Install"
+
+#: centreon/www/install/front_translate.php
+msgid "Install all"
+msgstr "Install all"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step7.php
+#: centreon/www/install/step_upgrade/step4.php
+msgid "Installation"
+msgstr "Installation"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step9.php
+msgid "Installation finished"
+msgstr "Installation finished"
+
+#: centreon/www/install/front_translate.php
+msgid "Installed"
+msgstr "Installed"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Instance timeout"
+msgstr "Instance timeout"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Inter-Check Sleep Time"
+msgstr "Inter-Check Sleep Time"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Interval"
+msgstr "Interval"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Interval Length"
+msgstr "Interval Length"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Interval length"
+msgstr "Interval length"
+
+#: centreon/www/install/front_translate.php
+msgid "Introspection endpoint"
+msgstr "Introspection endpoint"
+
+#: centreon/www/install/front_translate.php
+msgid "Introspection token endpoint"
+msgstr "Introspection token endpoint"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Invalid Credentials"
+msgstr "Invalid Credentials"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+#, php-format
+msgid "Invalid ID provided for %s"
+msgstr "Invalid ID provided for %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid IP Address"
+msgstr "Invalid IP Address"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Invalid Image Format."
+msgstr "Invalid Image Format."
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Invalid LDAP Host parameters"
+msgstr "Invalid LDAP Host parameters"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
+msgid "Invalid Provider authentication conditions"
+msgstr "Invalid Provider authentication conditions"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid URL"
+msgstr "Invalid URL"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid address"
+msgstr "Invalid address"
+
+#: centreon/src/Core/Domain/Exception/InvalidGeoCoordException.php
+msgid "Invalid coordinates format specified"
+msgstr "Invalid coordinates format specified"
+
+#: centreon/src/Core/Domain/Exception/InvalidGeoCoordException.php
+msgid "Invalid coordinates values specified"
+msgstr "Invalid coordinates values specified"
+
+#: centreon/src/Core/Domain/Configuration/Notification/Exception/NotificationException.php
+#, php-format
+msgid "Invalid event provided (%s)"
+msgstr "Invalid event provided (%s)"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid extension"
+msgstr "Invalid extension"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid file type"
+msgstr "Invalid file type"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid filename"
+msgstr "Invalid filename"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid format"
+msgstr "Invalid format"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid geo-coordinate format"
+msgstr "Invalid geo-coordinate format"
+
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "Invalid information entered"
+msgstr "Invalid information entered"
+
+#: centreon/src/Centreon/Application/Controller/Configuration/ProxyController.php
+msgid "Invalid json message received"
+msgstr "Invalid json message received"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid license"
+msgstr "Invalid license"
+
+#: centreon/src/Core/Metric/Application/Exception/MetricException.php
+msgid "Invalid metric format"
+msgstr "Invalid metric format"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Invalid name or description"
+msgstr "Invalid name or description"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "Invalid notification option (%d)"
+msgstr "Invalid notification option (%d)"
+
+#: centreon/src/Centreon/Application/Controller/FilterController.php
+#, php-format
+msgid "Invalid page name. Valid page names are: %s"
+msgstr "Invalid page name. Valid page names are: %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid path"
+msgstr "Invalid path"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid port number"
+msgstr "Invalid port number"
+
+#: centreon/www/install/front_translate.php
+msgid "Invalid regex"
+msgstr "Invalid regex"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "Invalid resource type"
+msgstr "Invalid resource type"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/AclConditionsException.php
+msgid "Invalid roles mapping fetched from provider"
+msgstr "Invalid roles mapping fetched from provider"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "Invalid stalking option (%d)"
+msgstr "Invalid stalking option (%d)"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Invert"
+msgstr "Invert"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+msgid "Ip address cannot be empty"
+msgstr "Ip address cannot be empty"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Is This Host Flapping?"
+msgstr "Is This Host Flapping?"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Is This Service Flapping?"
+msgstr "Is This Service Flapping?"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Is Volatile"
+msgstr "Is Volatile"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Is default poller ?"
+msgstr "Is default poller ?"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Is running ?"
+msgstr "Is running ?"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Is volatile"
+msgstr "Is volatile"
+
+#: centreon/www/install/front_translate.php
+msgid "Issuer (Entity ID) URL"
+msgstr "Issuer (Entity ID) URL"
+
+#: centreon/www/install/step_upgrade/step1.php
+msgid ""
+"It is strongly recommended to make a backup of your databases before going "
+"any further."
+msgstr ""
+"It is strongly recommended to make a backup of your databases before going "
+"any further."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"It will be permanently deleted and users will no longer have this permission."
+msgstr ""
+"It will be permanently deleted and users will no longer have this permission."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"It's possible to specify the criteria you precisely want to search, by using "
+"the following syntax:"
+msgstr ""
+"It's possible to specify the criteria you precisely want to search, by using "
+"the following syntax:"
+
+#: centreon/www/install/menu_translation.php
+msgid "Knowledge Base"
+msgstr "Knowledge Base"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Knowledge base"
+msgstr "Knowledge base"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Knowledge base configuration"
+msgstr "Knowledge base configuration"
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+msgid "Knowledge base url"
+msgstr "Knowledge base url"
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+msgid "Knowledge wiki account (with delete right)"
+msgstr "Knowledge wiki account (with delete right)"
+
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+msgid "Knowledge wiki account password"
+msgstr "Knowledge wiki account password"
+
+#: centreon/www/install/menu_translation.php
+msgid "LDAP"
+msgstr "LDAP"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "LDAP DN (Distinguished Name)"
+msgstr "LDAP DN (Distinguished Name)"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "LDAP Import"
+msgstr "LDAP Import"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP Information"
+msgstr "LDAP Information"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP Properties"
+msgstr "LDAP Properties"
+
+#: centreon/www/install/smarty_translate.php
+msgid "LDAP Server"
+msgstr "LDAP Server"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "LDAP Servers"
+msgstr "LDAP Servers"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "LDAP User Import debug"
+msgstr "LDAP User Import debug"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP connection timeout"
+msgstr "LDAP connection timeout"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP search size limit"
+msgstr "LDAP search size limit"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP search timeout"
+msgstr "LDAP search timeout"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP servers"
+msgstr "LDAP servers"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP synchronization interval (in hours)"
+msgstr "LDAP synchronization interval (in hours)"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "LVM Snapshot"
+msgstr "LVM Snapshot"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "Language"
+msgstr "Language"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 12 hours"
+msgstr "Last 12 hours"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Last 12 months"
+msgstr "Last 12 months"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 14 days"
+msgstr "Last 14 days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Last 2 days"
+msgstr "Last 2 days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 2 months"
+msgstr "Last 2 months"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 24 hours"
+msgstr "Last 24 hours"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Last 28 days"
+msgstr "Last 28 days"
+
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Last 3 days"
+msgstr "Last 3 days"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 3 hours"
+msgstr "Last 3 hours"
+
+#: centreon/www/install/front_translate.php
+msgid "Last 3 months"
+msgstr "Last 3 months"
+
+#: centreon/www/install/front_translate.php
+msgid "Last 3 passwords can be reused"
+msgstr "Last 3 passwords can be reused"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "Last 30 Days"
+msgstr "Last 30 Days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 30 days"
+msgstr "Last 30 days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 31 days"
+msgstr "Last 31 days"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Last 4 days"
+msgstr "Last 4 days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Last 4 months"
+msgstr "Last 4 months"
+
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Last 5 days"
+msgstr "Last 5 days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 6 hours"
+msgstr "Last 6 hours"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Last 6 months"
+msgstr "Last 6 months"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "Last 7 Days"
+msgstr "Last 7 Days"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last 7 days"
+msgstr "Last 7 days"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Last Check"
+msgstr "Last Check"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Last Check Type"
+msgstr "Last Check Type"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "Last LDAP sync"
+msgstr "Last LDAP sync"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "Last Month"
+msgstr "Last Month"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Last Notification"
+msgstr "Last Notification"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Last Service Notification"
+msgstr "Last Service Notification"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Last State Change"
+msgstr "Last State Change"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Last Status Change"
+msgstr "Last Status Change"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+msgid "Last Update"
+msgstr "Last Update"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "Last Year"
+msgstr "Last Year"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/front_translate.php
+msgid "Last check"
+msgstr "Last check"
+
+#: centreon/www/install/front_translate.php
+msgid "Last check with OK status"
+msgstr "Last check with OK status"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Last connection attempt"
+msgstr "Last connection attempt"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Last connection success"
+msgstr "Last connection success"
+
+#: centreon/www/install/front_translate.php
+msgid "Last day"
+msgstr "Last day"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Last event at"
+msgstr "Last event at"
+
+#: centreon/www/install/front_translate.php
+msgid "Last hour"
+msgstr "Last hour"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/install/front_translate.php
+msgid "Last month"
+msgstr "Last month"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Last name"
+msgstr "Last name"
+
+#: centreon/www/install/front_translate.php
+msgid "Last notification"
+msgstr "Last notification"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+msgid "Last of month"
+msgstr "Last of month"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
+msgid "Last page"
+msgstr "Last page"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "Last request"
+msgstr "Last request"
+
+#: centreon/www/install/front_translate.php
+msgid "Last status change"
+msgstr "Last status change"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Last time in "
+msgstr "Last time in "
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/install/front_translate.php
+msgid "Last update"
+msgstr "Last update"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Last week"
+msgstr "Last week"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphs/graph-split.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "Last year"
+msgstr "Last year"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/install/front_translate.php
+msgid "Latency"
+msgstr "Latency"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Latency detected, check configuration for better optimization"
+msgstr "Latency detected, check configuration for better optimization"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Layout"
+msgstr "Layout"
+
+#: centreon/www/install/front_translate.php
+msgid "Leave"
+msgstr "Leave"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Left"
+msgstr "Left"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Legacy version"
+msgstr "Legacy version"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "Legend"
+msgstr "Legend"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Legend Name"
+msgstr "Legend Name"
+
+#: centreon/www/install/front_translate.php
+msgid "Less"
+msgstr "Less"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "Level"
+msgstr "Level"
+
+#: centreon/www/install/front_translate.php
+msgid "License end date:"
+msgstr "License end date:"
+
+#: centreon/www/install/front_translate.php
+msgid "License expired"
+msgstr "License expired"
+
+#: centreon/www/install/front_translate.php
+msgid "License invalid or expired !"
+msgstr "License invalid or expired !"
+
+#: centreon/www/install/front_translate.php
+msgid "License not valid"
+msgstr "License not valid"
+
+#: centreon/www/install/front_translate.php
+msgid "License required"
+msgstr "License required"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Limit per page (default)"
+msgstr "Limit per page (default)"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Limit per page for Monitoring"
+msgstr "Limit per page for Monitoring"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Limited search"
+msgstr "Limited search"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Line"
+msgstr "Line"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Line color"
+msgstr "Line color"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Line style"
+msgstr "Line style"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Line width"
+msgstr "Line width"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Linear"
+msgstr "Linear"
+
+#: centreon/www/install/front_translate.php
+msgid "Link copied"
+msgstr "Link copied"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Link to cbd service"
+msgstr "Link to cbd service"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Link types"
+msgstr "Link types"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "Linked ACL groups"
+msgstr "Linked ACL groups"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Linked Contact Groups"
+msgstr "Linked Contact Groups"
+
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Linked Contacts"
+msgstr "Linked Contacts"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Linked Groups"
+msgstr "Linked Groups"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Linked Host Group Services"
+msgstr "Linked Host Group Services"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Linked Host Services"
+msgstr "Linked Host Services"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "Linked Host Template"
+msgstr "Linked Host Template"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "Linked Hosts"
+msgstr "Linked Hosts"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Linked Instances"
+msgstr "Linked Instances"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Linked Service Templates"
+msgstr "Linked Service Templates"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Linked Services"
+msgstr "Linked Services"
+
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+msgid "Linked Services Templates"
+msgstr "Linked Services Templates"
+
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "Linked Templates"
+msgstr "Linked Templates"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Linked poller"
+msgstr "Linked poller"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Linked service templates"
+msgstr "Linked service templates"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Linked services"
+msgstr "Linked services"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Linked to Contact Groups"
+msgstr "Linked to Contact Groups"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Linked with Host Groups"
+msgstr "Linked with Host Groups"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Linked with Hosts"
+msgstr "Linked with Hosts"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Linked with Service Groups"
+msgstr "Linked with Service Groups"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Linked with Services"
+msgstr "Linked with Services"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Links"
+msgstr "Links"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Links Management"
+msgstr "Links Management"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "List"
+msgstr "List"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Listening address (optional)"
+msgstr "Listening address (optional)"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Listening port"
+msgstr "Listening port"
+
+#: centreon/www/include/home/customViews/formLoad.php
+msgid "Load a public view"
+msgstr "Load a public view"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Load from existing view"
+msgstr "Load from existing view"
+
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
+msgid "Loaded"
+msgstr "Loaded"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/Local/ConfigurationException.php
+msgid "Local provider configuration not found"
+msgstr "Local provider configuration not found"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Localhost ?"
+msgstr "Localhost ?"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Lock Services"
+msgstr "Lock Services"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/install/smarty_translate.php
+msgid "Locked"
+msgstr "Locked"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Locked elements"
+msgstr "Locked elements"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Locked user groups"
+msgstr "Locked user groups"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Locked users"
+msgstr "Locked users"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Log Options"
+msgstr "Log Options"
+
+#: centreon/www/include/eventLogs/viewLog.php
+msgid "Log Period"
+msgstr "Log Period"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Log destination"
+msgstr "Log destination"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Log directory"
+msgstr "Log directory"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Log everything"
+msgstr "Log everything"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Log file"
+msgstr "Log file"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Log filename"
+msgstr "Log filename"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Log nothing (default)"
+msgstr "Log nothing (default)"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Log options"
+msgstr "Log options"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Logarithmic"
+msgstr "Logarithmic"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Logger version"
+msgstr "Logger version"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Logging Options"
+msgstr "Logging Options"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Logging level"
+msgstr "Logging level"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Login"
+msgstr "Login"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Login attribute"
+msgstr "Login attribute"
+
+#: centreon/www/install/front_translate.php
+msgid "Login attribute path"
+msgstr "Login attribute path"
+
+#: centreon/www/install/front_translate.php
+msgid "Login header attribute name"
+msgstr "Login header attribute name"
+
+#: centreon/www/install/front_translate.php
+msgid "Login succeeded"
+msgstr "Login succeeded"
+
+#: centreon/www/install/front_translate.php
+msgid "Login with"
+msgstr "Login with"
+
+#: centreon/www/include/common/mobile_menu.php
+#: centreon/www/install/front_translate.php
+msgid "Logout"
+msgstr "Logout"
+
+#: centreon/www/install/front_translate.php
+msgid "Logout URL"
+msgstr "Logout URL"
+
+#: centreon/www/install/front_translate.php
+msgid "Logout from"
+msgstr "Logout from"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "Logout user"
+msgstr "Logout user"
+
+#: centreon/www/install/menu_translation.php
+msgid "Logs"
+msgstr "Logs"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Logs Directory"
+msgstr "Logs Directory"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Logs for "
+msgstr "Logs for "
+
+#: centreon/www/install/front_translate.php
+msgid "Lost in space?"
+msgstr "Lost in space?"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Lotus Domino :"
+msgstr "Lotus Domino :"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Low Flap Threshold"
+msgstr "Low Flap Threshold"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Low Host Flap Threshold"
+msgstr "Low Host Flap Threshold"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Low Service Flap Threshold"
+msgstr "Low Service Flap Threshold"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Lower Limit"
+msgstr "Lower Limit"
+
+#: centreon/www/install/smarty_translate.php
+msgid "MB"
+msgstr "MB"
+
+#: centreon/www/install/front_translate.php
+msgid "MBI reporting widgets"
+msgstr "MBI reporting widgets"
+
+#: centreon/www/install/menu_translation.php
+msgid "MIBs"
+msgstr "MIBs"
+
+#: centreon/www/include/configuration/configObject/command/formMacros.php
+msgid "Macro Descriptions"
+msgstr "Macro Descriptions"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Macro name"
+msgstr "Macro name"
+
+#: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
+msgid "Macro passwords cannot be detected"
+msgstr "Macro passwords cannot be detected"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Macro value"
+msgstr "Macro value"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formMacros.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Macros"
+msgstr "Macros"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Macros Descriptions"
+msgstr "Macros Descriptions"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Macros Filters Configuration"
+msgstr "Macros Filters Configuration"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Macros whitelist"
+msgstr "Macros whitelist"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Mail Type"
+msgstr "Mail Type"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Mailer path"
+msgstr "Mailer path"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Main"
+msgstr "Main"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Main Menu"
+msgstr "Main Menu"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Main information"
+msgstr "Main information"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Main options"
+msgstr "Main options"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Manage API tokens"
+msgstr "Manage API tokens"
+
+#: centreon/www/install/front_translate.php
+msgid "Manage access rights"
+msgstr "Manage access rights"
+
+#: centreon/www/install/front_translate.php
+msgid "Manage envelope size"
+msgstr "Manage envelope size"
+
+#: centreon/www/install/front_translate.php
+msgid "Manage filters"
+msgstr "Manage filters"
+
+#: centreon/www/install/menu_translation.php
+msgid "Manager"
+msgstr "Manager"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Mandatory cache directory"
+msgstr "Mandatory cache directory"
+
+#: centreon/src/Centreon/Domain/Common/Exception/FactoryException.php
+#, php-format
+msgid "Mandatory data to create the entity '%s' is missing"
+msgstr "Mandatory data to create the entity '%s' is missing"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Mandatory directory"
+msgstr "Mandatory directory"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+msgid "Mandatory field"
+msgstr "Mandatory field"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Mandatory field for ACL purpose."
+msgstr "Mandatory field for ACL purpose."
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Mandatory filename"
+msgstr "Mandatory filename"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Mandatory name"
+msgstr "Mandatory name"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Manual"
+msgstr "Manual"
+
+#: centreon/www/install/front_translate.php
+msgid "Manual refresh"
+msgstr "Manual refresh"
+
+#: centreon/www/install/front_translate.php
+msgid "Manual refresh only"
+msgstr "Manual refresh only"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "Manually request to synchronize this contact with his LDAP"
+msgstr "Manually request to synchronize this contact with his LDAP"
+
+#: centreon/www/install/menu_translation.php
+msgid "Manufacturer"
+msgstr "Manufacturer"
+
+#: centreon/www/install/front_translate.php
+msgid "Many thanks to all the contributors to the security of Centreon"
+msgstr "Many thanks to all the contributors to the security of Centreon"
+
+#: centreon/src/Core/Platform/Infrastructure/Validator/RequirementValidators/DatabaseRequirementValidators/MariaDbRequirementException.php
+#, php-format
+msgid "MariaDB version %s required (%s installed)"
+msgstr "MariaDB version %s required (%s installed)"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+msgid "Mass Change"
+msgstr "Mass Change"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Max"
+msgstr "Max"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Max Check Attempts"
+msgstr "Max Check Attempts"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Max file size in bytes"
+msgstr "Max file size in bytes"
+
+#: centreon/www/include/options/media/images/formImg.php
+#, php-format
+msgid "Max file size: %s"
+msgstr "Max file size: %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Max value"
+msgstr "Max value"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
+#, php-format
+msgid "Max value of limit has to be %d instead %d"
+msgstr "Max value of limit has to be %d instead %d"
+
+#: centreon/www/install/front_translate.php
+msgid "Maximum"
+msgstr "Maximum"
+
+#: centreon/www/install/front_translate.php
+msgid "Maximum 128 characters"
+msgstr "Maximum 128 characters"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Maximum Concurrent Service Checks"
+msgstr "Maximum Concurrent Service Checks"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Maximum Host Check Spread"
+msgstr "Maximum Host Check Spread"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Maximum Service Check Spread"
+msgstr "Maximum Service Check Spread"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Maximum files size (in bytes)"
+msgstr "Maximum files size (in bytes)"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Maximum number of hosts to show"
+msgstr "Maximum number of hosts to show"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Maximum number of services to show"
+msgstr "Maximum number of services to show"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Maximum page size"
+msgstr "Maximum page size"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Maximum queries per transaction"
+msgstr "Maximum queries per transaction"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Maximum size of file"
+msgstr "Maximum size of file"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Mean Time"
+msgstr "Mean Time"
+
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Media"
+msgstr "Media"
+
+#: centreon/www/include/options/media/images/syncDir.php
+msgid "Media Detection"
+msgstr "Media Detection"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "Media already exists"
+msgstr "Media already exists"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Member of Host Groups"
+msgstr "Member of Host Groups"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Memory file"
+msgstr "Memory file"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Menu access"
+msgstr "Menu access"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Menu access list link"
+msgstr "Menu access list link"
+
+#: centreon/www/install/menu_translation.php
+msgid "Menus Access"
+msgstr "Menus Access"
+
+#: centreon/www/include/eventLogs/viewLog.php
+msgid "Message Type"
+msgstr "Message Type"
+
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#, php-format
+msgid "Message truncated (exceeded %s characters)"
+msgstr "Message truncated (exceeded %s characters)"
+
+#: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
+#, php-format
+msgid "Meta Host %d not found"
+msgstr "Meta Host %d not found"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Meta Service"
+msgstr "Meta Service"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+#: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
+#, php-format
+msgid "Meta Service %d not found"
+msgstr "Meta Service %d not found"
+
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+msgid "Meta Service Names"
+msgstr "Meta Service Names"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "Meta Service State"
+msgstr "Meta Service State"
+
+#: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
+#, php-format
+msgid "Meta Service linked to service %d not found"
+msgstr "Meta Service linked to service %d not found"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/menu_translation.php
+msgid "Meta Services"
+msgstr "Meta Services"
+
+#: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+#, php-format
+msgid "Meta host %d not found"
+msgstr "Meta host %d not found"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/install/front_translate.php
+msgid "Meta service"
+msgstr "Meta service"
+
+#: centreon/src/Centreon/Application/Controller/Monitoring/CommentController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+#, php-format
+msgid "Meta service %d not found"
+msgstr "Meta service %d not found"
+
+#: centreon/src/Centreon/Domain/MetaServiceConfiguration/Exception/MetaServiceConfigurationException.php
+#, php-format
+msgid "Meta service configuration (%s) not found"
+msgstr "Meta service configuration (%s) not found"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+msgid "Meta service not found"
+msgstr "Meta service not found"
+
+#: centreon/src/Centreon/Domain/Monitoring/MetaService/Exception/MetaServiceMetricException.php
+#, php-format
+msgid "Meta service with ID %d not found"
+msgstr "Meta service with ID %d not found"
+
+#: centreon/www/install/front_translate.php
+msgid "Meta-Service"
+msgstr "Meta-Service"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Meta-service dependency"
+msgstr "Meta-service dependency"
+
+#: centreon/www/install/front_translate.php
+msgid "Metaservice"
+msgstr "Metaservice"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Method"
+msgstr "Method"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/install/front_translate.php
+msgid "Metric"
+msgstr "Metric"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/smarty_translate.php
+msgid "Metric Name"
+msgstr "Metric Name"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Metric Unit"
+msgstr "Metric Unit"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Metric capacity planning"
+msgstr "Metric capacity planning"
+
+#: centreon/www/install/front_translate.php
+msgid "Metric name"
+msgstr "Metric name"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Metric naming"
+msgstr "Metric naming"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/install/front_translate.php
+msgid "Metrics"
+msgstr "Metrics"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Metrics column"
+msgstr "Metrics column"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Metrics graph"
+msgstr "Metrics graph"
+
+#: centreon/src/Core/Metric/Application/Exception/MetricException.php
+msgid "Metrics not found"
+msgstr "Metrics not found"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Metrics timeseries"
+msgstr "Metrics timeseries"
+
+#: centreon/www/install/front_translate.php
+msgid "Migrate"
+msgstr "Migrate"
+
+#: centreon/www/install/front_translate.php
+msgid "Migration script"
+msgstr "Migration script"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Min"
+msgstr "Min"
+
+#: centreon/www/install/front_translate.php
+msgid "Min value"
+msgstr "Min value"
+
+#: centreon/www/install/front_translate.php
+msgid "Mini Centreon Logo"
+msgstr "Mini Centreon Logo"
+
+#: centreon/www/install/front_translate.php
+msgid "Minimum"
+msgstr "Minimum"
+
+#: centreon/www/install/front_translate.php
+msgid "Minimum 8 characters"
+msgstr "Minimum 8 characters"
+
+#: centreon/www/install/front_translate.php
+msgid "Minimum password length"
+msgstr "Minimum password length"
+
+#: centreon/www/install/front_translate.php
+msgid "Minimum time between password changes"
+msgstr "Minimum time between password changes"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
+#, php-format
+msgid "Minimum value of limit has to be 1 instead %d"
+msgstr "Minimum value of limit has to be 1 instead %d"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
+#, php-format
+msgid "Minimum value of offset has to be 1 instead %d"
+msgstr "Minimum value of offset has to be 1 instead %d"
+
+#: centreon/www/install/front_translate.php
+msgid "Minute"
+msgstr "Minute"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
+msgid "Minutes"
+msgstr "Minutes"
+
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/install/smarty_translate.php
+msgid "Misc"
+msgstr "Misc"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Misc Options"
+msgstr "Misc Options"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/menu_translation.php
+msgid "Miscellaneous"
+msgstr "Miscellaneous"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "Missing input/output parameter: %s"
+msgstr "Missing input/output parameter: %s"
+
+#: centreon/src/Security/Infrastructure/Repository/Model/ProviderConfigurationFactoryRdb.php
+#, php-format
+msgid "Missing mandatory parameter: '%s'"
+msgstr "Missing mandatory parameter: '%s'"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+#, php-format
+msgid "Missing mandatory parent address, to link the platform : '%s'@'%s'"
+msgstr "Missing mandatory parent address, to link the platform : '%s'@'%s'"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+#, php-format
+msgid "Missing mandatory platform address of: '%s'"
+msgstr "Missing mandatory platform address of: '%s'"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+msgid "Missing mandatory platform name"
+msgstr "Missing mandatory platform name"
+
+#: centreon/src/Core/Metric/Application/Exception/MetricException.php
+#, php-format
+msgid "Missing property in the metric information: %s"
+msgstr "Missing property in the metric information: %s"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/Exception/ConfigurationException.php
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
+msgid "Missing token endpoint in your configuration"
+msgstr "Missing token endpoint in your configuration"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/Exception/ConfigurationException.php
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Exceptions/OpenIdConfigurationException.php
+msgid "Missing userinfo and introspection token endpoint"
+msgstr "Missing userinfo and introspection token endpoint"
+
+#: centreon/www/install/front_translate.php
+msgid "Mixed"
+msgstr "Mixed"
+
+#: centreon/www/install/front_translate.php
+msgid "Modal confirmation"
+msgstr "Modal confirmation"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Mode"
+msgstr "Mode"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Modificaton type"
+msgstr "Modificaton type"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Modify"
+msgstr "Modify"
+
+#: centreon/www/include/Administration/parameters/api/api.php
+msgid "Modify Centcore options"
+msgstr "Modify Centcore options"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Modify Data Processing"
+msgstr "Modify Data Processing"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "Modify General Options"
+msgstr "Modify General Options"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+msgid "Modify Gorgone options"
+msgstr "Modify Gorgone options"
+
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+msgid "Modify Group"
+msgstr "Modify Group"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Modify Image"
+msgstr "Modify Image"
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+msgid "Modify Vendor"
+msgstr "Modify Vendor"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "Modify a  host category"
+msgstr "Modify a  host category"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Modify a Centreon-Broker Configuration"
+msgstr "Modify a Centreon-Broker Configuration"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Modify a Command"
+msgstr "Modify a Command"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Modify a Connector"
+msgstr "Modify a Connector"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "Modify a Contact Group"
+msgstr "Modify a Contact Group"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Modify a Data Source Template"
+msgstr "Modify a Data Source Template"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Modify a Dependency"
+msgstr "Modify a Dependency"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Modify a Graph Template"
+msgstr "Modify a Graph Template"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Modify a Group"
+msgstr "Modify a Group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Modify a Host"
+msgstr "Modify a Host"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Modify a Host Extended Info"
+msgstr "Modify a Host Extended Info"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Modify a Host Template"
+msgstr "Modify a Host Template"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "Modify a Meta Service"
+msgstr "Modify a Meta Service"
+
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+msgid "Modify a Meta Service indicator"
+msgstr "Modify a Meta Service indicator"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Modify a Monitoring Engine Configuration File"
+msgstr "Modify a Monitoring Engine Configuration File"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Modify a Service"
+msgstr "Modify a Service"
+
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "Modify a Service Category"
+msgstr "Modify a Service Category"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Modify a Service Group"
+msgstr "Modify a Service Group"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Modify a Service Template Model"
+msgstr "Modify a Service Template Model"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Modify a Time Period"
+msgstr "Modify a Time Period"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Modify a Trap definition"
+msgstr "Modify a Trap definition"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Modify a User"
+msgstr "Modify a User"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Modify a User Template"
+msgstr "Modify a User Template"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Modify a Virtual Metric"
+msgstr "Modify a Virtual Metric"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Modify a downtime"
+msgstr "Modify a downtime"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Modify a global macro"
+msgstr "Modify a global macro"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Modify a poller Configuration"
+msgstr "Modify a poller Configuration"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Modify an ACL"
+msgstr "Modify an ACL"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Modify an Action"
+msgstr "Modify an Action"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Modify an Escalation"
+msgstr "Modify an Escalation"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Modify an Extended Info"
+msgstr "Modify an Extended Info"
+
+#: centreon/www/install/front_translate.php
+msgid "Modify an additional configuration"
+msgstr "Modify an additional configuration"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+msgid "Modify directory"
+msgstr "Modify directory"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Modify macros"
+msgstr "Modify macros"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Modify relations"
+msgstr "Modify relations"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Module"
+msgstr "Module"
+
+#: centreon/src/CentreonModule/Infrastructure/Source/ModuleException.php
+#, php-format
+msgid "Module \"%s\" is missing"
+msgstr "Module \"%s\" is missing"
+
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
+msgid "Module name"
+msgstr "Module name"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Modules"
+msgstr "Modules"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step8.php
+msgid "Modules installation"
+msgstr "Modules installation"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Monday"
+msgstr "Monday"
+
+#: centreon/www/install/front_translate.php
+msgid "Monitored hosts"
+msgstr "Monitored hosts"
+
+#: centreon/www/install/menu_translation.php
+msgid "Monitoring"
+msgstr "Monitoring"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/menu_translation.php
+msgid "Monitoring Engine"
+msgstr "Monitoring Engine"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine Binary"
+msgstr "Monitoring Engine Binary"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "Monitoring Engine Import debug"
+msgstr "Monitoring Engine Import debug"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine Information"
+msgstr "Monitoring Engine Information"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine Statistics Binary"
+msgstr "Monitoring Engine Statistics Binary"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Monitoring Engine information"
+msgstr "Monitoring Engine information"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine reload command"
+msgstr "Monitoring Engine reload command"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine restart command"
+msgstr "Monitoring Engine restart command"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine start command"
+msgstr "Monitoring Engine start command"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Monitoring Engine stop command"
+msgstr "Monitoring Engine stop command"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Monitoring database layer"
+msgstr "Monitoring database layer"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Monitoring engine"
+msgstr "Monitoring engine"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Monitoring engine config"
+msgstr "Monitoring engine config"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step3.php
+#: centreon/www/install/smarty_translate.php
+msgid "Monitoring engine information"
+msgstr "Monitoring engine information"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/install/front_translate.php
+msgid "Monitoring server"
+msgstr "Monitoring server"
+
+#: centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+#, php-format
+msgid "Monitoring server %s not found"
+msgstr "Monitoring server %s not found"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+#, php-format
+msgid "Monitoring server disabled (#%d)"
+msgstr "Monitoring server disabled (#%d)"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+msgid "Monitoring server is not correctly defined"
+msgstr "Monitoring server is not correctly defined"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+#, php-format
+msgid "Monitoring server not found (#%d)"
+msgstr "Monitoring server not found (#%d)"
+
+#: centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+#, php-format
+msgid "Monitoring server with id %d not found"
+msgstr "Monitoring server with id %d not found"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/install/smarty_translate.php
+msgid "Monitoring settings"
+msgstr "Monitoring settings"
+
+#: centreon/www/install/front_translate.php
+msgid "Month"
+msgstr "Month"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Monthly"
+msgstr "Monthly"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Monthly basis"
+msgstr "Monthly basis"
+
+#: centreon/www/install/front_translate.php
+msgid "Months"
+msgstr "Months"
+
+#: centreon/www/install/front_translate.php
+msgid "More"
+msgstr "More"
+
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "More actions"
+msgstr "More actions"
+
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+msgid "More actions..."
+msgstr "More actions..."
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "More detailed information"
+msgstr "More detailed information"
+
+#: centreon/www/install/front_translate.php
+msgid "More filters"
+msgstr "More filters"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Move Export Files"
+msgstr "Move Export Files"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+msgid "Move files to directory"
+msgstr "Move files to directory"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+msgid "Move host group's services to hosts"
+msgstr "Move host group's services to hosts"
+
+#: centreon/www/include/options/media/images/listImg.php
+msgid "Move images"
+msgstr "Move images"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Moving files"
+msgstr "Moving files"
+
+#: centreon/www/install/front_translate.php
+msgid "Multi Connected Autocomplete"
+msgstr "Multi Connected Autocomplete"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Multiple Broker Module"
+msgstr "Multiple Broker Module"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Must be a number"
+msgstr "Must be a number"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid "Must be a number between 1 and 65335 included."
+msgstr "Must be a number between 1 and 65335 included."
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Must be a positive integer or 0"
+msgstr "Must be a positive integer or 0"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/Exception/ConfigurationException.php
+#, php-format
+msgid "Must not Happen, got unexpected CustomConfiguration type %s"
+msgstr "Must not Happen, got unexpected CustomConfiguration type %s"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/ProviderException.php
+#, php-format
+msgid "Must not Happen, got unexpected Provider type %s"
+msgstr "Must not Happen, got unexpected Provider type %s"
+
+#: centreon/www/install/menu_translation.php
+msgid "My Account"
+msgstr "My Account"
+
+#: centreon/www/install/front_translate.php
+msgid "My filters"
+msgstr "My filters"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "MySQL configuration file path"
+msgstr "MySQL configuration file path"
+
+#: centreon/src/CentreonLegacy/Core/Module/Information.php
+#: centreon/src/CentreonLegacy/Core/Widget/Information.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "N/A"
+msgstr "N/A"
+
+#: centreon/www/class/centreonConfigCentreonBroker.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Name"
+msgstr "Name"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Name already in use"
+msgstr "Name already in use"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Name already in use for this Host/Service"
+msgstr "Name already in use for this Host/Service"
+
+#: centreon/www/install/front_translate.php
+msgid "Name cannot be empty"
+msgstr "Name cannot be empty"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Name is already in use"
+msgstr "Name is already in use"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Name must start and end with a '$'"
+msgstr "Name must start and end with a '$'"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Name of the logger"
+msgstr "Name of the logger"
+
+#: centreon/www/install/front_translate.php
+msgid "Need help using the search bar?"
+msgstr "Need help using the search bar?"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Never Started"
+msgstr "Never Started"
+
+#: centreon/www/install/front_translate.php
+msgid "Never expire"
+msgstr "Never expire"
+
+#: centreon/www/include/options/media/images/syncDir.php
+msgid "New directory added :"
+msgstr "New directory added :"
+
+#: centreon/www/install/front_translate.php
+msgid "New filter"
+msgstr "New filter"
+
+#: centreon/www/include/options/media/images/syncDir.php
+msgid "New images added :"
+msgstr "New images added :"
+
+#: centreon/www/install/front_translate.php
+msgid "New password"
+msgstr "New password"
+
+#: centreon/www/install/front_translate.php
+msgid "New password confirmation"
+msgstr "New password confirmation"
+
+#: centreon/www/install/front_translate.php
+msgid "New passwords must match"
+msgstr "New passwords must match"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "New version"
+msgstr "New version"
+
+#: centreon/www/install/front_translate.php
+msgid "Next"
+msgstr "Next"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Next Check"
+msgstr "Next Check"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Next Notification"
+msgstr "Next Notification"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Next Scheduled Active Check"
+msgstr "Next Scheduled Active Check"
+
+#: centreon/www/install/front_translate.php
+msgid "Next check"
+msgstr "Next check"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
+msgid "Next page"
+msgstr "Next page"
+
+#: centreon/www/class/centreonXMLBGRequest.class.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/install/front_translate.php
+msgid "No"
+msgstr "No"
+
+#: centreon/www/install/front_translate.php
+msgid "No Business Activity found"
+msgstr "No Business Activity found"
+
+#: centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+msgid "No Central in topology,please edit it from Configuration > Pollers menu"
+msgstr ""
+"No Central in topology,please edit it from Configuration > Pollers menu"
+
+#: centreon/www/include/monitoring/comments/listComment.php
+msgid "No Comment for services."
+msgstr "No Comment for services."
+
+#: centreon/www/install/front_translate.php
+msgid "No KPI found"
+msgstr "No KPI found"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+msgid "No Platform Topology found."
+msgstr "No Platform Topology found."
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "No Step"
+msgstr "No Step"
+
+#: centreon/www/install/front_translate.php
+msgid "No TLS"
+msgstr "No TLS"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "No access"
+msgstr "No access"
+
+#: centreon/www/install/front_translate.php
+msgid "No access rights"
+msgstr "No access rights"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+msgid "No acknowledgement found for this host"
+msgstr "No acknowledgement found for this host"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+msgid "No acknowledgement found for this meta service"
+msgstr "No acknowledgement found for this meta service"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+msgid "No acknowledgement found for this service"
+msgstr "No acknowledgement found for this service"
+
+#: centreon/www/include/home/customViews/formLoad.php
+msgid "No action"
+msgstr "No action"
+
+#: centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+msgid "No argument found for this command"
+msgstr "No argument found for this command"
+
+#: centreon/www/install/front_translate.php
+msgid "No contact groups are configured for this resource"
+msgstr "No contact groups are configured for this resource"
+
+#: centreon/www/install/front_translate.php
+msgid "No contacts are configured for this resource"
+msgstr "No contacts are configured for this resource"
+
+#: centreon/www/install/front_translate.php
+msgid "No contacts found"
+msgstr "No contacts found"
+
+#: centreon/www/install/front_translate.php
+msgid "No data available for this period"
+msgstr "No data available for this period"
+
+#: centreon/www/install/front_translate.php
+msgid "No data for"
+msgstr "No data for"
+
+#: centreon/www/install/front_translate.php
+msgid "No data found"
+msgstr "No data found"
+
+#: centreon/www/install/smarty_translate.php
+msgid "No downtime scheduled"
+msgstr "No downtime scheduled"
+
+#: centreon/www/install/front_translate.php
+msgid "No host found"
+msgstr "No host found"
+
+#: centreon/www/install/front_translate.php
+msgid "No hosts in this group are currently disabled."
+msgstr "No hosts in this group are currently disabled."
+
+#: centreon/www/install/front_translate.php
+msgid "No hosts in this group are currently enabled."
+msgstr "No hosts in this group are currently enabled."
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "No modification was made."
+msgstr "No modification was made."
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+#, php-format
+msgid "No parent platform was found for : '%s'@'%s'"
+msgstr "No parent platform was found for : '%s'@'%s'"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "No poller selected"
+msgstr "No poller selected"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "No refresh token has been found"
+msgstr "No refresh token has been found"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "No relation set for this downtime"
+msgstr "No relation set for this downtime"
+
+#: centreon/www/install/front_translate.php
+msgid "No resource found"
+msgstr "No resource found"
+
+#: centreon/www/install/front_translate.php
+msgid "No result found"
+msgstr "No result found"
+
+#: centreon/www/install/front_translate.php
+msgid "No results found"
+msgstr "No results found"
+
+#: centreon/www/install/front_translate.php
+msgid "No service found"
+msgstr "No service found"
+
+#: centreon/src/Core/Security/Authentication/Application/UseCase/LogoutSession/LogoutSession.php
+msgid "No session token provided"
+msgstr "No session token provided"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "No statistics file defined for this poller"
+msgstr "No statistics file defined for this poller"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "No sufficient access rights to contact group [%s] to give role [%s]"
+msgstr "No sufficient access rights to contact group [%s] to give role [%s]"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "No sufficient access rights to user [%s] to give role [%s]"
+msgstr "No sufficient access rights to user [%s] to give role [%s]"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "No time period selected"
+msgstr "No time period selected"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+msgid "No top level platform found to link the child platforms"
+msgstr "No top level platform found to link the child platforms"
+
+#: centreon/src/Core/Security/Vault/Application/Exceptions/VaultException.php
+msgid "No vault configured"
+msgstr "No vault configured"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"No view available. To create a new view, please click \"Add view\" button."
+msgstr ""
+"No view available. To create a new view, please click \"Add view\" button."
+
+#: centreon/www/include/home/customViews/views.php
+msgid ""
+"No widget configured in this view. Please add a new widget with the \"Add "
+"widget\" button."
+msgstr ""
+"No widget configured in this view. Please add a new widget with the \"Add "
+"widget\" button."
+
+#: centreon/www/install/front_translate.php
+msgid "No widget found"
+msgstr "No widget found"
+
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+msgid "No wiki page defined"
+msgstr "No wiki page defined"
+
+#: centreon/www/install/front_translate.php
+msgid "No {{type}} found with this status"
+msgstr "No {{type}} found with this status"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Non-workhours"
+msgstr "Non-workhours"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/install/smarty_translate.php
+msgid "None"
+msgstr "None"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Normal Check Interval"
+msgstr "Normal Check Interval"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Not Acknowledged"
+msgstr "Not Acknowledged"
+
+#: centreon/www/install/react_translation.php
+msgid "Not a valid IP address"
+msgstr "Not a valid IP address"
+
+#: centreon/src/Centreon/Infrastructure/Service/Traits/ServiceContainerTrait.php
+#, php-format
+msgid "Not found exporter with name: %d"
+msgstr "Not found exporter with name: %d"
+
+#: centreon/www/install/step_upgrade/step2.php
+msgid "Not initialized"
+msgstr "Not initialized"
+
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
+msgid "Not loaded"
+msgstr "Not loaded"
+
+#: centreon/src/Centreon/Domain/Repository/RepositoryException.php
+msgid "Not yet implemented"
+msgstr "Not yet implemented"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Note"
+msgstr "Note"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Note URL"
+msgstr "Note URL"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/install/front_translate.php
+msgid "Notes"
+msgstr "Notes"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Nothing here, use the \"Add\" button"
+msgstr "Nothing here, use the \"Add\" button"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+msgid "Notif"
+msgstr "Notif"
+
+#: centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/front_translate.php
+msgid "Notification"
+msgstr "Notification"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+#, php-format
+msgid "Notification #%d should have at least one user"
+msgstr "Notification #%d should have at least one user"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Notification Enabled"
+msgstr "Notification Enabled"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Notification Failure Criteria"
+msgstr "Notification Failure Criteria"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Notification Information"
+msgstr "Notification Information"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Notification Interval"
+msgstr "Notification Interval"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Notification Logging Option"
+msgstr "Notification Logging Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Notification Option"
+msgstr "Notification Option"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Notification Options"
+msgstr "Notification Options"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Notification Period"
+msgstr "Notification Period"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Notification Timeout"
+msgstr "Notification Timeout"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Notification Type"
+msgstr "Notification Type"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification channels"
+msgstr "Notification channels"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification deleted successfully"
+msgstr "Notification deleted successfully"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification duplicated"
+msgstr "Notification duplicated"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+msgid "Notification information"
+msgstr "Notification information"
+
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Notification is disabled"
+msgstr "Notification is disabled"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification name"
+msgstr "Notification name"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Notification options"
+msgstr "Notification options"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateFactoryException.php
+#, php-format
+msgid "Notification options not allowed (%s)"
+msgstr "Notification options not allowed (%s)"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Notification receivers"
+msgstr "Notification receivers"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification rules"
+msgstr "Notification rules"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification sent to"
+msgstr "Notification sent to"
+
+#: centreon/www/install/front_translate.php
+msgid "Notification settings"
+msgstr "Notification settings"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Notification status"
+msgstr "Notification status"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Notifications"
+msgstr "Notifications"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
+msgid "Notifications disabled"
+msgstr "Notifications disabled"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
+msgid "Notifications enabled"
+msgstr "Notifications enabled"
+
+#: centreon/www/install/front_translate.php
+msgid "Notifications will only be sent during this time period"
+msgstr "Notifications will only be sent during this time period"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Notified"
+msgstr "Notified"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Notify"
+msgstr "Notify"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Number"
+msgstr "Number"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "Number \"%s\" was expected to be at least \"%d\" and at most \"%d\""
+msgstr "Number \"%s\" was expected to be at least \"%d\" and at most \"%d\""
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Number between 5 and 600"
+msgstr "Number between 5 and 600"
+
+#: centreon/www/install/front_translate.php
+msgid "Number of attempts before user is blocked"
+msgstr "Number of attempts before user is blocked"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Number of connections to the database"
+msgstr "Number of connections to the database"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Number of elements loaded in select"
+msgstr "Number of elements loaded in select"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Number of entries"
+msgstr "Number of entries"
+
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+msgid "Number of linked services"
+msgstr "Number of linked services"
+
+#: centreon/www/install/front_translate.php
+msgid "Number of rows"
+msgstr "Number of rows"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/install/front_translate.php
+msgid "Number of values"
+msgstr "Number of values"
+
+#: centreon/src/Centreon/Domain/Entity/EntityCreator.php
+msgid "Numeric value expected"
+msgstr "Numeric value expected"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+msgid "OID"
+msgstr "OID"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/install/front_translate.php
+msgid "OK"
+msgstr "OK"
+
+#: centreon/www/install/front_translate.php
+msgid "OK status services"
+msgstr "OK status services"
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+msgid "OK: A reload signal has been sent to '"
+msgstr "OK: A reload signal has been sent to '"
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+msgid "OK: A restart signal has been sent to '"
+msgstr "OK: A restart signal has been sent to '"
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+msgid "OK: All configuration files copied with success."
+msgstr "OK: All configuration files copied with success."
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+msgid "OK: All configuration will be send to '"
+msgstr "OK: All configuration will be send to '"
+
+#: centreon/www/install/front_translate.php
+msgid "OK: all database poller updates are active"
+msgstr "OK: all database poller updates are active"
+
+#: centreon/www/install/front_translate.php
+msgid "OK: no latency detected on your platform"
+msgstr "OK: no latency detected on your platform"
+
+#: centreon/www/install/front_translate.php
+msgid "OTLP Receiver"
+msgstr "OTLP Receiver"
+
+#: centreon/www/install/front_translate.php
+msgid "OTLP receiver"
+msgstr "OTLP receiver"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object"
+msgstr "Object"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonWebserviceService.php
+#, php-format
+msgid "Object %s must extend %s class or %s class"
+msgstr "Object %s must extend %s class or %s class"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonClapiService.php
+#, php-format
+msgid "Object %s must implement %s"
+msgstr "Object %s must implement %s"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Object Configuration Directory"
+msgstr "Object Configuration Directory"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Object Configuration File"
+msgstr "Object Configuration File"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object ID"
+msgstr "Object ID"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Object Name"
+msgstr "Object Name"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object Type"
+msgstr "Object Type"
+
+#: centreon/www/include/eventLogs/xml/data.php
+msgid "Object name"
+msgstr "Object name"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object name : "
+msgstr "Object name : "
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object type : "
+msgstr "Object type : "
+
+#: centreon/www/install/smarty_translate.php
+msgid "Objects"
+msgstr "Objects"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Obsess Over Host"
+msgstr "Obsess Over Host"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Obsess Over Service"
+msgstr "Obsess Over Service"
+
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
+msgid "Ok"
+msgstr "Ok"
+
+#: centreon/www/install/react_translation.php
+msgid "Ok services"
+msgstr "Ok services"
+
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+msgid "Ok/Up"
+msgstr "Ok/Up"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Okta"
+msgstr "Okta"
+
+#: centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+msgid "Old password usage is disable"
+msgstr "Old password usage is disable"
+
+#: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
+msgid "On media update, only one file is allowed"
+msgstr "On media update, only one file is allowed"
+
+#: centreon/www/install/smarty_translate.php
+msgid "One column"
+msgstr "One column"
+
+#: centreon/src/Centreon/Domain/Monitoring/Resource.php
+msgid "One of the elements provided is not a ResourceGroup type"
+msgstr "One of the elements provided is not a ResourceGroup type"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "One peer retention"
+msgstr "One peer retention"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "One peer retention mode"
+msgstr "One peer retention mode"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Only one"
+msgstr "Only one"
+
+#: centreon/www/install/front_translate.php
+msgid "Only passive checks are enabled"
+msgstr "Only passive checks are enabled"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid ""
+"Only services, servicegroups, hosts and hostgroups are taken in account in "
+"order to calculate this status. If you modify a template, it won't tell you "
+"the configuration had changed."
+msgstr ""
+"Only services, servicegroups, hosts and hostgroups are taken in account in "
+"order to calculate this status. If you modify a template, it won't tell you "
+"the configuration had changed."
+
+#: centreon/www/install/front_translate.php
+msgid "Oops"
+msgstr "Oops"
+
+#: centreon/www/install/front_translate.php
+msgid "Oops !"
+msgstr "Oops !"
+
+#: centreon/www/install/front_translate.php
+msgid "Oops, something went wrong"
+msgstr "Oops, something went wrong"
+
+#: centreon/www/install/front_translate.php
+msgid "Open"
+msgstr "Open"
+
+#: centreon/www/install/front_translate.php
+msgid "Open ticket for host"
+msgstr "Open ticket for host"
+
+#: centreon/www/install/front_translate.php
+msgid "Open ticket for service"
+msgstr "Open ticket for service"
+
+#: centreon/www/install/front_translate.php
+msgid "OpenID Connect Configuration"
+msgstr "OpenID Connect Configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "OpenID Connect configuration saved"
+msgstr "OpenID Connect configuration saved"
+
+#: centreon/www/install/front_translate.php
+msgid "OpenID Connect only"
+msgstr "OpenID Connect only"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "OpenLDAP :"
+msgstr "OpenLDAP :"
+
+#: centreon/www/install/front_translate.php
+msgid "Opened on"
+msgstr "Opened on"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Opentelemetry"
+msgstr "Opentelemetry"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Optimization"
+msgstr "Optimization"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Option 1"
+msgstr "Option 1"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Option 2"
+msgstr "Option 2"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/menu_translation.php
+msgid "Options"
+msgstr "Options"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+msgid "Order"
+msgstr "Order"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Order sort "
+msgstr "Order sort "
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Order sort problems"
+msgstr "Order sort problems"
+
+#: centreon/www/install/front_translate.php
+msgid "Ordered List"
+msgstr "Ordered List"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Orientation"
+msgstr "Orientation"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Orphaned Host Check Option"
+msgstr "Orphaned Host Check Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Orphaned Service Check Option"
+msgstr "Orphaned Service Check Option"
+
+#: centreon/www/install/front_translate.php
+msgid "Other"
+msgstr "Other"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Ouput"
+msgstr "Ouput"
+
+#: centreon/www/install/front_translate.php
+msgid "Outdated"
+msgstr "Outdated"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Output"
+msgstr "Output"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+msgid "Output Message"
+msgstr "Output Message"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Output Transform"
+msgstr "Output Transform"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Output accepted events type"
+msgstr "Output accepted events type"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "Output format string (printf-style)"
+msgstr "Output format string (printf-style)"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+msgid "Outputs"
+msgstr "Outputs"
+
+#: centreon/src/Core/Platform/Infrastructure/Validator/RequirementValidators/PhpRequirementException.php
+#, php-format
+msgid "PHP extension %s not loaded"
+msgstr "PHP extension %s not loaded"
+
+#: centreon/src/Core/Platform/Infrastructure/Validator/RequirementValidators/PhpRequirementException.php
+#, php-format
+msgid "PHP version %s required (%s installed)"
+msgstr "PHP version %s required (%s installed)"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "PID"
+msgstr "PID"
+
+#: centreon/www/install/front_translate.php
+msgid "PNG (as displayed)"
+msgstr "PNG (as displayed)"
+
+#: centreon/www/install/front_translate.php
+msgid "PNG (medium size)"
+msgstr "PNG (medium size)"
+
+#: centreon/www/install/front_translate.php
+msgid "PNG (small size)"
+msgstr "PNG (small size)"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "PREEXEC command"
+msgstr "PREEXEC command"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/include/configuration/configKnowledge/pagination.php
+msgid "Page"
+msgstr "Page"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Page refresh interval"
+msgstr "Page refresh interval"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Pager"
+msgstr "Pager"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Parallel"
+msgstr "Parallel"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Parallel Check"
+msgstr "Parallel Check"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "Parameter '%s' (%s) is invalid"
+msgstr "Parameter '%s' (%s) is invalid"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#, php-format
+msgid "Parameter '%s' of type %s is invalid"
+msgstr "Parameter '%s' of type %s is invalid"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Parameters"
+msgstr "Parameters"
+
+#: centreon/www/install/front_translate.php
+msgid "Parameters tooltip"
+msgstr "Parameters tooltip"
+
+#: centreon/www/install/front_translate.php
+msgid "Parent"
+msgstr "Parent"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Parent Hosts"
+msgstr "Parent Hosts"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+msgid "Parent Resource Name"
+msgstr "Parent Resource Name"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+msgid "Parent Resource Status"
+msgstr "Parent Resource Status"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+msgid "Parent Resource Type"
+msgstr "Parent Resource Type"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
+msgid "Parent alias"
+msgstr "Parent alias"
+
+#: centreon/www/install/front_translate.php
+msgid "Parent name"
+msgstr "Parent name"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Parent relationship"
+msgstr "Parent relationship"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Partial backup"
+msgstr "Partial backup"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Partition name"
+msgstr "Partition name"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Partitioning Properties"
+msgstr "Partitioning Properties"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Partitioning database tables"
+msgstr "Partitioning database tables"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Partitioning retention options"
+msgstr "Partitioning retention options"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Passive"
+msgstr "Passive"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Passive Check Logging Option"
+msgstr "Passive Check Logging Option"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Passive Checks"
+msgstr "Passive Checks"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Passive Checks Enabled"
+msgstr "Passive Checks Enabled"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Passive Host Check Acceptance Option"
+msgstr "Passive Host Check Acceptance Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Passive Service Check Acceptance Option"
+msgstr "Passive Service Check Acceptance Option"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Password"
+msgstr "Password"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Password Management"
+msgstr "Password Management"
+
+#: centreon/www/install/front_translate.php
+msgid "Password blocking policy"
+msgstr "Password blocking policy"
+
+#: centreon/www/install/front_translate.php
+msgid "Password case policy"
+msgstr "Password case policy"
+
+#: centreon/www/install/front_translate.php
+msgid "Password expiration policy"
+msgstr "Password expiration policy"
+
+#: centreon/www/install/front_translate.php
+msgid "Password expires after"
+msgstr "Password expires after"
+
+#: centreon/www/install/front_translate.php
+msgid "Password has expired"
+msgstr "Password has expired"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/PasswordExpiredException.php
+msgid "Password is expired"
+msgstr "Password is expired"
+
+#: centreon/www/install/front_translate.php
+msgid "Password must contain lower case"
+msgstr "Password must contain lower case"
+
+#: centreon/www/install/front_translate.php
+msgid "Password must contain numbers"
+msgstr "Password must contain numbers"
+
+#: centreon/www/install/front_translate.php
+msgid "Password must contain special characters"
+msgstr "Password must contain special characters"
+
+#: centreon/www/install/front_translate.php
+msgid "Password must contain upper case"
+msgstr "Password must contain upper case"
+
+#: centreon/www/install/front_translate.php
+msgid "Password renewed"
+msgstr "Password renewed"
+
+#: centreon/www/install/front_translate.php
+msgid "Password security policy"
+msgstr "Password security policy"
+
+#: centreon/www/install/front_translate.php
+msgid "Password security policy saved"
+msgstr "Password security policy saved"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Passwords do not match"
+msgstr "Passwords do not match"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Path"
+msgstr "Path"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Path to RRDTool Database For Metrics"
+msgstr "Path to RRDTool Database For Metrics"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Path to RRDTool Database For Monitoring Engine Statistics"
+msgstr "Path to RRDTool Database For Monitoring Engine Statistics"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Path to RRDTool Database For Status"
+msgstr "Path to RRDTool Database For Status"
+
+#: centreon/www/install/front_translate.php
+msgid "Pattern match login (regex)"
+msgstr "Pattern match login (regex)"
+
+#: centreon/www/install/front_translate.php
+msgid "Pattern replace login (regex)"
+msgstr "Pattern replace login (regex)"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Peers"
+msgstr "Peers"
+
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Pending"
+msgstr "Pending"
+
+#: centreon/www/install/react_translation.php
+msgid "Pending services"
+msgstr "Pending services"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "People linked to this Access list"
+msgstr "People linked to this Access list"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Percent State Change"
+msgstr "Percent State Change"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Percentage"
+msgstr "Percentage"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Perfdata Options"
+msgstr "Perfdata Options"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Perfdata file"
+msgstr "Perfdata file"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Performance Data"
+msgstr "Performance Data"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Performance Data Management"
+msgstr "Performance Data Management"
+
+#: centreon/www/install/menu_translation.php
+msgid "Performance Management"
+msgstr "Performance Management"
+
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+#: centreon/www/install/front_translate.php
+msgid "Performance data"
+msgstr "Performance data"
+
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Performances"
+msgstr "Performances"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Period"
+msgstr "Period"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Periods"
+msgstr "Periods"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Persistent"
+msgstr "Persistent"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Pie chart"
+msgstr "Pie chart"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"Platform : '%s'@'%s' mandatory data are missing. Please check the Remote "
+"Access form"
+msgstr ""
+"Platform : '%s'@'%s' mandatory data are missing. Please check the Remote "
+"Access form"
+
+#: centreon/www/install/menu_translation.php
+msgid "Platform Status"
+msgstr "Platform Status"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/Model/PlatformInformation.php
+msgid "Platform name can't be empty"
+msgstr "Platform name can't be empty"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+msgid "Platform not found"
+msgstr "Platform not found"
+
+#: centreon/www/install/step_upgrade/step4.php
+#, php-format
+msgid ""
+"Please check the \"upgrade.log\" and the \"sql-error.log\" located in \"%s\" "
+"for more details"
+msgstr ""
+"Please check the \"upgrade.log\" and the \"sql-error.log\" located in \"%s\" "
+"for more details"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#, php-format
+msgid "Please choose a date before %d"
+msgstr "Please choose a date before %d"
+
+#: centreon/www/install/front_translate.php
+msgid "Please contact your administrator for more information."
+msgstr "Please contact your administrator for more information."
+
+#: centreon/www/install/front_translate.php
+msgid "Please contact your administrator."
+msgstr "Please contact your administrator."
+
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "Please correct these fields"
+msgstr "Please correct these fields"
+
+#: centreon/www/include/monitoring/status/Common/commonJS.php
+msgid "Please enter a comment"
+msgstr "Please enter a comment"
+
+#: centreon/www/install/front_translate.php
+msgid "Please enter a name for the duplicated notification"
+msgstr "Please enter a name for the duplicated notification"
+
+#: centreon/www/install/front_translate.php
+msgid "Please enter a name for the duplicated resource access rule"
+msgstr "Please enter a name for the duplicated resource access rule"
+
+#: centreon/www/install/front_translate.php
+msgid "Please enter a valid URL or IP address"
+msgstr "Please enter a valid URL or IP address"
+
+#: centreon/www/include/Administration/myAccount/DB-Func.php
+#: centreon/www/include/configuration/configObject/contact/DB-Func.php
+msgid "Please fill in all password fields"
+msgstr "Please fill in all password fields"
+
+#: centreon/www/install/steps/functions.php
+#, php-format
+msgid "Please install MariaDB version %s instead of %s."
+msgstr "Please install MariaDB version %s instead of %s."
+
+#: centreon/www/install/steps/functions.php
+#, php-format
+msgid "Please install PHP version %s instead of %s."
+msgstr "Please install PHP version %s instead of %s."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid ""
+"Please note that domains outside your organization must be authorized in "
+"your Apache configuration."
+msgstr ""
+"Please note that domains outside your organization must be authorized in "
+"your Apache configuration."
+
+#: centreon/www/widgets/graph-monitoring/index.php
+msgid "Please select a graph period"
+msgstr "Please select a graph period"
+
+#: centreon/www/install/front_translate.php
+msgid "Please select a metric"
+msgstr "Please select a metric"
+
+#: centreon/www/install/front_translate.php
+msgid "Please select a resource"
+msgstr "Please select a resource"
+
+#: centreon/www/widgets/graph-monitoring/index.php
+msgid "Please select a resource first"
+msgstr "Please select a resource first"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Please select a user in order to view his notifications"
+msgstr "Please select a user in order to view his notifications"
+
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Please select one or more items"
+msgstr "Please select one or more items"
+
+#: centreon/www/install/step_upgrade/step4.php
+msgid "Please upgrade to an intermediate release (ie. 2.8.x) first."
+msgstr "Please upgrade to an intermediate release (ie. 2.8.x) first."
+
+#: centreon/src/EventSubscriber/UpdateEventSubscriber.php
+msgid "Please use Web UI to install Centreon."
+msgstr "Please use Web UI to install Centreon."
+
+#: centreon/src/EventSubscriber/UpdateEventSubscriber.php
+#, php-format
+msgid "Please use Web UI to update Centreon."
+msgstr "Please use Web UI to update Centreon."
+
+#: centreon/www/install/front_translate.php
+msgid "Please, select a valid countdown"
+msgstr "Please, select a valid countdown"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+msgid "Plugin Help"
+msgstr "Plugin Help"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Plugins Directory"
+msgstr "Plugins Directory"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configKnowledge/search.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Poller"
+msgstr "Poller"
+
+#: centreon/www/install/front_translate.php
+msgid "Poller CA certificate file name"
+msgstr "Poller CA certificate file name"
+
+#: centreon/www/install/front_translate.php
+msgid "Poller CA name"
+msgstr "Poller CA name"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Poller Configuration Actions / Poller Management"
+msgstr "Poller Configuration Actions / Poller Management"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Poller Filter"
+msgstr "Poller Filter"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid ""
+"Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
+msgstr ""
+"Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/smarty_translate.php
+msgid "Poller Name"
+msgstr "Poller Name"
+
+#: centreon/src/Centreon/Domain/Repository/CfgCentreonBrokerRepository.php
+msgid "Poller broker config id not found"
+msgstr "Poller broker config id not found"
+
+#: centreon/www/install/front_translate.php
+msgid "Poller configuration"
+msgstr "Poller configuration"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Pollers"
+msgstr "Pollers"
+
+#: centreon/www/install/front_translate.php
+msgid "Pollers not running"
+msgstr "Pollers not running"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+msgid "Polling instance"
+msgstr "Polling instance"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Polling instances"
+msgstr "Polling instances"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Pool size"
+msgstr "Pool size"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Popup notifications"
+msgstr "Popup notifications"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/install/front_translate.php
+msgid "Port"
+msgstr "Port"
+
+#: centreon/www/install/front_translate.php
+msgid "Port number must be at least 1"
+msgstr "Port number must be at least 1"
+
+#: centreon/www/install/front_translate.php
+msgid "Port number must be at most 65535"
+msgstr "Port number must be at most 65535"
+
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+#: centreon/www/include/options/session/connected_user.php
+#: centreon/www/install/dashboard_widgets.php
+msgid "Position"
+msgstr "Position"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Posix"
+msgstr "Posix"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Post Validation"
+msgstr "Post Validation"
+
+#: centreon/www/include/configuration/configGenerate/xml/postcommand.php
+msgid "Post execution command results"
+msgstr "Post execution command results"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Post generation command"
+msgstr "Post generation command"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Post-Restart command"
+msgstr "Post-Restart command"
+
+#: centreon/www/install/front_translate.php
+msgid "Powered by Centreon"
+msgstr "Powered by Centreon"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Pre execution commands"
+msgstr "Pre execution commands"
+
+#: centreon/www/install/front_translate.php
+msgid "Predefined rows selection menu"
+msgstr "Predefined rows selection menu"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Predictive Host Dependency Checks"
+msgstr "Predictive Host Dependency Checks"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Predictive Service Dependency Checks"
+msgstr "Predictive Service Dependency Checks"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Preexec definition"
+msgstr "Preexec definition"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Preferences"
+msgstr "Preferences"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Preparing environment"
+msgstr "Preparing environment"
+
+#: centreon/www/install/front_translate.php
+msgid "Press Enter to accept"
+msgstr "Press Enter to accept"
+
+#: centreon/www/install/front_translate.php
+msgid "Previous"
+msgstr "Previous"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
+msgid "Previous page"
+msgstr "Previous page"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Print Average"
+msgstr "Print Average"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Print Last Value"
+msgstr "Print Last Value"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Print Max value"
+msgstr "Print Max value"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Print Min value"
+msgstr "Print Min value"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Print Total Value"
+msgstr "Print Total Value"
+
+#: centreon/www/install/front_translate.php
+msgid "Private key (.key)"
+msgstr "Private key (.key)"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Private key file."
+msgstr "Private key file."
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Private key path"
+msgstr "Private key path"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Problem (Critical)"
+msgstr "Problem (Critical)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Problem (Down/Critical)"
+msgstr "Problem (Down/Critical)"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Problem display properties"
+msgstr "Problem display properties"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Problem has been acknowledged"
+msgstr "Problem has been acknowledged"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Problems"
+msgstr "Problems"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Process"
+msgstr "Process"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Process Perf Data"
+msgstr "Process Perf Data"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Process information"
+msgstr "Process information"
+
+#: centreon/www/install/front_translate.php
+msgid "Profile"
+msgstr "Profile"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Progress"
+msgstr "Progress"
+
+#: centreon/www/install/front_translate.php
+msgid "Project leaders"
+msgstr "Project leaders"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Properties"
+msgstr "Properties"
+
+#: centreon/src/Centreon/Domain/Proxy/Proxy.php
+#: centreon/tests/php/Centreon/Domain/Proxy/ProxyTest.php
+#, php-format
+msgid "Protocol %s is not allowed"
+msgstr "Protocol %s is not allowed"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Protocol version"
+msgstr "Protocol version"
+
+#: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
+#, php-format
+msgid "Provider configuration (%s) not found"
+msgstr "Provider configuration (%s) not found"
+
+#: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
+msgid "Provider not found"
+msgstr "Provider not found"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Proxy URL"
+msgstr "Proxy URL"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Proxy options"
+msgstr "Proxy options"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Proxy password"
+msgstr "Proxy password"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Proxy port"
+msgstr "Proxy port"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Proxy user"
+msgstr "Proxy user"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Public"
+msgstr "Public"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Public certificate"
+msgstr "Public certificate"
+
+#: centreon/www/install/front_translate.php
+msgid "Public certificate (.crt, .cert, .cer)"
+msgstr "Public certificate (.crt, .cert, .cer)"
+
+#: centreon/www/include/home/customViews/formLoad.php
+msgid "Public views list"
+msgstr "Public views list"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Queue file"
+msgstr "Queue file"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Queued events"
+msgstr "Queued events"
+
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+msgid "Queued file enabled"
+msgstr "Queued file enabled"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "RPN (Reverse Polish Notation) Function"
+msgstr "RPN (Reverse Polish Notation) Function"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "RPN Function"
+msgstr "RPN Function"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "RRD file directory for metrics"
+msgstr "RRD file directory for metrics"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "RRD file directory for statuses"
+msgstr "RRD file directory for statuses"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "RRD length"
+msgstr "RRD length"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "RRDCacheD listening socket/port"
+msgstr "RRDCacheD listening socket/port"
+
+#: centreon/www/install/menu_translation.php
+msgid "RRDTool"
+msgstr "RRDTool"
+
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "RRDTool Configuration"
+msgstr "RRDTool Configuration"
+
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "RRDTool Properties"
+msgstr "RRDTool Properties"
+
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+msgid "RRDTool Version"
+msgstr "RRDTool Version"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "RRDTool debug"
+msgstr "RRDTool debug"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Radio"
+msgstr "Radio"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Radio 1"
+msgstr "Radio 1"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Radio 2"
+msgstr "Radio 2"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Random"
+msgstr "Random"
+
+#: centreon/www/install/front_translate.php
+msgid "Raw value"
+msgstr "Raw value"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Re-schedule the next check for a service"
+msgstr "Re-schedule the next check for a service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Re-schedule the next check for a service (Forced)"
+msgstr "Re-schedule the next check for a service (Forced)"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Re-schedule the next check for this service"
+msgstr "Re-schedule the next check for this service"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Re-schedule the next check for this service (forced)"
+msgstr "Re-schedule the next check for this service (forced)"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Reach API Configuration"
+msgstr "Reach API Configuration"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Reach API Realtime"
+msgstr "Reach API Realtime"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Reach Centreon Front-end"
+msgstr "Reach Centreon Front-end"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Read Only"
+msgstr "Read Only"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Read/Write"
+msgstr "Read/Write"
+
+#: centreon/www/install/front_translate.php
+msgid "Real time widgets"
+msgstr "Real time widgets"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Real-Time"
+msgstr "Real-Time"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Rebuild RRD Database"
+msgstr "Rebuild RRD Database"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Rebuild Waiting"
+msgstr "Rebuild Waiting"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Rebuild check interval in seconds"
+msgstr "Rebuild check interval in seconds"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Recovery"
+msgstr "Recovery"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Recovery Step"
+msgstr "Recovery Step"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Recovery notification delay"
+msgstr "Recovery notification delay"
+
+#: centreon/www/install/menu_translation.php
+msgid "Recurrent downtimes"
+msgstr "Recurrent downtimes"
+
+#: centreon/www/install/front_translate.php
+msgid "Redirect URL"
+msgstr "Redirect URL"
+
+#: centreon/www/install/front_translate.php
+msgid "Redo"
+msgstr "Redo"
+
+#: centreon/www/install/front_translate.php
+msgid "Reduce"
+msgstr "Reduce"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/install/front_translate.php
+msgid "Refresh"
+msgstr "Refresh"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Refresh Interval for monitoring"
+msgstr "Refresh Interval for monitoring"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Refresh Interval for statistics"
+msgstr "Refresh Interval for statistics"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "Refresh LDAP"
+msgstr "Refresh LDAP"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Refresh Properties"
+msgstr "Refresh Properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Refresh interval"
+msgstr "Refresh interval"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Refresh interval must be numeric"
+msgstr "Refresh interval must be numeric"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Regexp"
+msgstr "Regexp"
+
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+msgid "Regular"
+msgstr "Regular"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Regular Expression Matching Option"
+msgstr "Regular Expression Matching Option"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "Relation"
+msgstr "Relation"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/install/smarty_translate.php
+msgid "Relations"
+msgstr "Relations"
+
+#: centreon/www/install/front_translate.php
+msgid "Relative paths are not allowed"
+msgstr "Relative paths are not allowed"
+
+#: centreon/www/install/step_upgrade/step3.php
+msgid "Release notes"
+msgstr "Release notes"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Reload"
+msgstr "Reload"
+
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+#: centreon/www/install/menu_translation.php
+msgid "Reload ACL"
+msgstr "Reload ACL"
+
+#: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+#, php-format
+msgid "Reloading error on monitoring server #%d: %s"
+msgstr "Reloading error on monitoring server #%d: %s"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Remote Server"
+msgstr "Remote Server"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/react_translation.php
+msgid "Remote Server Configuration"
+msgstr "Remote Server Configuration"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/install/menu_translation.php
+msgid "Remote access"
+msgstr "Remote access"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Remote directory"
+msgstr "Remote directory"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Remote host"
+msgstr "Remote host"
+
+#: centreon/www/install/front_translate.php
+msgid "Remote login URL"
+msgstr "Remote login URL"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Remote user"
+msgstr "Remote user"
+
+#: centreon/www/class/centreonConfigCentreonBroker.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Remove"
+msgstr "Remove"
+
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+msgid "Remove Acknowledgement"
+msgstr "Remove Acknowledgement"
+
+#: centreon/www/install/front_translate.php
+msgid "Remove from favorites"
+msgstr "Remove from favorites"
+
+#: centreon/www/install/front_translate.php
+msgid "Remove vCenter/ESX"
+msgstr "Remove vCenter/ESX"
+
+#: centreon/www/install/front_translate.php
+msgid "Removed"
+msgstr "Removed"
+
+#: centreon/www/install/front_translate.php
+msgid "Rename"
+msgstr "Rename"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Replacement"
+msgstr "Replacement"
+
+#: centreon/www/install/menu_translation.php
+msgid "Reporting"
+msgstr "Reporting"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Reporting Period"
+msgstr "Reporting Period"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Reporting period"
+msgstr "Reporting period"
+
+#: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
+#, php-format
+msgid "Repository class %s has to implement %s"
+msgstr "Repository class %s has to implement %s"
+
+#: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
+#, php-format
+msgid "Request failed (%d)"
+msgstr "Request failed (%d)"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Request for authentication conditions custom endpoint has failed"
+msgstr "Request for authentication conditions custom endpoint has failed"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Request for connection token to external provider has failed"
+msgstr "Request for connection token to external provider has failed"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Request for introspection token to external provider has failed"
+msgstr "Request for introspection token to external provider has failed"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Request for refresh token to external provider has failed"
+msgstr "Request for refresh token to external provider has failed"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Request for user information to external provider has failed"
+msgstr "Request for user information to external provider has failed"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Request on custom endpoint failed"
+msgstr "Request on custom endpoint failed"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+msgid "Request to the Central's API failed"
+msgstr "Request to the Central's API failed"
+
+#: centreon/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
+msgid "Requested theme not found"
+msgstr "Requested theme not found"
+
+#: centreon/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
+msgid "Requested user interface view mode not handled"
+msgstr "Requested user interface view mode not handled"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+msgid "Requester"
+msgstr "Requester"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/front_translate.php
+msgid "Required"
+msgstr "Required"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Required Field"
+msgstr "Required Field"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Required field"
+msgstr "Required field"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Required fields"
+msgstr "Required fields"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Required service"
+msgstr "Required service"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Reschedule associated services"
+msgstr "Reschedule associated services"
+
+#: centreon/www/api/class/centreon_home_customview.class.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/home/customViews/formLoad.php
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+msgid "Reset"
+msgstr "Reset"
+
+#: centreon/www/install/front_translate.php
+msgid "Reset configuration"
+msgstr "Reset configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Reset password"
+msgstr "Reset password"
+
+#: centreon/www/install/front_translate.php
+msgid "Reset the form"
+msgstr "Reset the form"
+
+#: centreon/www/install/front_translate.php
+msgid "Reset to default value"
+msgstr "Reset to default value"
+
+#: centreon/www/install/front_translate.php
+msgid "Reset your password"
+msgstr "Reset your password"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "Resolve"
+msgstr "Resolve"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Resource"
+msgstr "Resource"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/install/menu_translation.php
+msgid "Resource Access Management"
+msgstr "Resource Access Management"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "Resource Access Rule"
+msgstr "Resource Access Rule"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+msgid "Resource Name"
+msgstr "Resource Name"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+msgid "Resource Type"
+msgstr "Resource Type"
+
+#: centreon/www/install/front_translate.php
+msgid "Resource access rule name"
+msgstr "Resource access rule name"
+
+#: centreon/www/install/front_translate.php
+msgid "Resource access rules"
+msgstr "Resource access rules"
+
+#: centreon/www/install/front_translate.php
+msgid "Resource link copied to the clipboard"
+msgstr "Resource link copied to the clipboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Resource name"
+msgstr "Resource name"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Resource status performance"
+msgstr "Resource status performance"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Resource table"
+msgstr "Resource table"
+
+#: centreon/www/install/front_translate.php
+msgid "Resource type"
+msgstr "Resource type"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Resource used by one of the instances"
+msgstr "Resource used by one of the instances"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Resources"
+msgstr "Resources"
+
+#: centreon/www/install/menu_translation.php
+msgid "Resources Access"
+msgstr "Resources Access"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Resources Status"
+msgstr "Resources Status"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Resources access"
+msgstr "Resources access"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "Resources access list link"
+msgstr "Resources access list link"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Resources linked to a ticket"
+msgstr "Resources linked to a ticket"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Resources storage"
+msgstr "Resources storage"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Resources with no ticket"
+msgstr "Resources with no ticket"
+
+#: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
+msgid "Response empty"
+msgstr "Response empty"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Restart"
+msgstr "Restart"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Restart Monitoring Engine"
+msgstr "Restart Monitoring Engine"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Restarting engine"
+msgstr "Restarting engine"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Result"
+msgstr "Result"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Resulting Time Period with inclusions"
+msgstr "Resulting Time Period with inclusions"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Retain Non Status Information"
+msgstr "Retain Non Status Information"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Retain Status Information"
+msgstr "Retain Status Information"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for audit logs"
+msgstr "Retention duration for audit logs"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for comments"
+msgstr "Retention duration for comments"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for downtimes"
+msgstr "Retention duration for downtimes"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for logs"
+msgstr "Retention duration for logs"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for partitioning"
+msgstr "Retention duration for partitioning"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for performance data in MySQL database"
+msgstr "Retention duration for performance data in MySQL database"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for performance data in RRDTool databases"
+msgstr "Retention duration for performance data in RRDTool databases"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention duration for reporting data (Dashboard)"
+msgstr "Retention duration for reporting data (Dashboard)"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Retention durations"
+msgstr "Retention durations"
+
+#: centreon/www/include/eventLogs/xml/data.php
+msgid "Retry"
+msgstr "Retry"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Retry Check Interval"
+msgstr "Retry Check Interval"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Retry interval"
+msgstr "Retry interval"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Retry interval (seconds)"
+msgstr "Retry interval (seconds)"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Return to list"
+msgstr "Return to list"
+
+#: centreon/www/install/front_translate.php
+msgid "Revert to previous password"
+msgstr "Revert to previous password"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "Review form after save"
+msgstr "Review form after save"
+
+#: centreon/www/install/front_translate.php
+msgid "Revoked"
+msgstr "Revoked"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Right"
+msgstr "Right"
+
+#: centreon/www/install/front_translate.php
+msgid "Role"
+msgstr "Role"
+
+#: centreon/www/install/front_translate.php
+msgid "Role ID"
+msgstr "Role ID"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Role Id"
+msgstr "Role Id"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/AclConditionsException.php
+msgid "Role mapping conditions do not match"
+msgstr "Role mapping conditions do not match"
+
+#: centreon/www/install/front_translate.php
+msgid "Role value"
+msgstr "Role value"
+
+#: centreon/www/install/front_translate.php
+msgid "Roles attribute path"
+msgstr "Roles attribute path"
+
+#: centreon/www/install/front_translate.php
+msgid "Roles mapping"
+msgstr "Roles mapping"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Root password"
+msgstr "Root password"
+
+#: centreon/www/install/front_translate.php
+msgid "Root path"
+msgstr "Root path"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Root user (default: root)"
+msgstr "Root user (default: root)"
+
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+msgid "Rotation"
+msgstr "Rotation"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Round the min and max"
+msgstr "Round the min and max"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Route definition"
+msgstr "Route definition"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Route parameters"
+msgstr "Route parameters"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/include/configuration/configKnowledge/pagination.php
+msgid "Rows"
+msgstr "Rows"
+
+#: centreon/www/install/front_translate.php
+msgid "Rows per page"
+msgstr "Rows per page"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Rule (ticket provider)"
+msgstr "Rule (ticket provider)"
+
+#: centreon/www/install/front_translate.php
+msgid "Rule properties"
+msgstr "Rule properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Rules are used to allow users to access resources."
+msgstr "Rules are used to allow users to access resources."
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Run monitoring engine debug (-v)"
+msgstr "Run monitoring engine debug (-v)"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "Running debug mode"
+msgstr "Running debug mode"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Runtime"
+msgstr "Runtime"
+
+#: centreon/www/install/front_translate.php
+msgid "SAML configuration"
+msgstr "SAML configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "SAML configuration saved"
+msgstr "SAML configuration saved"
+
+#: centreon/www/install/front_translate.php
+msgid "SAML only"
+msgstr "SAML only"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "SCHEDULED DOWNTIME"
+msgstr "SCHEDULED DOWNTIME"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "SCP export enabled"
+msgstr "SCP export enabled"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "SNMP Community"
+msgstr "SNMP Community"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "SNMP Trap Generation"
+msgstr "SNMP Trap Generation"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/menu_translation.php
+msgid "SNMP Traps"
+msgstr "SNMP Traps"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "SOFT"
+msgstr "SOFT"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "SQL LIKE-clause expression"
+msgstr "SQL LIKE-clause expression"
+
+#: centreon/www/include/Administration/parameters/debug/form.php
+msgid "SQL debug"
+msgstr "SQL debug"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "SQL matching"
+msgstr "SQL matching"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "SSH"
+msgstr "SSH"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "SSH Legacy port"
+msgstr "SSH Legacy port"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "SSL"
+msgstr "SSL"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "Same address and parent_address for platform : '%s'@'%s'"
+msgstr "Same address and parent_address for platform : '%s'@'%s'"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Satellite configuration"
+msgstr "Satellite configuration"
+
+#: centreon/www/include/configuration/configNagios/listNagios.php
+msgid "Satellites"
+msgstr "Satellites"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Saturday"
+msgstr "Saturday"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/command/formArguments.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/formMacros.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Save"
+msgstr "Save"
+
+#: centreon/www/install/front_translate.php
+msgid "Save as"
+msgstr "Save as"
+
+#: centreon/www/install/front_translate.php
+msgid "Save as new"
+msgstr "Save as new"
+
+#: centreon/www/install/front_translate.php
+msgid "Save filter"
+msgstr "Save filter"
+
+#: centreon/www/install/front_translate.php
+msgid "Save your dashboard to generate a thumbnail"
+msgstr "Save your dashboard to generate a thumbnail"
+
+#: centreon/www/install/front_translate.php
+msgid "Saved"
+msgstr "Saved"
+
+#: centreon/www/install/front_translate.php
+msgid "Saved link"
+msgstr "Saved link"
+
+#: centreon/www/install/front_translate.php
+msgid "Saving..."
+msgstr "Saving..."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Scale"
+msgstr "Scale"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Scale Graph Values"
+msgstr "Scale Graph Values"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "Scale of time"
+msgstr "Scale of time"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Schedule an immediate check of all services on this host"
+msgstr "Schedule an immediate check of all services on this host"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Schedule an immediate check of all services on this host (forced)"
+msgstr "Schedule an immediate check of all services on this host (forced)"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Schedule downtime for a host"
+msgstr "Schedule downtime for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Schedule downtime for a service"
+msgstr "Schedule downtime for a service"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Schedule downtime for this host"
+msgstr "Schedule downtime for this host"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Schedule downtime for this service"
+msgstr "Schedule downtime for this service"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Schedule the check for a host"
+msgstr "Schedule the check for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Schedule the check for a host (Forced)"
+msgstr "Schedule the check for a host (Forced)"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+msgid "Scheduled Downtimes"
+msgstr "Scheduled Downtimes"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Scheduled downtime"
+msgstr "Scheduled downtime"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Scheduled event information"
+msgstr "Scheduled event information"
+
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+msgid "Scheduling"
+msgstr "Scheduling"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Scheduling options"
+msgstr "Scheduling options"
+
+#: centreon/www/install/front_translate.php
+msgid "Scopes"
+msgstr "Scopes"
+
+#: centreon/www/install/front_translate.php
+msgid "Scroll to top"
+msgstr "Scroll to top"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configKnowledge/search.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Search"
+msgstr "Search"
+
+#: centreon/www/install/front_translate.php
+msgid "Search Business Views"
+msgstr "Search Business Views"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Search Filter"
+msgstr "Search Filter"
+
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+msgid "Search Result"
+msgstr "Search Result"
+
+#: centreon/www/install/front_translate.php
+msgid "Search bar"
+msgstr "Search bar"
+
+#: centreon/www/install/front_translate.php
+msgid "Search contacts"
+msgstr "Search contacts"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Search group base DN"
+msgstr "Search group base DN"
+
+#: centreon/www/install/front_translate.php
+msgid "Search help"
+msgstr "Search help"
+
+#: centreon/www/install/front_translate.php
+msgid "Search host groups"
+msgstr "Search host groups"
+
+#: centreon/www/install/front_translate.php
+msgid "Search service groups"
+msgstr "Search service groups"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Search user base DN"
+msgstr "Search user base DN"
+
+#: centreon/www/install/front_translate.php
+msgid "Second"
+msgstr "Second"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+msgid "Second of month"
+msgstr "Second of month"
+
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+msgid "Secondary Priority Hosts"
+msgstr "Secondary Priority Hosts"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/front_translate.php
+msgid "Seconds"
+msgstr "Seconds"
+
+#: centreon/www/install/front_translate.php
+msgid "Secret ID"
+msgstr "Secret ID"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Secret Id"
+msgstr "Secret Id"
+
+#: centreon/www/install/front_translate.php
+msgid "Security acknowledgement"
+msgstr "Security acknowledgement"
+
+#: centreon/www/install/front_translate.php
+msgid "See Documentation"
+msgstr "See Documentation"
+
+#: centreon/www/widgets/host-monitoring/src/index.php
+msgid "See Graphs of this host"
+msgstr "See Graphs of this host"
+
+#: centreon/www/install/front_translate.php
+msgid "See more information in the geoview"
+msgstr "See more information in the geoview"
+
+#: centreon/www/install/front_translate.php
+msgid "See more on the Resources Status page"
+msgstr "See more on the Resources Status page"
+
+#: centreon/www/install/front_translate.php
+msgid "See more on the {{ page }} page"
+msgstr "See more on the {{ page }} page"
+
+#: centreon/www/install/front_translate.php
+msgid "Seems that your Apache configuration is not up-to-date"
+msgstr "Seems that your Apache configuration is not up-to-date"
+
+#: centreon/www/install/react_translation.php
+msgid "Select IP"
+msgstr "Select IP"
+
+#: centreon/www/install/front_translate.php
+msgid "Select Pending Poller IP"
+msgstr "Select Pending Poller IP"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Select Pending Remote Links"
+msgstr "Select Pending Remote Links"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Select Timeperiod..."
+msgstr "Select Timeperiod..."
+
+#: centreon/www/install/front_translate.php
+msgid "Select a Business Activity to display the preview."
+msgstr "Select a Business Activity to display the preview."
+
+#: centreon/www/install/front_translate.php
+msgid "Select a Poller"
+msgstr "Select a Poller"
+
+#: centreon/www/install/front_translate.php
+msgid "Select a Remote Server"
+msgstr "Select a Remote Server"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "Select a connector..."
+msgstr "Select a connector..."
+
+#: centreon/www/install/front_translate.php
+msgid "Select a dataset to display the preview."
+msgstr "Select a dataset to display the preview."
+
+#: centreon/www/install/front_translate.php
+msgid "Select a server type"
+msgstr "Select a server type"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Select a template"
+msgstr "Select a template"
+
+#: centreon/www/install/front_translate.php
+msgid "Select a widget type"
+msgstr "Select a widget type"
+
+#: centreon/www/install/front_translate.php
+msgid "Select a widget type to activate the preview."
+msgstr "Select a widget type to activate the preview."
+
+#: centreon/www/install/front_translate.php
+msgid "Select all"
+msgstr "Select all"
+
+#: centreon/www/install/front_translate.php
+msgid "Select columns"
+msgstr "Select columns"
+
+#: centreon/www/install/front_translate.php
+msgid "Select criterias"
+msgstr "Select criterias"
+
+#: centreon/www/install/front_translate.php
+msgid "Select existing CMA token"
+msgstr "Select existing CMA token"
+
+#: centreon/www/install/front_translate.php
+msgid "Select existing CMA token(s)"
+msgstr "Select existing CMA token(s)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Select field"
+msgstr "Select field"
+
+#: centreon/www/install/front_translate.php
+msgid "Select host"
+msgstr "Select host"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Select host severities"
+msgstr "Select host severities"
+
+#: centreon/www/install/front_translate.php
+msgid "Select hosts"
+msgstr "Select hosts"
+
+#: centreon/www/install/react_translation.php
+msgid "Select linked Remote Server"
+msgstr "Select linked Remote Server"
+
+#: centreon/www/install/front_translate.php
+msgid "Select metric"
+msgstr "Select metric"
+
+#: centreon/www/install/front_translate.php
+msgid "Select pages"
+msgstr "Select pages"
+
+#: centreon/www/install/front_translate.php
+msgid "Select poller(s)"
+msgstr "Select poller(s)"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Select pollers to be attached to this new Remote Server"
+msgstr "Select pollers to be attached to this new Remote Server"
+
+#: centreon/www/install/front_translate.php
+msgid "Select resource"
+msgstr "Select resource"
+
+#: centreon/www/install/front_translate.php
+msgid "Select resource type"
+msgstr "Select resource type"
+
+#: centreon/www/install/front_translate.php
+msgid "Select resources and events"
+msgstr "Select resources and events"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Select rule (ticket provider)"
+msgstr "Select rule (ticket provider)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Select service severities"
+msgstr "Select service severities"
+
+#: centreon/www/install/front_translate.php
+msgid "Select time format"
+msgstr "Select time format"
+
+#: centreon/www/install/front_translate.php
+msgid "Select time period"
+msgstr "Select time period"
+
+#: centreon/www/install/front_translate.php
+msgid "Select time zone"
+msgstr "Select time zone"
+
+#: centreon/www/install/front_translate.php
+msgid "Select type"
+msgstr "Select type"
+
+#: centreon/www/install/front_translate.php
+msgid "Select users"
+msgstr "Select users"
+
+#: centreon/www/class/centreonConfigCentreonBroker.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Selected"
+msgstr "Selected"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "Selection Mode"
+msgstr "Selection Mode"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Send anonymous statistics"
+msgstr "Send anonymous statistics"
+
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+msgid "Send signal"
+msgstr "Send signal"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Sequential"
+msgstr "Sequential"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Serialization protocol"
+msgstr "Serialization protocol"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Server Configuration"
+msgstr "Server Configuration"
+
+#: centreon/www/install/react_translation.php
+msgid "Server Configuration Wizard"
+msgstr "Server Configuration Wizard"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Server Information"
+msgstr "Server Information"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Server Name"
+msgstr "Server Name"
+
+#: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Server address"
+msgstr "Server address"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Server port"
+msgstr "Server port"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Server type"
+msgstr "Server type"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configKnowledge/search.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Service"
+msgstr "Service"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
+#, php-format
+msgid "Service %d (parent: %d) not found"
+msgstr "Service %d (parent: %d) not found"
+
+#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
+#: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+#: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
+#, php-format
+msgid "Service %d not found"
+msgstr "Service %d not found"
+
+#: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+#, php-format
+msgid "Service %d on host %d not found"
+msgstr "Service %d on host %d not found"
+
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Service Acknowledgement"
+msgstr "Service Acknowledgement"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Service Basic Information"
+msgstr "Service Basic Information"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Service Categories"
+msgstr "Service Categories"
+
+#: centreon/www/install/front_translate.php
+msgid "Service Category"
+msgstr "Service Category"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Service Category Filter"
+msgstr "Service Category Filter"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Check Execution Option"
+msgstr "Service Check Execution Option"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Service Check Execution Time"
+msgstr "Service Check Execution Time"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/smarty_translate.php
+msgid "Service Check Options"
+msgstr "Service Check Options"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Check Retry Logging Option"
+msgstr "Service Check Retry Logging Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Check Scheduling Options"
+msgstr "Service Check Scheduling Options"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Check Timeout"
+msgstr "Service Check Timeout"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Service Commands"
+msgstr "Service Commands"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Service Configuration"
+msgstr "Service Configuration"
+
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/install/smarty_translate.php
+msgid "Service Description"
+msgstr "Service Description"
+
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Service Downtime"
+msgstr "Service Downtime"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Service Extended Info"
+msgstr "Service Extended Info"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Freshness Check Interval"
+msgstr "Service Freshness Check Interval"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Freshness Check Option"
+msgstr "Service Freshness Check Option"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/install/front_translate.php
+msgid "Service Group"
+msgstr "Service Group"
+
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/menu_translation.php
+msgid "Service Groups"
+msgstr "Service Groups"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Inter-Check Delay Method"
+msgstr "Service Inter-Check Delay Method"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Service Interleave Factor"
+msgstr "Service Interleave Factor"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "Service List"
+msgstr "Service List"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Service Notification Commands"
+msgstr "Service Notification Commands"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Service Notification Options"
+msgstr "Service Notification Options"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Service Notification Period"
+msgstr "Service Notification Period"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Service Notifications"
+msgstr "Service Notifications"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Service Problems"
+msgstr "Service Problems"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Service Resources"
+msgstr "Service Resources"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Service Scheduling Options"
+msgstr "Service Scheduling Options"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Service Shortcuts"
+msgstr "Service Shortcuts"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Service State"
+msgstr "Service State"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/install/smarty_translate.php
+msgid "Service Status"
+msgstr "Service Status"
+
+#: centreon/www/include/configuration/configKnowledge/search.php
+msgid "Service Template"
+msgstr "Service Template"
+
+#: centreon/www/install/menu_translation.php
+msgid "Service Templates"
+msgstr "Service Templates"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Service Trap Relation"
+msgstr "Service Trap Relation"
+
+#: centreon/www/install/front_translate.php
+msgid "Service category"
+msgstr "Service category"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Service category name already exists"
+msgstr "Service category name already exists"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Service check latency"
+msgstr "Service check latency"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Service dependency"
+msgstr "Service dependency"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+msgid "Service description cannot be empty"
+msgstr "Service description cannot be empty"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Service escalations"
+msgstr "Service escalations"
+
+#: centreon/www/install/front_translate.php
+msgid "Service graphs"
+msgstr "Service graphs"
+
+#: centreon/www/install/front_translate.php
+msgid "Service group"
+msgstr "Service group"
+
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+msgid "Service group state"
+msgstr "Service group state"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+msgid "Service groups"
+msgstr "Service groups"
+
+#: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
+msgid "Service id cannot be null"
+msgstr "Service id cannot be null"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Service is currently on Downtime"
+msgstr "Service is currently on Downtime"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+msgid "Service links (service template links)"
+msgstr "Service links (service template links)"
+
+#: centreon/www/install/front_translate.php
+msgid "Service name"
+msgstr "Service name"
+
+#: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+#: centreon/www/api/class/centreon_monitoring_externalcmd.class.php
+msgid "Service not found"
+msgstr "Service not found"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "Service notifications"
+msgstr "Service notifications"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Service severities"
+msgstr "Service severities"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/front_translate.php
+msgid "Service severity"
+msgstr "Service severity"
+
+#: centreon/www/install/front_translate.php
+msgid "Service severity level"
+msgstr "Service severity level"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Service severity name already exists"
+msgstr "Service severity name already exists"
+
+#: centreon/www/include/reporting/dashboard/viewServicesLog.php
+msgid "Service state"
+msgstr "Service state"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Service status"
+msgstr "Service status"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Service template"
+msgstr "Service template"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Acknowledge"
+msgstr "Service: Acknowledge"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Disable Check"
+msgstr "Service: Disable Check"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Disable Notification"
+msgstr "Service: Disable Notification"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Enable Check"
+msgstr "Service: Enable Check"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Enable Notification"
+msgstr "Service: Enable Notification"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Remove Acknowledgement"
+msgstr "Service: Remove Acknowledgement"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Schedule Immediate Check"
+msgstr "Service: Schedule Immediate Check"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Schedule Immediate Forced Check"
+msgstr "Service: Schedule Immediate Forced Check"
+
+#: centreon/www/widgets/service-monitoring/src/toolbar.php
+msgid "Service: Set Downtime"
+msgstr "Service: Set Downtime"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+msgid "ServiceGroup"
+msgstr "ServiceGroup"
+
+#: centreon/www/include/configuration/configKnowledge/search.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Servicegroup"
+msgstr "Servicegroup"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Servicegroup dependency"
+msgstr "Servicegroup dependency"
+
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Servicegroups"
+msgstr "Servicegroups"
+
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySGJS.php
+msgid "Servicegroups / Hosts"
+msgstr "Servicegroups / Hosts"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/global-health/src/global_health.php
+msgid "Services"
+msgstr "Services"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Services : Acknowledge"
+msgstr "Services : Acknowledge"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Services : Disable Check"
+msgstr "Services : Disable Check"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Services : Disable Notification"
+msgstr "Services : Disable Notification"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Services : Disacknowledge"
+msgstr "Services : Disacknowledge"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Services : Enable Check"
+msgstr "Services : Enable Check"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Services : Enable Notification"
+msgstr "Services : Enable Notification"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Services : Schedule immediate check"
+msgstr "Services : Schedule immediate check"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Services : Schedule immediate check (Forced)"
+msgstr "Services : Schedule immediate check (Forced)"
+
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Services : Set Downtime"
+msgstr "Services : Set Downtime"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Services Actions Access"
+msgstr "Services Actions Access"
+
+#: centreon/www/class/centreonGraphPoller.class.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+msgid "Services Actively Checked"
+msgstr "Services Actively Checked"
+
+#: centreon/www/include/monitoring/comments/listComment.php
+msgid "Services Comments"
+msgstr "Services Comments"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Services Downtimes"
+msgstr "Services Downtimes"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Services Escalation Options"
+msgstr "Services Escalation Options"
+
+#: centreon/www/install/menu_translation.php
+msgid "Services Grid"
+msgstr "Services Grid"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "Services Notification Period"
+msgstr "Services Notification Period"
+
+#: centreon/www/include/monitoring/status/HostGroups/hostGroupJS.php
+msgid "Services Status"
+msgstr "Services Status"
+
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+msgid "Services Templates"
+msgstr "Services Templates"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+msgid "Services Uses"
+msgstr "Services Uses"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "Services by Host"
+msgstr "Services by Host"
+
+#: centreon/www/install/menu_translation.php
+msgid "Services by Hostgroup"
+msgstr "Services by Hostgroup"
+
+#: centreon/www/install/menu_translation.php
+msgid "Services by Servicegroup"
+msgstr "Services by Servicegroup"
+
+#: centreon/www/install/menu_translation.php
+msgid "Services by host"
+msgstr "Services by host"
+
+#: centreon/www/install/menu_translation.php
+msgid "Services by host group"
+msgstr "Services by host group"
+
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHGJS.php
+msgid "Services information"
+msgstr "Services information"
+
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySGJS.php
+msgid "Services informations"
+msgstr "Services informations"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Services will not be affected because you don't have sufficient permission"
+msgstr ""
+"Services will not be affected because you don't have sufficient permission"
+
+#: centreon/www/api/class/centreon_keepalive.class.php
+msgid "Session is expired"
+msgstr "Session is expired"
+
+#: centreon/www/install/menu_translation.php
+msgid "Sessions"
+msgstr "Sessions"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Sessions Expiration Time"
+msgstr "Sessions Expiration Time"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Sessions Properties"
+msgstr "Sessions Properties"
+
+#: centreon/www/install/menu_translation.php
+msgid "Set Default"
+msgstr "Set Default"
+
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/host-monitoring/src/toolbar.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Set Downtime"
+msgstr "Set Downtime"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Set RRD Data Source Type to ABSOLUTE"
+msgstr "Set RRD Data Source Type to ABSOLUTE"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Set RRD Data Source Type to COUNTER"
+msgstr "Set RRD Data Source Type to COUNTER"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Set RRD Data Source Type to DERIVE"
+msgstr "Set RRD Data Source Type to DERIVE"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Set RRD Data Source Type to GAUGE"
+msgstr "Set RRD Data Source Type to GAUGE"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Set default"
+msgstr "Set default"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/install/front_translate.php
+msgid "Set downtime"
+msgstr "Set downtime"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Set downtime for hosts services"
+msgstr "Set downtime for hosts services"
+
+#: centreon/www/install/front_translate.php
+msgid "Set downtime on"
+msgstr "Set downtime on"
+
+#: centreon/www/install/front_translate.php
+msgid "Set downtime on services attached to host"
+msgstr "Set downtime on services attached to host"
+
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Set downtime on services of hosts"
+msgstr "Set downtime on services of hosts"
+
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "Set downtimes"
+msgstr "Set downtimes"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+msgid "Set downtimes on services attached to hosts"
+msgstr "Set downtimes on services attached to hosts"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step2.php
+#: centreon/www/install/step_upgrade/step2.php
+msgid "Set the default timezone in php.ini file"
+msgstr "Set the default timezone in php.ini file"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Set this view as your default view"
+msgstr "Set this view as your default view"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Set this view as your default view?"
+msgstr "Set this view as your default view?"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Setting up basic configuration"
+msgstr "Setting up basic configuration"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Setting up configuration file"
+msgstr "Setting up configuration file"
+
+#: centreon/www/install/front_translate.php
+msgid "Settings"
+msgstr "Settings"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/install/front_translate.php
+msgid "Severity"
+msgstr "Severity"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "Severity type"
+msgstr "Severity type"
+
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
+msgid "Share"
+msgstr "Share"
+
+#: centreon/www/install/menu_translation.php
+msgid "Share View"
+msgstr "Share View"
+
+#: centreon/www/install/front_translate.php
+msgid "Share the dashboard"
+msgstr "Share the dashboard"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Share view"
+msgstr "Share view"
+
+#: centreon/www/install/front_translate.php
+msgid "Share with"
+msgstr "Share with"
+
+#: centreon/www/install/front_translate.php
+msgid "Share with contacts"
+msgstr "Share with contacts"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Shared Resources"
+msgstr "Shared Resources"
+
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "Shared image folders"
+msgstr "Shared image folders"
+
+#: centreon/www/install/front_translate.php
+msgid "Shares"
+msgstr "Shares"
+
+#: centreon/www/install/front_translate.php
+msgid "Shares saved"
+msgstr "Shares saved"
+
+#: centreon/www/install/front_translate.php
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show"
+msgstr "Show"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show Critical status"
+msgstr "Show Critical status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show Down status"
+msgstr "Show Down status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show OK status"
+msgstr "Show OK status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show Unknown status"
+msgstr "Show Unknown status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show Unreachable status"
+msgstr "Show Unreachable status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show Up status"
+msgstr "Show Up status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Show Warning status"
+msgstr "Show Warning status"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show axis borders"
+msgstr "Show axis borders"
+
+#: centreon/www/install/front_translate.php
+msgid "Show criterias filters"
+msgstr "Show criterias filters"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show date"
+msgstr "Show date"
+
+#: centreon/www/install/front_translate.php
+msgid "Show description"
+msgstr "Show description"
+
+#: centreon/www/install/front_translate.php
+msgid "Show fewer filters"
+msgstr "Show fewer filters"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show gridlines"
+msgstr "Show gridlines"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show legend"
+msgstr "Show legend"
+
+#: centreon/www/install/front_translate.php
+msgid "Show more filters"
+msgstr "Show more filters"
+
+#: centreon/www/install/front_translate.php
+msgid "Show only dashboards added to favorites"
+msgstr "Show only dashboards added to favorites"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Show thresholds"
+msgstr "Show thresholds"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show time zone"
+msgstr "Show time zone"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show value label"
+msgstr "Show value label"
+
+#: centreon/www/install/front_translate.php
+msgid "Show value labels"
+msgstr "Show value labels"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Show value on chart"
+msgstr "Show value on chart"
+
+#: centreon/www/include/configuration/configKnowledge/search.php
+msgid "Show wiki pageless only"
+msgstr "Show wiki pageless only"
+
+#: centreon/www/include/configuration/configKnowledge/search.php
+msgid "Show wiki pageless only - inherited templates included"
+msgstr "Show wiki pageless only - inherited templates included"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Show/Hide edit mode"
+msgstr "Show/Hide edit mode"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Shutdown Monitoring Engine"
+msgstr "Shutdown Monitoring Engine"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Single metric"
+msgstr "Single metric"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Size to max"
+msgstr "Size to max"
+
+#: centreon/www/install/front_translate.php
+msgid "Slider"
+msgstr "Slider"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Smooth"
+msgstr "Smooth"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Snmp Traps"
+msgstr "Snmp Traps"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Snmp trap Groups"
+msgstr "Snmp trap Groups"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Snmp trap manufacturer"
+msgstr "Snmp trap manufacturer"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Soft"
+msgstr "Soft"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Soft Service Dependencies Option"
+msgstr "Soft Service Dependencies Option"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Solid"
+msgstr "Solid"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Some database poller updates are not active; check your configuration"
+msgstr "Some database poller updates are not active; check your configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Some examples:"
+msgstr "Some examples:"
+
+#: centreon/www/include/configuration/configObject/command/formArguments.php
+msgid "Sorry, your command line does not contain any $ARGn$ macro."
+msgstr "Sorry, your command line does not contain any $ARGn$ macro."
+
+#: centreon/www/include/configuration/configObject/command/formMacros.php
+msgid ""
+"Sorry, your command line does not contain any $_SERVICE$ macro or $_HOST$ "
+"macro."
+msgstr ""
+"Sorry, your command line does not contain any $_SERVICE$ macro or $_HOST$ "
+"macro."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Sort by"
+msgstr "Sort by"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Sort by  "
+msgstr "Sort by  "
+
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+msgid "Sort by Host Name"
+msgstr "Sort by Host Name"
+
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+msgid "Sort by Status"
+msgstr "Sort by Status"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by host name"
+msgstr "Sort by host name"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by last change date"
+msgstr "Sort by last change date"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by last check"
+msgstr "Sort by last check"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by last hard state change date"
+msgstr "Sort by last hard state change date"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by plugin output"
+msgstr "Sort by plugin output"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by retries number"
+msgstr "Sort by retries number"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by service description"
+msgstr "Sort by service description"
+
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by severity"
+msgstr "Sort by severity"
+
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort by status"
+msgstr "Sort by status"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Sort problems by"
+msgstr "Sort problems by"
+
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort results (ascendant)"
+msgstr "Sort results (ascendant)"
+
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+msgid "Sort results (descendant)"
+msgstr "Sort results (descendant)"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Sorting"
+msgstr "Sorting"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for Critical status"
+msgstr "Sound for Critical status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for Down status"
+msgstr "Sound for Down status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for OK status"
+msgstr "Sound for OK status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for Unknown status"
+msgstr "Sound for Unknown status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for Unreachable status"
+msgstr "Sound for Unreachable status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for Up status"
+msgstr "Sound for Up status"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Sound for Warning status"
+msgstr "Sound for Warning status"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Sound notifications"
+msgstr "Sound notifications"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Space"
+msgstr "Space"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Special Command"
+msgstr "Special Command"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Specific date"
+msgstr "Specific date"
+
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+msgid "Split Components"
+msgstr "Split Components"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Split chart"
+msgstr "Split chart"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Stack"
+msgstr "Stack"
+
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+msgid "Stacked"
+msgstr "Stacked"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Stacked bar"
+msgstr "Stacked bar"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Stacking"
+msgstr "Stacking"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Stalking Options"
+msgstr "Stalking Options"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateFactoryException.php
+#, php-format
+msgid "Stalking options not allowed (%s)"
+msgstr "Stalking options not allowed (%s)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Standard"
+msgstr "Standard"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Start"
+msgstr "Start"
+
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/install/smarty_translate.php
+msgid "Start Time"
+msgstr "Start Time"
+
+#: centreon/www/install/front_translate.php
+msgid "Start date"
+msgstr "Start date"
+
+#: centreon/www/install/front_translate.php
+msgid "Start time"
+msgstr "Start time"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Started"
+msgstr "Started"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "State"
+msgstr "State"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "State Breakdowns For Host Services"
+msgstr "State Breakdowns For Host Services"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "State Retention File"
+msgstr "State Retention File"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "State Retention Option"
+msgstr "State Retention Option"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "State Type"
+msgstr "State Type"
+
+#: centreon/www/install/front_translate.php
+msgid "State filter"
+msgstr "State filter"
+
+#: centreon/www/install/front_translate.php
+msgid "State information"
+msgstr "State information"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "States Retention"
+msgstr "States Retention"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Statistics"
+msgstr "Statistics"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
+#: centreon/www/install/step_upgrade/step4.php
+msgid "Status"
+msgstr "Status"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/menu_translation.php
+msgid "Status Details"
+msgstr "Status Details"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Status File Update Interval"
+msgstr "Status File Update Interval"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Status Graph"
+msgstr "Status Graph"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "Status Information"
+msgstr "Status Information"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Status Map Image"
+msgstr "Status Map Image"
+
+#: centreon/www/install/front_translate.php
+msgid "Status change percentage"
+msgstr "Status change percentage"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Status chart"
+msgstr "Status chart"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Status column"
+msgstr "Status column"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Status file"
+msgstr "Status file"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Status grid"
+msgstr "Status grid"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/install/front_translate.php
+msgid "Status information"
+msgstr "Status information"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Status naming"
+msgstr "Status naming"
+
+#: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResult.php
+#, php-format
+msgid "Status provided %d is invalid"
+msgstr "Status provided %d is invalid"
+
+#: centreon/www/install/front_translate.php
+msgid "Status submitted"
+msgstr "Status submitted"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Status timeseries"
+msgstr "Status timeseries"
+
+#: centreon/www/install/front_translate.php
+msgid "Status type"
+msgstr "Status type"
+
+#: centreon/www/install/front_translate.php
+msgid "Status:"
+msgstr "Status:"
+
+#: centreon/www/install/front_translate.php
+msgid "Stay"
+msgstr "Stay"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step4.php
+msgid "Step"
+msgstr "Step"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "Sticky"
+msgstr "Sticky"
+
+#: centreon/www/install/front_translate.php
+msgid "Sticky for any non-OK status"
+msgstr "Sticky for any non-OK status"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Stop hiding graphs of selected Services"
+msgstr "Stop hiding graphs of selected Services"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Stop rebuilding RRD Databases"
+msgstr "Stop rebuilding RRD Databases"
+
+#: centreon/www/install/front_translate.php
+msgid "Stop sharing"
+msgstr "Stop sharing"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Storage DB host"
+msgstr "Storage DB host"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Storage DB name"
+msgstr "Storage DB name"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Storage DB password"
+msgstr "Storage DB password"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Storage DB port"
+msgstr "Storage DB port"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Storage DB type"
+msgstr "Storage DB type"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Storage DB user"
+msgstr "Storage DB user"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Storage Type"
+msgstr "Storage Type"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Storage database"
+msgstr "Storage database"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Storage database name"
+msgstr "Storage database name"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+msgid "Storage folders"
+msgstr "Storage folders"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Storage near saturation"
+msgstr "Storage near saturation"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Store LDAP password"
+msgstr "Store LDAP password"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Store in performance data in data_bin"
+msgstr "Store in performance data in data_bin"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "String"
+msgstr "String"
+
+#: centreon/www/install/front_translate.php
+msgid "Strong"
+msgstr "Strong"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Style for average data"
+msgstr "Style for average data"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Sub input 1"
+msgstr "Sub input 1"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Sub input 2"
+msgstr "Sub input 2"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Sub input 3"
+msgstr "Sub input 3"
+
+#: centreon/www/install/front_translate.php
+msgid "Subject"
+msgstr "Subject"
+
+#: centreon/www/include/home/customViews/formLoad.php
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
+msgid "Submit"
+msgstr "Submit"
+
+#: centreon/www/install/front_translate.php
+msgid "Submit a status"
+msgstr "Submit a status"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Submit command?"
+msgstr "Submit command?"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Submit result"
+msgstr "Submit result"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Submit result for a host"
+msgstr "Submit result for a host"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "Submit result for a service"
+msgstr "Submit result for a service"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Submit result for this host"
+msgstr "Submit result for this host"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Submit result for this service"
+msgstr "Submit result for this service"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Success (OK)"
+msgstr "Success (OK)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Success (OK/Up)"
+msgstr "Success (OK/Up)"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+msgid "Sum"
+msgstr "Sum"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Summary"
+msgstr "Summary"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Sunday"
+msgstr "Sunday"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Support Information"
+msgstr "Support Information"
+
+#: centreon/www/install/front_translate.php
+msgid "Switch to graph mode"
+msgstr "Switch to graph mode"
+
+#: centreon/www/install/front_translate.php
+msgid "Switch to list mode"
+msgstr "Switch to list mode"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Synchronization Options"
+msgstr "Synchronization Options"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/options/session/connected_user.php
+msgid "Synchronize LDAP"
+msgstr "Synchronize LDAP"
+
+#: centreon/www/include/options/media/images/listImg.php
+msgid "Synchronize Media Directory"
+msgstr "Synchronize Media Directory"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Syslog"
+msgstr "Syslog"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Syslog Logging Option"
+msgstr "Syslog Logging Option"
+
+#: centreon/www/install/menu_translation.php
+msgid "System Logs"
+msgstr "System Logs"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/install/front_translate.php
+msgid "TLS"
+msgstr "TLS"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "TLS Host name"
+msgstr "TLS Host name"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "Tactical Overview"
+msgstr "Tactical Overview"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Tag"
+msgstr "Tag"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Template"
+msgstr "Template"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Template Name"
+msgstr "Template Name"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Template inheritance"
+msgstr "Template inheritance"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Template name is already in use"
+msgstr "Template name is already in use"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/install/menu_translation.php
+msgid "Templates"
+msgstr "Templates"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+msgid "Temporary directory"
+msgstr "Temporary directory"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Test Internet Connection"
+msgstr "Test Internet Connection"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Text"
+msgstr "Text"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+#, php-format
+msgid "The %s does not exist with ID(s) '%s'"
+msgstr "The %s does not exist with ID(s) '%s'"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+#, php-format
+msgid "The %s does not exist with id(s) '%s'"
+msgstr "The %s does not exist with id(s) '%s'"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+#, php-format
+msgid "The %s with value '%d' does not exist"
+msgstr "The %s with value '%d' does not exist"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+#, php-format
+msgid "The '%s' command name already exists"
+msgstr "The '%s' command name already exists"
+
+#: centreon/src/Centreon/Domain/Service/JsonValidator/Validator.php
+msgid "The JSON cannot be decoded"
+msgstr "The JSON cannot be decoded"
+
+#: centreon/www/install/step_upgrade/step4.php
+#, php-format
+msgid "The SQL files are located in \"%s\""
+msgstr "The SQL files are located in \"%s\""
+
+#: centreon/www/widgets/httploader/index.php
+msgid "The URL provided for the website does not use a valid URL pattern."
+msgstr "The URL provided for the website does not use a valid URL pattern."
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#, php-format
+msgid "The additional configuration name '%s' already exists"
+msgstr "The additional configuration name '%s' already exists"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
+#, php-format
+msgid "The address '%s' of '%s' is not valid or not resolvable"
+msgstr "The address '%s' of '%s' is not valid or not resolvable"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The address is already registered"
+msgstr "The address is already registered"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The address is already registered on another poller"
+msgstr "The address is already registered on another poller"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The address is incorrect"
+msgstr "The address is incorrect"
+
+#: centreon/www/install/front_translate.php
+msgid "The address is invalid"
+msgstr "The address is invalid"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "The check command cannot be null if the service template is null"
+msgstr "The check command cannot be null if the service template is null"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid ""
+"The chosen contact(s) will be disconnected. Do you confirm the LDAP "
+"synchronization request ?"
+msgstr ""
+"The chosen contact(s) will be disconnected. Do you confirm the LDAP "
+"synchronization request ?"
+
+#: centreon/src/Centreon/Domain/Entity/EntityCreator.php
+#, php-format
+msgid "The class %s does not exist"
+msgstr "The class %s does not exist"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The command format is invalid"
+msgstr "The command format is invalid"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+msgid "The contact alias is empty"
+msgstr "The contact alias is empty"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The contact groups [%s] are not in your contact groups"
+msgstr "The contact groups [%s] are not in your contact groups"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The contact groups [%s] do not exist"
+msgstr "The contact groups [%s] do not exist"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The contact groups [%s] do not have any dashboard Access rights"
+msgstr "The contact groups [%s] do not have any dashboard Access rights"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The contacts [%s] do not exist"
+msgstr "The contacts [%s] do not exist"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The contacts [%s] do not have any dashboard Access rights"
+msgstr "The contacts [%s] do not have any dashboard Access rights"
+
+#: centreon/www/install/front_translate.php
+msgid "The corresponding connectors will not work anymore."
+msgstr "The corresponding connectors will not work anymore."
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The dashboard [%d] does not exist"
+msgstr "The dashboard [%d] does not exist"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The dashboard [%d] is already set as favorite"
+msgstr "The dashboard [%d] is already set as favorite"
+
+#: centreon/www/install/front_translate.php
+msgid "The dashboard has been added to your favorites."
+msgstr "The dashboard has been added to your favorites."
+
+#: centreon/www/install/front_translate.php
+msgid "The dashboard has been removed from your favorites."
+msgstr "The dashboard has been removed from your favorites."
+
+#: centreon/www/install/front_translate.php
+msgid "The default value is the value defined for the first selected metric."
+msgstr "The default value is the value defined for the first selected metric."
+
+#: centreon/src/Centreon/Domain/Service/JsonValidator/Validator.php
+#, php-format
+msgid ""
+"The definition model \"%s\" to validate the JSON does not exist or is empty"
+msgstr ""
+"The definition model \"%s\" to validate the JSON does not exist or is empty"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#, php-format
+msgid "The description of service (id: %d) can not be empty"
+msgstr "The description of service (id: %d) can not be empty"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "The directory isn't valid"
+msgstr "The directory isn't valid"
+
+#: centreon/www/install/front_translate.php
+msgid "The duration must be less than a year"
+msgstr "The duration must be less than a year"
+
+#: centreon/www/install/front_translate.php
+msgid "The end date must be greater than the current date by at least one day"
+msgstr "The end date must be greater than the current date by at least one day"
+
+#: centreon/www/install/front_translate.php
+msgid "The end date must be greater than the start date"
+msgstr "The end date must be greater than the start date"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "The end time must be greater than the start time."
+msgstr "The end time must be greater than the start time."
+
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step1.php
+msgid "The entire process should take around ten minutes."
+msgstr "The entire process should take around ten minutes."
+
+#: centreon/www/install/react_translation.php
+msgid "The field is required"
+msgstr "The field is required"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+#, php-format
+msgid "The following arguments are not valid: %s"
+msgstr "The following arguments are not valid: %s"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+#, php-format
+msgid "The following bound attributes are missing: %s"
+msgstr "The following bound attributes are missing: %s"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+#, php-format
+msgid "The following macros are not valid: %s"
+msgstr "The following macros are not valid: %s"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"The following script will migrate all your credentials from Centreon, Auto-"
+"discovery and the database."
+msgstr ""
+"The following script will migrate all your credentials from Centreon, Auto-"
+"discovery and the database."
+
+#: centreon/www/include/common/common-Func.php
+#: centreon/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+msgid ""
+"The form has not been submitted since 15 minutes. Please retry to resubmit"
+msgstr ""
+"The form has not been submitted since 15 minutes. Please retry to resubmit"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"The form will be cleared and all data will be lost. Do you want to proceed?"
+msgstr ""
+"The form will be cleared and all data will be lost. Do you want to proceed?"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+#, php-format
+msgid "The host group icon '%s' with id '%d' does not exist"
+msgstr "The host group icon '%s' with id '%d' does not exist"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+#, php-format
+msgid "The host group name '%s' already exists"
+msgstr "The host group name '%s' already exists"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+msgid "The host id cannot be null"
+msgstr "The host id cannot be null"
+
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
+#, php-format
+msgid "The host of service (id: %d) is not defined"
+msgstr "The host of service (id: %d) is not defined"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+#, php-format
+msgid "The host severity icon with id '%d' does not exist"
+msgstr "The host severity icon with id '%d' does not exist"
+
+#: centreon/www/install/front_translate.php
+msgid "The message field should not be empty!"
+msgstr "The message field should not be empty!"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"The migration process can take several minutes depending on your "
+"configuration."
+msgstr ""
+"The migration process can take several minutes depending on your "
+"configuration."
+
+#: centreon/www/install/front_translate.php
+msgid "The min value must be lower than the max value."
+msgstr "The min value must be lower than the max value."
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "The minimum allowed value is 10"
+msgstr "The minimum allowed value is 10"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+#, php-format
+msgid "The name %s (original name: %s) already exists"
+msgstr "The name %s (original name: %s) already exists"
+
+#: centreon/www/install/front_translate.php
+msgid "The name can be at most 50 characters long"
+msgstr "The name can be at most 50 characters long"
+
+#: centreon/www/api/class/centreon_configuration_broker.class.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
+msgid "The name of block configuration"
+msgstr "The name of block configuration"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The name of the poller is mandatory"
+msgstr "The name of the poller is mandatory"
+
+#: centreon/www/install/front_translate.php
+msgid "The name of the vCenter should be unique"
+msgstr "The name of the vCenter should be unique"
+
+#: centreon/www/install/front_translate.php
+msgid "The name should be at least 3 characters long"
+msgstr "The name should be at least 3 characters long"
+
+#: centreon/www/install/front_translate.php
+msgid "The new password is the same as the old password"
+msgstr "The new password is the same as the old password"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "The notification configuration name already exists"
+msgstr "The notification configuration name already exists"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "The notification interval must be greater than or equal to 0"
+msgstr "The notification interval must be greater than or equal to 0"
+
+#: centreon/www/install/front_translate.php
+msgid "The notification was successfully added"
+msgstr "The notification was successfully added"
+
+#: centreon/www/install/front_translate.php
+msgid "The notification was successfully updated"
+msgstr "The notification was successfully updated"
+
+#: centreon/src/Core/TimePeriod/Domain/Exception/TimeRangeException.php
+msgid "The order of the time intervals is not consistent"
+msgstr "The order of the time intervals is not consistent"
+
+#: centreon/www/install/front_translate.php
+msgid "The page cannot be loaded"
+msgstr "The page cannot be loaded"
+
+#: centreon/src/Centreon/Domain/RequestParameters/RequestParametersException.php
+#, php-format
+msgid "The parameter \"%s\" must be an integer"
+msgstr "The parameter \"%s\" must be an integer"
+
+#: centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+#, php-format
+msgid "The parameter %s is not allowed"
+msgstr "The parameter %s is not allowed"
+
+#: centreon/www/include/Administration/parameters/DB-Func.php
+msgid "The password cannot be crypted. Please re-submit the form"
+msgstr "The password cannot be crypted. Please re-submit the form"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid ""
+"The password cannot be decrypted. Please re-enter the account password and "
+"submit the form"
+msgstr ""
+"The password cannot be decrypted. Please re-enter the account password and "
+"submit the form"
+
+#: centreon/src/Centreon/Infrastructure/Event/FileLoader.php
+msgid "The path does not exist"
+msgstr "The path does not exist"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The path format is invalid"
+msgstr "The path format is invalid"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "The platform '%s'@'%s' cannot be found on the Central"
+msgstr "The platform '%s'@'%s' cannot be found on the Central"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
+#: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
+#, php-format
+msgid "The platform type of '%s'@'%s' is not consistent"
+msgstr "The platform type of '%s'@'%s' is not consistent"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
+#, php-format
+msgid ""
+"The platform: '%s'@'%s' cannot be added to the Central linked to this Remote"
+msgstr ""
+"The platform: '%s'@'%s' cannot be added to the Central linked to this Remote"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
+#, php-format
+msgid "The platform: '%s'@'%s' cannot be delete from the Central"
+msgstr "The platform: '%s'@'%s' cannot be delete from the Central"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
+#, php-format
+msgid "The platform: '%s'@'%s' cannot be found on the Central"
+msgstr "The platform: '%s'@'%s' cannot be found on the Central"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "The platform: '%s'@'%s' is not declared as a 'remote'"
+msgstr "The platform: '%s'@'%s' is not declared as a 'remote'"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"The platform: '%s'@'%s' is not linked to a Central. Please use the wizard "
+"first"
+msgstr ""
+"The platform: '%s'@'%s' is not linked to a Central. Please use the wizard "
+"first"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "The poller/agent configuration name '%s' already exists"
+msgstr "The poller/agent configuration name '%s' already exists"
+
+#: centreon/src/Centreon/Domain/Proxy/Proxy.php
+#, php-format
+msgid "The port can only be between 0 and 65535 inclusive"
+msgstr "The port can only be between 0 and 65535 inclusive"
+
+#: centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+msgid "The property name of the normalizer cannot be empty."
+msgstr "The property name of the normalizer cannot be empty."
+
+#: centreon/src/Centreon/Domain/Entity/EntityCreator.php
+#, php-format
+msgid "The public method %s::%s has no parameters"
+msgstr "The public method %s::%s has no parameters"
+
+#: centreon/src/Centreon/Domain/Entity/EntityCreator.php
+#, php-format
+msgid "The public method %s::%s was not found"
+msgstr "The public method %s::%s was not found"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid ""
+"The related host no longer exists in Centreon configuration. Please reload "
+"the configuration."
+msgstr ""
+"The related host no longer exists in Centreon configuration. Please reload "
+"the configuration."
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "The request for roles mapping on custom endpoint has failed"
+msgstr "The request for roles mapping on custom endpoint has failed"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Domain/Exception/ConfigurationException.php
+msgid ""
+"The requested_authn_context_comparison value is missing but is required when "
+"requested_authn_context is set to true"
+msgstr ""
+"The requested_authn_context_comparison value is missing but is required when "
+"requested_authn_context is set to true"
+
+#: centreon/www/install/front_translate.php
+msgid "The resource access rule has been successfully deleted"
+msgstr "The resource access rule has been successfully deleted"
+
+#: centreon/www/install/front_translate.php
+msgid "The resource access rule has been successfully duplicated"
+msgstr "The resource access rule has been successfully duplicated"
+
+#: centreon/www/install/front_translate.php
+msgid "The resource access rule was successfully created"
+msgstr "The resource access rule was successfully created"
+
+#: centreon/www/install/front_translate.php
+msgid "The resource access rule was successfully updated"
+msgstr "The resource access rule was successfully updated"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The script path is invalid"
+msgstr "The script path is invalid"
+
+#: centreon/www/include/configuration/configObject/service/DB-Func.php
+msgid ""
+"The selected inherited service template does not contain any check command. "
+"You must select one here."
+msgstr ""
+"The selected inherited service template does not contain any check command. "
+"You must select one here."
+
+#: centreon/www/install/front_translate.php
+msgid "The selected notifications have been deleted successfully"
+msgstr "The selected notifications have been deleted successfully"
+
+#: centreon/www/install/front_translate.php
+msgid "The selected resource access rules have been deleted successfully"
+msgstr "The selected resource access rules have been deleted successfully"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "The selected template has the same time period as a template"
+msgstr "The selected template has the same time period as a template"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid ""
+"The server type '%s' : '%s'@'%s' does not match the one configured in "
+"Centreon or is disabled"
+msgstr ""
+"The server type '%s' : '%s'@'%s' does not match the one configured in "
+"Centreon or is disabled"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+#, php-format
+msgid "The service group name '%s' already exists"
+msgstr "The service group name '%s' already exists"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+#, php-format
+msgid "The service severity icon with id '%d' does not exist"
+msgstr "The service severity icon with id '%d' does not exist"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+#, php-format
+msgid "The service template '%s' is locked and cannot be deleted"
+msgstr "The service template '%s' is locked and cannot be deleted"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+#, php-format
+msgid "The service template name '%s' already exists"
+msgstr "The service template name '%s' already exists"
+
+#: centreon/www/install/front_translate.php
+msgid "The share list is empty"
+msgstr "The share list is empty"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The thumbnail provided for dashboard [%d] was not found"
+msgstr "The thumbnail provided for dashboard [%d] was not found"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"The ticket with ID #{{id}} will be closed for the selected ticket provider."
+msgstr ""
+"The ticket with ID #{{id}} will be closed for the selected ticket provider."
+
+#: centreon/www/install/front_translate.php
+msgid "The time period field should not be empty!"
+msgstr "The time period field should not be empty!"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+#, php-format
+msgid "The time period name '%s' already exists"
+msgstr "The time period name '%s' already exists"
+
+#: centreon/src/Core/TimePeriod/Domain/Exception/TimeRangeException.php
+#, php-format
+msgid "The time range format is wrong (%s)"
+msgstr "The time range format is wrong (%s)"
+
+#: centreon/src/Core/Common/Infrastructure/Command/Exception/MigrationCommandException.php
+msgid "The token cannot be empty"
+msgstr "The token cannot be empty"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+#, php-format
+msgid "The token name '%s' already exists"
+msgstr "The token name '%s' already exists"
+
+#: centreon/www/api/class/centreon_configuration_broker.class.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
+msgid "The type of block configuration"
+msgstr "The type of block configuration"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+#, php-format
+msgid "The user with ID %d doesn't exist"
+msgstr "The user with ID %d doesn't exist"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "The user(s) will be unblocked. Do you confirm the request?"
+msgstr "The user(s) will be unblocked. Do you confirm the request?"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The users [%s] are not in your access groups"
+msgstr "The users [%s] are not in your access groups"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The users [%s] are not in your contact groups"
+msgstr "The users [%s] are not in your contact groups"
+
+#: centreon/src/Centreon/Application/Validation/CentreonValidatorFactory.php
+#, php-format
+msgid "The validator \"%s\" is not found"
+msgstr "The validator \"%s\" is not found"
+
+#: centreon/src/Centreon/Domain/Entity/EntityCreator.php
+msgid "The value cannot be null"
+msgstr "The value cannot be null"
+
+#: centreon/www/install/front_translate.php
+msgid "The widget will be permanently deleted."
+msgstr "The widget will be permanently deleted."
+
+#: centreon/www/install/front_translate.php
+msgid "The {{name}} additional configuration will be permanently deleted."
+msgstr "The {{name}} additional configuration will be permanently deleted."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"The {{name}} dashboard is part of one or several playlists. It will be "
+"permanently deleted from any playlists it belongs to."
+msgstr ""
+"The {{name}} dashboard is part of one or several playlists. It will be "
+"permanently deleted from any playlists it belongs to."
+
+#: centreon/www/install/front_translate.php
+msgid "The {{name}} dashboard will be permanently deleted."
+msgstr "The {{name}} dashboard will be permanently deleted."
+
+#: centreon/www/install/front_translate.php
+msgid "The {{name}} widget will be permanently deleted."
+msgstr "The {{name}} widget will be permanently deleted."
+
+#: centreon/src/Centreon/Infrastructure/Serializer/Exception/SerializerException.php
+#, php-format
+msgid "There are not enough arguments to build the object %s"
+msgstr "There are not enough arguments to build the object %s"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "These time periods are defined in MBI'S ETL options."
+msgstr "These time periods are defined in MBI'S ETL options."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"They will be permanently deleted and users will no longer have these "
+"permissions."
+msgstr ""
+"They will be permanently deleted and users will no longer have these "
+"permissions."
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+msgid "Thickness"
+msgstr "Thickness"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+msgid "Third of month"
+msgstr "Third of month"
+
+#: centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+msgid "This IP Address already exist"
+msgstr "This IP Address already exist"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "This Month"
+msgstr "This Month"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "This SNMP version (%s) is not allowed"
+msgstr "This SNMP version (%s) is not allowed"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This Service is flapping"
+msgstr "This Service is flapping"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "This Week"
+msgstr "This Week"
+
+#: centreon/www/include/reporting/dashboard/common-Func.php
+msgid "This Year"
+msgstr "This Year"
+
+#: centreon/www/install/front_translate.php
+msgid "This action cannot be undone."
+msgstr "This action cannot be undone."
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "This active checks status (%d) is not allowed"
+msgstr "This active checks status (%d) is not allowed"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid ""
+"This description is in conflict with another one that is already defined in "
+"the selected relation(s)"
+msgstr ""
+"This description is in conflict with another one that is already defined in "
+"the selected relation(s)"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "This directive can be used multiple times, see nagios documentation."
+msgstr "This directive can be used multiple times, see nagios documentation."
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This host is never checked"
+msgstr "This host is never checked"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Host.php
+msgid "This host is not a host template"
+msgstr "This host is not a host template"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This host is only checked in passive mode"
+msgstr "This host is only checked in passive mode"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid ""
+"This host no longer exists in Centreon configuration. Please reload the "
+"configuration."
+msgstr ""
+"This host no longer exists in Centreon configuration. Please reload the "
+"configuration."
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"This installer will help you setup your database and your monitoring "
+"configuration."
+msgstr ""
+"This installer will help you setup your database and your monitoring "
+"configuration."
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+msgid "This is a contact template."
+msgstr "This is a contact template."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "This is the description of the data widget"
+msgstr "This is the description of the data widget"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "This is the description of the generic input widget"
+msgstr "This is the description of the generic input widget"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "This is the description of the text widget"
+msgstr "This is the description of the text widget"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"This is the most common case: the agent initiates the connection to the "
+"poller."
+msgstr ""
+"This is the most common case: the agent initiates the connection to the "
+"poller."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "This month"
+msgstr "This month"
+
+#: centreon/www/install/front_translate.php
+msgid "This name already exists"
+msgstr "This name already exists"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "This notifications status (%d) is not allowed"
+msgstr "This notifications status (%d) is not allowed"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "This operation requires an admin user"
+msgstr "This operation requires an admin user"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "This option must be disable in order to avoid latency problem."
+msgstr "This option must be disable in order to avoid latency problem."
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "This option must be enabled for Centreon Dashboard module."
+msgstr "This option must be enabled for Centreon Dashboard module."
+
+#: centreon/www/install/front_translate.php
+msgid "This page could not be found"
+msgstr "This page could not be found"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
+#, php-format
+msgid "This passive checks status (%d) is not allowed"
+msgstr "This passive checks status (%d) is not allowed"
+
+#: centreon/www/install/front_translate.php
+msgid "This resource is flapping"
+msgstr "This resource is flapping"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"This search bar will search matching occurences you type, contained in: host "
+"name or alias or address or service description"
+msgstr ""
+"This search bar will search matching occurences you type, contained in: host "
+"name or alias or address or service description"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"This section allows you to give authorizations in order to link an imported "
+"user to an access group."
+msgstr ""
+"This section allows you to give authorizations in order to link an imported "
+"user to an access group."
+
+#: centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+msgid "This server is already registered"
+msgstr "This server is already registered"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This service is neither active nor passive"
+msgstr "This service is neither active nor passive"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This service is only checked in passive mode"
+msgstr "This service is only checked in passive mode"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "This user is a simple user."
+msgstr "This user is a simple user."
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "This user is an administrator."
+msgstr "This user is an administrator."
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "This user isn't linked to a LDAP"
+msgstr "This user isn't linked to a LDAP"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+msgid "This value must be a numerical value."
+msgstr "This value must be a numerical value."
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "This value needs to be an integer lesser than"
+msgstr "This value needs to be an integer lesser than"
+
+#: centreon/www/install/smarty_translate.php
+msgid "This view name is required"
+msgstr "This view name is required"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "This week"
+msgstr "This week"
+
+#: centreon/www/install/front_translate.php
+msgid "This will export and reload the configuration on all of your platform"
+msgstr "This will export and reload the configuration on all of your platform"
+
+#: centreon/www/install/front_translate.php
+msgid "This will not be used because the number of attempts is not defined"
+msgstr "This will not be used because the number of attempts is not defined"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "This year"
+msgstr "This year"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Three columns"
+msgstr "Three columns"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Thresholds"
+msgstr "Thresholds"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Thresholds are automatically hidden when you select several metrics with "
+"different units."
+msgstr ""
+"Thresholds are automatically hidden when you select several metrics with "
+"different units."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Thumbnails show a snapshot of your data, taken when the dashboard is saved"
+msgstr ""
+"Thumbnails show a snapshot of your data, taken when the dashboard is saved"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Thursday"
+msgstr "Thursday"
+
+#: centreon/www/install/front_translate.php
+msgid "Ticket ID"
+msgstr "Ticket ID"
+
+#: centreon/www/install/front_translate.php
+msgid "Ticket closed"
+msgstr "Ticket closed"
+
+#: centreon/www/install/front_translate.php
+msgid "Ticket created"
+msgstr "Ticket created"
+
+#: centreon/www/install/front_translate.php
+msgid "Ticket subject"
+msgstr "Ticket subject"
+
+#: centreon/www/install/front_translate.php
+msgid "Tickets"
+msgstr "Tickets"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+msgid "Time"
+msgstr "Time"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Time Period Name"
+msgstr "Time Period Name"
+
+#: centreon/www/install/menu_translation.php
+msgid "Time Periods"
+msgstr "Time Periods"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Time Range"
+msgstr "Time Range"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Time Range Exceptions"
+msgstr "Time Range Exceptions"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Time Range exceptions"
+msgstr "Time Range exceptions"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Time Unit"
+msgstr "Time Unit"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Time Zone"
+msgstr "Time Zone"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Time format"
+msgstr "Time format"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/front_translate.php
+msgid "Time period"
+msgstr "Time period"
+
+#: centreon/www/install/front_translate.php
+msgid "Time that must pass before new connection is allowed"
+msgstr "Time that must pass before new connection is allowed"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Time zone"
+msgstr "Time zone"
+
+#: centreon/www/install/front_translate.php
+msgid "Timeline"
+msgstr "Timeline"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Timeout"
+msgstr "Timeout"
+
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+msgid "Timeout value for Gorgone commands"
+msgstr "Timeout value for Gorgone commands"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Timeouts"
+msgstr "Timeouts"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Timeperiod"
+msgstr "Timeperiod"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Timeperiod Alias"
+msgstr "Timeperiod Alias"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Timeperiod Name"
+msgstr "Timeperiod Name"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "Timeperiod templates"
+msgstr "Timeperiod templates"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Timeperiods"
+msgstr "Timeperiods"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Timer"
+msgstr "Timer"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Timerange Overlaps"
+msgstr "Timerange Overlaps"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Timezone"
+msgstr "Timezone"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Timezone / Location"
+msgstr "Timezone / Location"
+
+#: centreon/www/install/front_translate.php
+msgid "Tips"
+msgstr "Tips"
+
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
+msgid "Title"
+msgstr "Title"
+
+#: centreon/www/class/centreonWidget/Params/Date.class.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "To"
+msgstr "To"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "To manually request a LDAP synchronization of a contact"
+msgstr "To manually request a LDAP synchronization of a contact"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid ""
+"To use additional Remote Servers a Master Remote Server must be selected."
+msgstr ""
+"To use additional Remote Servers a Master Remote Server must be selected."
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/install/front_translate.php
+msgid "Today"
+msgstr "Today"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Today's Host log"
+msgstr "Today's Host log"
+
+#: centreon/www/install/front_translate.php
+msgid "Token"
+msgstr "Token"
+
+#: centreon/www/install/front_translate.php
+msgid "Token could not be copied"
+msgstr "Token could not be copied"
+
+#: centreon/www/install/front_translate.php
+msgid "Token deleted"
+msgstr "Token deleted"
+
+#: centreon/www/install/front_translate.php
+msgid "Token disabled"
+msgstr "Token disabled"
+
+#: centreon/www/install/front_translate.php
+msgid "Token enabled"
+msgstr "Token enabled"
+
+#: centreon/www/install/front_translate.php
+msgid "Token endpoint"
+msgstr "Token endpoint"
+
+#: centreon/www/install/front_translate.php
+msgid "Token has been created"
+msgstr "Token has been created"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "Token not found"
+msgstr "Token not found"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "Token with name \"%s\" and creator ID \"%d\" is not valid"
+msgstr "Token with name \"%s\" and creator ID \"%d\" is not valid"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Tokens are mandatory"
+msgstr "Tokens are mandatory"
+
+#: centreon/www/install/front_translate.php
+msgid "Too many elements to be displayed (>{{graphsCapNumber}})"
+msgstr "Too many elements to be displayed (>{{graphsCapNumber}})"
+
+#: centreon/www/include/views/graphs/graphs.php
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr "Too many metrics (X). More than 20 may cause performance issues."
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "Tools"
+msgstr "Tools"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Tooltips"
+msgstr "Tooltips"
+
+#: centreon/www/install/front_translate.php
+msgid "Top"
+msgstr "Top"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Top Bottom Settings"
+msgstr "Top Bottom Settings"
+
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+msgid "Top Priority Hosts"
+msgstr "Top Priority Hosts"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Top/bottom"
+msgstr "Top/bottom"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Topology"
+msgstr "Topology"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Total"
+msgstr "Total"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Total Time"
+msgstr "Total Time"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Total size"
+msgstr "Total size"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Trace"
+msgstr "Trace"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Transaction commit timeout"
+msgstr "Transaction commit timeout"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+msgid "Transparency"
+msgstr "Transparency"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Transport protocol"
+msgstr "Transport protocol"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Trap description"
+msgstr "Trap description"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Trap name"
+msgstr "Trap name"
+
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+msgid "Traps"
+msgstr "Traps"
+
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/install/front_translate.php
+msgid "Tries"
+msgstr "Tries"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "True Regular Expression Matching Option"
+msgstr "True Regular Expression Matching Option"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Trusted CA"
+msgstr "Trusted CA"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Trusted CA's certificate path (optional)"
+msgstr "Trusted CA's certificate path (optional)"
+
+#: centreon/www/install/front_translate.php
+msgid "Trusted client addresses"
+msgstr "Trusted client addresses"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Tuesday"
+msgstr "Tuesday"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Tuning"
+msgstr "Tuning"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Two columns"
+msgstr "Two columns"
+
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Type"
+msgstr "Type"
+
+#: centreon/src/Centreon/Domain/ActionLog/ActionLog.php
+msgid "Type of action not recognized"
+msgstr "Type of action not recognized"
+
+#: centreon/www/install/front_translate.php
+msgid "Type of resource"
+msgstr "Type of resource"
+
+#: centreon/www/install/front_translate.php
+msgid "Type your text here"
+msgstr "Type your text here"
+
+#: centreon/www/install/front_translate.php
+msgid "Types"
+msgstr "Types"
+
+#: centreon/www/install/smarty_translate.php
+msgid "UI Notifications"
+msgstr "UI Notifications"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "UNDETERMINED"
+msgstr "UNDETERMINED"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "UNKNOWN"
+msgstr "UNKNOWN"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "UNREACHABLE"
+msgstr "UNREACHABLE"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "UP"
+msgstr "UP"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "URL"
+msgstr "URL"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "URL Notes"
+msgstr "URL Notes"
+
+#: centreon/www/install/front_translate.php
+msgid "Unable to copy the link"
+msgstr "Unable to copy the link"
+
+#: centreon/src/Centreon/Infrastructure/PlatformInformation/Repository/Model/PlatformInformationFactoryRDB.php
+msgid ""
+"Unable to decipher central's credentials. Please check the credentials in "
+"the 'Remote Access' form"
+msgstr ""
+"Unable to decipher central's credentials. Please check the credentials in "
+"the 'Remote Access' form"
+
+#: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+msgid "Unable to decode Central's API response"
+msgstr "Unable to decode Central's API response"
+
+#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+#, php-format
+msgid "Unable to find host by service id %d"
+msgstr "Unable to find host by service id %d"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "Unable to find local monitoring server name"
+msgstr "Unable to find local monitoring server name"
+
+#: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+#, php-format
+msgid "Unable to find the Engine configuration"
+msgstr "Unable to find the Engine configuration"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
+#: centreon/src/Centreon/Infrastructure/PlatformInformation/Repository/Model/PlatformInformationFactoryRDB.php
+msgid "Unable to find the encryption key."
+msgstr "Unable to find the encryption key."
+
+#: centreon/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
+#: centreon/src/Core/Application/RealTime/UseCase/FindService/FindService.php
+#, php-format
+msgid "Unable to hide passwords in command (Reason: %s)"
+msgstr "Unable to hide passwords in command (Reason: %s)"
+
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
+#, php-format
+msgid "Unable to link a 'remote': '%s'@'%s' to another remote platform"
+msgstr "Unable to link a 'remote': '%s'@'%s' to another remote platform"
+
+#: centreon/www/include/configuration/configGenerate/xml/generateFiles.php
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+#: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+msgid "Unable to load the Symfony container"
+msgstr "Unable to load the Symfony container"
+
+#: centreon/src/Core/Security/Vault/Application/Exceptions/VaultException.php
+msgid "Unable to migrate passwords"
+msgstr "Unable to migrate passwords"
+
+#: centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/Factory/OpenIdProviderDtoFactory.php
+msgid "Unable to parse authorization url"
+msgstr "Unable to parse authorization url"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/PlatformInformationService.php
+msgid "Unable to retrieve platform information's data."
+msgstr "Unable to retrieve platform information's data."
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "Unauthorized value"
+msgstr "Unauthorized value"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "Unblock"
+msgstr "Unblock"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Undefined (Unreachable/Unknown)"
+msgstr "Undefined (Unreachable/Unknown)"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+msgid "Undetermined"
+msgstr "Undetermined"
+
+#: centreon/www/install/front_translate.php
+msgid "Undo"
+msgstr "Undo"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Unhandled"
+msgstr "Unhandled"
+
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid "Unhandled Problems"
+msgstr "Unhandled Problems"
+
+#: centreon/www/install/front_translate.php
+msgid "Unhandled alerts"
+msgstr "Unhandled alerts"
+
+#: centreon/www/install/front_translate.php
+msgid "Uninstalled"
+msgstr "Uninstalled"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "Unique"
+msgstr "Unique"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Unit"
+msgstr "Unit"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/front_translate.php
+msgid "Unknown"
+msgstr "Unknown"
+
+#: centreon/www/install/react_translation.php
+msgid "Unknown services"
+msgstr "Unknown services"
+
+#: centreon/www/install/front_translate.php
+msgid "Unknown status services"
+msgstr "Unknown status services"
+
+#: centreon/src/Centreon/Domain/Monitoring/MetaService/Exception/MetaServiceMetricException.php
+#, php-format
+msgid "Unkown meta metrics selection mode provided for %d"
+msgstr "Unkown meta metrics selection mode provided for %d"
+
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+msgid "Unlock Services"
+msgstr "Unlock Services"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Unlocked user groups"
+msgstr "Unlocked user groups"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Unlocked users"
+msgstr "Unlocked users"
+
+#: centreon/www/install/front_translate.php
+msgid "Unordered List"
+msgstr "Unordered List"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/install/front_translate.php
+msgid "Unreachable"
+msgstr "Unreachable"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Unreachable Alert"
+msgstr "Unreachable Alert"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Unreachable Mean Time"
+msgstr "Unreachable Mean Time"
+
+#: centreon/www/install/front_translate.php
+msgid "Unreachable status hosts"
+msgstr "Unreachable status hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Unselect all"
+msgstr "Unselect all"
+
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+msgid "Unset Timerange"
+msgstr "Unset Timerange"
+
+#: centreon/www/install/front_translate.php
+msgid "Until"
+msgstr "Until"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/install/front_translate.php
+msgid "Up"
+msgstr "Up"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Up Alert"
+msgstr "Up Alert"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+msgid "Up Mean Time"
+msgstr "Up Mean Time"
+
+#: centreon/www/install/front_translate.php
+msgid "Up status hosts"
+msgstr "Up status hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "Up to date"
+msgstr "Up to date"
+
+#: centreon/www/install/front_translate.php
+msgid "Update"
+msgstr "Update"
+
+#: centreon/www/install/front_translate.php
+msgid "Update agent configuration"
+msgstr "Update agent configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Update all"
+msgstr "Update all"
+
+#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
+msgid "Update already in progress"
+msgstr "Update already in progress"
+
+#: centreon/www/install/front_translate.php
+msgid "Update dashboard"
+msgstr "Update dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Update filter"
+msgstr "Update filter"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "Update mode"
+msgstr "Update mode"
+
+#: centreon/www/install/front_translate.php
+msgid "Updated"
+msgstr "Updated"
+
+#: centreon/www/install/front_translate.php
+msgid "Updated by"
+msgstr "Updated by"
+
+#: centreon/www/install/step_upgrade/step5.php
+msgid "Upgrade finished"
+msgstr "Upgrade finished"
+
+#: centreon/www/install/step_upgrade/step4.php
+msgid "Upgrade to this release requires Centreon >= 2.8.0-beta1."
+msgstr "Upgrade to this release requires Centreon >= 2.8.0-beta1."
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Upper Limit"
+msgstr "Upper Limit"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid "Uptime"
+msgstr "Uptime"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Use Retained Program State Option"
+msgstr "Use Retained Program State Option"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Use Retained Scheduling Info Option"
+msgstr "Use Retained Scheduling Info Option"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+msgid "Use SSL/TLS"
+msgstr "Use SSL/TLS"
+
+#: centreon/www/install/front_translate.php
+msgid "Use basic authentication for token endpoint authentication"
+msgstr "Use basic authentication for token endpoint authentication"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Use deprecated custom views"
+msgstr "Use deprecated custom views"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Use deprecated monitoring pages"
+msgstr "Use deprecated monitoring pages"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "Use service DNS"
+msgstr "Use service DNS"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "Use the Remote Server as a proxy"
+msgstr "Use the Remote Server as a proxy"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "Used by command"
+msgstr "Used by command"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/install/front_translate.php
+msgid "User"
+msgstr "User"
+
+#: centreon/www/install/front_translate.php
+msgid "User ID (login) attribute for Centreon user"
+msgstr "User ID (login) attribute for Centreon user"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "User cannot be logout"
+msgstr "User cannot be logout"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "User cannot be retrieved from the provider"
+msgstr "User cannot be retrieved from the provider"
+
+#: centreon/www/install/front_translate.php
+msgid "User deleted"
+msgstr "User deleted"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "User disconnected"
+msgstr "User disconnected"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User displayname attribute"
+msgstr "User displayname attribute"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User email attribute"
+msgstr "User email attribute"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User filter"
+msgstr "User filter"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User firstname attribute"
+msgstr "User firstname attribute"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User group attribute"
+msgstr "User group attribute"
+
+#: centreon/www/install/front_translate.php
+msgid "User information"
+msgstr "User information"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "User information cannot be updated"
+msgstr "User information cannot be updated"
+
+#: centreon/www/install/front_translate.php
+msgid "User information endpoint"
+msgstr "User information endpoint"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "User is not allowed to reach web application"
+msgstr "User is not allowed to reach web application"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User lastname attribute"
+msgstr "User lastname attribute"
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "User not found and cannot be created"
+msgstr "User not found and cannot be created"
+
+#: centreon/www/include/Administration/parameters/ldap/form.php
+msgid "User pager attribute"
+msgstr "User pager attribute"
+
+#: centreon/www/install/front_translate.php
+msgid "User rights"
+msgstr "User rights"
+
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/install/front_translate.php
+msgid "Username"
+msgstr "Username"
+
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/options/session/connected_user.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Users"
+msgstr "Users"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid ""
+"Using a Template Model allows you to have multi-level Template connections"
+msgstr ""
+"Using a Template Model allows you to have multi-level Template connections"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "Using a Template allows you to have multi-level Template connection"
+msgstr "Using a Template allows you to have multi-level Template connection"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "Using a Template exempts you to fill required fields"
+msgstr "Using a Template exempts you to fill required fields"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "V1 (legacy, with epoch timestamps)"
+msgstr "V1 (legacy, with epoch timestamps)"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "V2 (ISO-8601, with log level fine tuning)"
+msgstr "V2 (ISO-8601, with log level fine tuning)"
+
+#: centreon/www/install/smarty_translate.php
+msgid "VAULT INFORMATION"
+msgstr "VAULT INFORMATION"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Valid Email"
+msgstr "Valid Email"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/install/front_translate.php
+msgid "Value"
+msgstr "Value"
+
+#: centreon/www/install/front_translate.php
+msgid "Value defined by the {{metric}} metric"
+msgstr "Value defined by the {{metric}} metric"
+
+#: centreon/www/install/front_translate.php
+msgid "Value defined by {{metric}} metric"
+msgstr "Value defined by {{metric}} metric"
+
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Value format"
+msgstr "Value format"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Value must be a positive numeric"
+msgstr "Value must be a positive numeric"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Value must be numeric"
+msgstr "Value must be numeric"
+
+#: centreon/www/install/front_translate.php
+msgid "Value settings"
+msgstr "Value settings"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Value sort order"
+msgstr "Value sort order"
+
+#: centreon/www/include/configuration/configResources/listResources.php
+msgid "Values"
+msgstr "Values"
+
+#: centreon/www/install/menu_translation.php
+msgid "Vault"
+msgstr "Vault"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Vault Address"
+msgstr "Vault Address"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Vault Port (default: 443)"
+msgstr "Vault Port (default: 443)"
+
+#: centreon/www/install/front_translate.php
+msgid "Vault address"
+msgstr "Vault address"
+
+#: centreon/www/install/front_translate.php
+msgid "Vault configuration"
+msgstr "Vault configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Vault configuration updated"
+msgstr "Vault configuration updated"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step6Vault.php
+msgid "Vault information"
+msgstr "Vault information"
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+msgid "Vendor Name"
+msgstr "Vendor Name"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Verification Check"
+msgstr "Verification Check"
+
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+msgid "Verification Check (Forced)"
+msgstr "Verification Check (Forced)"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/install/smarty_translate.php
+msgid "Version"
+msgstr "Version"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Vertical"
+msgstr "Vertical"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Vertical Inheritance Only"
+msgstr "Vertical Inheritance Only"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Vertical Label"
+msgstr "Vertical Label"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Vertical bar chart"
+msgstr "Vertical bar chart"
+
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+msgid "View"
+msgstr "View"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"View\n"
+"                    History"
+msgstr ""
+"View\n"
+"                    History"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"View\n"
+"                    history"
+msgstr ""
+"View\n"
+"                    history"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "View Data Processing"
+msgstr "View Data Processing"
+
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+msgid "View Group"
+msgstr "View Group"
+
+#: centreon/www/include/options/media/images/formImg.php
+msgid "View Image"
+msgstr "View Image"
+
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+msgid "View Vendor"
+msgstr "View Vendor"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "View a  host category"
+msgstr "View a  host category"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "View a Centreon-Broker Configuration"
+msgstr "View a Centreon-Broker Configuration"
+
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+msgid "View a Command"
+msgstr "View a Command"
+
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+msgid "View a Connector"
+msgstr "View a Connector"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "View a Contact Group"
+msgstr "View a Contact Group"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "View a Data Source Template"
+msgstr "View a Data Source Template"
+
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+msgid "View a Dependency"
+msgstr "View a Dependency"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "View a Graph Template"
+msgstr "View a Graph Template"
+
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+msgid "View a Group"
+msgstr "View a Group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "View a Host"
+msgstr "View a Host"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "View a Host Extended Info"
+msgstr "View a Host Extended Info"
+
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+msgid "View a Host Template"
+msgstr "View a Host Template"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+msgid "View a Meta Service"
+msgstr "View a Meta Service"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "View a Monitoring Engine Configuration File"
+msgstr "View a Monitoring Engine Configuration File"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "View a Service"
+msgstr "View a Service"
+
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "View a Service Category"
+msgstr "View a Service Category"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "View a Service Group"
+msgstr "View a Service Group"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "View a Service Template Model"
+msgstr "View a Service Template Model"
+
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+msgid "View a Time Period"
+msgstr "View a Time Period"
+
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+msgid "View a Trap definition"
+msgstr "View a Trap definition"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "View a User"
+msgstr "View a User"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "View a User Template"
+msgstr "View a User Template"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "View a Virtual Metric"
+msgstr "View a Virtual Metric"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "View a downtime"
+msgstr "View a downtime"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "View a poller Configuration"
+msgstr "View a poller Configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "View all resources"
+msgstr "View all resources"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+msgid "View an ACL"
+msgstr "View an ACL"
+
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+msgid "View an Action"
+msgstr "View an Action"
+
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+msgid "View an Escalation"
+msgstr "View an Escalation"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "View an Extended Info"
+msgstr "View an Extended Info"
+
+#: centreon/www/install/front_translate.php
+msgid "View as cards"
+msgstr "View as cards"
+
+#: centreon/www/install/front_translate.php
+msgid "View as list"
+msgstr "View as list"
+
+#: centreon/www/install/front_translate.php
+msgid "View by host"
+msgstr "View by host"
+
+#: centreon/www/install/front_translate.php
+msgid "View by service"
+msgstr "View by service"
+
+#: centreon/www/include/monitoring/comments/listComment.php
+msgid "View comments of hosts"
+msgstr "View comments of hosts"
+
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+msgid "View contact group notifications"
+msgstr "View contact group notifications"
+
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+msgid "View contact notifications"
+msgstr "View contact notifications"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "View downtimes of hosts"
+msgstr "View downtimes of hosts"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "View global macro"
+msgstr "View global macro"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#, php-format
+msgid "View graphs for host %s"
+msgstr "View graphs for host %s"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "View host status page"
+msgstr "View host status page"
+
+#: centreon/www/install/front_translate.php
+msgid "View logs"
+msgstr "View logs"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#, php-format
+msgid "View logs for host %s"
+msgstr "View logs for host %s"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#, php-format
+msgid "View logs for service %s"
+msgstr "View logs for service %s"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "View macros"
+msgstr "View macros"
+
+#: centreon/www/install/front_translate.php
+msgid "View properties"
+msgstr "View properties"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "View relations"
+msgstr "View relations"
+
+#: centreon/www/install/front_translate.php
+msgid "View report"
+msgstr "View report"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#, php-format
+msgid "View report for host %s"
+msgstr "View report for host %s"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#, php-format
+msgid "View report for service %s"
+msgstr "View report for service %s"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#, php-format
+msgid "View status of all services on host %s"
+msgstr "View status of all services on host %s"
+
+#: centreon/www/install/front_translate.php
+msgid "View widget properties"
+msgstr "View widget properties"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"View wiki\n"
+"                    page"
+msgstr ""
+"View wiki\n"
+"                    page"
+
+#: centreon/www/install/smarty_translate.php
+msgid "View wiki page"
+msgstr "View wiki page"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+msgid "Viewer"
+msgstr "Viewer"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "Views"
+msgstr "Views"
+
+#: centreon/www/install/menu_translation.php
+msgid "Virtual Metrics"
+msgstr "Virtual Metrics"
+
+#: centreon/www/install/smarty_translate.php
+msgid "Virtual metrics"
+msgstr "Virtual metrics"
+
+#: centreon/www/install/front_translate.php
+msgid "Visible columns only"
+msgstr "Visible columns only"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Visible page"
+msgstr "Visible page"
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+msgid "WARNING"
+msgstr "WARNING"
+
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Warning"
+msgstr "Warning"
+
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid "Warning Area color"
+msgstr "Warning Area color"
+
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+msgid "Warning Level"
+msgstr "Warning Level"
+
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+msgid "Warning Threshold"
+msgstr "Warning Threshold"
+
+#: centreon/www/install/react_translation.php
+msgid "Warning services"
+msgstr "Warning services"
+
+#: centreon/www/install/front_translate.php
+msgid "Warning status services"
+msgstr "Warning status services"
+
+#: centreon/www/install/front_translate.php
+msgid "Warning threshold"
+msgstr "Warning threshold"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#, php-format
+msgid ""
+"Warning, maximum size exceeded for input '%s' (max: %d), it will be "
+"truncated upon saving"
+msgstr ""
+"Warning, maximum size exceeded for input '%s' (max: %d), it will be "
+"truncated upon saving"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid ""
+"Warning, unconventional use of interval check. You should prefer to use an "
+"interval lower than 24h, if needed, pair this configuration with the use of "
+"timeperiods"
+msgstr ""
+"Warning, unconventional use of interval check. You should prefer to use an "
+"interval lower than 24h, if needed, pair this configuration with the use of "
+"timeperiods"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "Warning: this value can be dangerous, use -1 if you have any doubt."
+msgstr "Warning: this value can be dangerous, use -1 if you have any doubt."
+
+#: centreon/www/install/front_translate.php
+msgid "Weak"
+msgstr "Weak"
+
+#: centreon/www/install/front_translate.php
+msgid "Web SSO configuration"
+msgstr "Web SSO configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "Web SSO configuration saved"
+msgstr "Web SSO configuration saved"
+
+#: centreon/www/install/front_translate.php
+msgid "Web SSO only"
+msgstr "Web SSO only"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Web page"
+msgstr "Web page"
+
+#: centreon/www/install/front_translate.php
+msgid "Web page preview"
+msgstr "Web page preview"
+
+#: centreon/www/install/front_translate.php
+msgid "Webpage Display"
+msgstr "Webpage Display"
+
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Wednesday"
+msgstr "Wednesday"
+
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "Weekly basis"
+msgstr "Weekly basis"
+
+#: centreon/src/CentreonLegacy/Core/Install/Step/Step1.php
+msgid "Welcome to Centreon Setup"
+msgstr "Welcome to Centreon Setup"
+
+#: centreon/www/install/front_translate.php
+msgid "Welcome to the Dashboards interface!"
+msgstr "Welcome to the Dashboards interface!"
+
+#: centreon/www/install/front_translate.php
+msgid "Welcome to the additional configurations page"
+msgstr "Welcome to the additional configurations page"
+
+#: centreon/www/install/front_translate.php
+msgid "Welcome to the agent configuration page"
+msgstr "Welcome to the agent configuration page"
+
+#: centreon/www/install/front_translate.php
+msgid "Welcome to the authentication tokens page"
+msgstr "Welcome to the authentication tokens page"
+
+#: centreon/www/install/front_translate.php
+msgid "Welcome to the host groups page"
+msgstr "Welcome to the host groups page"
+
+#: centreon/www/install/front_translate.php
+msgid "Welcome to the notifications interface"
+msgstr "Welcome to the notifications interface"
+
+#: centreon/www/install/front_translate.php
+msgid "Which endpoint does the conditions attribute path come from?"
+msgstr "Which endpoint does the conditions attribute path come from?"
+
+#: centreon/www/install/front_translate.php
+msgid "Which endpoint does the groups attribute path come from?"
+msgstr "Which endpoint does the groups attribute path come from?"
+
+#: centreon/www/install/front_translate.php
+msgid "Which endpoint does the roles attribute path come from?"
+msgstr "Which endpoint does the roles attribute path come from?"
+
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+msgid "Widget"
+msgstr "Widget"
+
+#: centreon/www/install/menu_translation.php
+msgid "Widget Parameters"
+msgstr "Widget Parameters"
+
+#: centreon/www/api/class/centreon_home_customview.class.php
+msgid "Widget Preferences"
+msgstr "Widget Preferences"
+
+#: centreon/www/api/class/centreon_home_customview.class.php
+#, php-format
+msgid "Widget Preferences for %s"
+msgstr "Widget Preferences for %s"
+
+#: centreon/www/install/front_translate.php
+msgid "Widget properties"
+msgstr "Widget properties"
+
+#: centreon/www/install/front_translate.php
+msgid "Widget type"
+msgstr "Widget type"
+
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+msgid "Width"
+msgstr "Width"
+
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+msgid "Wiki page defined"
+msgstr "Wiki page defined"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Workhours"
+msgstr "Workhours"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Write metrics"
+msgstr "Write metrics"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Write status"
+msgstr "Write status"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Write thread id (deprecated)"
+msgstr "Write thread id (deprecated)"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+msgid "Write timestamp (deprecated)"
+msgstr "Write timestamp (deprecated)"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Y-axis boundaries"
+msgstr "Y-axis boundaries"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Y-axis label rotation"
+msgstr "Y-axis label rotation"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+msgid "Y/m/d - H:i:s"
+msgstr "Y/m/d - H:i:s"
+
+#: centreon/www/include/monitoring/status/Common/commonJS.php
+msgid "Y/m/d H:i:s"
+msgstr "Y/m/d H:i:s"
+
+#: centreon/www/class/centreonXMLBGRequest.class.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/install/front_translate.php
+msgid "Yes"
+msgstr "Yes"
+
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/reporting/dashboard/common-Func.php
+#: centreon/www/install/dashboard_widgets.php
+#: centreon/www/install/front_translate.php
+msgid "Yesterday"
+msgstr "Yesterday"
+
+#: centreon/www/include/configuration/configServers/listServers.php
+msgid ""
+"You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE."
+"\\nDo you confirm the deletion ?"
+msgstr ""
+"You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE."
+"\\nDo you confirm the deletion ?"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are about to delete the <strong>{{tokenName}}</strong> token. This "
+"action cannot be undone. Do you want to delete this token anyway ? You must "
+"export the configuration for the change to be taken into account."
+msgstr ""
+"You are about to delete the <strong>{{tokenName}}</strong> token. This "
+"action cannot be undone. Do you want to delete this token anyway ? You must "
+"export the configuration for the change to be taken into account."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are about to disable the <strong>{{tokenName}}</strong> token. If you "
+"disable it, all requests made with this token will be rejected. Do you want "
+"to disable it ? You must export the configuration for the change to be taken "
+"into account."
+msgstr ""
+"You are about to disable the <strong>{{tokenName}}</strong> token. If you "
+"disable it, all requests made with this token will be rejected. Do you want "
+"to disable it ? You must export the configuration for the change to be taken "
+"into account."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are about to enable the <strong>{{tokenName}}</strong> token. You must "
+"export the configuration for the change to be taken into account."
+msgstr ""
+"You are about to enable the <strong>{{tokenName}}</strong> token. You must "
+"export the configuration for the change to be taken into account."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are about to export the status of the resources you have filtered. You "
+"can export up to 10,000 rows."
+msgstr ""
+"You are about to export the status of the resources you have filtered. You "
+"can export up to 10,000 rows."
+
+#: centreon/www/install/step_upgrade/step1.php
+msgid "You are about to upgrade Centreon."
+msgstr "You are about to upgrade Centreon."
+
+#: centreon/www/install/front_translate.php
+msgid "You are disconnected"
+msgstr "You are disconnected"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are going to delete <strong>{{name}}</strong> from the user list. This "
+"user will no longer access the dashboard."
+msgstr ""
+"You are going to delete <strong>{{name}}</strong> from the user list. This "
+"user will no longer access the dashboard."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are going to delete the <strong>{{ agent }}</strong> agent "
+"configuration. All parameters for this agent configuration will be deleted. "
+"This action cannot be undone."
+msgstr ""
+"You are going to delete the <strong>{{ agent }}</strong> agent "
+"configuration. All parameters for this agent configuration will be deleted. "
+"This action cannot be undone."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are going to delete the configuration for the <strong>{{ poller }}</"
+"strong> poller from the <strong>{{ agent }}</strong> agent configuration. "
+"All configuration parameters for this poller will be deleted. This action "
+"cannot be undone."
+msgstr ""
+"You are going to delete the configuration for the <strong>{{ poller }}</"
+"strong> poller from the <strong>{{ agent }}</strong> agent configuration. "
+"All configuration parameters for this poller will be deleted. This action "
+"cannot be undone."
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+msgid "You are not allowed to access additional configurations"
+msgstr "You are not allowed to access additional configurations"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+msgid "You are not allowed to access commands"
+msgstr "You are not allowed to access commands"
+
+#: centreon/src/Core/Connector/Application/Exception/ConnectorException.php
+msgid "You are not allowed to access connectors"
+msgstr "You are not allowed to access connectors"
+
+#: centreon/src/Core/Contact/Application/Exception/ContactGroupException.php
+msgid "You are not allowed to access contact groups"
+msgstr "You are not allowed to access contact groups"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "You are not allowed to access dashboards"
+msgstr "You are not allowed to access dashboards"
+
+#: centreon/src/Core/GraphTemplate/Application/Exception/GraphTemplateException.php
+msgid "You are not allowed to access graph templates"
+msgstr "You are not allowed to access graph templates"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "You are not allowed to access host categories"
+msgstr "You are not allowed to access host categories"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "You are not allowed to access host groups"
+msgstr "You are not allowed to access host groups"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "You are not allowed to access host severities"
+msgstr "You are not allowed to access host severities"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "You are not allowed to access host templates"
+msgstr "You are not allowed to access host templates"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "You are not allowed to access hosts in the real time context"
+msgstr "You are not allowed to access hosts in the real time context"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "You are not allowed to access poller/agent configurations"
+msgstr "You are not allowed to access poller/agent configurations"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "You are not allowed to access service categories"
+msgstr "You are not allowed to access service categories"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "You are not allowed to access service groups"
+msgstr "You are not allowed to access service groups"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "You are not allowed to access service severities"
+msgstr "You are not allowed to access service severities"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "You are not allowed to access service templates"
+msgstr "You are not allowed to access service templates"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "You are not allowed to access services"
+msgstr "You are not allowed to access services"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "You are not allowed to access services in the real time context"
+msgstr "You are not allowed to access services in the real time context"
+
+#: centreon/src/Centreon/Application/Controller/FilterController.php
+msgid "You are not allowed to access the Resources Status page"
+msgstr "You are not allowed to access the Resources Status page"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "You are not allowed to access this contact"
+msgstr "You are not allowed to access this contact"
+
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+msgid "You are not allowed to access this contact group"
+msgstr "You are not allowed to access this contact group"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "You are not allowed to access this host"
+msgstr "You are not allowed to access this host"
+
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+msgid "You are not allowed to access this host category"
+msgstr "You are not allowed to access this host category"
+
+#: centreon/www/include/configuration/configObject/meta_service/metaService.php
+msgid "You are not allowed to access this meta service"
+msgstr "You are not allowed to access this meta service"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "You are not allowed to access this monitoring instance"
+msgstr "You are not allowed to access this monitoring instance"
+
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "You are not allowed to access this object configuration"
+msgstr "You are not allowed to access this object configuration"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "You are not allowed to access this service"
+msgstr "You are not allowed to access this service"
+
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+msgid "You are not allowed to access this service category"
+msgstr "You are not allowed to access this service category"
+
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "You are not allowed to access this service group"
+msgstr "You are not allowed to access this service group"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+msgid "You are not allowed to access time periods"
+msgstr "You are not allowed to access time periods"
+
+#: centreon/src/Core/User/Application/Exception/UserException.php
+msgid "You are not allowed to access users"
+msgstr "You are not allowed to access users"
+
+#: centreon/src/Core/Command/Application/Exception/CommandException.php
+msgid "You are not allowed to add a command"
+msgstr "You are not allowed to add a command"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to add a notification configuration"
+msgstr "You are not allowed to add a notification configuration"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "You are not allowed to add a service"
+msgstr "You are not allowed to add a service"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "You are not allowed to add a service template"
+msgstr "You are not allowed to add a service template"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "You are not allowed to add host templates"
+msgstr "You are not allowed to add host templates"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "You are not allowed to add hosts"
+msgstr "You are not allowed to add hosts"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "You are not allowed to add media"
+msgstr "You are not allowed to add media"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "You are not allowed to add tokens"
+msgstr "You are not allowed to add tokens"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+#, php-format
+msgid "You are not allowed to add tokens linked to user ID %d"
+msgstr "You are not allowed to add tokens linked to user ID %d"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "You are not allowed to create service categories"
+msgstr "You are not allowed to create service categories"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "You are not allowed to create service severities"
+msgstr "You are not allowed to create service severities"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "You are not allowed to create/modify a host severity"
+msgstr "You are not allowed to create/modify a host severity"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "You are not allowed to create/modify host categories"
+msgstr "You are not allowed to create/modify host categories"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "You are not allowed to delete a host"
+msgstr "You are not allowed to delete a host"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to delete a notification configuration"
+msgstr "You are not allowed to delete a notification configuration"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "You are not allowed to delete a service"
+msgstr "You are not allowed to delete a service"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "You are not allowed to delete a service template"
+msgstr "You are not allowed to delete a service template"
+
+#: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
+msgid "You are not allowed to delete host categories"
+msgstr "You are not allowed to delete host categories"
+
+#: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
+msgid "You are not allowed to delete host severities"
+msgstr "You are not allowed to delete host severities"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "You are not allowed to delete host templates"
+msgstr "You are not allowed to delete host templates"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "You are not allowed to delete service categories"
+msgstr "You are not allowed to delete service categories"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "You are not allowed to delete service severities"
+msgstr "You are not allowed to delete service severities"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "You are not allowed to delete tokens"
+msgstr "You are not allowed to delete tokens"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+#, php-format
+msgid "You are not allowed to delete tokens linked to user ID %d"
+msgstr "You are not allowed to delete tokens linked to user ID %d"
+
+#: centreon/www/include/options/session/connected_user.php
+msgid "You are not allowed to disconnect this user"
+msgstr "You are not allowed to disconnect this user"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to display the details of the notification"
+msgstr "You are not allowed to display the details of the notification"
+
+#: centreon/src/Core/Broker/Application/Exception/BrokerException.php
+msgid "You are not allowed to edit a broker configuration"
+msgstr "You are not allowed to edit a broker configuration"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "You are not allowed to edit a host"
+msgstr "You are not allowed to edit a host"
+
+#: centreon/src/Core/Service/Application/Exception/ServiceException.php
+msgid "You are not allowed to edit a service"
+msgstr "You are not allowed to edit a service"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "You are not allowed to edit access rights on the dashboard #%d"
+msgstr "You are not allowed to edit access rights on the dashboard #%d"
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "You are not allowed to edit service severities"
+msgstr "You are not allowed to edit service severities"
+
+#: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
+msgid "You are not allowed to edit time periods"
+msgstr "You are not allowed to edit time periods"
+
+#: centreon/src/Core/Contact/Application/Exception/ContactTemplateException.php
+msgid "You are not allowed to list contact templates"
+msgstr "You are not allowed to list contact templates"
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "You are not allowed to list hosts"
+msgstr "You are not allowed to list hosts"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "You are not allowed to list media"
+msgstr "You are not allowed to list media"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to list notification resources"
+msgstr "You are not allowed to list notification resources"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to list notifications configurations"
+msgstr "You are not allowed to list notifications configurations"
+
+#: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+msgid "You are not allowed to list resource access rules"
+msgstr "You are not allowed to list resource access rules"
+
+#: centreon/www/install/front_translate.php
+msgid "You are not allowed to log in"
+msgstr "You are not allowed to log in"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to partially update a notification configuration"
+msgstr "You are not allowed to partially update a notification configuration"
+
+#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
+msgid "You are not allowed to partially update the token"
+msgstr "You are not allowed to partially update the token"
+
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+msgid "You are not allowed to perform write actions on host templates"
+msgstr "You are not allowed to perform write actions on host templates"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "You are not allowed to perform write operations on dashboards"
+msgstr "You are not allowed to perform write operations on dashboards"
+
+#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+msgid "You are not allowed to perform write operations on host groups"
+msgstr "You are not allowed to perform write operations on host groups"
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "You are not allowed to perform write operations on service groups"
+msgstr "You are not allowed to perform write operations on service groups"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/core/errors/alt_error.php
+msgid "You are not allowed to reach this page"
+msgstr "You are not allowed to reach this page"
+
+#: centreon/www/install/front_translate.php
+msgid "You are not allowed to see this page"
+msgstr "You are not allowed to see this page"
+
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+msgid "You are not allowed to update a service template"
+msgstr "You are not allowed to update a service template"
+
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "You are not allowed to update media"
+msgstr "You are not allowed to update media"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+msgid "You are not allowed to update the notification configuration"
+msgstr "You are not allowed to update the notification configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "You are not authorized to access the configuration"
+msgstr "You are not authorized to access the configuration"
+
+#: centreon/www/install/front_translate.php
+msgid "You can choose only one resource for each resource type."
+msgstr "You can choose only one resource for each resource type."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You can create two types of tokens: API tokens to manipulate Centreon "
+"objects via the API, or CMA tokens to allow the CMA monitoring agent to "
+"authenticate to the corresponding poller."
+msgstr ""
+"You can create two types of tokens: API tokens to manipulate Centreon "
+"objects via the API, or CMA tokens to allow the CMA monitoring agent to "
+"authenticate to the corresponding poller."
+
+#: centreon/www/install/front_translate.php
+msgid "You can see the full list on"
+msgstr "You can see the full list on"
+
+#: centreon/www/install/front_translate.php
+msgid "You can use regular expression syntax to retrieve more relevant results"
+msgstr ""
+"You can use regular expression syntax to retrieve more relevant results"
+
+#: centreon/www/class/centreonContact.class.php
+msgid ""
+"You can't change your password because the delay before changing password is "
+"not over."
+msgstr ""
+"You can't change your password because the delay before changing password is "
+"not over."
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"You can't edit this downtime because you don't have access to all of its "
+"resources"
+msgstr ""
+"You can't edit this downtime because you don't have access to all of its "
+"resources"
+
+#: centreon/www/install/smarty_translate.php
+msgid "You cannot add more charts. The maximum charts is "
+msgstr "You cannot add more charts. The maximum charts is "
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+msgid "You cannot override reserved macros"
+msgstr "You cannot override reserved macros"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "You cannot share the same dashboard to a contact group several times"
+msgstr "You cannot share the same dashboard to a contact group several times"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "You cannot share the same dashboard to a contact several times"
+msgstr "You cannot share the same dashboard to a contact several times"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "You cannot view access rights on the dashboard #%d"
+msgstr "You cannot view access rights on the dashboard #%d"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/Exception/PlatformInformationException.php
+msgid "You do not have sufficent rights for this action."
+msgstr "You do not have sufficent rights for this action."
+
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+msgid "You don't have access to this resource"
+msgstr "You don't have access to this resource"
+
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "You don't have sufficient permissions for this action"
+msgstr "You don't have sufficient permissions for this action"
+
+#: centreon/www/install/front_translate.php
+msgid "You have been logged out"
+msgstr "You have been logged out"
+
+#: centreon/www/install/front_translate.php
+msgid "You have selected No TLS for the encryption level."
+msgstr "You have selected No TLS for the encryption level."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You have selected No TLS for the encryption level. This parameter is meant "
+"for test purposes only and is not allowed in production. The agent "
+"monitoring will stop after 1 hour."
+msgstr ""
+"You have selected No TLS for the encryption level. This parameter is meant "
+"for test purposes only and is not allowed in production. The agent "
+"monitoring will stop after 1 hour."
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "You have to keep at least one contact to access to Centreon"
+msgstr "You have to keep at least one contact to access to Centreon"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You have too many metrics, please filter more resources to optimize platform "
+"performance."
+msgstr ""
+"You have too many metrics, please filter more resources to optimize platform "
+"performance."
+
+#: centreon/www/install/step_upgrade/step4.php
+msgid ""
+"You may refer to the line in the specified file in order to correct the "
+"issue."
+msgstr ""
+"You may refer to the line in the specified file in order to correct the "
+"issue."
+
+#: centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
+msgid "You must add at least one provider"
+msgstr "You must add at least one provider"
+
+#: centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+msgid "You must add at least one resource provider"
+msgstr "You must add at least one resource provider"
+
+#: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
+msgid "You must at least add one authentication provider"
+msgstr "You must at least add one authentication provider"
+
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+msgid "You must either fill all the arguments or leave them all empty"
+msgstr "You must either fill all the arguments or leave them all empty"
+
+#: centreon/src/Core/Notification/Application/Exception/NotificationException.php
+#, php-format
+msgid "You must provide at least one %s"
+msgstr "You must provide at least one %s"
+
+#: centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+msgid "You must provide at least one ACL provider"
+msgstr "You must provide at least one ACL provider"
+
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+msgid "You need to select a least one polling instance."
+msgstr "You need to select a least one polling instance."
+
+#: centreon/www/install/react_translation.php
+#, php-format
+msgid "You need to send '%s' in the request."
+msgstr "You need to send '%s' in the request."
+
+#: centreon/www/install/step_upgrade/step4.php
+msgid "You seem to be having trouble with your upgrade."
+msgstr "You seem to be having trouble with your upgrade."
+
+#: centreon/www/install/front_translate.php
+msgid "You will be disconnected"
+msgstr "You will be disconnected"
+
+#: centreon/www/api/class/centreon_topcounter.class.php
+msgid "You're not authorized to access poller data"
+msgstr "You're not authorized to access poller data"
+
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
+msgid ""
+"Your Central is linked to another remote(s), conversion in Remote isn't "
+"allowed"
+msgstr ""
+"Your Central is linked to another remote(s), conversion in Remote isn't "
+"allowed"
+
+#: centreon/www/install/step_upgrade/step3.php
+msgid "Your Centreon Platform is about to be upgraded from version "
+msgstr "Your Centreon Platform is about to be upgraded from version "
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Your IP is blacklisted"
+msgstr "Your IP is blacklisted"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+msgid "Your IP is not whitelisted"
+msgstr "Your IP is not whitelisted"
+
+#: centreon/lib/Centreon/Object/Contact/Contact.php
+#: centreon/www/include/Administration/myAccount/DB-Func.php
+#: centreon/www/include/configuration/configObject/contact/DB-Func.php
+msgid "Your autologin key must be different than your current password"
+msgstr "Your autologin key must be different than your current password"
+
+#: centreon/www/install/front_translate.php
+msgid "Your changes will not be saved if you leave classic mode."
+msgstr "Your changes will not be saved if you leave classic mode."
+
+#: centreon/www/install/front_translate.php
+msgid "Your changes will not be saved if you leave regex mode."
+msgstr "Your changes will not be saved if you leave regex mode."
+
+#: centreon/www/install/front_translate.php
+msgid "Your changes will not be saved if you leave this page."
+msgstr "Your changes will not be saved if you leave this page."
+
+#: centreon/www/include/monitoring/external_cmd/functions.php
+#: centreon/www/include/monitoring/external_cmd/functionsPopup.php
+msgid "Your command has been sent"
+msgstr "Your command has been sent"
+
+#: centreon/www/install/front_translate.php
+msgid "Your comment has been saved."
+msgstr "Your comment has been saved."
+
+#: centreon/www/class/centreonAuth.class.php
+msgid "Your credentials are incorrect."
+msgstr "Your credentials are incorrect."
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Your current password"
+msgstr "Your current password"
+
+#: centreon/www/install/step_upgrade/step4.php
+#, php-format
+msgid "Your current version is %s."
+msgstr "Your current version is %s."
+
+#: centreon/www/install/front_translate.php
+msgid "Your dashboard has been saved"
+msgstr "Your dashboard has been saved"
+
+#: centreon/www/install/front_translate.php
+msgid "Your form has unsaved changes"
+msgstr "Your form has unsaved changes"
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"Your form has unsaved changes. Do you want to quit the form without saving "
+"the changes?"
+msgstr ""
+"Your form has unsaved changes. Do you want to quit the form without saving "
+"the changes?"
+
+#: centreon/www/include/Administration/myAccount/DB-Func.php
+msgid "Your new password and autologin key must be different"
+msgstr "Your new password and autologin key must be different"
+
+#: centreon/src/Core/Security/User/Domain/Exception/UserPasswordException.php
+msgid "Your password doesn't match the security policy"
+msgstr "Your password doesn't match the security policy"
+
+#: centreon/www/class/centreonContact.class.php
+msgid ""
+"Your password has already been used. Please choose a different password from "
+"the previous three."
+msgstr ""
+"Your password has already been used. Please choose a different password from "
+"the previous three."
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Your password has expired. Please change it."
+msgstr "Your password has expired. Please change it."
+
+#: centreon/www/class/centreonContact.class.php
+#, php-format
+msgid "Your password must be %d characters long"
+msgstr "Your password must be %d characters long"
+
+#: centreon/www/install/front_translate.php
+msgid "Your password will expire in"
+msgstr "Your password will expire in"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#, php-format
+msgid "Your password will expire in %s days."
+msgstr "Your password will expire in %s days."
+
+#: centreon/www/install/front_translate.php
+msgid "Your rights only allow you to view the properties of a widget."
+msgstr "Your rights only allow you to view the properties of a widget."
+
+#: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
+msgid "Your session has expired"
+msgstr "Your session has expired"
+
+#: centreon/www/install/front_translate.php
+msgid "Your widget has been created successfully!"
+msgstr "Your widget has been created successfully!"
+
+#: centreon/www/install/front_translate.php
+msgid "Your widget has been modified successfully!"
+msgstr "Your widget has been modified successfully!"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "ZMQ"
+msgstr "ZMQ"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "Zero-centered"
+msgstr "Zero-centered"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] (%s) was expected to be an instance of the class '%s'"
+msgstr "[%s] (%s) was expected to be an instance of the class '%s'"
+
+#: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
+#, php-format
+msgid "[%s] Empty value found, but a string is required"
+msgstr "[%s] Empty value found, but a string is required"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The date \"%s\" was expected to be at least %s"
+msgstr "[%s] The date \"%s\" was expected to be at least %s"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The date \"%s\" was expected to be at most %s"
+msgstr "[%s] The date \"%s\" was expected to be at most %s"
+
+#: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
+#, php-format
+msgid "[%s] The property %s is required"
+msgstr "[%s] The property %s is required"
+
+#: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
+#, php-format
+msgid "[%s] The property does not contain the file"
+msgstr "[%s] The property does not contain the file"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The string is empty, but non empty string was expected"
+msgstr "[%s] The string is empty, but non empty string was expected"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value \"%d\" is not greater or equal than %d"
+msgstr "[%s] The value \"%d\" is not greater or equal than %d"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value \"%d\" was expected to be at least %d"
+msgstr "[%s] The value \"%d\" was expected to be at least %d"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value \"%d\" was expected to be at most %d"
+msgstr "[%s] The value \"%d\" was expected to be at most %d"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid ""
+"[%s] The value \"%s\" is too long, it should have no more than %d "
+"characters, but has %d characters"
+msgstr ""
+"[%s] The value \"%s\" is too long, it should have no more than %d "
+"characters, but has %d characters"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid ""
+"[%s] The value \"%s\" is too short, it should have at least %d characters, "
+"but only has %d characters"
+msgstr ""
+"[%s] The value \"%s\" is too short, it should have at least %d characters, "
+"but only has %d characters"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid ""
+"[%s] The value \"%s\" was expected to be a valid URL, IP address or domain"
+msgstr ""
+"[%s] The value \"%s\" was expected to be a valid URL, IP address or domain"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value \"%s\" was expected to be a valid e-mail address"
+msgstr "[%s] The value \"%s\" was expected to be a valid e-mail address"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid ""
+"[%s] The value \"%s\" was expected to be a valid ip address or domain name"
+msgstr ""
+"[%s] The value \"%s\" was expected to be a valid ip address or domain name"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value '%s' was expected to be a valid ip address"
+msgstr "[%s] The value '%s' was expected to be a valid ip address"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value (%s) doesn't match the regex '%s'"
+msgstr "[%s] The value (%s) doesn't match the regex '%s'"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value cannot be encoded to a valid JSON string"
+msgstr "[%s] The value cannot be encoded to a valid JSON string"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value contains unauthorized characters: %s"
+msgstr "[%s] The value contains unauthorized characters: %s"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value is empty, but non empty value was expected"
+msgstr "[%s] The value is empty, but non empty value was expected"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value is not a valid JSON string"
+msgstr "[%s] The value is not a valid JSON string"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value is null, but non null value was expected"
+msgstr "[%s] The value is null, but non null value was expected"
+
+#: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+#, php-format
+msgid "[%s] The value provided (%s) was not expected. Possible values %s"
+msgstr "[%s] The value provided (%s) was not expected. Possible values %s"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+#, php-format
+msgid "[%s]: An error occured during your request"
+msgstr "[%s]: An error occured during your request"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+#, php-format
+msgid "[%s]: Both provider and refresh tokens have expired"
+msgstr "[%s]: Both provider and refresh tokens have expired"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+#, php-format
+msgid "[%s]: Login claim [%s] not found from external provider user"
+msgstr "[%s]: Login claim [%s] not found from external provider user"
+
+#: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
+#, php-format
+msgid "[%s]: No authorization code return by external provider"
+msgstr "[%s]: No authorization code return by external provider"
+
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Services/service.php
+msgid ""
+"[Page deprecated] This page will be removed in the next major version. "
+"Please use the new page: "
+msgstr ""
+"[Page deprecated] This page will be removed in the next major version. "
+"Please use the new page: "
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+msgid "_Module_ is not a legal expression"
+msgstr "_Module_ is not a legal expression"
+
+#: centreon/www/install/front_translate.php
+msgid "a-z"
+msgstr "a-z"
+
+#: centreon/www/install/front_translate.php
+msgid "added"
+msgstr "added"
+
+#: centreon/www/install/front_translate.php
+msgid "align picker"
+msgstr "align picker"
+
+#: centreon/www/install/front_translate.php
+msgid "and"
+msgstr "and"
+
+#: centreon/www/install/front_translate.php
+msgid "and an access group:"
+msgstr "and an access group:"
+
+#: centreon/www/install/front_translate.php
+msgid "and host alias containing"
+msgstr "and host alias containing"
+
+#: centreon/www/class/centreonContact.class.php
+msgid "and must contain"
+msgstr "and must contain"
+
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+msgid "apiPath"
+msgstr "apiPath"
+
+#: centreon/www/install/front_translate.php
+msgid "are working fine."
+msgstr "are working fine."
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "areaOpacity"
+msgstr "areaOpacity"
+
+#: centreon/www/install/react_translation.php
+msgid "as"
+msgstr "as"
+
+#: centreon/www/install/front_translate.php
+msgid "at"
+msgstr "at"
+
+#: centreon/www/install/front_translate.php
+msgid "available"
+msgstr "available"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "boundaries"
+msgstr "boundaries"
+
+#: centreon/www/install/front_translate.php
+msgid "business activity"
+msgstr "business activity"
+
+#: centreon/www/install/front_translate.php
+msgid "by"
+msgstr "by"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
+msgid "bytes"
+msgstr "bytes"
+
+#: centreon/src/Core/Application/Platform/UseCase/FindInstallationStatus/FindInstallationStatus.php
+msgid "centreon is not properly installed"
+msgstr "centreon is not properly installed"
+
+#: centreon/www/install/front_translate.php
+msgid "characters"
+msgstr "characters"
+
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+msgid "comment"
+msgstr "comment"
+
+#: centreon/www/include/home/customViews/index.php
+msgid "create or load"
+msgstr "create or load"
+
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+msgid "d/m/Y H:i:s"
+msgstr "d/m/Y H:i:s"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "dashLength"
+msgstr "dashLength"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "dashOffset"
+msgstr "dashOffset"
+
+#: centreon/www/install/front_translate.php
+msgid "day"
+msgstr "day"
+
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "days"
+msgstr "days"
+
+#: centreon/www/install/front_translate.php
+msgid "delete multiple notifications"
+msgstr "delete multiple notifications"
+
+#: centreon/www/lib/HTML/QuickForm/select2.php
+msgid "disabled"
+msgstr "disabled"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "dotOffset"
+msgstr "dotOffset"
+
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+msgid "error"
+msgstr "error"
+
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+msgid "geo coords are not valid"
+msgstr "geo coords are not valid"
+
+#: centreon/www/install/front_translate.php
+msgid "get some help while creating your regular expression query at"
+msgstr "get some help while creating your regular expression query at"
+
+#: centreon/www/class/centreonGraphNg.class.php
+msgid "graph on"
+msgstr "graph on"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "gridLinesType"
+msgstr "gridLinesType"
+
+#: centreon/www/install/front_translate.php
+msgid "group"
+msgstr "group"
+
+#: centreon/www/install/front_translate.php
+msgid "groups"
+msgstr "groups"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+msgid "here"
+msgstr "here"
+
+#: centreon/www/install/front_translate.php
+msgid "hosts"
+msgstr "hosts"
+
+#: centreon/www/install/front_translate.php
+msgid "hour"
+msgstr "hour"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "hours"
+msgstr "hours"
+
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+msgid "impossible to validate, one or more field is incorrect"
+msgstr "impossible to validate, one or more field is incorrect"
+
+#: centreon/www/install/front_translate.php
+msgid "is defined by default. You can define another one."
+msgstr "is defined by default. You can define another one."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"is the selected metric by default. Refine filters to select another specific "
+"resource."
+msgstr ""
+"is the selected metric by default. Refine filters to select another specific "
+"resource."
+
+#: centreon/www/install/front_translate.php
+msgid "is used to allow users to access resources."
+msgstr "is used to allow users to access resources."
+
+#: centreon/www/include/views/graphs/graph-periods.php
+msgid "last day"
+msgstr "last day"
+
+#: centreon/www/include/views/graphs/graph-periods.php
+msgid "last month"
+msgstr "last month"
+
+#: centreon/www/include/views/graphs/graph-periods.php
+msgid "last week"
+msgstr "last week"
+
+#: centreon/www/include/views/graphs/graph-periods.php
+msgid "last year"
+msgstr "last year"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "legendDisplayMode"
+msgstr "legendDisplayMode"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "legendPlacement"
+msgstr "legendPlacement"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "lineWidth"
+msgstr "lineWidth"
+
+#: centreon/www/class/centreonContact.class.php
+msgid "lowercase characters"
+msgstr "lowercase characters"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "lua parameter"
+msgstr "lua parameter"
+
+#: centreon/www/install/front_translate.php
+msgid "manual"
+msgstr "manual"
+
+#: centreon/www/install/front_translate.php
+msgid "minute"
+msgstr "minute"
+
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "minutes"
+msgstr "minutes"
+
+#: centreon/www/install/front_translate.php
+msgid "month"
+msgstr "month"
+
+#: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+msgid "movement"
+msgstr "movement"
+
+#: centreon/www/install/front_translate.php
+msgid "none"
+msgstr "none"
+
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+msgid "notify"
+msgstr "notify"
+
+#: centreon/www/class/centreonContact.class.php
+msgid "numbers"
+msgstr "numbers"
+
+#: centreon/www/include/common/pagination.php
+#: centreon/www/install/front_translate.php
+msgid "of"
+msgstr "of"
+
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+msgid "on host"
+msgstr "on host"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "or"
+msgstr "or"
+
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+msgid "persistent"
+msgstr "persistent"
+
+#: centreon/www/install/front_translate.php
+msgid "points outside of the envelope"
+msgstr "points outside of the envelope"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "px"
+msgstr "px"
+
+#: centreon/www/install/front_translate.php
+msgid "removed"
+msgstr "removed"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "s"
+msgstr "s"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "scaleLogarithmicBase"
+msgstr "scaleLogarithmicBase"
+
+#: centreon/www/install/front_translate.php
+msgid "second"
+msgstr "second"
+
+#: centreon/cron/centAcl.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/widgets/service-monitoring/src/action.php
+msgid "seconds"
+msgstr "seconds"
+
+#: centreon/www/install/front_translate.php
+msgid "select a file"
+msgstr "select a file"
+
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "services"
+msgstr "services"
+
+#: centreon/www/class/centreonContact.class.php
+#, php-format
+msgid "special characters among '%s'"
+msgstr "special characters among '%s'"
+
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+msgid "sticky"
+msgstr "sticky"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "sub1"
+msgstr "sub1"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "sub2"
+msgstr "sub2"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "sub3"
+msgstr "sub3"
+
+#: centreon/www/install/front_translate.php
+msgid "technical"
+msgstr "technical"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/UseCase/V20/UpdatePartiallyPlatformInformation.php
+#, php-format
+msgid ""
+"the address %s is already used has proxy address and can't be provided as "
+"Central Server Address"
+msgstr ""
+"the address %s is already used has proxy address and can't be provided as "
+"Central Server Address"
+
+#: centreon/src/Centreon/Domain/PlatformInformation/UseCase/V20/UpdatePartiallyPlatformInformation.php
+#, php-format
+msgid ""
+"the address %s is already used in the topology and can't be provided as "
+"Central Server Address"
+msgstr ""
+"the address %s is already used in the topology and can't be provided as "
+"Central Server Address"
+
+#: centreon/www/install/front_translate.php
+msgid "the community"
+msgstr "the community"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "threshold"
+msgstr "threshold"
+
+#: centreon/www/install/front_translate.php
+msgid "tiles"
+msgstr "tiles"
+
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/install/front_translate.php
+msgid "to"
+msgstr "to"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "unknown"
+msgstr "unknown"
+
+#: centreon/www/install/front_translate.php
+msgid "updated"
+msgstr "updated"
+
+#: centreon/www/class/centreonContact.class.php
+msgid "uppercase characters"
+msgstr "uppercase characters"
+
+#: centreon/www/install/front_translate.php
+msgid "vCenter/ESX"
+msgstr "vCenter/ESX"
+
+#: centreon/www/install/dashboard_widgets.php
+msgid "warningtext"
+msgstr "warningtext"
+
+#: centreon/www/install/front_translate.php
+msgid "will display all resources with host having alias containing"
+msgstr "will display all resources with host having alias containing"
+
+#: centreon/www/install/front_translate.php
+msgid "will display resources having FQDN that doesn't contain"
+msgstr "will display resources having FQDN that doesn't contain"
+
+#: centreon/www/install/front_translate.php
+msgid "will display resources with host name starting by"
+msgstr "will display resources with host name starting by"
+
+#: centreon/www/install/front_translate.php
+msgid "will display resources with service description finishing by"
+msgstr "will display resources with service description finishing by"
+
+#: centreon/www/install/front_translate.php
+msgid "year"
+msgstr "year"
+
+#: centreon/www/install/front_translate.php
+msgid "{{label}} can be at most {{max}} characters"
+msgstr "{{label}} can be at most {{max}} characters"
+
+#: centreon/www/install/front_translate.php
+msgid "{{label}} should be at least {{min}} characters long"
+msgstr "{{label}} should be at least {{min}} characters long"
+
+#: centreon/www/install/front_translate.php
+msgid "{{total}} element(s) found"
+msgstr "{{total}} element(s) found"

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -70,10 +70,6 @@ msgid "*The timezone used is configured on your user settings"
 msgstr "*The timezone used is configured on your user settings"
 
 #: centreon/www/install/front_translate.php
-msgid "/*+&"
-msgstr "/*+&"
-
-#: centreon/www/install/front_translate.php
 msgid "0-9"
 msgstr "0-9"
 
@@ -198,6 +194,10 @@ msgstr ""
 #: centreon/www/install/step_upgrade/step4.php
 msgid "<p>Currently upgrading... please do not interrupt this process.</p>"
 msgstr "<p>Currently upgrading... please do not interrupt this process.</p>"
+
+#: centreon/www/install/front_translate.php
+msgid "@$!%*?&"
+msgstr ""
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -732,6 +732,10 @@ msgstr "Add a Meta Service indicator"
 msgid "Add a Monitoring Engine Configuration File"
 msgstr "Add a Monitoring Engine Configuration File"
 
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Add a Resource"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Add a Service"
 msgstr "Add a Service"
@@ -797,10 +801,6 @@ msgstr "Add a contact group"
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "Add a downtime"
 msgstr "Add a downtime"
-
-#: centreon/www/include/configuration/configResources/formResources.php
-msgid "Add a global macro"
-msgstr "Add a global macro"
 
 #: centreon/www/install/front_translate.php
 msgid "Add a host"
@@ -1040,8 +1040,6 @@ msgstr "Additional information"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configServers/listServers.php
 msgid "Address"
 msgstr "Address"
 
@@ -1172,7 +1170,6 @@ msgstr "Aggregation frequency"
 #: centreon/www/include/reporting/dashboard/viewHostLog.php
 #: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
 #: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "Alert"
 msgstr "Alert"
 
@@ -1690,7 +1687,6 @@ msgstr "Audit log activation"
 msgid "Authentication"
 msgstr "Authentication"
 
-#: centreon/src/App/Security/Infrastructure/Security/TokenAuthenticator.php
 #: centreon/src/Security/TokenAPIAuthenticator.php
 msgid "Authentication Required"
 msgstr "Authentication Required"
@@ -2513,8 +2509,8 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
-msgid "Centreon Central address, as seen by this server"
-msgstr "Centreon Central address, as seen by this server"
+msgid "Centreon Central IP address, as seen by this server"
+msgstr ""
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Centreon Connector"
@@ -3692,6 +3688,10 @@ msgstr "Create authentication token"
 #: centreon/www/install/front_translate.php
 msgid "Create dashboard"
 msgstr "Create dashboard"
+
+#: centreon/www/install/front_translate.php
+msgid "Create hosts automatically"
+msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "Create new CMA token"
@@ -4959,14 +4959,6 @@ msgid ""
 msgstr ""
 "Displays a detailed view of the current status for selected resources as a "
 "chart."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays a list of storage with saturation foreseen, current usage, days "
-"until saturation, and evolution of usage since the past day."
-msgstr ""
-"Displays a list of storage with saturation foreseen, current usage, days "
-"until saturation, and evolution of usage since the past day."
 
 #: centreon/www/install/dashboard_widgets.php
 msgid ""
@@ -6340,6 +6332,10 @@ msgstr "Error while deleting a host group"
 msgid "Error while deleting a host template"
 msgstr "Error while deleting a host template"
 
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "Error while deleting a media"
+msgstr ""
+
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error while deleting a notification configuration"
 msgstr "Error while deleting a notification configuration"
@@ -6506,6 +6502,10 @@ msgstr "Error while retrieving a host group"
 msgid "Error while retrieving a host template"
 msgstr "Error while retrieving a host template"
 
+#: centreon/src/Core/Media/Application/Exception/MediaException.php
+msgid "Error while retrieving a media"
+msgstr ""
+
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error while retrieving a notification configuration"
 msgstr "Error while retrieving a notification configuration"
@@ -6591,6 +6591,18 @@ msgstr "Error while retrieving recently created service severity"
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Error while retrieving remote server information"
 msgstr "Error while retrieving remote server information"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while retrieving service category"
+msgstr ""
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "Error while retrieving service group"
+msgstr ""
+
+#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
+msgid "Error while retrieving service severity"
+msgstr ""
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "Error while retrieving service statuses distribution"
@@ -6802,6 +6814,10 @@ msgstr "Error while updating a poller/agent configuration"
 msgid "Error while updating a service"
 msgstr "Error while updating a service"
 
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "Error while updating a service group"
+msgstr ""
+
 #: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
 msgid "Error while updating a service template"
 msgstr "Error while updating a service template"
@@ -6825,6 +6841,10 @@ msgstr "Error while updating contact (massive change)"
 #: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
 msgid "Error while updating host severity"
 msgstr "Error while updating host severity"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "Error while updating service category"
+msgstr ""
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "Error while updating the dashboard share"
@@ -6869,6 +6889,7 @@ msgid "Escalations"
 msgstr "Escalations"
 
 #: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/centreon_broker_translation.php
 #: centreon/www/install/front_translate.php
 msgid "Event"
 msgstr "Event"
@@ -7868,10 +7889,6 @@ msgstr "Global Monitoring Engine Actions (External Process Commands)"
 msgid "Global Service Event Handler"
 msgstr "Global Service Event Handler"
 
-#: centreon/www/install/menu_translation.php
-msgid "Global macros"
-msgstr "Global macros"
-
 #: centreon/www/install/front_translate.php
 msgid "Global refresh interval"
 msgstr "Global refresh interval"
@@ -8866,6 +8883,8 @@ msgstr "Human readable"
 msgid "IP"
 msgstr "IP"
 
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/status/Hosts/hostJS.php
 #: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
 #: centreon/www/include/options/session/connected_user.php
@@ -9299,6 +9318,11 @@ msgstr "Invalid URL"
 msgid "Invalid address"
 msgstr "Invalid address"
 
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#, php-format
+msgid "Invalid argument for '%s', expected type: %s"
+msgstr ""
+
 #: centreon/src/Core/Domain/Exception/InvalidGeoCoordException.php
 msgid "Invalid coordinates format specified"
 msgstr "Invalid coordinates format specified"
@@ -9306,6 +9330,13 @@ msgstr "Invalid coordinates format specified"
 #: centreon/src/Core/Domain/Exception/InvalidGeoCoordException.php
 msgid "Invalid coordinates values specified"
 msgstr "Invalid coordinates values specified"
+
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/media/images/formImg.php
+msgid ""
+"Invalid directory name. Only alphanumeric characters, hyphens and "
+"underscores are allowed."
+msgstr ""
 
 #: centreon/src/Core/Domain/Configuration/Notification/Exception/NotificationException.php
 #, php-format
@@ -9868,6 +9899,12 @@ msgstr "Legend"
 msgid "Legend Name"
 msgstr "Legend Name"
 
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+msgid ""
+"Legend is disabled for the default template because it cannot be displayed "
+"in the graph. Metric name will be displayed by default."
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Less"
 msgstr "Less"
@@ -10242,6 +10279,10 @@ msgstr "Low Service Flap Threshold"
 msgid "Lower Limit"
 msgstr "Lower Limit"
 
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "MACRO Expression"
+msgstr ""
+
 #: centreon/www/install/smarty_translate.php
 msgid "MB"
 msgstr "MB"
@@ -10332,6 +10373,10 @@ msgstr "Manage envelope size"
 #: centreon/www/install/front_translate.php
 msgid "Manage filters"
 msgstr "Manage filters"
+
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Managed event TTL"
+msgstr ""
 
 #: centreon/www/install/menu_translation.php
 msgid "Manager"
@@ -10961,6 +11006,10 @@ msgstr "Modify a Meta Service indicator"
 msgid "Modify a Monitoring Engine Configuration File"
 msgstr "Modify a Monitoring Engine Configuration File"
 
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "Modify a Resource"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Modify a Service"
 msgstr "Modify a Service"
@@ -11000,10 +11049,6 @@ msgstr "Modify a Virtual Metric"
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "Modify a downtime"
 msgstr "Modify a downtime"
-
-#: centreon/www/include/configuration/configResources/formResources.php
-msgid "Modify a global macro"
-msgstr "Modify a global macro"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Modify a poller Configuration"
@@ -11383,7 +11428,6 @@ msgstr "N/A"
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
 #: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/include/configuration/configResources/listResources.php
 #: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/home/customViews/index.php
@@ -11444,10 +11488,6 @@ msgstr "Name cannot be empty"
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Name is already in use"
 msgstr "Name is already in use"
-
-#: centreon/www/include/configuration/configResources/formResources.php
-msgid "Name must start and end with a '$'"
-msgstr "Name must start and end with a '$'"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Name of the logger"
@@ -13816,6 +13856,7 @@ msgid "Resource Access Rule"
 msgstr "Resource Access Rule"
 
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configResources/formResources.php
 msgid "Resource Name"
 msgstr "Resource Name"
 
@@ -13858,6 +13899,7 @@ msgstr "Resource used by one of the instances"
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 #: centreon/www/install/smarty_translate.php
 msgid "Resources"
 msgstr "Resources"
@@ -14349,6 +14391,10 @@ msgstr "Scheduling options"
 msgid "Scopes"
 msgstr "Scopes"
 
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Script path"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Scroll to top"
 msgstr "Scroll to top"
@@ -14679,6 +14725,11 @@ msgstr "Server Configuration"
 msgid "Server Configuration Wizard"
 msgstr "Server Configuration Wizard"
 
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
+msgid "Server IP address"
+msgstr ""
+
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Server Information"
 msgstr "Server Information"
@@ -14689,8 +14740,6 @@ msgid "Server Name"
 msgstr "Server Name"
 
 #: centreon/www/install/centreon_broker_translation.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/react_translation.php
 msgid "Server address"
 msgstr "Server address"
 
@@ -15468,10 +15517,6 @@ msgstr "Show thresholds"
 msgid "Show time zone"
 msgstr "Show time zone"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show value label"
-msgstr "Show value label"
-
 #: centreon/www/install/front_translate.php
 msgid "Show value labels"
 msgstr "Show value labels"
@@ -16026,10 +16071,6 @@ msgstr "Storage database name"
 msgid "Storage folders"
 msgstr "Storage folders"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Storage near saturation"
-msgstr "Storage near saturation"
-
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Store LDAP password"
 msgstr "Store LDAP password"
@@ -16269,6 +16310,18 @@ msgstr "The %s with value '%d' does not exist"
 msgid "The '%s' command name already exists"
 msgstr "The '%s' command name already exists"
 
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The IP address is already registered"
+msgstr ""
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The IP address is already registered on another poller"
+msgstr ""
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The IP address is incorrect"
+msgstr ""
+
 #: centreon/src/Centreon/Domain/Service/JsonValidator/Validator.php
 msgid "The JSON cannot be decoded"
 msgstr "The JSON cannot be decoded"
@@ -16292,18 +16345,6 @@ msgstr "The additional configuration name '%s' already exists"
 #, php-format
 msgid "The address '%s' of '%s' is not valid or not resolvable"
 msgstr "The address '%s' of '%s' is not valid or not resolvable"
-
-#: centreon/www/include/configuration/configServers/formServers.php
-msgid "The address is already registered"
-msgstr "The address is already registered"
-
-#: centreon/www/include/configuration/configServers/formServers.php
-msgid "The address is already registered on another poller"
-msgstr "The address is already registered on another poller"
-
-#: centreon/www/include/configuration/configServers/formServers.php
-msgid "The address is incorrect"
-msgstr "The address is incorrect"
 
 #: centreon/www/install/front_translate.php
 msgid "The address is invalid"
@@ -16728,6 +16769,11 @@ msgid ""
 msgstr ""
 "The server type '%s' : '%s'@'%s' does not match the one configured in "
 "Centreon or is disabled"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+#, php-format
+msgid "The service category name '%s' already exists"
+msgstr ""
 
 #: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
 #, php-format
@@ -17185,6 +17231,7 @@ msgid "Timeline"
 msgstr "Timeline"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/install/centreon_broker_translation.php
 msgid "Timeout"
 msgstr "Timeout"
 
@@ -17959,7 +18006,6 @@ msgstr "Valid Email"
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/install/centreon_broker_translation.php
 #: centreon/www/install/front_translate.php
 msgid "Value"
@@ -18103,6 +18149,10 @@ msgstr "View Group"
 #: centreon/www/include/options/media/images/formImg.php
 msgid "View Image"
 msgstr "View Image"
+
+#: centreon/www/include/configuration/configResources/formResources.php
+msgid "View Resource"
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
 msgid "View Vendor"
@@ -18266,10 +18316,6 @@ msgstr "View contact notifications"
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "View downtimes of hosts"
 msgstr "View downtimes of hosts"
-
-#: centreon/www/include/configuration/configResources/formResources.php
-msgid "View global macro"
-msgstr "View global macro"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -18778,6 +18824,10 @@ msgid "You are not allowed to access host templates"
 msgstr "You are not allowed to access host templates"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
+msgid "You are not allowed to access hosts"
+msgstr ""
+
+#: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "You are not allowed to access hosts in the real time context"
 msgstr "You are not allowed to access hosts in the real time context"
 
@@ -19062,6 +19112,14 @@ msgstr "You are not allowed to update a service template"
 #: centreon/src/Core/Media/Application/Exception/MediaException.php
 msgid "You are not allowed to update media"
 msgstr "You are not allowed to update media"
+
+#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+msgid "You are not allowed to update service categories"
+msgstr ""
+
+#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
+msgid "You are not allowed to update service groups"
+msgstr ""
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "You are not allowed to update the notification configuration"
@@ -19988,3 +20046,59 @@ msgstr "{{label}} should be at least {{min}} characters long"
 #: centreon/www/install/front_translate.php
 msgid "{{total}} element(s) found"
 msgstr "{{total}} element(s) found"
+
+#: unknown
+msgid "/*+&"
+msgstr "/*+&"
+
+#: unknown
+msgid "Add a global macro"
+msgstr "Add a global macro"
+
+#: unknown
+msgid "Centreon Central address, as seen by this server"
+msgstr "Centreon Central address, as seen by this server"
+
+#: unknown
+msgid ""
+"Displays a list of storage with saturation foreseen, current usage, days "
+"until saturation, and evolution of usage since the past day."
+msgstr ""
+"Displays a list of storage with saturation foreseen, current usage, days "
+"until saturation, and evolution of usage since the past day."
+
+#: unknown
+msgid "Global macros"
+msgstr "Global macros"
+
+#: unknown
+msgid "Modify a global macro"
+msgstr "Modify a global macro"
+
+#: unknown
+msgid "Name must start and end with a '$'"
+msgstr "Name must start and end with a '$'"
+
+#: unknown
+msgid "Show value label"
+msgstr "Show value label"
+
+#: unknown
+msgid "Storage near saturation"
+msgstr "Storage near saturation"
+
+#: unknown
+msgid "The address is already registered"
+msgstr "The address is already registered"
+
+#: unknown
+msgid "The address is already registered on another poller"
+msgstr "The address is already registered on another poller"
+
+#: unknown
+msgid "The address is incorrect"
+msgstr "The address is incorrect"
+
+#: unknown
+msgid "View global macro"
+msgstr "View global macro"

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -70,6 +70,10 @@ msgid "*The timezone used is configured on your user settings"
 msgstr "*The timezone used is configured on your user settings"
 
 #: centreon/www/install/front_translate.php
+msgid "/*+&"
+msgstr "/*+&"
+
+#: centreon/www/install/front_translate.php
 msgid "0-9"
 msgstr "0-9"
 
@@ -105,10 +109,6 @@ msgstr "24 hours"
 msgid "24h/24h - 7/7 days"
 msgstr "24h/24h - 7/7 days"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "24x7"
-msgstr "24x7"
-
 #: centreon/www/include/home/customViews/index.php
 msgid "3 Columns"
 msgstr "3 Columns"
@@ -138,14 +138,6 @@ msgstr ""
 "<b><i>Help :</i></b> Select hosts and hostgroups that can be seen by "
 "associated users. You also have the possibility to exclude host(s) from "
 "selected hostgroup(s)."
-
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-msgid ""
-"<b><i>Help :</i></b> Select image folders that can be seen by associated "
-"users."
-msgstr ""
-"<b><i>Help :</i></b> Select image folders that can be seen by associated "
-"users."
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid ""
@@ -195,10 +187,6 @@ msgstr ""
 msgid "<p>Currently upgrading... please do not interrupt this process.</p>"
 msgstr "<p>Currently upgrading... please do not interrupt this process.</p>"
 
-#: centreon/www/install/front_translate.php
-msgid "@$!%*?&"
-msgstr ""
-
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid "A '%s': '%s'@'%s' is already saved"
@@ -221,13 +209,6 @@ msgstr "A macro is malformated."
 #, php-format
 msgid "A platform using the name : '%s' or address : '%s' already exists"
 msgstr "A platform using the name : '%s' or address : '%s' already exists"
-
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-#, php-format
-msgid ""
-"A poller/agent configuration is already associated with poller ID(s) '%s'"
-msgstr ""
-"A poller/agent configuration is already associated with poller ID(s) '%s'"
 
 #: centreon/www/install/front_translate.php
 msgid "A-Z"
@@ -414,7 +395,6 @@ msgstr "Acknowledge services of hosts"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Acknowledged"
@@ -482,6 +462,7 @@ msgstr "Action Name"
 
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
@@ -586,6 +567,7 @@ msgstr "Actual End"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -716,6 +698,10 @@ msgstr "Add a Host"
 msgid "Add a Host Extended Info"
 msgstr "Add a Host Extended Info"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Add a Host Group"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "Add a Host Template"
 msgstr "Add a Host Template"
@@ -836,10 +822,6 @@ msgid "Add a widget"
 msgstr "Add a widget"
 
 #: centreon/www/install/front_translate.php
-msgid "Add additional configurations"
-msgstr "Add additional configurations"
-
-#: centreon/www/install/front_translate.php
 msgid "Add advanced server configuration"
 msgstr "Add advanced server configuration"
 
@@ -866,10 +848,6 @@ msgid "Add an Extended Info"
 msgstr "Add an Extended Info"
 
 #: centreon/www/install/front_translate.php
-msgid "Add an additional configuration"
-msgstr "Add an additional configuration"
-
-#: centreon/www/install/front_translate.php
 msgid "Add an advanced configuration"
 msgstr "Add an advanced configuration"
 
@@ -892,10 +870,6 @@ msgstr "Add downtime"
 #: centreon/www/install/front_translate.php
 msgid "Add filter"
 msgstr "Add filter"
-
-#: centreon/www/install/front_translate.php
-msgid "Add host group"
-msgstr "Add host group"
 
 #: centreon/www/install/steps/process/installConfigurationDb.php
 msgid ""
@@ -1002,6 +976,7 @@ msgstr "Additional Configurations"
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -1034,12 +1009,10 @@ msgstr "Additional configuration updated"
 msgid "Additional freshness latency"
 msgstr "Additional freshness latency"
 
-#: centreon/www/install/front_translate.php
-msgid "Additional information"
-msgstr "Additional information"
-
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
 msgid "Address"
 msgstr "Address"
 
@@ -1157,10 +1130,6 @@ msgstr "Agent configurations"
 msgid "Agent type"
 msgstr "Agent type"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Aggregation frequency"
-msgstr "Aggregation frequency"
-
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
@@ -1188,6 +1157,8 @@ msgstr "Alerts"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -1230,7 +1201,6 @@ msgstr "Alias already exists"
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
 #: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "All"
 msgstr "All"
@@ -1315,15 +1285,6 @@ msgstr "All hosts"
 msgid "All hosts selected"
 msgstr "All hosts selected"
 
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/install/front_translate.php
-msgid "All image folders"
-msgstr "All image folders"
-
-#: centreon/www/install/front_translate.php
-msgid "All image folders selected"
-msgstr "All image folders selected"
-
 #: centreon/www/install/front_translate.php
 msgid "All metrics on this service are working fine."
 msgstr "All metrics on this service are working fine."
@@ -1373,14 +1334,6 @@ msgstr ""
 msgid "Allow self signed certificate"
 msgstr "Allow self signed certificate"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Allows you to add free text to your dashboards (section titles, information, "
-"etc.)."
-msgstr ""
-"Allows you to add free text to your dashboards (section titles, information, "
-"etc.)."
-
 #: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid "Already exists"
@@ -1411,6 +1364,11 @@ msgid ""
 msgstr ""
 "An additional configuration of type '%s' is already associated with poller "
 "ID(s) '%s'"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "An agent configuration is already associated with poller ID(s) '%s'"
+msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -1458,10 +1416,6 @@ msgstr "An error occurred when retrieving available updates"
 #: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
 msgid "An error occurred when retrieving the current version"
 msgstr "An error occurred when retrieving the current version"
-
-#: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
-msgid "An error occurred when writing engine context configuration"
-msgstr "An error occurred when writing engine context configuration"
 
 #: centreon/src/Core/Broker/Application/Exception/BrokerException.php
 #, php-format
@@ -1546,10 +1500,6 @@ msgstr "Apply only first role"
 msgid "Apply period"
 msgstr "Apply period"
 
-#: centreon/www/install/front_translate.php
-msgid "Apply resource access rules to the host group"
-msgstr "Apply resource access rules to the host group"
-
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Archives"
 msgstr "Archives"
@@ -1566,10 +1516,6 @@ msgstr ""
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 msgid "Are you sure you want to detach the service ?"
 msgstr "Are you sure you want to detach the service ?"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Area"
-msgstr "Area"
 
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Area color"
@@ -1600,7 +1546,6 @@ msgid "Arguments"
 msgstr "Arguments"
 
 #: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "Ascending"
 msgstr "Ascending"
 
@@ -1615,10 +1560,6 @@ msgstr "At least one authorization relation is required"
 #: centreon/www/install/front_translate.php
 msgid "At least one column must be selected"
 msgstr "At least one column must be selected"
-
-#: centreon/www/install/front_translate.php
-msgid "At least one connection mode must be enabled."
-msgstr "At least one connection mode must be enabled."
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "At least one contact or contactgroup should be linked to the rule"
@@ -1677,6 +1618,10 @@ msgstr "Attach to Master Remote Server"
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Attempt"
 msgstr "Attempt"
+
+#: centreon/www/install/front_translate.php
+msgid "Au moins un des modes de connexion doit être activé."
+msgstr ""
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Audit log activation"
@@ -1785,10 +1730,6 @@ msgstr "Authorized conditions not found in provider conditions"
 msgid "Authors"
 msgstr "Authors"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Auto"
-msgstr "Auto"
-
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Auto Rescheduling"
 msgstr "Auto Rescheduling"
@@ -1809,14 +1750,6 @@ msgstr "Auto-Rescheduling Option"
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Auto-Rescheduling Window"
 msgstr "Auto-Rescheduling Window"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Auto: Default value defined for the corresponding curve template (Monitoring "
-"> Performances > Curves)."
-msgstr ""
-"Auto: Default value defined for the corresponding curve template (Monitoring "
-"> Performances > Curves)."
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
@@ -1855,10 +1788,6 @@ msgstr "Average"
 msgid "Avg"
 msgstr "Avg"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Axes"
-msgstr "Axes"
-
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "BBDO version"
 msgstr "BBDO version"
@@ -1868,7 +1797,6 @@ msgstr "BBDO version"
 msgid "Back"
 msgstr "Back"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Background color"
 msgstr "Background color"
@@ -1955,34 +1883,14 @@ msgstr "Bad search operator"
 msgid "Bad service ID"
 msgstr "Bad service ID"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Bar"
-msgstr "Bar"
-
 #: centreon/www/install/front_translate.php
 msgid "Bar chart"
 msgstr "Bar chart"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Bar opacity"
-msgstr "Bar opacity"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Bar radius"
-msgstr "Bar radius"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 msgid "Base"
 msgstr "Base"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Base 10"
-msgstr "Base 10"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Base 2"
-msgstr "Base 2"
 
 #: centreon/www/install/front_translate.php
 msgid "Base URL"
@@ -2035,15 +1943,10 @@ msgstr "Blacklist client addresses"
 msgid "Blocking duration must be less than or equal to 7 days"
 msgstr "Blocking duration must be less than or equal to 7 days"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Both"
-msgstr "Both"
-
 #: centreon/www/install/front_translate.php
 msgid "Both identity provider and Centreon UI"
 msgstr "Both identity provider and Centreon UI"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Bottom"
 msgstr "Bottom"
@@ -2055,10 +1958,6 @@ msgstr "Breadcrumb copied"
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Broker Module"
 msgstr "Broker Module"
-
-#: centreon/www/include/configuration/configNagios/formNagios.php
-msgid "Broker Module Configuration File"
-msgstr "Broker Module Configuration File"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Broker Module Options"
@@ -2097,26 +1996,6 @@ msgstr "Build full URI (SCHEME://IP:PORT/PATH)."
 msgid "Business Activity"
 msgstr "Business Activity"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Business Activity Diagram"
-msgstr "Business Activity Diagram"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Business Activity availability"
-msgstr "Business Activity availability"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Business Activity availability history"
-msgstr "Business Activity availability history"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Business Activity status timeline"
-msgstr "Business Activity status timeline"
-
-#: centreon/www/install/front_translate.php
-msgid "Business View"
-msgstr "Business View"
-
 #: centreon/www/install/front_translate.php
 msgid "Business Views"
 msgstr "Business Views"
@@ -2136,22 +2015,6 @@ msgid ""
 msgstr ""
 "But do not edit the SQL files unless you know what you are doing.Refresh "
 "this page when the problem is fixed."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Button 1"
-msgstr "Button 1"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Button 2"
-msgstr "Button 2"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Button 3"
-msgstr "Button 3"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Button 4"
-msgstr "Button 4"
 
 #: centreon/www/install/front_translate.php
 msgid "By"
@@ -2189,14 +2052,6 @@ msgstr "By Status"
 msgid "By agent"
 msgstr "By agent"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"By default, the data of Business Views is aggregated monthly over the past "
-"12 months (if available)."
-msgstr ""
-"By default, the data of Business Views is aggregated monthly over the past "
-"12 months (if available)."
-
 #: centreon/www/install/front_translate.php
 msgid ""
 "By executing this script, your platform will be in a locked mode and you "
@@ -2208,22 +2063,18 @@ msgstr ""
 "will not be able to do <strong>anything</strong> during the migration "
 "process (example: deploying your configuration, updating administration "
 "parameters, etc...)."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "By name"
-msgstr "By name"
 
 #: centreon/www/install/front_translate.php
 msgid "By poller"
 msgstr "By poller"
 
 #: centreon/www/install/front_translate.php
-msgid "CA (.crt, .cert, .cer)"
-msgstr "CA (.crt, .cert, .cer)"
-
-#: centreon/www/install/front_translate.php
 msgid "CA Common Name (CN)"
 msgstr "CA Common Name (CN)"
+
+#: centreon/www/install/front_translate.php
+msgid "CA(.crt,.cer)"
+msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "CMA authentication token(s)"
@@ -2276,10 +2127,6 @@ msgstr "Calculation method provided not supported (%s)"
 #: centreon/www/install/front_translate.php
 msgid "Calculation type"
 msgstr "Calculation type"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Calculations based on time period"
-msgstr "Calculations based on time period"
 
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 msgid "Can't Use This Virtual Metric '"
@@ -2492,11 +2339,8 @@ msgstr "Centreon Broker reload command"
 msgid ""
 "Centreon Broker's configuration directory '%s' does not exist and could not\n"
 "                                             be created for monitoring "
-"engine '%s'. Please check its path or create it"
+"engine '%s'. Please check it's path or create it"
 msgstr ""
-"Centreon Broker's configuration directory '%s' does not exist and could not\n"
-"                                             be created for monitoring "
-"engine '%s'. Please check its path or create it"
 
 #: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
 #, php-format
@@ -2509,8 +2353,8 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
-msgid "Centreon Central IP address, as seen by this server"
-msgstr ""
+msgid "Centreon Central address, as seen by this server"
+msgstr "Centreon Central address, as seen by this server"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Centreon Connector"
@@ -2648,10 +2492,8 @@ msgid "Changes to the envelope size will be applied immediately"
 msgstr "Changes to the envelope size will be applied immediately"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid ""
-"Changing the type of an existing poller/agent configuration is not allowed"
+msgid "Changing the type of an existing agent configuration is not allowed"
 msgstr ""
-"Changing the type of an existing poller/agent configuration is not allowed"
 
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid ""
@@ -2917,14 +2759,6 @@ msgstr "Client addresses"
 msgid "Client secret"
 msgstr "Client secret"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Clock"
-msgstr "Clock"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Clock / Timer"
-msgstr "Clock / Timer"
-
 #: centreon/www/include/configuration/configObject/command/formArguments.php
 #: centreon/www/include/configuration/configObject/command/formMacros.php
 #: centreon/www/include/options/media/images/syncDir.php
@@ -3079,6 +2913,7 @@ msgstr "Comment type"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/metric.php
@@ -3102,7 +2937,6 @@ msgstr "Comment type"
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/install/menu_translation.php
 #: centreon/www/install/smarty_translate.php
 msgid "Comments"
@@ -3198,6 +3032,7 @@ msgstr "Compulsory Instance"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
@@ -3253,10 +3088,6 @@ msgstr "Compulsory image name"
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Compulsory name"
 msgstr "Compulsory name"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Condensed"
-msgstr "Condensed"
 
 #: centreon/www/install/front_translate.php
 msgid "Condition value"
@@ -3407,6 +3238,10 @@ msgstr "Connection failed, please contact your administrator"
 #: centreon/www/install/front_translate.php
 msgid "Connection initiated"
 msgstr "Connection initiated"
+
+#: centreon/www/install/front_translate.php
+msgid "Connection initiated by poller"
+msgstr ""
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Connection port"
@@ -3605,10 +3440,8 @@ msgstr "Could not establish connection to Centreon IMP servers ("
 #, php-format
 msgid ""
 "Could not find configuration directory '%s' for monitoring engine '%s'.\n"
-"                                 Please check its path or create it"
+"                                 Please check it's path or create it"
 msgstr ""
-"Could not find configuration directory '%s' for monitoring engine '%s'.\n"
-"                                 Please check its path or create it"
 
 #: centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
 #: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -3645,10 +3478,6 @@ msgstr ""
 "Could not write to file '%s' for monitoring engine '%s'. Please add writing\n"
 "                                     permissions for the webserver's user"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Countdown"
-msgstr "Countdown"
-
 #: centreon/www/install/front_translate.php
 msgid "Create"
 msgstr "Create"
@@ -3677,6 +3506,10 @@ msgstr "Create a ticket"
 msgid "Create a view"
 msgstr "Create a view"
 
+#: centreon/www/install/front_translate.php
+msgid "Create additional configuration"
+msgstr ""
+
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 msgid "Create and edit pollers"
 msgstr "Create and edit pollers"
@@ -3688,10 +3521,6 @@ msgstr "Create authentication token"
 #: centreon/www/install/front_translate.php
 msgid "Create dashboard"
 msgstr "Create dashboard"
-
-#: centreon/www/install/front_translate.php
-msgid "Create hosts automatically"
-msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "Create new CMA token"
@@ -3850,20 +3679,14 @@ msgstr ""
 "Currently installing database and generating cache... please do not "
 "interrupt this process."
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/smarty_translate.php
 msgid "Curve"
 msgstr "Curve"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Curve type"
-msgstr "Curve type"
 
 #: centreon/www/install/menu_translation.php
 msgid "Curves"
 msgstr "Curves"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Custom"
 msgstr "Custom"
@@ -3871,10 +3694,6 @@ msgstr "Custom"
 #: centreon/www/install/menu_translation.php
 msgid "Custom Views"
 msgstr "Custom Views"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Custom boundaries apply to the percentage."
-msgstr "Custom boundaries apply to the percentage."
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Custom code"
@@ -3940,14 +3759,6 @@ msgstr "DNS/IP"
 msgid "DOWN"
 msgstr "DOWN"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Daily"
-msgstr "Daily"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Dash width"
-msgstr "Dash width"
-
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Dashboard Integration Properties"
 msgstr "Dashboard Integration Properties"
@@ -3976,10 +3787,6 @@ msgstr "Dashboard updated"
 #: centreon/www/install/menu_translation.php
 msgid "Dashboards"
 msgstr "Dashboards"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Dashes"
-msgstr "Dashes"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/install/menu_translation.php
@@ -4020,26 +3827,6 @@ msgstr "Data Sources"
 #: centreon/www/install/smarty_translate.php
 msgid "Data free"
 msgstr "Data free"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Data is aggregated daily for graphs presenting hosts."
-msgstr "Data is aggregated daily for graphs presenting hosts."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Data is aggregated monthly over the last 12 months for graphs presenting "
-"host categories."
-msgstr ""
-"Data is aggregated monthly over the last 12 months for graphs presenting "
-"host categories."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Data is aggregated monthly over the last 12 months for graphs presenting "
-"host groups."
-msgstr ""
-"Data is aggregated monthly over the last 12 months for graphs presenting "
-"host groups."
 
 #: centreon/www/install/smarty_translate.php
 msgid "Data size"
@@ -4122,10 +3909,6 @@ msgstr "Date"
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Date Format"
 msgstr "Date Format"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Date format"
-msgstr "Date format"
 
 #: centreon/www/include/eventLogs/xml/data.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
@@ -4286,6 +4069,7 @@ msgstr "Define your endpoint"
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -4481,7 +4265,6 @@ msgid "Deploy configuration"
 msgstr "Deploy configuration"
 
 #: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "Descending"
 msgstr "Descending"
 
@@ -4523,10 +4306,6 @@ msgstr "Describe macros"
 #: centreon/www/install/front_translate.php
 msgid "Description"
 msgstr "Description"
-
-#: centreon/www/include/options/media/images/formDirectory.php
-msgid "Destination Directory"
-msgstr "Destination Directory"
 
 #: centreon/www/include/options/media/images/formDirectory.php
 msgid "Destination directory"
@@ -4594,6 +4373,7 @@ msgstr "Directory of light database for traps"
 #: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -4697,6 +4477,8 @@ msgstr "Disable verify peer"
 #: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -4729,11 +4511,11 @@ msgid "Disabled"
 msgstr "Disabled"
 
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 msgid "Disabled Hosts"
 msgstr "Disabled Hosts"
 
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/install/front_translate.php
 msgid "Disabled hosts"
 msgstr "Disabled hosts"
 
@@ -4777,7 +4559,6 @@ msgstr "Discovery"
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Display"
 msgstr "Display"
@@ -4843,25 +4624,9 @@ msgstr "Display anyway"
 msgid "Display as"
 msgstr "Display as"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display availability and performance as"
-msgstr "Display availability and performance as"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display availability as"
-msgstr "Display availability as"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display average as"
-msgstr "Display average as"
-
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Display comment on chart"
 msgstr "Display comment on chart"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display curve points"
-msgstr "Display curve points"
 
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
 #: centreon/www/include/monitoring/status/Services/serviceSummary.php
@@ -4884,10 +4649,6 @@ msgstr "Display events"
 msgid "Display executed command by monitoring engine"
 msgstr "Display executed command by monitoring engine"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display mode"
-msgstr "Display mode"
-
 #: centreon/www/install/smarty_translate.php
 msgid "Display multiple periods"
 msgstr "Display multiple periods"
@@ -4896,45 +4657,13 @@ msgstr "Display multiple periods"
 msgid "Display properties"
 msgstr "Display properties"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display resources"
-msgstr "Display resources"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display resources with these status types"
-msgstr "Display resources with these status types"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display resources with this state"
-msgstr "Display resources with this state"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display resources with this status"
-msgstr "Display resources with this status"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display resources with this type"
-msgstr "Display resources with this type"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display resources with this unit"
-msgstr "Display resources with this unit"
-
 #: centreon/www/install/front_translate.php
 msgid "Display the complete graph"
 msgstr "Display the complete graph"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display the diagram with this status"
-msgstr "Display the diagram with this status"
-
 #: centreon/www/install/front_translate.php
 msgid "Display the password"
 msgstr "Display the password"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display ticket creation buttons"
-msgstr "Display ticket creation buttons"
 
 #: centreon/www/install/front_translate.php
 msgid "Display up to"
@@ -4943,104 +4672,6 @@ msgstr "Display up to"
 #: centreon/www/install/front_translate.php
 msgid "Display view:"
 msgstr "Display view:"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display with this resource type"
-msgstr "Display with this resource type"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Display with this view"
-msgstr "Display with this view"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays a detailed view of the current status for selected resources as a "
-"chart."
-msgstr ""
-"Displays a detailed view of the current status for selected resources as a "
-"chart."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays a status overview for selected resources, grouped by hosts or by "
-"services."
-msgstr ""
-"Displays a status overview for selected resources, grouped by hosts or by "
-"services."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Displays a web page"
-msgstr "Displays a web page"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays availability and alerts of a Business Activity for a given period."
-msgstr ""
-"Displays availability and alerts of a Business Activity for a given period."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Displays availability, performance and alerts for a Business Activity"
-msgstr "Displays availability, performance and alerts for a Business Activity"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Displays data on resource status and events, centralized in a table."
-msgstr "Displays data on resource status and events, centralized in a table."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays graphically a business activity hierarchy of KPIs and lets you "
-"navigate through it."
-msgstr ""
-"Displays graphically a business activity hierarchy of KPIs and lets you "
-"navigate through it."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Displays metrics for a given time period."
-msgstr "Displays metrics for a given time period."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays the availability history of hosts, host categories or hostgroups."
-msgstr ""
-"Displays the availability history of hosts, host categories or hostgroups."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays the distribution of current statuses on a Business Activity, as a "
-"chronological timeline for a given time period."
-msgstr ""
-"Displays the distribution of current statuses on a Business Activity, as a "
-"chronological timeline for a given time period."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays the distribution of current statuses on selected groups of "
-"resources, as a table."
-msgstr ""
-"Displays the distribution of current statuses on selected groups of "
-"resources, as a table."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays the future evolution of a metric as a trend curve, based on its "
-"recent average data."
-msgstr ""
-"Displays the future evolution of a metric as a trend curve, based on its "
-"recent average data."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Displays the time according to the selected time zone, or a timer."
-msgstr "Displays the time according to the selected time zone, or a timer."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Displays the top or bottom x hosts, for a selected metric."
-msgstr "Displays the top or bottom x hosts, for a selected metric."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Displays the value of a single metric as a text, a gauge or a bar chart."
-msgstr ""
-"Displays the value of a single metric as a text, a gauge or a bar chart."
 
 #: centreon/www/install/smarty_translate.php
 msgid "Dissociate"
@@ -5093,6 +4724,7 @@ msgstr ""
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -5134,6 +4766,7 @@ msgstr "Do you confirm the deletion ?"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
@@ -5189,16 +4822,9 @@ msgstr "Do you want to reset the form?"
 msgid "Do you want to save the changes?"
 msgstr "Do you want to save the changes?"
 
-#: centreon/www/install/front_translate.php
-msgid "Do you want to switch to classic mode?"
-msgstr "Do you want to switch to classic mode?"
-
-#: centreon/www/install/front_translate.php
-msgid "Do you want to switch to regex mode?"
-msgstr "Do you want to switch to regex mode?"
-
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Documentation"
@@ -5207,14 +4833,6 @@ msgstr "Documentation"
 #: centreon/www/install/front_translate.php
 msgid "Done"
 msgstr "Done"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Donut chart"
-msgstr "Donut chart"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Dots"
-msgstr "Dots"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -5335,6 +4953,7 @@ msgstr "Dump"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
@@ -5376,10 +4995,6 @@ msgstr "Duplicate dashboard"
 #, php-format
 msgid "Duplicates not allowed for property '%s'"
 msgstr "Duplicates not allowed for property '%s'"
-
-#: centreon/www/install/front_translate.php
-msgid "Duplications"
-msgstr "Duplications"
 
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
 #: centreon/www/include/Administration/parameters/engine/form.php
@@ -5448,10 +5063,6 @@ msgid "Edit name"
 msgstr "Edit name"
 
 #: centreon/www/install/front_translate.php
-msgid "Edit password"
-msgstr "Edit password"
-
-#: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
 msgid "Edit profile"
 msgstr "Edit profile"
@@ -5518,6 +5129,7 @@ msgstr "Empty directory"
 #: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -5683,18 +5295,6 @@ msgstr "Enable routing"
 msgid "Enable shell"
 msgstr "Enable shell"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Enable ticket creation for hosts"
-msgstr "Enable ticket creation for hosts"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Enable ticket creation for services"
-msgstr "Enable ticket creation for services"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Enable ticket management"
-msgstr "Enable ticket management"
-
 #: centreon/www/install/front_translate.php
 msgid "Enable token"
 msgstr "Enable token"
@@ -5792,6 +5392,7 @@ msgid "Enable/Disable service checks"
 msgstr "Enable/Disable service checks"
 
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Enable/disable resource"
 msgstr "Enable/disable resource"
@@ -5816,6 +5417,8 @@ msgstr "Enable/disable resource"
 #: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -5848,12 +5451,9 @@ msgid "Enabled"
 msgstr "Enabled"
 
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 msgid "Enabled Hosts"
 msgstr "Enabled Hosts"
-
-#: centreon/www/install/front_translate.php
-msgid "Enabled hosts"
-msgstr "Enabled hosts"
 
 #: centreon/www/install/front_translate.php
 msgid "Encryption level"
@@ -5911,14 +5511,6 @@ msgstr "Engine Status"
 #: centreon/www/install/menu_translation.php
 msgid "Engine configuration"
 msgstr "Engine configuration"
-
-#: centreon/www/install/front_translate.php
-msgid "Enter Regex"
-msgstr "Enter Regex"
-
-#: centreon/www/install/front_translate.php
-msgid "Enter regex mode"
-msgstr "Enter regex mode"
 
 #: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
@@ -6264,10 +5856,6 @@ msgstr "Error while adding a host template"
 msgid "Error while adding a media"
 msgstr "Error while adding a media"
 
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid "Error while adding a poller/agent configuration"
-msgstr "Error while adding a poller/agent configuration"
-
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while adding a resource access rule"
 msgstr "Error while adding a resource access rule"
@@ -6283,6 +5871,10 @@ msgstr "Error while adding a token"
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid "Error while adding an additional configuration"
 msgstr "Error while adding an additional configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while adding an agent configuration"
+msgstr ""
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Error while adding authentication token"
@@ -6332,17 +5924,9 @@ msgstr "Error while deleting a host group"
 msgid "Error while deleting a host template"
 msgstr "Error while deleting a host template"
 
-#: centreon/src/Core/Media/Application/Exception/MediaException.php
-msgid "Error while deleting a media"
-msgstr ""
-
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error while deleting a notification configuration"
 msgstr "Error while deleting a notification configuration"
-
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid "Error while deleting a poller/agent configuration"
-msgstr "Error while deleting a poller/agent configuration"
 
 #: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
 msgid "Error while deleting a service group"
@@ -6355,6 +5939,10 @@ msgstr "Error while deleting a token"
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid "Error while deleting an additional configuration"
 msgstr "Error while deleting an additional configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while deleting an agent configuration"
+msgstr ""
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Error while deleting expired token"
@@ -6396,17 +5984,9 @@ msgstr "Error while deleting the service"
 msgid "Error while deleting the service template"
 msgstr "Error while deleting the service template"
 
-#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
-msgid "Error while duplicating a host group"
-msgstr "Error while duplicating a host group"
-
 #: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
 msgid "Error while editing service severity"
 msgstr "Error while editing service severity"
-
-#: centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
-msgid "Error while enabling/disabling host groups"
-msgstr "Error while enabling/disabling host groups"
 
 #: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
 msgid "Error while fetching ACL topologies"
@@ -6502,17 +6082,9 @@ msgstr "Error while retrieving a host group"
 msgid "Error while retrieving a host template"
 msgstr "Error while retrieving a host template"
 
-#: centreon/src/Core/Media/Application/Exception/MediaException.php
-msgid "Error while retrieving a media"
-msgstr ""
-
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error while retrieving a notification configuration"
 msgstr "Error while retrieving a notification configuration"
-
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid "Error while retrieving a poller/agent configuration"
-msgstr "Error while retrieving a poller/agent configuration"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while retrieving a resource access rule"
@@ -6533,6 +6105,10 @@ msgstr "Error while retrieving a token"
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid "Error while retrieving an additional configuration"
 msgstr "Error while retrieving an additional configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while retrieving an agent configuration"
+msgstr ""
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid ""
@@ -6565,8 +6141,8 @@ msgid "Error while retrieving host statuses distribution"
 msgstr "Error while retrieving host statuses distribution"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid "Error while retrieving multiple poller/agent configurations"
-msgstr "Error while retrieving multiple poller/agent configurations"
+msgid "Error while retrieving multiple agent configurations"
+msgstr ""
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "Error while retrieving newly created dashboard"
@@ -6591,18 +6167,6 @@ msgstr "Error while retrieving recently created service severity"
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Error while retrieving remote server information"
 msgstr "Error while retrieving remote server information"
-
-#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
-msgid "Error while retrieving service category"
-msgstr ""
-
-#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
-msgid "Error while retrieving service group"
-msgstr ""
-
-#: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
-msgid "Error while retrieving service severity"
-msgstr ""
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "Error while retrieving service statuses distribution"
@@ -6806,17 +6370,9 @@ msgstr "Error while updating a media"
 msgid "Error while updating a notification configuration"
 msgstr "Error while updating a notification configuration"
 
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid "Error while updating a poller/agent configuration"
-msgstr "Error while updating a poller/agent configuration"
-
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "Error while updating a service"
 msgstr "Error while updating a service"
-
-#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
-msgid "Error while updating a service group"
-msgstr ""
 
 #: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
 msgid "Error while updating a service template"
@@ -6825,6 +6381,10 @@ msgstr "Error while updating a service template"
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid "Error while updating an additional configuration"
 msgstr "Error while updating an additional configuration"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "Error while updating an agent configuration"
+msgstr ""
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Error while updating authentication tokens"
@@ -6841,10 +6401,6 @@ msgstr "Error while updating contact (massive change)"
 #: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
 msgid "Error while updating host severity"
 msgstr "Error while updating host severity"
-
-#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
-msgid "Error while updating service category"
-msgstr ""
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "Error while updating the dashboard share"
@@ -6889,7 +6445,6 @@ msgid "Escalations"
 msgstr "Escalations"
 
 #: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/install/centreon_broker_translation.php
 #: centreon/www/install/front_translate.php
 msgid "Event"
 msgstr "Event"
@@ -7038,10 +6593,6 @@ msgid "Execution was too long and reached timeout"
 msgstr "Execution was too long and reached timeout"
 
 #: centreon/www/include/options/media/images/formImg.php
-msgid "Existing directory"
-msgstr "Existing directory"
-
-#: centreon/www/include/options/media/images/formImg.php
 msgid "Existing or new directory"
 msgstr "Existing or new directory"
 
@@ -7052,10 +6603,6 @@ msgstr "Exit"
 #: centreon/www/install/front_translate.php
 msgid "Exit edition mode"
 msgstr "Exit edition mode"
-
-#: centreon/www/install/front_translate.php
-msgid "Exit regex mode"
-msgstr "Exit regex mode"
 
 #: centreon/www/install/front_translate.php
 msgid "Exit {{dashboardName}}"
@@ -7160,6 +6707,10 @@ msgstr "Extended"
 msgid "Extended Info"
 msgstr "Extended Info"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Extended Information"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
 msgid "Extended Settings"
 msgstr "Extended Settings"
@@ -7240,10 +6791,6 @@ msgid "Failed to create the dashboard"
 msgstr "Failed to create the dashboard"
 
 #: centreon/www/install/front_translate.php
-msgid "Failed to delete"
-msgstr "Failed to delete"
-
-#: centreon/www/install/front_translate.php
 msgid "Failed to delete the dashboard"
 msgstr "Failed to delete the dashboard"
 
@@ -7268,14 +6815,6 @@ msgid "Failed to delete the selected resource access rules"
 msgstr "Failed to delete the selected resource access rules"
 
 #: centreon/www/install/front_translate.php
-msgid "Failed to disable"
-msgstr "Failed to disable"
-
-#: centreon/www/install/front_translate.php
-msgid "Failed to duplicate"
-msgstr "Failed to duplicate"
-
-#: centreon/www/install/front_translate.php
 msgid "Failed to duplicate the dashboard"
 msgstr "Failed to duplicate the dashboard"
 
@@ -7286,10 +6825,6 @@ msgstr "Failed to duplicate the notification"
 #: centreon/www/install/front_translate.php
 msgid "Failed to duplicate the resource access rule"
 msgstr "Failed to duplicate the resource access rule"
-
-#: centreon/www/install/front_translate.php
-msgid "Failed to enable"
-msgstr "Failed to enable"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -7387,10 +6922,6 @@ msgstr "File too big"
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Files"
 msgstr "Files"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Fill opacity"
-msgstr "Fill opacity"
 
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
@@ -7544,7 +7075,6 @@ msgstr "Flap Detection Option"
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Flapping"
 msgstr "Flapping"
@@ -7586,14 +7116,6 @@ msgstr ""
 "For security reasons, the token can only be displayed once. Remember to "
 "store it well."
 
-#: centreon/www/install/front_translate.php
-msgid ""
-"For some connectors, you must define on the poller the credentials required "
-"to access the monitored hosts. You can do it easily from here."
-msgstr ""
-"For some connectors, you must define on the poller the credentials required "
-"to access the monitored hosts. You can do it easily from here."
-
 #: centreon/www/include/Administration/parameters/engine/form.php
 msgid "Force Active Checks"
 msgstr "Force Active Checks"
@@ -7626,10 +7148,6 @@ msgstr ""
 #: centreon/www/install/front_translate.php
 msgid "Forced check command sent!"
 msgstr "Forced check command sent!"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Forecast based on past X days"
-msgstr "Forecast based on past X days"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configResources/formResources.php
@@ -7743,7 +7261,6 @@ msgstr "Functions"
 msgid "GMT is activated on your system. Exceptions will not be generated."
 msgstr "GMT is activated on your system. Exceptions will not be generated."
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Gauge"
 msgstr "Gauge"
@@ -7760,6 +7277,7 @@ msgstr "General"
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
@@ -7786,7 +7304,6 @@ msgstr "General Options"
 #: centreon/www/include/Administration/parameters/ldap/form.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
 #: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/install/front_translate.php
 msgid "General information"
 msgstr "General information"
 
@@ -7835,43 +7352,16 @@ msgstr "Generating files"
 msgid "Generation error on monitoring server #%d: %s"
 msgstr "Generation error on monitoring server #%d: %s"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Generic data (example)"
-msgstr "Generic data (example)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Generic data for single metric (example)"
-msgstr "Generic data for single metric (example)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Generic input (example)"
-msgstr "Generic input (example)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Generic text"
-msgstr "Generic text"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Generic text (example)"
-msgstr "Generic text (example)"
-
-#: centreon/www/install/front_translate.php
-msgid "Generic widgets"
-msgstr "Generic widgets"
-
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
 msgid "Geo coordinates"
 msgstr "Geo coordinates"
 
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Geographic coordinates"
 msgstr "Geographic coordinates"
-
-#: centreon/www/install/front_translate.php
-msgid "Geographic coordinates for MAP"
-msgstr "Geographic coordinates for MAP"
 
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 msgid "Global Functionalities Access"
@@ -7951,10 +7441,6 @@ msgstr "Graph options"
 msgid "Graph per page for Performances"
 msgstr "Graph per page for Performances"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Graph style"
-msgstr "Graph style"
-
 #: centreon/www/include/configuration/configObject/command/formCommand.php
 #: centreon/www/install/smarty_translate.php
 msgid "Graph template"
@@ -7967,15 +7453,6 @@ msgstr "Graph template"
 msgid "Graphs"
 msgstr "Graphs"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Grid"
-msgstr "Grid"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Gridline type"
-msgstr "Gridline type"
-
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/menu_translation.php
 msgid "Group"
@@ -8009,18 +7486,6 @@ msgstr "Group filter"
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Group member attribute"
 msgstr "Group member attribute"
-
-#: centreon/www/install/front_translate.php
-msgid "Group members"
-msgstr "Group members"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Group monitoring"
-msgstr "Group monitoring"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Group name"
-msgstr "Group name"
 
 #: centreon/www/install/front_translate.php
 msgid "Group value"
@@ -8059,7 +7524,6 @@ msgstr "HTTP Method"
 msgid "HTTP Port"
 msgstr "HTTP Port"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Hard"
 msgstr "Hard"
@@ -8100,6 +7564,7 @@ msgstr "Height"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
@@ -8123,7 +7588,6 @@ msgstr "Help"
 #: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/smarty_translate.php
 msgid "Hidden"
 msgstr "Hidden"
@@ -8132,22 +7596,10 @@ msgstr "Hidden"
 msgid "Hidden Graph And Legend"
 msgstr "Hidden Graph And Legend"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Hide"
-msgstr "Hide"
-
 #: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
 msgid "Hide graphs of selected Services"
 msgstr "Hide graphs of selected Services"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Hide services with Down host"
-msgstr "Hide services with Down host"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Hide services with Unreachable host"
-msgstr "Hide services with Unreachable host"
 
 #: centreon/www/install/front_translate.php
 msgid "Hide the password"
@@ -8187,14 +7639,6 @@ msgstr "History Options"
 msgid "Home"
 msgstr "Home"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Horizontal"
-msgstr "Horizontal"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Horizontal bar chart"
-msgstr "Horizontal bar chart"
-
 #: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/configuration/configKnowledge/search.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
@@ -8214,7 +7658,6 @@ msgstr "Horizontal bar chart"
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
 #: centreon/www/include/reporting/dashboard/viewHostLog.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Host"
@@ -8247,7 +7690,6 @@ msgstr "Host Acknowledgement"
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "Host Categories"
 msgstr "Host Categories"
 
@@ -8478,7 +7920,6 @@ msgstr "Host group"
 msgid "Host group (%s) not found"
 msgstr "Host group (%s) not found"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Host groups"
 msgstr "Host groups"
@@ -8575,10 +8016,6 @@ msgstr "Host not found"
 #: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Host notifications"
 msgstr "Host notifications"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Host severities"
-msgstr "Host severities"
 
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -8698,10 +8135,6 @@ msgstr "Hostgroup"
 msgid "Hostgroup Relations"
 msgstr "Hostgroup Relations"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Hostgroup availability history"
-msgstr "Hostgroup availability history"
-
 #: centreon/www/install/smarty_translate.php
 msgid "Hostgroup dependency"
 msgstr "Hostgroup dependency"
@@ -8753,7 +8186,6 @@ msgstr "Hostgroups Summary"
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/menu_translation.php
 #: centreon/www/widgets/global-health/src/global_health.php
@@ -8883,8 +8315,6 @@ msgstr "Human readable"
 msgid "IP"
 msgstr "IP"
 
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/status/Hosts/hostJS.php
 #: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
 #: centreon/www/include/options/session/connected_user.php
@@ -8902,10 +8332,10 @@ msgstr "IP address or hostname"
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/install/front_translate.php
 msgid "Icon"
 msgstr "Icon"
 
@@ -8958,12 +8388,6 @@ msgstr ""
 "you want to request a data synchronization at the next login of this "
 "Contact ?"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"If ticket management is enabled, only the “by service” view is available."
-msgstr ""
-"If ticket management is enabled, only the “by service” view is available."
-
 #: centreon/www/install/front_translate.php
 msgid ""
 "If we consider the following example in the JSON received from the "
@@ -8989,14 +8413,6 @@ msgstr ""
 #: centreon/www/install/front_translate.php
 msgid "If you leave {{dashboardName}}, your changes will not be saved."
 msgstr "If you leave {{dashboardName}}, your changes will not be saved."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"If you want to display the graph with host categories and hosts, you must "
-"select only one hostgroup."
-msgstr ""
-"If you want to display the graph with host categories and hosts, you must "
-"select only one hostgroup."
 
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
 msgid "Ignore ssl certificate"
@@ -9026,11 +8442,6 @@ msgstr "Image Name"
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Image Type"
 msgstr "Image Type"
-
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/install/front_translate.php
-msgid "Image folders"
-msgstr "Image folders"
 
 #: centreon/www/include/options/media/images/formImg.php
 msgid "Image or archive"
@@ -9107,7 +8518,6 @@ msgstr "In Downtime"
 msgid "In Scheduled Downtime?"
 msgstr "In Scheduled Downtime?"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "In downtime"
 msgstr "In downtime"
@@ -9119,10 +8529,6 @@ msgstr "Include all hostgroups"
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid "Include all hosts"
 msgstr "Include all hosts"
-
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-msgid "Include all image folders"
-msgstr "Include all image folders"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid "Include all servicegroups"
@@ -9264,7 +8670,6 @@ msgstr "Instance timeout"
 msgid "Inter-Check Sleep Time"
 msgstr "Inter-Check Sleep Time"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Interval"
 msgstr "Interval"
@@ -9331,13 +8736,6 @@ msgstr "Invalid coordinates format specified"
 msgid "Invalid coordinates values specified"
 msgstr "Invalid coordinates values specified"
 
-#: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/include/options/media/images/formImg.php
-msgid ""
-"Invalid directory name. Only alphanumeric characters, hyphens and "
-"underscores are allowed."
-msgstr ""
-
 #: centreon/src/Core/Domain/Configuration/Notification/Exception/NotificationException.php
 #, php-format
 msgid "Invalid event provided (%s)"
@@ -9358,10 +8756,6 @@ msgstr "Invalid filename"
 #: centreon/www/install/front_translate.php
 msgid "Invalid format"
 msgstr "Invalid format"
-
-#: centreon/www/install/front_translate.php
-msgid "Invalid geo-coordinate format"
-msgstr "Invalid geo-coordinate format"
 
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
@@ -9575,7 +8969,6 @@ msgstr "Language"
 msgid "Last 12 hours"
 msgstr "Last 12 hours"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Last 12 months"
 msgstr "Last 12 months"
@@ -9584,7 +8977,6 @@ msgstr "Last 12 months"
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
-#: centreon/www/install/front_translate.php
 msgid "Last 14 days"
 msgstr "Last 14 days"
 
@@ -9599,7 +8991,6 @@ msgstr "Last 2 days"
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
-#: centreon/www/install/front_translate.php
 msgid "Last 2 months"
 msgstr "Last 2 months"
 
@@ -9693,7 +9084,6 @@ msgstr "Last 6 hours"
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Last 6 months"
 msgstr "Last 6 months"
@@ -9846,7 +9236,6 @@ msgid "Last update"
 msgstr "Last update"
 
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Last week"
 msgstr "Last week"
@@ -9880,10 +9269,6 @@ msgstr "Layout"
 msgid "Leave"
 msgstr "Leave"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Left"
-msgstr "Left"
-
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Legacy version"
 msgstr "Legacy version"
@@ -9891,7 +9276,6 @@ msgstr "Legacy version"
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "Legend"
 msgstr "Legend"
 
@@ -9946,25 +9330,9 @@ msgstr "Limit per page for Monitoring"
 msgid "Limited search"
 msgstr "Limited search"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Line"
-msgstr "Line"
-
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Line color"
 msgstr "Line color"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Line style"
-msgstr "Line style"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Line width"
-msgstr "Line width"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Linear"
-msgstr "Linear"
 
 #: centreon/www/install/front_translate.php
 msgid "Link copied"
@@ -9973,10 +9341,6 @@ msgstr "Link copied"
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Link to cbd service"
 msgstr "Link to cbd service"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Link types"
-msgstr "Link types"
 
 #: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
 msgid "Linked ACL groups"
@@ -10090,7 +9454,6 @@ msgstr "Links Management"
 #: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 #: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "List"
 msgstr "List"
 
@@ -10181,10 +9544,6 @@ msgstr "Log nothing (default)"
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Log options"
 msgstr "Log options"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Logarithmic"
-msgstr "Logarithmic"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Logger version"
@@ -10287,10 +9646,6 @@ msgstr ""
 msgid "MB"
 msgstr "MB"
 
-#: centreon/www/install/front_translate.php
-msgid "MBI reporting widgets"
-msgstr "MBI reporting widgets"
-
 #: centreon/www/install/menu_translation.php
 msgid "MIBs"
 msgstr "MIBs"
@@ -10374,10 +9729,6 @@ msgstr "Manage envelope size"
 msgid "Manage filters"
 msgstr "Manage filters"
 
-#: centreon/www/install/centreon_broker_translation.php
-msgid "Managed event TTL"
-msgstr ""
-
 #: centreon/www/install/menu_translation.php
 msgid "Manager"
 msgstr "Manager"
@@ -10403,6 +9754,7 @@ msgid "Mandatory field"
 msgstr "Mandatory field"
 
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
 msgid "Mandatory field for ACL purpose."
 msgstr "Mandatory field for ACL purpose."
@@ -10438,6 +9790,10 @@ msgstr "Manufacturer"
 #: centreon/www/install/front_translate.php
 msgid "Many thanks to all the contributors to the security of Centreon"
 msgstr "Many thanks to all the contributors to the security of Centreon"
+
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Map Icon"
+msgstr ""
 
 #: centreon/src/Core/Platform/Infrastructure/Validator/RequirementValidators/DatabaseRequirementValidators/MariaDbRequirementException.php
 #, php-format
@@ -10481,15 +9837,6 @@ msgstr "Max Check Attempts"
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Max file size in bytes"
 msgstr "Max file size in bytes"
-
-#: centreon/www/include/options/media/images/formImg.php
-#, php-format
-msgid "Max file size: %s"
-msgstr "Max file size: %s"
-
-#: centreon/www/install/front_translate.php
-msgid "Max value"
-msgstr "Max value"
 
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
@@ -10564,6 +9911,10 @@ msgstr "Media already exists"
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Member of Host Groups"
 msgstr "Member of Host Groups"
+
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Members"
+msgstr ""
 
 #: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
 msgid "Memory file"
@@ -10689,10 +10040,6 @@ msgstr "Metric Name"
 msgid "Metric Unit"
 msgstr "Metric Unit"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Metric capacity planning"
-msgstr "Metric capacity planning"
-
 #: centreon/www/install/front_translate.php
 msgid "Metric name"
 msgstr "Metric name"
@@ -10710,10 +10057,6 @@ msgstr "Metrics"
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Metrics column"
 msgstr "Metrics column"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Metrics graph"
-msgstr "Metrics graph"
 
 #: centreon/src/Core/Metric/Application/Exception/MetricException.php
 msgid "Metrics not found"
@@ -10739,10 +10082,6 @@ msgstr "Migration script"
 #: centreon/www/install/smarty_translate.php
 msgid "Min"
 msgstr "Min"
-
-#: centreon/www/install/front_translate.php
-msgid "Min value"
-msgstr "Min value"
 
 #: centreon/www/install/front_translate.php
 msgid "Mini Centreon Logo"
@@ -10878,6 +10217,7 @@ msgstr "Modificaton type"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
@@ -10990,6 +10330,10 @@ msgstr "Modify a Host"
 msgid "Modify a Host Extended Info"
 msgstr "Modify a Host Extended Info"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Modify a Host Group"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "Modify a Host Template"
 msgstr "Modify a Host Template"
@@ -11071,10 +10415,6 @@ msgstr "Modify an Escalation"
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Modify an Extended Info"
 msgstr "Modify an Extended Info"
-
-#: centreon/www/install/front_translate.php
-msgid "Modify an additional configuration"
-msgstr "Modify an additional configuration"
 
 #: centreon/www/include/options/media/images/formDirectory.php
 msgid "Modify directory"
@@ -11234,10 +10574,6 @@ msgstr "Monitoring settings"
 msgid "Month"
 msgstr "Month"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Monthly"
-msgstr "Monthly"
-
 #: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "Monthly basis"
@@ -11274,6 +10610,7 @@ msgstr "More actions"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -11356,10 +10693,6 @@ msgstr "Must be a number"
 msgid "Must be a number between 1 and 65335 included."
 msgstr "Must be a number between 1 and 65335 included."
 
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-msgid "Must be a positive integer or 0"
-msgstr "Must be a positive integer or 0"
-
 #: centreon/src/Core/Security/ProviderConfiguration/Domain/Exception/ConfigurationException.php
 #, php-format
 msgid "Must not Happen, got unexpected CustomConfiguration type %s"
@@ -11408,6 +10741,8 @@ msgstr "N/A"
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
@@ -11443,7 +10778,6 @@ msgstr "N/A"
 #: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
 #: centreon/www/install/centreon_broker_translation.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Name"
@@ -11470,6 +10804,7 @@ msgstr "Name cannot be empty"
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
@@ -11494,8 +10829,8 @@ msgid "Name of the logger"
 msgstr "Name of the logger"
 
 #: centreon/www/install/front_translate.php
-msgid "Need help using the search bar?"
-msgstr "Need help using the search bar?"
+msgid "Need help using the search bar ?"
+msgstr ""
 
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Never Started"
@@ -11684,14 +11019,6 @@ msgstr "No downtime scheduled"
 msgid "No host found"
 msgstr "No host found"
 
-#: centreon/www/install/front_translate.php
-msgid "No hosts in this group are currently disabled."
-msgstr "No hosts in this group are currently disabled."
-
-#: centreon/www/install/front_translate.php
-msgid "No hosts in this group are currently enabled."
-msgstr "No hosts in this group are currently enabled."
-
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
 msgid "No modification was made."
 msgstr "No modification was made."
@@ -11789,10 +11116,6 @@ msgstr "No wiki page defined"
 msgid "No {{type}} found with this status"
 msgstr "No {{type}} found with this status"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Non-workhours"
-msgstr "Non-workhours"
-
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
@@ -11862,11 +11185,16 @@ msgid "Note URL"
 msgstr "Note URL"
 
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 #: centreon/www/install/front_translate.php
 msgid "Notes"
 msgstr "Notes"
+
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Notes URL"
+msgstr ""
 
 #: centreon/www/install/smarty_translate.php
 msgid "Nothing here, use the \"Add\" button"
@@ -12047,10 +11375,6 @@ msgstr "Notified"
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Notify"
 msgstr "Notify"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Number"
-msgstr "Number"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
@@ -12256,10 +11580,6 @@ msgstr "One peer retention"
 msgid "One peer retention mode"
 msgstr "One peer retention mode"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Only one"
-msgstr "Only one"
-
 #: centreon/www/install/front_translate.php
 msgid "Only passive checks are enabled"
 msgstr "Only passive checks are enabled"
@@ -12319,20 +11639,8 @@ msgid "Opened on"
 msgstr "Opened on"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
-msgid "Opentelemetry"
-msgstr "Opentelemetry"
-
-#: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Optimization"
 msgstr "Optimization"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Option 1"
-msgstr "Option 1"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Option 2"
-msgstr "Option 2"
 
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
 #: centreon/www/include/configuration/configNagios/listNagios.php
@@ -12345,6 +11653,7 @@ msgstr "Option 2"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -12392,10 +11701,6 @@ msgstr "Order sort problems"
 #: centreon/www/install/front_translate.php
 msgid "Ordered List"
 msgstr "Ordered List"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Orientation"
-msgstr "Orientation"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Orphaned Host Check Option"
@@ -12718,7 +12023,6 @@ msgstr "Peers"
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 #: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Pending"
 msgstr "Pending"
@@ -12735,10 +12039,6 @@ msgstr "People linked to this Access list"
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Percent State Change"
 msgstr "Percent State Change"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Percentage"
-msgstr "Percentage"
 
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -12800,10 +12100,6 @@ msgstr "Periods"
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Persistent"
 msgstr "Persistent"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Pie chart"
-msgstr "Pie chart"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -12886,14 +12182,6 @@ msgstr "Please install MariaDB version %s instead of %s."
 msgid "Please install PHP version %s instead of %s."
 msgstr "Please install PHP version %s instead of %s."
 
-#: centreon/www/install/dashboard_widgets.php
-msgid ""
-"Please note that domains outside your organization must be authorized in "
-"your Apache configuration."
-msgstr ""
-"Please note that domains outside your organization must be authorized in "
-"your Apache configuration."
-
 #: centreon/www/widgets/graph-monitoring/index.php
 msgid "Please select a graph period"
 msgstr "Please select a graph period"
@@ -12925,6 +12213,7 @@ msgstr "Please select a user in order to view his notifications"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
@@ -13014,10 +12303,8 @@ msgstr "Poller Filter"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid ""
-"Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
+msgid "Poller ID #%d is the only one linked to agent configuration ID #%d"
 msgstr ""
-"Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 #: centreon/www/install/smarty_translate.php
@@ -13078,7 +12365,6 @@ msgstr "Port number must be at most 65535"
 
 #: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
 #: centreon/www/include/options/session/connected_user.php
-#: centreon/www/install/dashboard_widgets.php
 msgid "Position"
 msgstr "Position"
 
@@ -13170,10 +12456,6 @@ msgstr "Print Min value"
 msgid "Print Total Value"
 msgstr "Print Total Value"
 
-#: centreon/www/install/front_translate.php
-msgid "Private key (.key)"
-msgstr "Private key (.key)"
-
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Private key file."
 msgstr "Private key file."
@@ -13182,13 +12464,9 @@ msgstr "Private key file."
 msgid "Private key path"
 msgstr "Private key path"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Problem (Critical)"
-msgstr "Problem (Critical)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Problem (Down/Critical)"
-msgstr "Problem (Down/Critical)"
+#: centreon/www/install/front_translate.php
+msgid "Private key(.key)"
+msgstr ""
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Problem display properties"
@@ -13286,8 +12564,8 @@ msgid "Public certificate"
 msgstr "Public certificate"
 
 #: centreon/www/install/front_translate.php
-msgid "Public certificate (.crt, .cert, .cer)"
-msgstr "Public certificate (.crt, .cert, .cer)"
+msgid "Public certificate(.crt,.cer)"
+msgstr ""
 
 #: centreon/www/include/home/customViews/formLoad.php
 msgid "Public views list"
@@ -13325,6 +12603,10 @@ msgstr "RRD file directory for statuses"
 msgid "RRD length"
 msgstr "RRD length"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "RRD retention"
+msgstr ""
+
 #: centreon/www/install/centreon_broker_translation.php
 msgid "RRDCacheD listening socket/port"
 msgstr "RRDCacheD listening socket/port"
@@ -13348,18 +12630,6 @@ msgstr "RRDTool Version"
 #: centreon/www/include/Administration/parameters/debug/form.php
 msgid "RRDTool debug"
 msgstr "RRDTool debug"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Radio"
-msgstr "Radio"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Radio 1"
-msgstr "Radio 1"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Radio 2"
-msgstr "Radio 2"
 
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Random"
@@ -13404,10 +12674,6 @@ msgstr "Read Only"
 #: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Read/Write"
 msgstr "Read/Write"
-
-#: centreon/www/install/front_translate.php
-msgid "Real time widgets"
-msgstr "Real time widgets"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Real-Time"
@@ -13459,10 +12725,6 @@ msgstr "Redirect URL"
 msgid "Redo"
 msgstr "Redo"
 
-#: centreon/www/install/front_translate.php
-msgid "Reduce"
-msgstr "Reduce"
-
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/install/front_translate.php
 msgid "Refresh"
@@ -13506,6 +12768,7 @@ msgid "Regular Expression Matching Option"
 msgstr "Regular Expression Matching Option"
 
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 msgid "Relation"
 msgstr "Relation"
 
@@ -13614,6 +12877,10 @@ msgstr "Rename"
 msgid "Replacement"
 msgstr "Replacement"
 
+#: centreon/www/install/centreon_broker_translation.php
+msgid "Replication enabled"
+msgstr ""
+
 #: centreon/www/install/menu_translation.php
 msgid "Reporting"
 msgstr "Reporting"
@@ -13621,10 +12888,6 @@ msgstr "Reporting"
 #: centreon/www/include/reporting/dashboard/initReport.php
 msgid "Reporting Period"
 msgstr "Reporting Period"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Reporting period"
-msgstr "Reporting period"
 
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
@@ -13723,6 +12986,7 @@ msgstr "Required field"
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
@@ -13780,6 +13044,7 @@ msgstr "Reschedule associated services"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/metric.php
@@ -13846,11 +13111,16 @@ msgstr "Resolve"
 msgid "Resource"
 msgstr "Resource"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Resource Access"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
 #: centreon/www/install/menu_translation.php
 msgid "Resource Access Management"
 msgstr "Resource Access Management"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
 msgid "Resource Access Rule"
 msgstr "Resource Access Rule"
@@ -13883,10 +13153,6 @@ msgstr "Resource name"
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Resource status performance"
 msgstr "Resource status performance"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Resource table"
-msgstr "Resource table"
 
 #: centreon/www/install/front_translate.php
 msgid "Resource type"
@@ -13925,17 +13191,9 @@ msgstr "Resources access"
 msgid "Resources access list link"
 msgstr "Resources access list link"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Resources linked to a ticket"
-msgstr "Resources linked to a ticket"
-
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Resources storage"
 msgstr "Resources storage"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Resources with no ticket"
-msgstr "Resources with no ticket"
 
 #: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
 msgid "Response empty"
@@ -14033,10 +13291,6 @@ msgstr "Retry interval (seconds)"
 msgid "Return to list"
 msgstr "Return to list"
 
-#: centreon/www/install/front_translate.php
-msgid "Revert to previous password"
-msgstr "Revert to previous password"
-
 #: centreon/www/include/options/media/images/formImg.php
 msgid "Review form after save"
 msgstr "Review form after save"
@@ -14044,10 +13298,6 @@ msgstr "Review form after save"
 #: centreon/www/install/front_translate.php
 msgid "Revoked"
 msgstr "Revoked"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Right"
-msgstr "Right"
 
 #: centreon/www/install/front_translate.php
 msgid "Role"
@@ -14114,10 +13364,6 @@ msgstr "Rows"
 #: centreon/www/install/front_translate.php
 msgid "Rows per page"
 msgstr "Rows per page"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Rule (ticket provider)"
-msgstr "Rule (ticket provider)"
 
 #: centreon/www/install/front_translate.php
 msgid "Rule properties"
@@ -14252,6 +13498,7 @@ msgstr "Saturday"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/metric.php
@@ -14316,10 +13563,6 @@ msgstr "Saved link"
 #: centreon/www/install/front_translate.php
 msgid "Saving..."
 msgstr "Saving..."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Scale"
-msgstr "Scale"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Scale Graph Values"
@@ -14391,10 +13634,6 @@ msgstr "Scheduling options"
 msgid "Scopes"
 msgstr "Scopes"
 
-#: centreon/www/install/centreon_broker_translation.php
-msgid "Script path"
-msgstr ""
-
 #: centreon/www/install/front_translate.php
 msgid "Scroll to top"
 msgstr "Scroll to top"
@@ -14413,6 +13652,7 @@ msgstr "Scroll to top"
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
@@ -14612,21 +13852,9 @@ msgstr "Select existing CMA token"
 msgid "Select existing CMA token(s)"
 msgstr "Select existing CMA token(s)"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Select field"
-msgstr "Select field"
-
 #: centreon/www/install/front_translate.php
 msgid "Select host"
 msgstr "Select host"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Select host severities"
-msgstr "Select host severities"
-
-#: centreon/www/install/front_translate.php
-msgid "Select hosts"
-msgstr "Select hosts"
 
 #: centreon/www/install/react_translation.php
 msgid "Select linked Remote Server"
@@ -14660,14 +13888,6 @@ msgstr "Select resource type"
 #: centreon/www/install/front_translate.php
 msgid "Select resources and events"
 msgstr "Select resources and events"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Select rule (ticket provider)"
-msgstr "Select rule (ticket provider)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Select service severities"
-msgstr "Select service severities"
 
 #: centreon/www/install/front_translate.php
 msgid "Select time format"
@@ -14725,11 +13945,6 @@ msgstr "Server Configuration"
 msgid "Server Configuration Wizard"
 msgstr "Server Configuration Wizard"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/react_translation.php
-msgid "Server IP address"
-msgstr ""
-
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Server Information"
 msgstr "Server Information"
@@ -14740,6 +13955,8 @@ msgid "Server Name"
 msgstr "Server Name"
 
 #: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/react_translation.php
 msgid "Server address"
 msgstr "Server address"
 
@@ -14768,7 +13985,6 @@ msgstr "Server type"
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
 #: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/reporting/dashboard/viewServicesLog.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Service"
@@ -15024,10 +14240,6 @@ msgstr "Service not found"
 #: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Service notifications"
 msgstr "Service notifications"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Service severities"
-msgstr "Service severities"
 
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -15424,10 +14636,6 @@ msgstr "Share with contacts"
 msgid "Shared Resources"
 msgstr "Shared Resources"
 
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-msgid "Shared image folders"
-msgstr "Shared image folders"
-
 #: centreon/www/install/front_translate.php
 msgid "Shares"
 msgstr "Shares"
@@ -15439,10 +14647,6 @@ msgstr "Shares saved"
 #: centreon/www/install/front_translate.php
 msgid "Shortcuts"
 msgstr "Shortcuts"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show"
-msgstr "Show"
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Show Critical status"
@@ -15472,17 +14676,9 @@ msgstr "Show Up status"
 msgid "Show Warning status"
 msgstr "Show Warning status"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show axis borders"
-msgstr "Show axis borders"
-
 #: centreon/www/install/front_translate.php
 msgid "Show criterias filters"
 msgstr "Show criterias filters"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show date"
-msgstr "Show date"
 
 #: centreon/www/install/front_translate.php
 msgid "Show description"
@@ -15492,14 +14688,6 @@ msgstr "Show description"
 msgid "Show fewer filters"
 msgstr "Show fewer filters"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show gridlines"
-msgstr "Show gridlines"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show legend"
-msgstr "Show legend"
-
 #: centreon/www/install/front_translate.php
 msgid "Show more filters"
 msgstr "Show more filters"
@@ -15508,22 +14696,13 @@ msgstr "Show more filters"
 msgid "Show only dashboards added to favorites"
 msgstr "Show only dashboards added to favorites"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Show thresholds"
 msgstr "Show thresholds"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show time zone"
-msgstr "Show time zone"
-
 #: centreon/www/install/front_translate.php
 msgid "Show value labels"
 msgstr "Show value labels"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Show value on chart"
-msgstr "Show value on chart"
 
 #: centreon/www/include/configuration/configKnowledge/search.php
 msgid "Show wiki pageless only"
@@ -15541,10 +14720,6 @@ msgstr "Show/Hide edit mode"
 msgid "Shutdown Monitoring Engine"
 msgstr "Shutdown Monitoring Engine"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Single metric"
-msgstr "Single metric"
-
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Size to max"
 msgstr "Size to max"
@@ -15552,10 +14727,6 @@ msgstr "Size to max"
 #: centreon/www/install/front_translate.php
 msgid "Slider"
 msgstr "Slider"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Smooth"
-msgstr "Smooth"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Snmp Traps"
@@ -15569,7 +14740,6 @@ msgstr "Snmp trap Groups"
 msgid "Snmp trap manufacturer"
 msgstr "Snmp trap manufacturer"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Soft"
 msgstr "Soft"
@@ -15577,10 +14747,6 @@ msgstr "Soft"
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Soft Service Dependencies Option"
 msgstr "Soft Service Dependencies Option"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Solid"
-msgstr "Solid"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
@@ -15602,10 +14768,6 @@ msgid ""
 msgstr ""
 "Sorry, your command line does not contain any $_SERVICE$ macro or $_HOST$ "
 "macro."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Sort by"
-msgstr "Sort by"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Sort by  "
@@ -15707,10 +14869,6 @@ msgstr "Sound for Warning status"
 msgid "Sound notifications"
 msgstr "Sound notifications"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Space"
-msgstr "Space"
-
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Special Command"
 msgstr "Special Command"
@@ -15736,10 +14894,6 @@ msgstr "Stack"
 msgid "Stacked"
 msgstr "Stacked"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Stacked bar"
-msgstr "Stacked bar"
-
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Stacking"
 msgstr "Stacking"
@@ -15754,10 +14908,6 @@ msgstr "Stalking Options"
 #, php-format
 msgid "Stalking options not allowed (%s)"
 msgstr "Stalking options not allowed (%s)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Standard"
-msgstr "Standard"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/widgets/host-monitoring/src/action.php
@@ -15851,6 +15001,7 @@ msgstr "Statistics"
 #: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -15900,7 +15051,6 @@ msgstr "Statistics"
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 #: centreon/www/install/step_upgrade/step2.php
@@ -15936,10 +15086,6 @@ msgstr "Status Map Image"
 msgid "Status change percentage"
 msgstr "Status change percentage"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Status chart"
-msgstr "Status chart"
-
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Status column"
 msgstr "Status column"
@@ -15947,10 +15093,6 @@ msgstr "Status column"
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Status file"
 msgstr "Status file"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Status grid"
-msgstr "Status grid"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -15998,7 +15140,6 @@ msgstr "Status:"
 msgid "Stay"
 msgstr "Stay"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/smarty_translate.php
 #: centreon/www/install/step_upgrade/step4.php
 msgid "Step"
@@ -16013,10 +15154,6 @@ msgstr "Step"
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Sticky"
 msgstr "Sticky"
-
-#: centreon/www/install/front_translate.php
-msgid "Sticky for any non-OK status"
-msgstr "Sticky for any non-OK status"
 
 #: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
@@ -16087,22 +15224,6 @@ msgstr "String"
 msgid "Strong"
 msgstr "Strong"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Style for average data"
-msgstr "Style for average data"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Sub input 1"
-msgstr "Sub input 1"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Sub input 2"
-msgstr "Sub input 2"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Sub input 3"
-msgstr "Sub input 3"
-
 #: centreon/www/install/front_translate.php
 msgid "Subject"
 msgstr "Subject"
@@ -16141,14 +15262,6 @@ msgstr "Submit result for this host"
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Submit result for this service"
 msgstr "Submit result for this service"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Success (OK)"
-msgstr "Success (OK)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Success (OK/Up)"
-msgstr "Success (OK/Up)"
 
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -16276,7 +15389,6 @@ msgstr "Temporary directory"
 msgid "Test Internet Connection"
 msgstr "Test Internet Connection"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Text"
 msgstr "Text"
@@ -16310,18 +15422,6 @@ msgstr "The %s with value '%d' does not exist"
 msgid "The '%s' command name already exists"
 msgstr "The '%s' command name already exists"
 
-#: centreon/www/include/configuration/configServers/formServers.php
-msgid "The IP address is already registered"
-msgstr ""
-
-#: centreon/www/include/configuration/configServers/formServers.php
-msgid "The IP address is already registered on another poller"
-msgstr ""
-
-#: centreon/www/include/configuration/configServers/formServers.php
-msgid "The IP address is incorrect"
-msgstr ""
-
 #: centreon/src/Centreon/Domain/Service/JsonValidator/Validator.php
 msgid "The JSON cannot be decoded"
 msgstr "The JSON cannot be decoded"
@@ -16346,9 +15446,26 @@ msgstr "The additional configuration name '%s' already exists"
 msgid "The address '%s' of '%s' is not valid or not resolvable"
 msgstr "The address '%s' of '%s' is not valid or not resolvable"
 
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The address is already registered"
+msgstr "The address is already registered"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The address is already registered on another poller"
+msgstr "The address is already registered on another poller"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The address is incorrect"
+msgstr "The address is incorrect"
+
 #: centreon/www/install/front_translate.php
 msgid "The address is invalid"
 msgstr "The address is invalid"
+
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+#, php-format
+msgid "The agent configuration name '%s' already exists"
+msgstr ""
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "The check command cannot be null if the service template is null"
@@ -16540,10 +15657,6 @@ msgstr ""
 "The migration process can take several minutes depending on your "
 "configuration."
 
-#: centreon/www/install/front_translate.php
-msgid "The min value must be lower than the max value."
-msgstr "The min value must be lower than the max value."
-
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "The minimum allowed value is 10"
 msgstr "The minimum allowed value is 10"
@@ -16677,11 +15790,6 @@ msgstr ""
 "The platform: '%s'@'%s' is not linked to a Central. Please use the wizard "
 "first"
 
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-#, php-format
-msgid "The poller/agent configuration name '%s' already exists"
-msgstr "The poller/agent configuration name '%s' already exists"
-
 #: centreon/src/Centreon/Domain/Proxy/Proxy.php
 #, php-format
 msgid "The port can only be between 0 and 65535 inclusive"
@@ -16769,11 +15877,6 @@ msgid ""
 msgstr ""
 "The server type '%s' : '%s'@'%s' does not match the one configured in "
 "Centreon or is disabled"
-
-#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
-#, php-format
-msgid "The service category name '%s' already exists"
-msgstr ""
 
 #: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
 #, php-format
@@ -16866,6 +15969,11 @@ msgstr "The validator \"%s\" is not found"
 msgid "The value cannot be null"
 msgstr "The value cannot be null"
 
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "The value contains unauthorized characters"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "The widget will be permanently deleted."
 msgstr "The widget will be permanently deleted."
@@ -16894,10 +16002,6 @@ msgstr "The {{name}} widget will be permanently deleted."
 #, php-format
 msgid "There are not enough arguments to build the object %s"
 msgstr "There are not enough arguments to build the object %s"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "These time periods are defined in MBI'S ETL options."
-msgstr "These time periods are defined in MBI'S ETL options."
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -16995,18 +16099,6 @@ msgstr ""
 msgid "This is a contact template."
 msgstr "This is a contact template."
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "This is the description of the data widget"
-msgstr "This is the description of the data widget"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "This is the description of the generic input widget"
-msgstr "This is the description of the generic input widget"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "This is the description of the text widget"
-msgstr "This is the description of the text widget"
-
 #: centreon/www/install/front_translate.php
 msgid ""
 "This is the most common case: the agent initiates the connection to the "
@@ -17014,10 +16106,6 @@ msgid ""
 msgstr ""
 "This is the most common case: the agent initiates the connection to the "
 "poller."
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "This month"
-msgstr "This month"
 
 #: centreon/www/install/front_translate.php
 msgid "This name already exists"
@@ -17105,7 +16193,6 @@ msgstr "This value needs to be an integer lesser than"
 msgid "This view name is required"
 msgstr "This view name is required"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "This week"
 msgstr "This week"
@@ -17118,15 +16205,10 @@ msgstr "This will export and reload the configuration on all of your platform"
 msgid "This will not be used because the number of attempts is not defined"
 msgstr "This will not be used because the number of attempts is not defined"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "This year"
-msgstr "This year"
-
 #: centreon/www/install/smarty_translate.php
 msgid "Three columns"
 msgstr "Three columns"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Thresholds"
 msgstr "Thresholds"
@@ -17208,10 +16290,6 @@ msgstr "Time Unit"
 msgid "Time Zone"
 msgstr "Time Zone"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Time format"
-msgstr "Time format"
-
 #: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/install/front_translate.php
@@ -17222,16 +16300,11 @@ msgstr "Time period"
 msgid "Time that must pass before new connection is allowed"
 msgstr "Time that must pass before new connection is allowed"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Time zone"
-msgstr "Time zone"
-
 #: centreon/www/install/front_translate.php
 msgid "Timeline"
 msgstr "Timeline"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/install/centreon_broker_translation.php
 msgid "Timeout"
 msgstr "Timeout"
 
@@ -17263,10 +16336,6 @@ msgstr "Timeperiod templates"
 #: centreon/www/install/smarty_translate.php
 msgid "Timeperiods"
 msgstr "Timeperiods"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Timer"
-msgstr "Timer"
 
 #: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
 msgid "Timerange Overlaps"
@@ -17349,10 +16418,6 @@ msgstr "Token endpoint"
 msgid "Token has been created"
 msgstr "Token has been created"
 
-#: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
-msgid "Token not found"
-msgstr "Token not found"
-
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
 msgid "Token with name \"%s\" and creator ID \"%d\" is not valid"
@@ -17374,25 +16439,13 @@ msgstr "Too many metrics (X). More than 20 may cause performance issues."
 msgid "Tools"
 msgstr "Tools"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Tooltips"
-msgstr "Tooltips"
-
 #: centreon/www/install/front_translate.php
 msgid "Top"
 msgstr "Top"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Top Bottom Settings"
-msgstr "Top Bottom Settings"
-
 #: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
 msgid "Top Priority Hosts"
 msgstr "Top Priority Hosts"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Top/bottom"
-msgstr "Top/bottom"
 
 #: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Topology"
@@ -17540,7 +16593,6 @@ msgstr "UNREACHABLE"
 msgid "UP"
 msgstr "UP"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "URL"
 msgstr "URL"
@@ -17628,10 +16680,6 @@ msgstr "Unauthorized value"
 msgid "Unblock"
 msgstr "Unblock"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Undefined (Unreachable/Unknown)"
-msgstr "Undefined (Unreachable/Unknown)"
-
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
@@ -17643,7 +16691,6 @@ msgstr "Undetermined"
 msgid "Undo"
 msgstr "Undo"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Unhandled"
 msgstr "Unhandled"
@@ -17791,6 +16838,10 @@ msgid "Update"
 msgstr "Update"
 
 #: centreon/www/install/front_translate.php
+msgid "Update additional configuration"
+msgstr ""
+
+#: centreon/www/install/front_translate.php
 msgid "Update agent configuration"
 msgstr "Update agent configuration"
 
@@ -17860,12 +16911,8 @@ msgid "Use basic authentication for token endpoint authentication"
 msgstr "Use basic authentication for token endpoint authentication"
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
-msgid "Use deprecated custom views"
-msgstr "Use deprecated custom views"
-
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
-msgid "Use deprecated monitoring pages"
-msgstr "Use deprecated monitoring pages"
+msgid "Use deprecated pages"
+msgstr ""
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Use service DNS"
@@ -18019,7 +17066,6 @@ msgstr "Value defined by the {{metric}} metric"
 msgid "Value defined by {{metric}} metric"
 msgstr "Value defined by {{metric}} metric"
 
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Value format"
 msgstr "Value format"
@@ -18035,10 +17081,6 @@ msgstr "Value must be numeric"
 #: centreon/www/install/front_translate.php
 msgid "Value settings"
 msgstr "Value settings"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Value sort order"
-msgstr "Value sort order"
 
 #: centreon/www/include/configuration/configResources/listResources.php
 msgid "Values"
@@ -18099,10 +17141,6 @@ msgstr "Verification Check (Forced)"
 msgid "Version"
 msgstr "Version"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Vertical"
-msgstr "Vertical"
-
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Vertical Inheritance Only"
 msgstr "Vertical Inheritance Only"
@@ -18110,10 +17148,6 @@ msgstr "Vertical Inheritance Only"
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Vertical Label"
 msgstr "Vertical Label"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Vertical bar chart"
-msgstr "Vertical bar chart"
 
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 msgid "View"
@@ -18206,6 +17240,10 @@ msgstr "View a Host"
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "View a Host Extended Info"
 msgstr "View a Host Extended Info"
+
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "View a Host Group"
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "View a Host Template"
@@ -18446,7 +17484,6 @@ msgstr "WARNING"
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
 #: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Warning"
@@ -18518,10 +17555,6 @@ msgstr "Web SSO configuration saved"
 msgid "Web SSO only"
 msgstr "Web SSO only"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Web page"
-msgstr "Web page"
-
 #: centreon/www/install/front_translate.php
 msgid "Web page preview"
 msgstr "Web page preview"
@@ -18552,20 +17585,12 @@ msgid "Welcome to the Dashboards interface!"
 msgstr "Welcome to the Dashboards interface!"
 
 #: centreon/www/install/front_translate.php
-msgid "Welcome to the additional configurations page"
-msgstr "Welcome to the additional configurations page"
-
-#: centreon/www/install/front_translate.php
 msgid "Welcome to the agent configuration page"
 msgstr "Welcome to the agent configuration page"
 
 #: centreon/www/install/front_translate.php
 msgid "Welcome to the authentication tokens page"
 msgstr "Welcome to the authentication tokens page"
-
-#: centreon/www/install/front_translate.php
-msgid "Welcome to the host groups page"
-msgstr "Welcome to the host groups page"
 
 #: centreon/www/install/front_translate.php
 msgid "Welcome to the notifications interface"
@@ -18621,10 +17646,6 @@ msgstr "Width"
 msgid "Wiki page defined"
 msgstr "Wiki page defined"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "Workhours"
-msgstr "Workhours"
-
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Write metrics"
 msgstr "Write metrics"
@@ -18640,14 +17661,6 @@ msgstr "Write thread id (deprecated)"
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Write timestamp (deprecated)"
 msgstr "Write timestamp (deprecated)"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Y-axis boundaries"
-msgstr "Y-axis boundaries"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Y-axis label rotation"
-msgstr "Y-axis label rotation"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Y/m/d - H:i:s"
@@ -18694,7 +17707,6 @@ msgstr "Yes"
 
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
 #: centreon/www/include/reporting/dashboard/common-Func.php
-#: centreon/www/install/dashboard_widgets.php
 #: centreon/www/install/front_translate.php
 msgid "Yesterday"
 msgstr "Yesterday"
@@ -18787,6 +17799,10 @@ msgstr ""
 msgid "You are not allowed to access additional configurations"
 msgstr "You are not allowed to access additional configurations"
 
+#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+msgid "You are not allowed to access agent configurations"
+msgstr ""
+
 #: centreon/src/Core/Command/Application/Exception/CommandException.php
 msgid "You are not allowed to access commands"
 msgstr "You are not allowed to access commands"
@@ -18824,16 +17840,8 @@ msgid "You are not allowed to access host templates"
 msgstr "You are not allowed to access host templates"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
-msgid "You are not allowed to access hosts"
-msgstr ""
-
-#: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "You are not allowed to access hosts in the real time context"
 msgstr "You are not allowed to access hosts in the real time context"
-
-#: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-msgid "You are not allowed to access poller/agent configurations"
-msgstr "You are not allowed to access poller/agent configurations"
 
 #: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
 msgid "You are not allowed to access service categories"
@@ -18878,6 +17886,10 @@ msgstr "You are not allowed to access this host"
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "You are not allowed to access this host category"
 msgstr "You are not allowed to access this host category"
+
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "You are not allowed to access this host group"
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/meta_service/metaService.php
 msgid "You are not allowed to access this meta service"
@@ -19113,14 +18125,6 @@ msgstr "You are not allowed to update a service template"
 msgid "You are not allowed to update media"
 msgstr "You are not allowed to update media"
 
-#: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
-msgid "You are not allowed to update service categories"
-msgstr ""
-
-#: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
-msgid "You are not allowed to update service groups"
-msgstr ""
-
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "You are not allowed to update the notification configuration"
 msgstr "You are not allowed to update the notification configuration"
@@ -19167,6 +18171,12 @@ msgid ""
 msgstr ""
 "You can't edit this downtime because you don't have access to all of its "
 "resources"
+
+#: centreon/www/install/smarty_translate.php
+msgid ""
+"You can't edit this hostgroup because you don't have access to all its "
+"resources"
+msgstr ""
 
 #: centreon/www/install/smarty_translate.php
 msgid "You cannot add more charts. The maximum charts is "
@@ -19316,14 +18326,6 @@ msgid "Your autologin key must be different than your current password"
 msgstr "Your autologin key must be different than your current password"
 
 #: centreon/www/install/front_translate.php
-msgid "Your changes will not be saved if you leave classic mode."
-msgstr "Your changes will not be saved if you leave classic mode."
-
-#: centreon/www/install/front_translate.php
-msgid "Your changes will not be saved if you leave regex mode."
-msgstr "Your changes will not be saved if you leave regex mode."
-
-#: centreon/www/install/front_translate.php
 msgid "Your changes will not be saved if you leave this page."
 msgstr "Your changes will not be saved if you leave this page."
 
@@ -19418,10 +18420,6 @@ msgstr "Your widget has been modified successfully!"
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "ZMQ"
 msgstr "ZMQ"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "Zero-centered"
-msgstr "Zero-centered"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
@@ -19621,10 +18619,6 @@ msgstr "apiPath"
 msgid "are working fine."
 msgstr "are working fine."
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "areaOpacity"
-msgstr "areaOpacity"
-
 #: centreon/www/install/react_translation.php
 msgid "as"
 msgstr "as"
@@ -19636,10 +18630,6 @@ msgstr "at"
 #: centreon/www/install/front_translate.php
 msgid "available"
 msgstr "available"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "boundaries"
-msgstr "boundaries"
 
 #: centreon/www/install/front_translate.php
 msgid "business activity"
@@ -19676,20 +18666,13 @@ msgstr "create or load"
 msgid "d/m/Y H:i:s"
 msgstr "d/m/Y H:i:s"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "dashLength"
-msgstr "dashLength"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "dashOffset"
-msgstr "dashOffset"
-
 #: centreon/www/install/front_translate.php
 msgid "day"
 msgstr "day"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/install/smarty_translate.php
 #: centreon/www/widgets/host-monitoring/src/action.php
@@ -19705,15 +18688,13 @@ msgstr "delete multiple notifications"
 msgid "disabled"
 msgstr "disabled"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "dotOffset"
-msgstr "dotOffset"
-
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "error"
 msgstr "error"
 
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
@@ -19727,10 +18708,6 @@ msgstr "get some help while creating your regular expression query at"
 #: centreon/www/class/centreonGraphNg.class.php
 msgid "graph on"
 msgstr "graph on"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "gridLinesType"
-msgstr "gridLinesType"
 
 #: centreon/www/install/front_translate.php
 msgid "group"
@@ -19800,18 +18777,6 @@ msgstr "last week"
 msgid "last year"
 msgstr "last year"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "legendDisplayMode"
-msgstr "legendDisplayMode"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "legendPlacement"
-msgstr "legendPlacement"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "lineWidth"
-msgstr "lineWidth"
-
 #: centreon/www/class/centreonContact.class.php
 msgid "lowercase characters"
 msgstr "lowercase characters"
@@ -19858,7 +18823,6 @@ msgstr "notify"
 msgid "numbers"
 msgstr "numbers"
 
-#: centreon/www/include/common/pagination.php
 #: centreon/www/install/front_translate.php
 msgid "of"
 msgstr "of"
@@ -19881,10 +18845,6 @@ msgstr "persistent"
 msgid "points outside of the envelope"
 msgstr "points outside of the envelope"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "px"
-msgstr "px"
-
 #: centreon/www/install/front_translate.php
 msgid "removed"
 msgstr "removed"
@@ -19892,10 +18852,6 @@ msgstr "removed"
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "s"
 msgstr "s"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "scaleLogarithmicBase"
-msgstr "scaleLogarithmicBase"
 
 #: centreon/www/install/front_translate.php
 msgid "second"
@@ -19939,18 +18895,6 @@ msgstr "special characters among '%s'"
 msgid "sticky"
 msgstr "sticky"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "sub1"
-msgstr "sub1"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "sub2"
-msgstr "sub2"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "sub3"
-msgstr "sub3"
-
 #: centreon/www/install/front_translate.php
 msgid "technical"
 msgstr "technical"
@@ -19977,10 +18921,6 @@ msgstr ""
 msgid "the community"
 msgstr "the community"
 
-#: centreon/www/install/dashboard_widgets.php
-msgid "threshold"
-msgstr "threshold"
-
 #: centreon/www/install/front_translate.php
 msgid "tiles"
 msgstr "tiles"
@@ -20006,14 +18946,6 @@ msgstr "updated"
 #: centreon/www/class/centreonContact.class.php
 msgid "uppercase characters"
 msgstr "uppercase characters"
-
-#: centreon/www/install/front_translate.php
-msgid "vCenter/ESX"
-msgstr "vCenter/ESX"
-
-#: centreon/www/install/dashboard_widgets.php
-msgid "warningtext"
-msgstr "warningtext"
 
 #: centreon/www/install/front_translate.php
 msgid "will display all resources with host having alias containing"
@@ -20043,21 +18975,340 @@ msgstr "{{label}} can be at most {{max}} characters"
 msgid "{{label}} should be at least {{min}} characters long"
 msgstr "{{label}} should be at least {{min}} characters long"
 
-#: centreon/www/install/front_translate.php
-msgid "{{total}} element(s) found"
-msgstr "{{total}} element(s) found"
+#: unknown
+msgid "24x7"
+msgstr "24x7"
 
 #: unknown
-msgid "/*+&"
-msgstr "/*+&"
+msgid ""
+"<b><i>Help :</i></b> Select image folders that can be seen by associated "
+"users."
+msgstr ""
+"<b><i>Help :</i></b> Select image folders that can be seen by associated "
+"users."
+
+#, php-format
+#: unknown
+msgid ""
+"A poller/agent configuration is already associated with poller ID(s) '%s'"
+msgstr ""
+"A poller/agent configuration is already associated with poller ID(s) '%s'"
 
 #: unknown
 msgid "Add a global macro"
 msgstr "Add a global macro"
 
 #: unknown
-msgid "Centreon Central address, as seen by this server"
-msgstr "Centreon Central address, as seen by this server"
+msgid "Add additional configurations"
+msgstr "Add additional configurations"
+
+#: unknown
+msgid "Add an additional configuration"
+msgstr "Add an additional configuration"
+
+#: unknown
+msgid "Add host group"
+msgstr "Add host group"
+
+#: unknown
+msgid "Additional information"
+msgstr "Additional information"
+
+#: unknown
+msgid "Aggregation frequency"
+msgstr "Aggregation frequency"
+
+#: unknown
+msgid "All image folders"
+msgstr "All image folders"
+
+#: unknown
+msgid "All image folders selected"
+msgstr "All image folders selected"
+
+#: unknown
+msgid ""
+"Allows you to add free text to your dashboards (section titles, "
+"information, etc.)."
+msgstr ""
+"Allows you to add free text to your dashboards (section titles, "
+"information, etc.)."
+
+#: unknown
+msgid "An error occurred when writing engine context configuration"
+msgstr "An error occurred when writing engine context configuration"
+
+#: unknown
+msgid "Apply resource access rules to the host group"
+msgstr "Apply resource access rules to the host group"
+
+#: unknown
+msgid "Area"
+msgstr "Area"
+
+#: unknown
+msgid "At least one connection mode must be enabled."
+msgstr "At least one connection mode must be enabled."
+
+#: unknown
+msgid "Auto"
+msgstr "Auto"
+
+#: unknown
+msgid ""
+"Auto: Default value defined for the corresponding curve template "
+"(Monitoring > Performances > Curves)."
+msgstr ""
+"Auto: Default value defined for the corresponding curve template "
+"(Monitoring > Performances > Curves)."
+
+#: unknown
+msgid "Axes"
+msgstr "Axes"
+
+#: unknown
+msgid "Bar"
+msgstr "Bar"
+
+#: unknown
+msgid "Bar opacity"
+msgstr "Bar opacity"
+
+#: unknown
+msgid "Bar radius"
+msgstr "Bar radius"
+
+#: unknown
+msgid "Base 10"
+msgstr "Base 10"
+
+#: unknown
+msgid "Base 2"
+msgstr "Base 2"
+
+#: unknown
+msgid "Both"
+msgstr "Both"
+
+#: unknown
+msgid "Broker Module Configuration File"
+msgstr "Broker Module Configuration File"
+
+#: unknown
+msgid "Business Activity Diagram"
+msgstr "Business Activity Diagram"
+
+#: unknown
+msgid "Business Activity availability"
+msgstr "Business Activity availability"
+
+#: unknown
+msgid "Business Activity availability history"
+msgstr "Business Activity availability history"
+
+#: unknown
+msgid "Business Activity status timeline"
+msgstr "Business Activity status timeline"
+
+#: unknown
+msgid "Business View"
+msgstr "Business View"
+
+#: unknown
+msgid "Button 1"
+msgstr "Button 1"
+
+#: unknown
+msgid "Button 2"
+msgstr "Button 2"
+
+#: unknown
+msgid "Button 3"
+msgstr "Button 3"
+
+#: unknown
+msgid "Button 4"
+msgstr "Button 4"
+
+#: unknown
+msgid ""
+"By default, the data of Business Views is aggregated monthly over the "
+"past 12 months (if available)."
+msgstr ""
+"By default, the data of Business Views is aggregated monthly over the "
+"past 12 months (if available)."
+
+#: unknown
+msgid "By name"
+msgstr "By name"
+
+#: unknown
+msgid "CA (.crt, .cert, .cer)"
+msgstr "CA (.crt, .cert, .cer)"
+
+#: unknown
+msgid "Calculations based on time period"
+msgstr "Calculations based on time period"
+
+#, php-format
+#: unknown
+msgid ""
+"Centreon Broker's configuration directory '%s' does not exist and could "
+"not\n"
+"                                             be created for monitoring "
+"engine '%s'. Please check its path or create it"
+msgstr ""
+"Centreon Broker's configuration directory '%s' does not exist and could "
+"not\n"
+"                                             be created for monitoring "
+"engine '%s'. Please check its path or create it"
+
+#: unknown
+msgid ""
+"Changing the type of an existing poller/agent configuration is not allowed"
+msgstr ""
+"Changing the type of an existing poller/agent configuration is not allowed"
+
+#: unknown
+msgid "Clock"
+msgstr "Clock"
+
+#: unknown
+msgid "Clock / Timer"
+msgstr "Clock / Timer"
+
+#: unknown
+msgid "Condensed"
+msgstr "Condensed"
+
+#, php-format
+#: unknown
+msgid ""
+"Could not find configuration directory '%s' for monitoring engine '%s'.\n"
+"                                 Please check its path or create it"
+msgstr ""
+"Could not find configuration directory '%s' for monitoring engine '%s'.\n"
+"                                 Please check its path or create it"
+
+#: unknown
+msgid "Countdown"
+msgstr "Countdown"
+
+#: unknown
+msgid "Curve type"
+msgstr "Curve type"
+
+#: unknown
+msgid "Custom boundaries apply to the percentage."
+msgstr "Custom boundaries apply to the percentage."
+
+#: unknown
+msgid "Daily"
+msgstr "Daily"
+
+#: unknown
+msgid "Dash width"
+msgstr "Dash width"
+
+#: unknown
+msgid "Dashes"
+msgstr "Dashes"
+
+#: unknown
+msgid "Data is aggregated daily for graphs presenting hosts."
+msgstr "Data is aggregated daily for graphs presenting hosts."
+
+#: unknown
+msgid ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host categories."
+msgstr ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host categories."
+
+#: unknown
+msgid ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host groups."
+msgstr ""
+"Data is aggregated monthly over the last 12 months for graphs presenting "
+"host groups."
+
+#: unknown
+msgid "Date format"
+msgstr "Date format"
+
+#: unknown
+msgid "Destination Directory"
+msgstr "Destination Directory"
+
+#: unknown
+msgid "Display availability and performance as"
+msgstr "Display availability and performance as"
+
+#: unknown
+msgid "Display availability as"
+msgstr "Display availability as"
+
+#: unknown
+msgid "Display average as"
+msgstr "Display average as"
+
+#: unknown
+msgid "Display curve points"
+msgstr "Display curve points"
+
+#: unknown
+msgid "Display mode"
+msgstr "Display mode"
+
+#: unknown
+msgid "Display resources"
+msgstr "Display resources"
+
+#: unknown
+msgid "Display resources with these status types"
+msgstr "Display resources with these status types"
+
+#: unknown
+msgid "Display resources with this state"
+msgstr "Display resources with this state"
+
+#: unknown
+msgid "Display resources with this status"
+msgstr "Display resources with this status"
+
+#: unknown
+msgid "Display resources with this type"
+msgstr "Display resources with this type"
+
+#: unknown
+msgid "Display resources with this unit"
+msgstr "Display resources with this unit"
+
+#: unknown
+msgid "Display the diagram with this status"
+msgstr "Display the diagram with this status"
+
+#: unknown
+msgid "Display ticket creation buttons"
+msgstr "Display ticket creation buttons"
+
+#: unknown
+msgid "Display with this resource type"
+msgstr "Display with this resource type"
+
+#: unknown
+msgid "Display with this view"
+msgstr "Display with this view"
+
+#: unknown
+msgid ""
+"Displays a detailed view of the current status for selected resources as "
+"a chart."
+msgstr ""
+"Displays a detailed view of the current status for selected resources as "
+"a chart."
 
 #: unknown
 msgid ""
@@ -20068,37 +19319,847 @@ msgstr ""
 "until saturation, and evolution of usage since the past day."
 
 #: unknown
+msgid ""
+"Displays a status overview for selected resources, grouped by hosts or by "
+"services."
+msgstr ""
+"Displays a status overview for selected resources, grouped by hosts or by "
+"services."
+
+#: unknown
+msgid "Displays a web page"
+msgstr "Displays a web page"
+
+#: unknown
+msgid ""
+"Displays availability and alerts of a Business Activity for a given "
+"period."
+msgstr ""
+"Displays availability and alerts of a Business Activity for a given "
+"period."
+
+#: unknown
+msgid ""
+"Displays availability, performance and alerts for a Business Activity"
+msgstr ""
+"Displays availability, performance and alerts for a Business Activity"
+
+#: unknown
+msgid "Displays data on resource status and events, centralized in a table."
+msgstr ""
+"Displays data on resource status and events, centralized in a table."
+
+#: unknown
+msgid ""
+"Displays graphically a business activity hierarchy of KPIs and lets you "
+"navigate through it."
+msgstr ""
+"Displays graphically a business activity hierarchy of KPIs and lets you "
+"navigate through it."
+
+#: unknown
+msgid "Displays metrics for a given time period."
+msgstr "Displays metrics for a given time period."
+
+#: unknown
+msgid ""
+"Displays the availability history of hosts, host categories or hostgroups."
+msgstr ""
+"Displays the availability history of hosts, host categories or hostgroups."
+
+#: unknown
+msgid ""
+"Displays the distribution of current statuses on a Business Activity, as "
+"a chronological timeline for a given time period."
+msgstr ""
+"Displays the distribution of current statuses on a Business Activity, as "
+"a chronological timeline for a given time period."
+
+#: unknown
+msgid ""
+"Displays the distribution of current statuses on selected groups of "
+"resources, as a table."
+msgstr ""
+"Displays the distribution of current statuses on selected groups of "
+"resources, as a table."
+
+#: unknown
+msgid ""
+"Displays the future evolution of a metric as a trend curve, based on its "
+"recent average data."
+msgstr ""
+"Displays the future evolution of a metric as a trend curve, based on its "
+"recent average data."
+
+#: unknown
+msgid "Displays the time according to the selected time zone, or a timer."
+msgstr "Displays the time according to the selected time zone, or a timer."
+
+#: unknown
+msgid "Displays the top or bottom x hosts, for a selected metric."
+msgstr "Displays the top or bottom x hosts, for a selected metric."
+
+#: unknown
+msgid ""
+"Displays the value of a single metric as a text, a gauge or a bar chart."
+msgstr ""
+"Displays the value of a single metric as a text, a gauge or a bar chart."
+
+#: unknown
+msgid "Do you want to switch to classic mode?"
+msgstr "Do you want to switch to classic mode?"
+
+#: unknown
+msgid "Do you want to switch to regex mode?"
+msgstr "Do you want to switch to regex mode?"
+
+#: unknown
+msgid "Donut chart"
+msgstr "Donut chart"
+
+#: unknown
+msgid "Dots"
+msgstr "Dots"
+
+#: unknown
+msgid "Duplications"
+msgstr "Duplications"
+
+#: unknown
+msgid "Edit password"
+msgstr "Edit password"
+
+#: unknown
+msgid "Enable ticket creation for hosts"
+msgstr "Enable ticket creation for hosts"
+
+#: unknown
+msgid "Enable ticket creation for services"
+msgstr "Enable ticket creation for services"
+
+#: unknown
+msgid "Enable ticket management"
+msgstr "Enable ticket management"
+
+#: unknown
+msgid "Enabled hosts"
+msgstr "Enabled hosts"
+
+#: unknown
+msgid "Enter Regex"
+msgstr "Enter Regex"
+
+#: unknown
+msgid "Enter regex mode"
+msgstr "Enter regex mode"
+
+#: unknown
+msgid "Error while adding a poller/agent configuration"
+msgstr "Error while adding a poller/agent configuration"
+
+#: unknown
+msgid "Error while deleting a poller/agent configuration"
+msgstr "Error while deleting a poller/agent configuration"
+
+#: unknown
+msgid "Error while duplicating a host group"
+msgstr "Error while duplicating a host group"
+
+#: unknown
+msgid "Error while enabling/disabling host groups"
+msgstr "Error while enabling/disabling host groups"
+
+#: unknown
+msgid "Error while retrieving a poller/agent configuration"
+msgstr "Error while retrieving a poller/agent configuration"
+
+#: unknown
+msgid "Error while retrieving multiple poller/agent configurations"
+msgstr "Error while retrieving multiple poller/agent configurations"
+
+#: unknown
+msgid "Error while updating a poller/agent configuration"
+msgstr "Error while updating a poller/agent configuration"
+
+#: unknown
+msgid "Existing directory"
+msgstr "Existing directory"
+
+#: unknown
+msgid "Exit regex mode"
+msgstr "Exit regex mode"
+
+#: unknown
+msgid "Failed to delete"
+msgstr "Failed to delete"
+
+#: unknown
+msgid "Failed to disable"
+msgstr "Failed to disable"
+
+#: unknown
+msgid "Failed to duplicate"
+msgstr "Failed to duplicate"
+
+#: unknown
+msgid "Failed to enable"
+msgstr "Failed to enable"
+
+#: unknown
+msgid "Fill opacity"
+msgstr "Fill opacity"
+
+#: unknown
+msgid ""
+"For some connectors, you must define on the poller the credentials "
+"required to access the monitored hosts. You can do it easily from here."
+msgstr ""
+"For some connectors, you must define on the poller the credentials "
+"required to access the monitored hosts. You can do it easily from here."
+
+#: unknown
+msgid "Forecast based on past X days"
+msgstr "Forecast based on past X days"
+
+#: unknown
+msgid "Generic data (example)"
+msgstr "Generic data (example)"
+
+#: unknown
+msgid "Generic data for single metric (example)"
+msgstr "Generic data for single metric (example)"
+
+#: unknown
+msgid "Generic input (example)"
+msgstr "Generic input (example)"
+
+#: unknown
+msgid "Generic text"
+msgstr "Generic text"
+
+#: unknown
+msgid "Generic text (example)"
+msgstr "Generic text (example)"
+
+#: unknown
+msgid "Generic widgets"
+msgstr "Generic widgets"
+
+#: unknown
+msgid "Geographic coordinates for MAP"
+msgstr "Geographic coordinates for MAP"
+
+#: unknown
 msgid "Global macros"
 msgstr "Global macros"
+
+#: unknown
+msgid "Graph style"
+msgstr "Graph style"
+
+#: unknown
+msgid "Grid"
+msgstr "Grid"
+
+#: unknown
+msgid "Gridline type"
+msgstr "Gridline type"
+
+#: unknown
+msgid "Group members"
+msgstr "Group members"
+
+#: unknown
+msgid "Group monitoring"
+msgstr "Group monitoring"
+
+#: unknown
+msgid "Group name"
+msgstr "Group name"
+
+#: unknown
+msgid "Hide"
+msgstr "Hide"
+
+#: unknown
+msgid "Hide services with Down host"
+msgstr "Hide services with Down host"
+
+#: unknown
+msgid "Hide services with Unreachable host"
+msgstr "Hide services with Unreachable host"
+
+#: unknown
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#: unknown
+msgid "Horizontal bar chart"
+msgstr "Horizontal bar chart"
+
+#: unknown
+msgid "Host severities"
+msgstr "Host severities"
+
+#: unknown
+msgid "Hostgroup availability history"
+msgstr "Hostgroup availability history"
+
+#: unknown
+msgid ""
+"If ticket management is enabled, only the “by service” view is available."
+msgstr ""
+"If ticket management is enabled, only the “by service” view is available."
+
+#: unknown
+msgid ""
+"If you want to display the graph with host categories and hosts, you must "
+"select only one hostgroup."
+msgstr ""
+"If you want to display the graph with host categories and hosts, you must "
+"select only one hostgroup."
+
+#: unknown
+msgid "Image folders"
+msgstr "Image folders"
+
+#: unknown
+msgid "Include all image folders"
+msgstr "Include all image folders"
+
+#: unknown
+msgid "Invalid geo-coordinate format"
+msgstr "Invalid geo-coordinate format"
+
+#: unknown
+msgid "Left"
+msgstr "Left"
+
+#: unknown
+msgid "Line"
+msgstr "Line"
+
+#: unknown
+msgid "Line style"
+msgstr "Line style"
+
+#: unknown
+msgid "Line width"
+msgstr "Line width"
+
+#: unknown
+msgid "Linear"
+msgstr "Linear"
+
+#: unknown
+msgid "Link types"
+msgstr "Link types"
+
+#: unknown
+msgid "Logarithmic"
+msgstr "Logarithmic"
+
+#: unknown
+msgid "MBI reporting widgets"
+msgstr "MBI reporting widgets"
+
+#, php-format
+#: unknown
+msgid "Max file size: %s"
+msgstr "Max file size: %s"
+
+#: unknown
+msgid "Max value"
+msgstr "Max value"
+
+#: unknown
+msgid "Metric capacity planning"
+msgstr "Metric capacity planning"
+
+#: unknown
+msgid "Metrics graph"
+msgstr "Metrics graph"
+
+#: unknown
+msgid "Min value"
+msgstr "Min value"
 
 #: unknown
 msgid "Modify a global macro"
 msgstr "Modify a global macro"
 
 #: unknown
+msgid "Modify an additional configuration"
+msgstr "Modify an additional configuration"
+
+#: unknown
+msgid "Monthly"
+msgstr "Monthly"
+
+#: unknown
+msgid "Must be a positive integer or 0"
+msgstr "Must be a positive integer or 0"
+
+#: unknown
 msgid "Name must start and end with a '$'"
 msgstr "Name must start and end with a '$'"
+
+#: unknown
+msgid "Need help using the search bar?"
+msgstr "Need help using the search bar?"
+
+#: unknown
+msgid "No hosts in this group are currently disabled."
+msgstr "No hosts in this group are currently disabled."
+
+#: unknown
+msgid "No hosts in this group are currently enabled."
+msgstr "No hosts in this group are currently enabled."
+
+#: unknown
+msgid "Non-workhours"
+msgstr "Non-workhours"
+
+#: unknown
+msgid "Number"
+msgstr "Number"
+
+#: unknown
+msgid "Only one"
+msgstr "Only one"
+
+#: unknown
+msgid "Opentelemetry"
+msgstr "Opentelemetry"
+
+#: unknown
+msgid "Option 1"
+msgstr "Option 1"
+
+#: unknown
+msgid "Option 2"
+msgstr "Option 2"
+
+#: unknown
+msgid "Orientation"
+msgstr "Orientation"
+
+#: unknown
+msgid "Percentage"
+msgstr "Percentage"
+
+#: unknown
+msgid "Pie chart"
+msgstr "Pie chart"
+
+#: unknown
+msgid ""
+"Please note that domains outside your organization must be authorized in "
+"your Apache configuration."
+msgstr ""
+"Please note that domains outside your organization must be authorized in "
+"your Apache configuration."
+
+#, php-format
+#: unknown
+msgid ""
+"Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
+msgstr ""
+"Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
+
+#: unknown
+msgid "Private key (.key)"
+msgstr "Private key (.key)"
+
+#: unknown
+msgid "Problem (Critical)"
+msgstr "Problem (Critical)"
+
+#: unknown
+msgid "Problem (Down/Critical)"
+msgstr "Problem (Down/Critical)"
+
+#: unknown
+msgid "Public certificate (.crt, .cert, .cer)"
+msgstr "Public certificate (.crt, .cert, .cer)"
+
+#: unknown
+msgid "Radio"
+msgstr "Radio"
+
+#: unknown
+msgid "Radio 1"
+msgstr "Radio 1"
+
+#: unknown
+msgid "Radio 2"
+msgstr "Radio 2"
+
+#: unknown
+msgid "Real time widgets"
+msgstr "Real time widgets"
+
+#: unknown
+msgid "Reduce"
+msgstr "Reduce"
+
+#: unknown
+msgid "Reporting period"
+msgstr "Reporting period"
+
+#: unknown
+msgid "Resource table"
+msgstr "Resource table"
+
+#: unknown
+msgid "Resources linked to a ticket"
+msgstr "Resources linked to a ticket"
+
+#: unknown
+msgid "Resources with no ticket"
+msgstr "Resources with no ticket"
+
+#: unknown
+msgid "Revert to previous password"
+msgstr "Revert to previous password"
+
+#: unknown
+msgid "Right"
+msgstr "Right"
+
+#: unknown
+msgid "Rule (ticket provider)"
+msgstr "Rule (ticket provider)"
+
+#: unknown
+msgid "Scale"
+msgstr "Scale"
+
+#: unknown
+msgid "Select field"
+msgstr "Select field"
+
+#: unknown
+msgid "Select host severities"
+msgstr "Select host severities"
+
+#: unknown
+msgid "Select hosts"
+msgstr "Select hosts"
+
+#: unknown
+msgid "Select rule (ticket provider)"
+msgstr "Select rule (ticket provider)"
+
+#: unknown
+msgid "Select service severities"
+msgstr "Select service severities"
+
+#: unknown
+msgid "Service severities"
+msgstr "Service severities"
+
+#: unknown
+msgid "Shared image folders"
+msgstr "Shared image folders"
+
+#: unknown
+msgid "Show"
+msgstr "Show"
+
+#: unknown
+msgid "Show axis borders"
+msgstr "Show axis borders"
+
+#: unknown
+msgid "Show date"
+msgstr "Show date"
+
+#: unknown
+msgid "Show gridlines"
+msgstr "Show gridlines"
+
+#: unknown
+msgid "Show legend"
+msgstr "Show legend"
+
+#: unknown
+msgid "Show time zone"
+msgstr "Show time zone"
 
 #: unknown
 msgid "Show value label"
 msgstr "Show value label"
 
 #: unknown
+msgid "Show value on chart"
+msgstr "Show value on chart"
+
+#: unknown
+msgid "Single metric"
+msgstr "Single metric"
+
+#: unknown
+msgid "Smooth"
+msgstr "Smooth"
+
+#: unknown
+msgid "Solid"
+msgstr "Solid"
+
+#: unknown
+msgid "Sort by"
+msgstr "Sort by"
+
+#: unknown
+msgid "Space"
+msgstr "Space"
+
+#: unknown
+msgid "Stacked bar"
+msgstr "Stacked bar"
+
+#: unknown
+msgid "Standard"
+msgstr "Standard"
+
+#: unknown
+msgid "Status chart"
+msgstr "Status chart"
+
+#: unknown
+msgid "Status grid"
+msgstr "Status grid"
+
+#: unknown
+msgid "Sticky for any non-OK status"
+msgstr "Sticky for any non-OK status"
+
+#: unknown
 msgid "Storage near saturation"
 msgstr "Storage near saturation"
 
 #: unknown
-msgid "The address is already registered"
-msgstr "The address is already registered"
+msgid "Style for average data"
+msgstr "Style for average data"
 
 #: unknown
-msgid "The address is already registered on another poller"
-msgstr "The address is already registered on another poller"
+msgid "Sub input 1"
+msgstr "Sub input 1"
 
 #: unknown
-msgid "The address is incorrect"
-msgstr "The address is incorrect"
+msgid "Sub input 2"
+msgstr "Sub input 2"
+
+#: unknown
+msgid "Sub input 3"
+msgstr "Sub input 3"
+
+#: unknown
+msgid "Success (OK)"
+msgstr "Success (OK)"
+
+#: unknown
+msgid "Success (OK/Up)"
+msgstr "Success (OK/Up)"
+
+#: unknown
+msgid "The min value must be lower than the max value."
+msgstr "The min value must be lower than the max value."
+
+#, php-format
+#: unknown
+msgid "The poller/agent configuration name '%s' already exists"
+msgstr "The poller/agent configuration name '%s' already exists"
+
+#: unknown
+msgid "These time periods are defined in MBI'S ETL options."
+msgstr "These time periods are defined in MBI'S ETL options."
+
+#: unknown
+msgid "This is the description of the data widget"
+msgstr "This is the description of the data widget"
+
+#: unknown
+msgid "This is the description of the generic input widget"
+msgstr "This is the description of the generic input widget"
+
+#: unknown
+msgid "This is the description of the text widget"
+msgstr "This is the description of the text widget"
+
+#: unknown
+msgid "This month"
+msgstr "This month"
+
+#: unknown
+msgid "This year"
+msgstr "This year"
+
+#: unknown
+msgid "Time format"
+msgstr "Time format"
+
+#: unknown
+msgid "Time zone"
+msgstr "Time zone"
+
+#: unknown
+msgid "Timer"
+msgstr "Timer"
+
+#: unknown
+msgid "Token not found"
+msgstr "Token not found"
+
+#: unknown
+msgid "Tooltips"
+msgstr "Tooltips"
+
+#: unknown
+msgid "Top Bottom Settings"
+msgstr "Top Bottom Settings"
+
+#: unknown
+msgid "Top/bottom"
+msgstr "Top/bottom"
+
+#: unknown
+msgid "Undefined (Unreachable/Unknown)"
+msgstr "Undefined (Unreachable/Unknown)"
+
+#: unknown
+msgid "Use deprecated custom views"
+msgstr "Use deprecated custom views"
+
+#: unknown
+msgid "Use deprecated monitoring pages"
+msgstr "Use deprecated monitoring pages"
+
+#: unknown
+msgid "Value sort order"
+msgstr "Value sort order"
+
+#: unknown
+msgid "Vertical"
+msgstr "Vertical"
+
+#: unknown
+msgid "Vertical bar chart"
+msgstr "Vertical bar chart"
 
 #: unknown
 msgid "View global macro"
 msgstr "View global macro"
+
+#: unknown
+msgid "Web page"
+msgstr "Web page"
+
+#: unknown
+msgid "Welcome to the additional configurations page"
+msgstr "Welcome to the additional configurations page"
+
+#: unknown
+msgid "Welcome to the host groups page"
+msgstr "Welcome to the host groups page"
+
+#: unknown
+msgid "Workhours"
+msgstr "Workhours"
+
+#: unknown
+msgid "Y-axis boundaries"
+msgstr "Y-axis boundaries"
+
+#: unknown
+msgid "Y-axis label rotation"
+msgstr "Y-axis label rotation"
+
+#: unknown
+msgid "You are not allowed to access poller/agent configurations"
+msgstr "You are not allowed to access poller/agent configurations"
+
+#: unknown
+msgid "Your changes will not be saved if you leave classic mode."
+msgstr "Your changes will not be saved if you leave classic mode."
+
+#: unknown
+msgid "Your changes will not be saved if you leave regex mode."
+msgstr "Your changes will not be saved if you leave regex mode."
+
+#: unknown
+msgid "Zero-centered"
+msgstr "Zero-centered"
+
+#: unknown
+msgid "areaOpacity"
+msgstr "areaOpacity"
+
+#: unknown
+msgid "boundaries"
+msgstr "boundaries"
+
+#: unknown
+msgid "dashLength"
+msgstr "dashLength"
+
+#: unknown
+msgid "dashOffset"
+msgstr "dashOffset"
+
+#: unknown
+msgid "dotOffset"
+msgstr "dotOffset"
+
+#: unknown
+msgid "gridLinesType"
+msgstr "gridLinesType"
+
+#: unknown
+msgid "legendDisplayMode"
+msgstr "legendDisplayMode"
+
+#: unknown
+msgid "legendPlacement"
+msgstr "legendPlacement"
+
+#: unknown
+msgid "lineWidth"
+msgstr "lineWidth"
+
+#: unknown
+msgid "px"
+msgstr "px"
+
+#: unknown
+msgid "scaleLogarithmicBase"
+msgstr "scaleLogarithmicBase"
+
+#: unknown
+msgid "sub1"
+msgstr "sub1"
+
+#: unknown
+msgid "sub2"
+msgstr "sub2"
+
+#: unknown
+msgid "sub3"
+msgstr "sub3"
+
+#: unknown
+msgid "threshold"
+msgstr "threshold"
+
+#: unknown
+msgid "vCenter/ESX"
+msgstr "vCenter/ESX"
+
+#: unknown
+msgid "warningtext"
+msgstr "warningtext"
+
+#: unknown
+msgid "{{total}} element(s) found"
+msgstr "{{total}} element(s) found"

--- a/centreon/phpstan.legacy.src.baseline.neon
+++ b/centreon/phpstan.legacy.src.baseline.neon
@@ -420,11 +420,6 @@ parameters:
 			path: src/Centreon/Application/Validation/Constraints/UniqueEntity.php
 
 		-
-			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) i must contain 3 or more characters\.$#'
-			count: 4
-			path: src/Centreon/Domain/Service/I18nService.php
-
-		-
 			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostGroupRepositoryRDB\.php\:226\:\:normalize\(\) never returns bool so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1

--- a/centreon/src/Centreon/Domain/Service/I18nService.php
+++ b/centreon/src/Centreon/Domain/Service/I18nService.php
@@ -31,6 +31,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class I18nService
 {
+    private const SUPPORTED_LANGUAGES = [
+        'fr_FR.UTF-8',
+        'de_DE.UTF-8',
+        'es_ES.UTF-8',
+        'pt_PT.UTF-8',
+        'pt_BR.UTF-8',
+        'en_US.UTF-8',
+    ];
+
     /** @var Information */
     private $modulesInformation;
 
@@ -190,9 +199,7 @@ class I18nService
     {
         $data = [];
 
-        $languages = array_map(static function ($i) {
-            return $i . '.UTF-8';
-        }, self::getAvailableCentreonLanguages());
+        $languages = self::SUPPORTED_LANGUAGES;
 
         foreach ($languages as $language) {
             $translationPath = __DIR__ . "/../../../../www/locale/{$language}/LC_MESSAGES";
@@ -204,7 +211,7 @@ class I18nService
                     ->in($translationPath);
 
                 foreach ($files as $file) {
-                    $data += unserialize($file->getContents());
+                    $data = array_replace_recursive($data, unserialize($file->getContents()));
                 }
             }
         }
@@ -252,9 +259,7 @@ class I18nService
     {
         $data = [];
 
-        $languages = array_map(static function ($i) {
-            return $i . '.UTF-8';
-        }, self::getAvailableCentreonLanguages());
+        $languages = self::SUPPORTED_LANGUAGES;
 
         foreach ($languages as $language) {
             // loop over each installed modules to get translation


### PR DESCRIPTION
## Summary

- Add `en_US` language to the translation script (`make_translation.sh`)
- Add English `.po` files (`messages.po`, `help.po`) for translation overrides
- Fix English translation generation logic in `centreon-translations.php`: when processing the English `.po` file, use the actual translated string instead of the key
- Add `SUPPORTED_LANGUAGES` constant in `I18nService.php` (includes `en_US.UTF-8`), fix `pt-PT.UTF-8` typo → `pt_PT.UTF-8`, and use `array_replace_recursive` for consistency
- Remove the legacy manual `en_US.UTF-8` `.ser` generation step from `web.yml` (now handled in the main loop)

> **Note:** This backport keeps `serialize`/`unserialize` and `.ser` file format (no JSON conversion).

## Reference

Backport of https://github.com/centreon/centreon/pull/10216 (dev-25.10.x) → dev-24.10.x

## Test plan

- [ ] Verify `translation-build` workflow runs correctly
- [ ] Verify `messages.ser` files are generated for `en_US.UTF-8` locale
- [ ] Verify English UI strings are resolved correctly from the `.po` override files

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added en_US to supported LANGS for English .po generation

**⚡ Enhancements**
* Removed legacy manual en_US .ser generation from build script

**🔧 Refactors**
* Introduced SUPPORTED_LANGUAGES and used array_replace_recursive for merges including en_US.UTF-8 and pt_PT.UTF-8 fix


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106589405?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->