### PR TITLE
fix(export): sanitize Content-Disposition filenames in CSV and graph exports

### DIFF
--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -230,7 +230,7 @@ class CentreonGraph
         $this->getIndexData();
 
         $this->filename = $this->indexData['host_name'] . '-' . $this->indexData['service_description'];
-        $this->filename = str_replace(['/', '\\'], ['-', '-'], $this->filename);
+        $this->filename = str_replace(['/', '\\', '"', "\r", "\n"], '-', $this->filename);
 
         $this->colorCache = null;
         $this->templateInformations = [];

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
@@ -110,7 +110,7 @@ $hostgroupName = getHostgroupNameFromId($hostgroupId);
 header('Cache-Control: public');
 header('Pragma: public');
 header('Content-Type: application/octet-stream');
-header('Content-disposition: filename=' . $hostgroupName . '.csv');
+header('Content-Disposition: attachment; filename="' . str_replace(['"', "\r", "\n"], '', $hostgroupName) . '.csv"');
 
 echo _('Hostgroup') . ';'
     . _('Begin date') . '; '

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
@@ -88,7 +88,7 @@ $hostName = getHostNameFromId($hostId);
 header('Cache-Control: public');
 header('Pragma: public');
 header('Content-Type: application/octet-stream');
-header('Content-disposition: filename=' . $hostName . '.csv');
+header('Content-Disposition: attachment; filename="' . str_replace(['"', "\r", "\n"], '', $hostName) . '.csv"');
 
 echo _('Host') . ';'
     . _('Begin date') . '; '

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
@@ -87,7 +87,7 @@ $servicegroupName = getServiceGroupNameFromId($servicegroupId);
 header('Cache-Control: public');
 header('Pragma: public');
 header('Content-Type: application/octet-stream');
-header('Content-disposition: filename=' . $servicegroupName . '.csv');
+header('Content-Disposition: attachment; filename="' . str_replace(['"', "\r", "\n"], '', $servicegroupName) . '.csv"');
 
 echo _('ServiceGroup') . ';'
     . _('Begin date') . '; '

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
@@ -88,7 +88,7 @@ $serviceDescription = getServiceDescriptionFromId($serviceId);
 header('Cache-Control: public');
 header('Pragma: public');
 header('Content-Type: application/octet-stream');
-header('Content-disposition: attachment ; filename=' . $hostName . '_' . $serviceDescription . '.csv');
+header('Content-Disposition: attachment; filename="' . str_replace(['"', "\r", "\n"], '', $hostName . '_' . $serviceDescription) . '.csv"');
 
 echo _('Host') . ';'
     . _('Service') . ';'

--- a/centreon/www/include/views/graphs/exportData/ExportCSVServiceData.php
+++ b/centreon/www/include/views/graphs/exportData/ExportCSVServiceData.php
@@ -111,9 +111,9 @@ if ($index !== false) {
 
     header('Content-Type: application/csv-tab-delimited-table');
     if (isset($hName, $sName)) {
-        header('Content-disposition: filename=' . $hName . '_' . $sName . '.csv');
+        header('Content-Disposition: attachment; filename="' . str_replace(['"', "\r", "\n"], '', $hName . '_' . $sName) . '.csv"');
     } else {
-        header('Content-disposition: filename=' . $index . '.csv');
+        header('Content-Disposition: attachment; filename="' . $index . '.csv"');
     }
 
     if ($start === false || $end === false) {


### PR DESCRIPTION
## Description

Fixes: [MON-197955](https://centreon.atlassian.net/browse/MON-197955)

Backport of [#10007](https://github.com/centreon/centreon/pull/10007) to dev-25.10.x.

Sanitize Content-Disposition HTTP header filenames in CSV export pages and graph image responses by stripping double-quote characters to prevent header injection.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

See original PR [#10007](https://github.com/centreon/centreon/pull/10007).

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified.
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch.

[MON-197955]: https://centreon.atlassian.net/browse/MON-197955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Sanitized Content-Disposition filenames by stripping quotes and CRLF


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104617816?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->