### PR TITLE
feat(security): add poller token type to token management

### DIFF
--- a/centreon/src/Core/Security/Token/Application/UseCase/AddToken/AddToken.php
+++ b/centreon/src/Core/Security/Token/Application/UseCase/AddToken/AddToken.php
@@ -139,7 +139,9 @@ final class AddToken
      */
     private function createToken(AddTokenRequest $request): string
     {
-        $this->validation->assertIsValidUser($request->userId);
+        if ($request->userId !== null) {
+            $this->validation->assertIsValidUser($request->userId);
+        }
         $this->validation->assertIsValidName($request->name, $request->userId);
 
         $newToken = TokenFactory::createNew(

--- a/centreon/src/Core/Security/Token/Application/UseCase/AddToken/AddTokenRequest.php
+++ b/centreon/src/Core/Security/Token/Application/UseCase/AddToken/AddTokenRequest.php
@@ -30,13 +30,13 @@ final class AddTokenRequest
     /**
      * @param string $name
      * @param TokenTypeEnum $type
-     * @param int $userId
+     * @param ?int $userId
      * @param \DateTimeInterface|null $expirationDate
      */
     public function __construct(
         public string $name = '',
         public TokenTypeEnum $type = TokenTypeEnum::API,
-        public int $userId = 0,
+        public ?int $userId = null,
         public ?\DateTimeInterface $expirationDate = null,
     ) {
     }

--- a/centreon/src/Core/Security/Token/Application/UseCase/AddToken/AddTokenValidation.php
+++ b/centreon/src/Core/Security/Token/Application/UseCase/AddToken/AddTokenValidation.php
@@ -45,18 +45,24 @@ class AddTokenValidation
      * Assert name is not already used.
      *
      * @param string $name
-     * @param int $userId
+     * @param ?int $userId
      *
      * @throws TokenException|\Throwable
      */
-    public function assertIsValidName(string $name, int $userId): void
+    public function assertIsValidName(string $name, ?int $userId): void
     {
         $trimmedName = trim($name);
-        if ($this->readTokenRepository->existsByNameAndUserId($trimmedName, $userId)) {
+
+        $exists = $userId !== null
+            ? $this->readTokenRepository->existsByNameAndUserId($trimmedName, $userId)
+            : ! empty($this->readTokenRepository->findByNames([$trimmedName]));
+
+        if ($exists) {
             $this->error('Token name already exists', ['name' => $trimmedName, 'userId' => $userId]);
 
             throw TokenException::nameAlreadyExists($trimmedName);
         }
+
     }
 
     /**

--- a/centreon/src/Core/Security/Token/Application/UseCase/GetToken/GetToken.php
+++ b/centreon/src/Core/Security/Token/Application/UseCase/GetToken/GetToken.php
@@ -31,6 +31,7 @@ use Core\Application\Common\UseCase\ResponseStatusInterface;
 use Core\Security\Token\Application\Exception\TokenException;
 use Core\Security\Token\Application\Repository\ReadTokenRepositoryInterface;
 use Core\Security\Token\Domain\Model\JwtToken;
+use Core\Security\Token\Domain\Model\PollerToken;
 use Core\Security\Token\Domain\Model\TokenTypeEnum;
 
 final class GetToken
@@ -53,13 +54,13 @@ final class GetToken
 
             if (
                 $token === null
-                || $token->getType() !== TokenTypeEnum::CMA
+                || ! in_array($token->getType(),[TokenTypeEnum::CMA, TokenTypeEnum::POLLER], true)
             ) {
 
                 return new NotFoundResponse('Token');
             }
 
-            /** @var JwtToken $token */
+            /** @var JwtToken|PollerToken $token */
             return new GetTokenResponse($token, $token->getToken());
         } catch (\Throwable $ex) {
             $this->error(

--- a/centreon/src/Core/Security/Token/Application/UseCase/GetToken/GetToken.php
+++ b/centreon/src/Core/Security/Token/Application/UseCase/GetToken/GetToken.php
@@ -54,7 +54,7 @@ final class GetToken
 
             if (
                 $token === null
-                || ! in_array($token->getType(),[TokenTypeEnum::CMA, TokenTypeEnum::POLLER], true)
+                || ! in_array($token->getType(), [TokenTypeEnum::CMA, TokenTypeEnum::POLLER], true)
             ) {
 
                 return new NotFoundResponse('Token');

--- a/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
@@ -42,9 +42,9 @@ final class NewPollerToken extends NewToken
      */
     public function __construct(
         TrimmedString $name,
+        TrimmedString $creatorName,
         ?\DateTimeInterface $expirationDate = null,
         ?int $creatorId = null,
-        TrimmedString $creatorName = new TrimmedString('system'),
     ) {
         $this->shortName = (new \ReflectionClass($this))->getShortName();
 

--- a/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security\Token\Domain\Model;
+
+use Assert\AssertionFailedException;
+use Core\Common\Domain\TrimmedString;
+use Security\Encryption;
+
+final class NewPollerToken extends NewToken
+{
+    private string $token;
+
+    /**
+     * @param TrimmedString $name
+     * @param ?int $creatorId
+     * @param TrimmedString $creatorName
+     * @param \DateTimeInterface|null $expirationDate
+     *
+     * @throws AssertionFailedException
+     * @throws \Exception
+     */
+    public function __construct(
+        TrimmedString $name,
+        ?\DateTimeInterface $expirationDate = null,
+        ?int $creatorId = null,
+        TrimmedString $creatorName = 'system',
+    ) {
+        $this->shortName = (new \ReflectionClass($this))->getShortName();
+
+        parent::__construct(
+            $name,
+            $creatorId,
+            $creatorName,
+            $expirationDate,
+            TokenTypeEnum::API,
+        );
+
+        $this->generateToken();
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    protected function generateToken(): void
+    {
+        $this->token = Encryption::generateRandomString();
+    }
+}

--- a/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
@@ -44,7 +44,7 @@ final class NewPollerToken extends NewToken
         TrimmedString $name,
         ?\DateTimeInterface $expirationDate = null,
         ?int $creatorId = null,
-        TrimmedString $creatorName = 'system',
+        TrimmedString $creatorName = new TrimmedString('system'),
     ) {
         $this->shortName = (new \ReflectionClass($this))->getShortName();
 

--- a/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
@@ -53,7 +53,7 @@ final class NewPollerToken extends NewToken
             $creatorId,
             $creatorName,
             $expirationDate,
-            TokenTypeEnum::API,
+            TokenTypeEnum::POLLER,
         );
 
         $this->generateToken();

--- a/centreon/src/Core/Security/Token/Domain/Model/NewToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewToken.php
@@ -45,7 +45,7 @@ abstract class NewToken
      */
     public function __construct(
         private readonly TrimmedString $name,
-        private readonly int $creatorId,
+        private readonly ?int $creatorId,
         private readonly TrimmedString $creatorName,
         private readonly ?\DateTimeInterface $expirationDate,
         private readonly TokenTypeEnum $type,
@@ -56,7 +56,9 @@ abstract class NewToken
         }
         Assertion::notEmptyString($this->name->value, "{$this->shortName}::name");
         Assertion::maxLength($this->name->value, Token::MAX_TOKEN_NAME_LENGTH, "{$this->shortName}::name");
-        Assertion::positiveInt($this->creatorId, "{$this->shortName}::creatorId");
+        if ($this->creatorId !== null) {
+            Assertion::positiveInt($this->creatorId, "{$this->shortName}::creatorId");
+        }
         Assertion::notEmptyString($this->creatorName->value, "{$this->shortName}::creatorName");
         Assertion::maxLength($this->creatorName->value, Token::MAX_USER_NAME_LENGTH, "{$this->shortName}::creatorName");
     }
@@ -78,7 +80,7 @@ abstract class NewToken
         return $this->name->value;
     }
 
-    public function getCreatorId(): int
+    public function getCreatorId(): ?int
     {
         return $this->creatorId;
     }

--- a/centreon/src/Core/Security/Token/Domain/Model/PollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/PollerToken.php
@@ -55,7 +55,7 @@ final class PollerToken extends Token
             $creatorName,
             $creationDate,
             $expirationDate,
-            TokenTypeEnum::API,
+            TokenTypeEnum::POLLER,
             $isRevoked
         );
     }

--- a/centreon/src/Core/Security/Token/Domain/Model/PollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/PollerToken.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security\Token\Domain\Model;
+
+use Assert\AssertionFailedException;
+use Core\Common\Domain\TrimmedString;
+
+final class PollerToken extends Token
+{
+    /**
+     * @param TrimmedString $name
+     * @param ?int $creatorId
+     * @param TrimmedString $creatorName
+     * @param \DateTimeInterface $creationDate
+     * @param ?\DateTimeInterface $expirationDate
+     * @param bool $isRevoked
+     *
+     * @throws AssertionFailedException
+     */
+    public function __construct(
+        TrimmedString $name,
+        ?int $creatorId,
+        TrimmedString $creatorName,
+        \DateTimeInterface $creationDate,
+        ?\DateTimeInterface $expirationDate,
+        bool $isRevoked = false,
+        private readonly string $tokenString = '',
+    ) {
+        $this->shortName = (new \ReflectionClass($this))->getShortName();
+
+        parent::__construct(
+            $name,
+            $creatorId,
+            $creatorName,
+            $creationDate,
+            $expirationDate,
+            TokenTypeEnum::API,
+            $isRevoked
+        );
+    }
+
+    public function getToken(): string
+    {
+        return $this->tokenString;
+    }
+}

--- a/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
@@ -60,7 +60,8 @@ use Respect\Validation\Exceptions\DateTimeException;
  *      creation_date: int,
  *      expiration_date: ?int,
  *      token_type: string,
- *      is_revoked: int
+ *      is_revoked: int,
+ *      token_string:string,
  *  }
  *
  * @phpstan-type _Token array{
@@ -116,7 +117,7 @@ final class TokenFactory
      * @param _Token $data
      *
      * @throws DateTimeException
-     * @return ApiToken|JwtToken
+     * @return ApiToken|JwtToken|PollerToken
      */
     public static function create(
         TokenTypeEnum $type,
@@ -143,12 +144,13 @@ final class TokenFactory
                 $token = new PollerToken(
                     new TrimmedString($data['name']),
                     $data['creator_id'] ?? null,
-                    $data['creator_name'] ? new TrimmedString($data['creator_name']) : null,
+                    new TrimmedString($data['creator_name']),
                     (new DateTimeImmutable())->setTimestamp($data['creation_date']),
                     $data['expiration_date'] !== null
                     ? (new DateTimeImmutable())->setTimestamp($data['expiration_date'])
                     : null,
-                    (bool) $data['is_revoked']
+                    (bool) $data['is_revoked'],
+                    $data['token_string'],
                 );
                 break;
             default:
@@ -176,7 +178,7 @@ final class TokenFactory
      * @param _NewToken $data
      *
      * @throws DateTimeException
-     * @return NewApiToken|NewJwtToken
+     * @return NewApiToken|NewJwtToken|NewPollerToken
      */
     public static function createNew(TokenTypeEnum $type, array $data): NewToken
     {
@@ -194,9 +196,9 @@ final class TokenFactory
                 /** @var _NewPollerToken $data */
                 $token = new NewPollerToken(
                     new TrimmedString($data['name']),
+                    $data['creator_name'] ? new TrimmedString($data['creator_name']) : new TrimmedString('system'),
                     $data['expiration_date'],
                     $data['creator_id'] ?? null,
-                    $data['creator_name'] ? new TrimmedString($data['creator_name']) : null,
                 );
                 break;
             default:

--- a/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace Core\Security\Token\Domain\Model;
 
 use Core\Common\Domain\TrimmedString;
-use Core\Security\Token\Domain\Model\NewPollerToken;
-use Core\Security\Token\Domain\Model\PollerToken;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Respect\Validation\Exceptions\DateTimeException;
@@ -198,7 +196,7 @@ final class TokenFactory
                     new TrimmedString($data['name']),
                     $data['expiration_date'],
                     $data['creator_id'] ?? null,
-                    $data['creator_name'] ? new TrimmedString($data['creator_name']): null,
+                    $data['creator_name'] ? new TrimmedString($data['creator_name']) : null,
                 );
                 break;
             default:

--- a/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace Core\Security\Token\Domain\Model;
 
 use Core\Common\Domain\TrimmedString;
+use Core\Security\Token\Domain\Model\NewPollerToken;
+use Core\Security\Token\Domain\Model\PollerToken;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Respect\Validation\Exceptions\DateTimeException;
@@ -51,6 +53,16 @@ use Respect\Validation\Exceptions\DateTimeException;
  *      is_revoked: int,
  *      token_string:string,
  *      encoding_key: string
+ *  }
+ *
+ * @phpstan-type _PollerToken array{
+ *      name: string,
+ *      creator_id: ?int,
+ *      creator_name: string,
+ *      creation_date: int,
+ *      expiration_date: ?int,
+ *      token_type: string,
+ *      is_revoked: int
  *  }
  *
  * @phpstan-type _Token array{
@@ -91,6 +103,13 @@ use Respect\Validation\Exceptions\DateTimeException;
  *      expiration_date: ?DateTimeInterface,
  *      configuration_provider_id: int,
  *  }
+ *
+ * @phpstan-type _NewPollerToken array{
+ *      name: string,
+ *      creator_id: ?int,
+ *      creator_name: ?string,
+ *      expiration_date: ?DateTimeInterface,
+ *  }
  */
 final class TokenFactory
 {
@@ -105,35 +124,53 @@ final class TokenFactory
         TokenTypeEnum $type,
         array $data,
     ): Token {
-        if ($type === TokenTypeEnum::CMA) {
-            /** @var _JwtToken $data */
-            return new JwtToken(
-                new TrimmedString($data['name']),
-                $data['creator_id'],
-                new TrimmedString($data['creator_name']),
-                (new DateTimeImmutable())->setTimestamp($data['creation_date']),
-                $data['expiration_date'] !== null
+        switch ($type) {
+            case TokenTypeEnum::CMA:
+                /** @var _JwtToken $data */
+                $token = new JwtToken(
+                    new TrimmedString($data['name']),
+                    $data['creator_id'],
+                    new TrimmedString($data['creator_name']),
+                    (new DateTimeImmutable())->setTimestamp($data['creation_date']),
+                    $data['expiration_date'] !== null
                     ? (new DateTimeImmutable())->setTimestamp($data['expiration_date'])
                     : null,
-                (bool) $data['is_revoked'],
-                $data['encoding_key'],
-                $data['token_string'],
-            );
+                    (bool) $data['is_revoked'],
+                    $data['encoding_key'],
+                    $data['token_string'],
+                );
+                break;
+            case TokenTypeEnum::POLLER:
+                /** @var _PollerToken $data */
+                $token = new PollerToken(
+                    new TrimmedString($data['name']),
+                    $data['creator_id'] ?? null,
+                    $data['creator_name'] ? new TrimmedString($data['creator_name']) : null,
+                    (new DateTimeImmutable())->setTimestamp($data['creation_date']),
+                    $data['expiration_date'] !== null
+                    ? (new DateTimeImmutable())->setTimestamp($data['expiration_date'])
+                    : null,
+                    (bool) $data['is_revoked']
+                );
+                break;
+            default:
+                /** @var _ApiToken $data */
+                $token = new ApiToken(
+                    new TrimmedString($data['name']),
+                    $data['user_id'],
+                    new TrimmedString($data['user_name']),
+                    $data['creator_id'],
+                    new TrimmedString($data['creator_name']),
+                    (new DateTimeImmutable())->setTimestamp($data['creation_date']),
+                    $data['expiration_date'] !== null
+                    ? (new DateTimeImmutable())->setTimestamp($data['expiration_date'])
+                    : null,
+                    (bool) $data['is_revoked'],
+                );
+                break;
         }
 
-        /** @var _ApiToken $data */
-        return new ApiToken(
-            new TrimmedString($data['name']),
-            $data['user_id'],
-            new TrimmedString($data['user_name']),
-            $data['creator_id'],
-            new TrimmedString($data['creator_name']),
-            (new DateTimeImmutable())->setTimestamp($data['creation_date']),
-            $data['expiration_date'] !== null
-                ? (new DateTimeImmutable())->setTimestamp($data['expiration_date'])
-                : null,
-            (bool) $data['is_revoked'],
-        );
+        return $token;
     }
 
     /**
@@ -145,24 +182,38 @@ final class TokenFactory
      */
     public static function createNew(TokenTypeEnum $type, array $data): NewToken
     {
-        if ($type === TokenTypeEnum::CMA) {
-            /** @var _NewJwtToken $data */
-            return new NewJwtToken(
-                new TrimmedString($data['name']),
-                $data['creator_id'],
-                new TrimmedString($data['creator_name']),
-                $data['expiration_date'],
-            );
+        switch ($type) {
+            case TokenTypeEnum::CMA:
+                /** @var _NewJwtToken $data */
+                $token =  new NewJwtToken(
+                    new TrimmedString($data['name']),
+                    $data['creator_id'],
+                    new TrimmedString($data['creator_name']),
+                    $data['expiration_date'],
+                );
+                break;
+            case TokenTypeEnum::POLLER:
+                /** @var _NewPollerToken $data */
+                $token = new NewPollerToken(
+                    new TrimmedString($data['name']),
+                    $data['expiration_date'],
+                    $data['creator_id'] ?? null,
+                    $data['creator_name'] ? new TrimmedString($data['creator_name']): null,
+                );
+                break;
+            default:
+                /** @var _NewApiToken $data */
+                $token = new NewApiToken(
+                    $data['configuration_provider_id'],
+                    new TrimmedString($data['name']),
+                    $data['user_id'],
+                    $data['creator_id'],
+                    new TrimmedString($data['creator_name']),
+                    $data['expiration_date'],
+                );
+                break;
         }
 
-        /** @var _NewApiToken $data */
-        return new NewApiToken(
-            $data['configuration_provider_id'],
-            new TrimmedString($data['name']),
-            $data['user_id'],
-            $data['creator_id'],
-            new TrimmedString($data['creator_name']),
-            $data['expiration_date'],
-        );
+        return $token;
     }
 }

--- a/centreon/src/Core/Security/Token/Domain/Model/TokenTypeEnum.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/TokenTypeEnum.php
@@ -27,4 +27,5 @@ enum TokenTypeEnum
 {
     case API;
     case CMA;
+    case POLLER;
 }

--- a/centreon/src/Core/Security/Token/Infrastructure/API/AddToken/AddTokenInput.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/API/AddToken/AddTokenInput.php
@@ -29,6 +29,7 @@ final readonly class AddTokenInput
 {
     public const API_TYPE = 'api';
     public const CMA_TYPE = 'cma';
+    public const POLLER_TYPE = 'poller';
 
     /**
      * @param string $name
@@ -45,9 +46,8 @@ final readonly class AddTokenInput
         )]
         public mixed $expirationDate,
         #[Assert\NotNull()]
-        #[Assert\Choice(choices: [self::API_TYPE, self::CMA_TYPE])]
+        #[Assert\Choice(choices: [self::API_TYPE, self::CMA_TYPE, self::POLLER_TYPE])]
         public mixed $type,
-        #[Assert\NotNull()]
         #[Assert\Type('int')]
         public mixed $userId,
     ) {

--- a/centreon/src/Core/Security/Token/Infrastructure/API/AddToken/AddTokenRequestTransformer.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/API/AddToken/AddTokenRequestTransformer.php
@@ -40,8 +40,12 @@ final class AddTokenRequestTransformer
 
         return new AddTokenRequest(
             $input->name,
-            $input->type === 'cma' ? TokenTypeEnum::CMA : TokenTypeEnum::API,
-            $input->userId,
+            match ($input->type) {
+                AddTokenInput::API_TYPE => TokenTypeEnum::API,
+                AddTokenInput::CMA_TYPE => TokenTypeEnum::CMA,
+                AddTokenInput::POLLER_TYPE => TokenTypeEnum::POLLER,
+            },
+            $input->userId ?? null,
             $expirationDate
         );
     }

--- a/centreon/src/Core/Security/Token/Infrastructure/API/AddToken/AddTokenRequestTransformer.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/API/AddToken/AddTokenRequestTransformer.php
@@ -41,9 +41,9 @@ final class AddTokenRequestTransformer
         return new AddTokenRequest(
             $input->name,
             match ($input->type) {
-                AddTokenInput::API_TYPE => TokenTypeEnum::API,
                 AddTokenInput::CMA_TYPE => TokenTypeEnum::CMA,
                 AddTokenInput::POLLER_TYPE => TokenTypeEnum::POLLER,
+                default => TokenTypeEnum::API,
             },
             $input->userId ?? null,
             $expirationDate

--- a/centreon/src/Core/Security/Token/Infrastructure/API/GetToken/GetTokenController.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/API/GetToken/GetTokenController.php
@@ -53,6 +53,8 @@ final class GetTokenController extends AbstractController
             return $this->createResponse($response);
         }
 
+        \CentreonLog::create()->error(logTypeId: \CentreonLog::TYPE_BUSINESS_LOG, message: 'get token', customContext: ['response' => $response]);
+
         return JsonResponse::fromJsonString($presenter->present(
             $response,
             ['groups' => ['Token:Get']]

--- a/centreon/src/Core/Security/Token/Infrastructure/Repository/DbReadTokenRepository.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/Repository/DbReadTokenRepository.php
@@ -147,8 +147,8 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                         is_revoked,
                         token_string,
                         encoding_key,
-                        'JWT' as token_type
-                    FROM jwt_tokens
+                        `type` as token_type
+                    FROM authentication_tokens
                     WHERE token_string = :tokenString
                     SQL,
                 QueryParameters::create([
@@ -230,8 +230,8 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                         is_revoked,
                         token_string,
                         encoding_key,
-                        'JWT' as token_type
-                    FROM jwt_tokens
+                        `type` as token_type
+                    FROM authentication_tokens
                     WHERE token_name IN ({$tokensQuery})
                     SQL,
                 $queryParams
@@ -324,8 +324,8 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                         is_revoked,
                         token_string,
                         encoding_key,
-                        'JWT' as token_type
-                    FROM jwt_tokens
+                        `type` as token_type
+                    FROM authentication_tokens
                     WHERE token_name = :tokenName
                     SQL,
                 QueryParameters::create([
@@ -400,7 +400,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                         AND sat.token_type = :tokenApiType
                     UNION
                     SELECT 1
-                    FROM jwt_tokens
+                    FROM authentication_tokens
                     WHERE token_name = :tokenName
                     SQL,
                 QueryParameters::create([
@@ -537,7 +537,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                 WHERE sat.token_type = :tokenApiType
                 {$userIdFilter}
                 SQL;
-            $jwtTokens = <<<SQL
+            $authenticationTokens = <<<SQL
                 SELECT
                     token_name as name,
                     null as user_id,
@@ -547,10 +547,10 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                     creation_date,
                     expiration_date,
                     is_revoked,
-                    'CMA' as token_type,
+                    type as token_type,
                     token_string,
                     encoding_key
-                FROM jwt_tokens
+                FROM authentication_tokens
                 {$creatorIdFilter}
                 SQL;
 
@@ -571,7 +571,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
                     FROM (
                         {$apiTokens}
                         UNION
-                        {$jwtTokens}
+                        {$authenticationTokens}
                     ) AS tokenUnion
                     {$search}
                     {$sort}
@@ -584,7 +584,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
             foreach ($results as $result) {
                 /** @var _Token $result */
                 $tokens[] = TokenFactory::create(
-                    $result['token_type'] === 'CMA' ? TokenTypeEnum::CMA : TokenTypeEnum::API,
+                    TokenTypeEnum::{$result['token_type']},
                     $result
                 );
             }

--- a/centreon/src/Core/Security/Token/Infrastructure/Repository/DbReadTokenRepository.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/Repository/DbReadTokenRepository.php
@@ -584,7 +584,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
             foreach ($results as $result) {
                 /** @var _Token $result */
                 $tokens[] = TokenFactory::create(
-                    TokenTypeEnum::{$result['token_type']},
+                    \constant("TokenTypeEnum::{$result['token_type']}"),
                     $result
                 );
             }

--- a/centreon/src/Core/Security/Token/Infrastructure/Repository/DbReadTokenRepository.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/Repository/DbReadTokenRepository.php
@@ -160,7 +160,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
             if ($result !== []) {
                 /** @var _Token $result */
                 return TokenFactory::create(
-                    $result['token_type'] === 'JWT' ? TokenTypeEnum::CMA : TokenTypeEnum::API,
+                    \constant(TokenTypeEnum::class . '::' . mb_strtoupper($result['token_type'])),
                     $result
                 );
             }
@@ -241,7 +241,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
             foreach ($data as $row) {
                 /** @var _Token $row */
                 $results[$row['name']] = TokenFactory::create(
-                    TokenTypeEnum::CMA,
+                    \constant(TokenTypeEnum::class . '::' . mb_strtoupper($row['token_type'])),
                     $row
                 );
             }
@@ -341,7 +341,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
 
             /** @var _Token $result */
             return TokenFactory::create(
-                $result['token_type'] === 'JWT' ? TokenTypeEnum::CMA : TokenTypeEnum::API,
+                \constant(TokenTypeEnum::class . '::' . mb_strtoupper($result['token_type'])),
                 $result
             );
 
@@ -584,7 +584,7 @@ class DbReadTokenRepository extends DatabaseRepository implements ReadTokenRepos
             foreach ($results as $result) {
                 /** @var _Token $result */
                 $tokens[] = TokenFactory::create(
-                    \constant("TokenTypeEnum::{$result['token_type']}"),
+                    \constant(TokenTypeEnum::class . '::' . mb_strtoupper($result['token_type'])),
                     $result
                 );
             }

--- a/centreon/src/Core/Security/Token/Infrastructure/Repository/DbWriteTokenRepository.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/Repository/DbWriteTokenRepository.php
@@ -41,7 +41,6 @@ use Core\Security\Token\Domain\Model\NewPollerToken;
 use Core\Security\Token\Domain\Model\NewToken;
 use Core\Security\Token\Domain\Model\PollerToken;
 use Core\Security\Token\Domain\Model\Token;
-use Core\Security\Token\Domain\Model\TokenTypeEnum;
 
 class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRepositoryInterface
 {
@@ -105,6 +104,7 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
             if ($newToken instanceof NewApiToken) {
                 $this->addApiToken($newToken);
             } else {
+                /** @var NewJwtToken|NewPollerToken $newToken */
                 $this->addAuthenticationToken($newToken);
             }
         } catch (ValueObjectException|CollectionException|ConnectionException $exception) {
@@ -134,6 +134,7 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
             if ($token instanceof ApiToken) {
                 $this->updateApiToken($token);
             } else {
+                /** @var JwtToken|PollerToken $token */
                 $this->updateAuthenticationToken($token);
             }
         } catch (ValueObjectException|CollectionException|ConnectionException $exception) {
@@ -165,6 +166,7 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
         $this->connection->insert(
             $this->connection->createQueryBuilder()->insert('authentication_tokens')
                 ->values([
+                    'type' => ':tokenType',
                     'token_string' => ':tokenString',
                     'token_name' => ':tokenName',
                     'creator_id' => ':creatorId',
@@ -175,11 +177,12 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
                 ])
                 ->getQuery(),
             QueryParameters::create([
+                QueryParameter::string('tokenType', mb_strtolower($token->getType()->name)),
                 QueryParameter::string('tokenString', $token->getToken()),
                 QueryParameter::string('tokenName', $token->getName()),
                 QueryParameter::int('creatorId', $token->getCreatorId()),
                 QueryParameter::string('creatorName', $token->getCreatorName()),
-                QueryParameter::string('encodingKey', $token->getType() === TokenTypeEnum::CMA ? $token->getEncodingKey() : null),
+                QueryParameter::string('encodingKey', $token instanceof NewJwtToken ? $token->getEncodingKey() : null),
                 QueryParameter::int('createdAt', $token->getCreationDate()->getTimestamp()),
                 QueryParameter::int('expireAt', $token->getExpirationDate()?->getTimestamp()),
             ])

--- a/centreon/src/Core/Security/Token/Infrastructure/Repository/DbWriteTokenRepository.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/Repository/DbWriteTokenRepository.php
@@ -37,8 +37,11 @@ use Core\Security\Token\Domain\Model\ApiToken;
 use Core\Security\Token\Domain\Model\JwtToken;
 use Core\Security\Token\Domain\Model\NewApiToken;
 use Core\Security\Token\Domain\Model\NewJwtToken;
+use Core\Security\Token\Domain\Model\NewPollerToken;
 use Core\Security\Token\Domain\Model\NewToken;
+use Core\Security\Token\Domain\Model\PollerToken;
 use Core\Security\Token\Domain\Model\Token;
+use Core\Security\Token\Domain\Model\TokenTypeEnum;
 
 class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRepositoryInterface
 {
@@ -66,7 +69,7 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
             );
 
             $this->connection->delete(
-                $this->connection->createQueryBuilder()->delete('jwt_tokens')
+                $this->connection->createQueryBuilder()->delete('authentication_tokens')
                     ->where('token_name = :tokenName')
                     ->andWhere('creator_id = :userId')
                     ->getQuery(),
@@ -99,11 +102,10 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
     public function add(NewToken $newToken): void
     {
         try {
-            if ($newToken instanceof NewJwtToken) {
-                $this->addJwtToken($newToken);
-            } else {
-                /** @var NewApiToken $newToken */
+            if ($newToken instanceof NewApiToken) {
                 $this->addApiToken($newToken);
+            } else {
+                $this->addAuthenticationToken($newToken);
             }
         } catch (ValueObjectException|CollectionException|ConnectionException $exception) {
             $this->error(
@@ -129,11 +131,10 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
     public function update(Token $token): void
     {
         try {
-            if ($token instanceof JwtToken) {
-                $this->updateJwtToken($token);
-            } else {
-                /** @var ApiToken $token */
+            if ($token instanceof ApiToken) {
                 $this->updateApiToken($token);
+            } else {
+                $this->updateAuthenticationToken($token);
             }
         } catch (ValueObjectException|CollectionException|ConnectionException $exception) {
             $this->error(
@@ -153,16 +154,16 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
         }
     }
 
-    // ------------------------------ JWT TOKEN METHODS ------------------------------
+    // ------------------------------ JWT&POLLER TOKEN METHODS ------------------------------
 
     /**
      * @param NewJwtToken $token
      * @throws \Throwable
      */
-    private function addJwtToken(NewJwtToken $token): void
+    private function addAuthenticationToken(NewJwtToken|NewPollerToken $token): void
     {
         $this->connection->insert(
-            $this->connection->createQueryBuilder()->insert('jwt_tokens')
+            $this->connection->createQueryBuilder()->insert('authentication_tokens')
                 ->values([
                     'token_string' => ':tokenString',
                     'token_name' => ':tokenName',
@@ -178,7 +179,7 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
                 QueryParameter::string('tokenName', $token->getName()),
                 QueryParameter::int('creatorId', $token->getCreatorId()),
                 QueryParameter::string('creatorName', $token->getCreatorName()),
-                QueryParameter::string('encodingKey', $token->getEncodingKey()),
+                QueryParameter::string('encodingKey', $token->getType() === TokenTypeEnum::CMA ? $token->getEncodingKey() : null),
                 QueryParameter::int('createdAt', $token->getCreationDate()->getTimestamp()),
                 QueryParameter::int('expireAt', $token->getExpirationDate()?->getTimestamp()),
             ])
@@ -189,10 +190,10 @@ class DbWriteTokenRepository extends DatabaseRepository implements WriteTokenRep
      * @param JwtToken $token
      * @throws \Throwable
      */
-    private function updateJwtToken(JwtToken $token): void
+    private function updateAuthenticationToken(JwtToken|PollerToken $token): void
     {
         $this->connection->update(
-            $this->connection->createQueryBuilder()->update('jwt_tokens')
+            $this->connection->createQueryBuilder()->update('authentication_tokens')
                 ->set('is_revoked', ':isRevoked')
                 ->where('token_name = :tokenName')
                 ->getQuery(),

--- a/centreon/src/Core/Security/Token/Infrastructure/Serializer/TokenNormalizer.php
+++ b/centreon/src/Core/Security/Token/Infrastructure/Serializer/TokenNormalizer.php
@@ -108,6 +108,7 @@ class TokenNormalizer implements NormalizerInterface, NormalizerAwareInterface
         return match ($code) {
             TokenTypeEnum::CMA => 'cma',
             TokenTypeEnum::API => 'api',
+            TokenTypeEnum::POLLER => 'poller',
         };
     }
 }

--- a/centreon/tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenTest.php
+++ b/centreon/tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenTest.php
@@ -41,6 +41,7 @@ use Core\Security\Token\Application\UseCase\AddToken\AddTokenResponse;
 use Core\Security\Token\Application\UseCase\AddToken\AddTokenValidation;
 use Core\Security\Token\Domain\Model\ApiToken;
 use Core\Security\Token\Domain\Model\JwtToken;
+use Core\Security\Token\Domain\Model\PollerToken;
 use Core\Security\Token\Domain\Model\TokenTypeEnum;
 
 beforeEach(function (): void {
@@ -75,6 +76,13 @@ beforeEach(function (): void {
         expirationDate: $this->expirationDate
     );
 
+    $this->requestPoller = new AddTokenRequest(
+        name: '  token name POLLER  ',
+        type: TokenTypeEnum::POLLER,
+        userId: $this->linkedUser['id'],
+        expirationDate: $this->expirationDate
+    );
+
     $this->tokenJwt = new JwtToken(
         name: new TrimmedString($this->requestJwt->name),
         creatorId: $this->creator['id'],
@@ -88,6 +96,15 @@ beforeEach(function (): void {
         name: new TrimmedString($this->requestApi->name),
         userId: $this->linkedUser['id'],
         userName: new TrimmedString($this->linkedUser['name']),
+        creatorId: $this->creator['id'],
+        creatorName: new TrimmedString($this->creator['name']),
+        creationDate: $this->creationDate,
+        expirationDate: $this->expirationDate,
+        isRevoked: false
+    );
+
+    $this->tokenPoller = new PollerToken(
+        name: new TrimmedString($this->requestPoller->name),
         creatorId: $this->creator['id'],
         creatorName: new TrimmedString($this->creator['name']),
         creationDate: $this->creationDate,
@@ -313,4 +330,45 @@ it('should return created object on success (CMA)', function (): void {
         ->toBe($this->tokenJwt->isRevoked())
         ->and($response->token->getType())
         ->toBe($this->tokenJwt->getType());
+});
+
+it('should return created object on success (POLLER)', function (): void {
+    $this->validation->expects($this->once())->method('assertIsValidName');
+    $this->validation->expects($this->once())->method('assertIsValidUser');
+
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('getId')
+        ->willReturn($this->creator['id']);
+    $this->user
+        ->expects($this->once())
+        ->method('getName')
+        ->willReturn($this->creator['name']);
+
+    $this->writeTokenRepository
+        ->expects($this->once())
+        ->method('add');
+
+    $this->readTokenRepository
+        ->expects($this->once())
+        ->method('find')
+        ->willReturn($this->tokenPoller);
+
+    $response = ($this->useCase)($this->requestPoller);
+
+    expect($response)->toBeInstanceOf(AddTokenResponse::class)
+        ->and($response->token->getName())
+        ->toBe($this->tokenPoller->getName())
+        ->and($response->token->getCreatorName())
+        ->toBe($this->creator['name'])
+        ->and($response->token->getCreatorId())
+        ->toBe($this->creator['id'])
+        ->and($response->token->getCreationDate())
+        ->toBe($this->creationDate)
+        ->and($response->token->getExpirationDate())
+        ->toBe($this->expirationDate)
+        ->and($response->token->isRevoked())
+        ->toBe($this->tokenPoller->isRevoked())
+        ->and($response->token->getType())
+        ->toBe($this->tokenPoller->getType());
 });

--- a/centreon/tests/php/Core/Security/Token/Application/UseCase/GetToken/GetTokenTest.php
+++ b/centreon/tests/php/Core/Security/Token/Application/UseCase/GetToken/GetTokenTest.php
@@ -33,6 +33,7 @@ use Core\Security\Token\Application\UseCase\GetToken\GetToken;
 use Core\Security\Token\Application\UseCase\GetToken\GetTokenResponse;
 use Core\Security\Token\Domain\Model\ApiToken;
 use Core\Security\Token\Domain\Model\JwtToken;
+use Core\Security\Token\Domain\Model\PollerToken;
 
 beforeEach(function (): void {
     $this->useCase = new GetToken(
@@ -66,6 +67,16 @@ beforeEach(function (): void {
         encodingKey: 'encodingKey',
         tokenString: $this->tokenString,
     );
+
+    $this->tokenPoller = new PollerToken(
+        name: new TrimmedString($this->tokenName),
+        creatorId: $this->creator['id'],
+        creatorName: new TrimmedString($this->creator['name']),
+        creationDate: $this->creationDate,
+        expirationDate: $this->expirationDate,
+        isRevoked: false,
+        tokenString: $this->tokenString,
+    );
 });
 
 it('should present an ErrorResponse when a generic exception is thrown', function (): void {
@@ -82,7 +93,7 @@ it('should present an ErrorResponse when a generic exception is thrown', functio
         ->toBe(TokenException::errorWhileRetrievingObject()->getMessage());
 });
 
-it('should return a NotFoundResponse when token is not of type CMA', function (): void {
+it('should return a NotFoundResponse when token is not of type CMA or POLLER', function (): void {
     $this->readTokenRepository
         ->expects($this->once())
         ->method('findByNameAndUserId')
@@ -95,7 +106,7 @@ it('should return a NotFoundResponse when token is not of type CMA', function ()
         ->toBe((new NotFoundResponse('Token'))->getMessage());
 });
 
-it('should return created object on success', function (): void {
+it('should return created object on success (CMA)', function (): void {
     $this->readTokenRepository
         ->expects($this->once())
         ->method('findByNameAndUserId')
@@ -106,6 +117,21 @@ it('should return created object on success', function (): void {
     expect($response)->toBeInstanceOf(GetTokenResponse::class)
         ->and($response->token)
         ->toBe($this->tokenCma)
+        ->and($response->tokenString)
+        ->toBe($this->tokenString);
+});
+
+it('should return created object on success (POLLER)', function (): void {
+    $this->readTokenRepository
+        ->expects($this->once())
+        ->method('findByNameAndUserId')
+        ->willReturn($this->tokenPoller);
+
+    $response = ($this->useCase)($this->tokenName, $this->linkedUser['id']);
+
+    expect($response)->toBeInstanceOf(GetTokenResponse::class)
+        ->and($response->token)
+        ->toBe($this->tokenPoller)
         ->and($response->tokenString)
         ->toBe($this->tokenString);
 });

--- a/centreon/tests/php/Core/Security/Token/Domain/Model/NewPollerTokenTest.php
+++ b/centreon/tests/php/Core/Security/Token/Domain/Model/NewPollerTokenTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Token\Domain\Model;
+
+use Assert\InvalidArgumentException;
+use Centreon\Domain\Common\Assertion\AssertionException;
+use Core\Common\Domain\TrimmedString;
+use Core\Security\Token\Domain\Model\NewPollerToken;
+use Core\Security\Token\Domain\Model\NewToken;
+use Core\Security\Token\Domain\Model\Token;
+use Core\Security\Token\Domain\Model\TokenTypeEnum;
+
+beforeEach(function (): void {
+    $this->createToken = static fn (array $fields = []): NewToken => new NewPollerToken(
+        ...[
+            'name' => new TrimmedString('poller-token'),
+            'expirationDate' => (new \DateTimeImmutable())->add(new \DateInterval('P1Y')),
+            'creatorId' => 12,
+            'creatorName' => new TrimmedString('John Doe'),
+            ...$fields,
+        ]
+    );
+});
+
+it('should return properly set token instance', function (): void {
+    $token = ($this->createToken)();
+
+    expect($token->getName())->toBe('poller-token')
+        ->and($token->getCreatorId())->toBe(12)
+        ->and($token->getCreatorName())->toBe('John Doe')
+        ->and($token->getType())->toBe(TokenTypeEnum::POLLER);
+});
+
+it('should generate a non-empty token string', function (): void {
+    $token = ($this->createToken)();
+
+    expect($token->getToken())->not->toBeEmpty();
+});
+
+foreach (
+    [
+        'name',
+        'creatorName',
+    ] as $field
+) {
+    it(
+        "should throw an exception when token {$field} is an empty string",
+        fn () => ($this->createToken)([$field => new TrimmedString('    ')])
+    )->throws(
+        InvalidArgumentException::class,
+        AssertionException::notEmptyString("NewPollerToken::{$field}")->getMessage()
+    );
+}
+
+foreach (
+    [
+        'name',
+        'creatorName',
+    ] as $field
+) {
+    it(
+        "should return a trimmed field {$field}",
+        function () use ($field): void {
+            $token = ($this->createToken)([$field => new TrimmedString('  some-text   ')]);
+            $valueFromGetter = $token->{'get' . $field}();
+
+            expect($valueFromGetter)->toBe('some-text');
+        }
+    );
+}
+
+// too long fields
+foreach (
+    [
+        'name' => Token::MAX_TOKEN_NAME_LENGTH,
+        'creatorName' => Token::MAX_USER_NAME_LENGTH,
+    ] as $field => $length
+) {
+    $tooLong = str_repeat('a', $length + 1);
+    it(
+        "should throw an exception when token {$field} is too long",
+        fn () => ($this->createToken)([$field => new TrimmedString($tooLong)])
+    )->throws(
+        InvalidArgumentException::class,
+        AssertionException::maxLength($tooLong, $length + 1, $length, "NewPollerToken::{$field}")->getMessage()
+    );
+}
+
+// foreign key field
+it(
+    'should throw an exception when token creatorId is not > 0',
+    fn () => ($this->createToken)(['creatorId' => 0])
+)->throws(
+    InvalidArgumentException::class,
+    AssertionException::positiveInt(0, 'NewPollerToken::creatorId')->getMessage()
+);

--- a/centreon/tests/php/Core/Security/Token/Domain/Model/PollerTokenTest.php
+++ b/centreon/tests/php/Core/Security/Token/Domain/Model/PollerTokenTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Token\Domain\Model;
+
+use Assert\InvalidArgumentException;
+use Centreon\Domain\Common\Assertion\AssertionException;
+use Core\Common\Domain\TrimmedString;
+use Core\Security\Token\Domain\Model\PollerToken;
+use Core\Security\Token\Domain\Model\Token;
+use Core\Security\Token\Domain\Model\TokenTypeEnum;
+
+beforeEach(function (): void {
+    $this->createToken = static fn (array $fields = []): PollerToken => new PollerToken(
+        ...[
+            'name' => new TrimmedString('poller-token'),
+            'creatorId' => 12,
+            'creatorName' => new TrimmedString('John Doe'),
+            'creationDate' => new \DateTimeImmutable(),
+            'expirationDate' => (new \DateTimeImmutable())->add(new \DateInterval('P1Y')),
+            'isRevoked' => false,
+            'tokenString' => 'some-token-string',
+            ...$fields,
+        ]
+    );
+});
+
+it('should return properly set token instance', function (): void {
+    $token = ($this->createToken)();
+
+    expect($token->getName())->toBe('poller-token')
+        ->and($token->getCreatorId())->toBe(12)
+        ->and($token->getCreatorName())->toBe('John Doe')
+        ->and($token->isRevoked())->toBe(false)
+        ->and($token->getToken())->toBe('some-token-string')
+        ->and($token->getType())->toBe(TokenTypeEnum::POLLER);
+});
+
+foreach (
+    [
+        'name',
+        'creatorName',
+    ] as $field
+) {
+    it(
+        "should throw an exception when token {$field} is an empty string",
+        fn () => ($this->createToken)([$field => new TrimmedString('    ')])
+    )->throws(
+        InvalidArgumentException::class,
+        AssertionException::notEmptyString("PollerToken::{$field}")->getMessage()
+    );
+}
+
+foreach (
+    [
+        'name',
+        'creatorName',
+    ] as $field
+) {
+    it("should return a trimmed field {$field}", function () use ($field): void {
+        $token = ($this->createToken)([$field => new TrimmedString('  some-text   ')]);
+        $valueFromGetter = $token->{'get' . $field}();
+
+        expect($valueFromGetter)->toBe('some-text');
+    });
+}
+
+// too long fields
+foreach (
+    [
+        'name' => Token::MAX_TOKEN_NAME_LENGTH,
+        'creatorName' => Token::MAX_USER_NAME_LENGTH,
+    ] as $field => $length
+) {
+    $tooLong = str_repeat('a', $length + 1);
+    it(
+        "should throw an exception when token {$field} is too long",
+        fn () => ($this->createToken)([$field => new TrimmedString($tooLong)])
+    )->throws(
+        InvalidArgumentException::class,
+        AssertionException::maxLength($tooLong, $length + 1, $length, "PollerToken::{$field}")->getMessage()
+    );
+}

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2750,8 +2750,8 @@ CREATE TABLE IF NOT EXISTS `user_profile_favorite_dashboards` (
     REFERENCES `dashboard` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS `jwt_tokens` (
-    `token_string` varchar(4096) DEFAULT NULL COMMENT 'Encoded JWT token',
+CREATE TABLE IF NOT EXISTS `authentication_tokens` (
+    `token_string` varchar(4096) DEFAULT NULL COMMENT 'token string',
     `token_name` VARCHAR(255) NOT NULL COMMENT 'Token name',
     `creator_id` INT(11) DEFAULT NULL COMMENT 'User ID of the token creator',
     `creator_name` VARCHAR(255) DEFAULT NULL COMMENT 'User name of the token creator',
@@ -2759,10 +2759,11 @@ CREATE TABLE IF NOT EXISTS `jwt_tokens` (
     `is_revoked` BOOLEAN NOT NULL DEFAULT 0 COMMENT 'Define if token is revoked',
     `creation_date` bigint UNSIGNED NOT NULL COMMENT 'Creation date of the token',
     `expiration_date` bigint UNSIGNED DEFAULT NULL COMMENT 'Expiration date of the token',
+    `type` enum('cma','poller') DEFAULT 'cma' COMMENT 'Define token usage',
     PRIMARY KEY (`token_name`),
     CONSTRAINT `jwt_tokens_user_id_fk` FOREIGN KEY (`creator_id`)
     REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Table for JWT tokens';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Table for tokens not used for api/ui login';
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -865,7 +865,7 @@ $deleteOldCommandsTopologies = function () use ($pearDB, &$errorMessage, $versio
 
 /** -------------------------------------- Poller tokens -------------------------------------- */
 $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version): void {
-    $errorMessage = "Unable to update and rename jwt_tokens table";
+    $errorMessage = 'Unable to update and rename jwt_tokens table';
     CentreonLog::create()->info(
         logTypeId: CentreonLog::TYPE_UPGRADE,
         message: "UPGRADE - {$version}: Updating jwt_tokens table",
@@ -896,9 +896,9 @@ $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version)
     );
 
     if ($pearDB->columnExists(
-            $pearDB->getConnectionConfig()->getDatabaseNameRealTime(),
-            'authentication_tokens',
-            'type'
+        $pearDB->getConnectionConfig()->getDatabaseNameRealTime(),
+        'authentication_tokens',
+        'type'
     )) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -920,7 +920,6 @@ $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version)
             SQL
     );
 };
-
 
 try {
     // DDL statements for real time database

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -873,8 +873,11 @@ $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version)
     $tableExistWithOldName = $pearDB->fetchOne(
         <<<'SQL'
             SELECT true FROM INFORMATION_SCHEMA.TABLES
-            WHERE table_schema = 'db_name' AND table_name LIKE 'jwt_tokens'
-            SQL
+            WHERE table_schema = :db_name AND table_name LIKE 'jwt_tokens'
+            SQL,
+        QueryParameters::create([
+            QueryParameter::create('db_name', $pearDB->getDatabaseName()),
+        ])
     );
     if (! $tableExistWithOldName) {
         CentreonLog::create()->info(
@@ -891,7 +894,7 @@ $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version)
     );
     $pearDB->executeStatement(
         <<<'SQL'
-            ALTER TABLE `jwt_tokens` RENAME TO `authentication_tokens`, MODIFY COMMENT 'Table for tokens not used for api/ui login'
+            ALTER TABLE `jwt_tokens` RENAME TO `authentication_tokens`, COMMENT 'Table for tokens not used for api/ui login'
             SQL
     );
 
@@ -916,7 +919,7 @@ $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version)
         <<<'SQL'
             ALTER TABLE `authentication_tokens`
             ADD COLUMN `type` enum('cma','poller') DEFAULT 'cma' COMMENT 'Define token usage',
-            ALTER COLUMN `token_string` SET COMMENT 'token string',
+            MODIFY COLUMN `token_string` varchar(4096) DEFAULT NULL COMMENT 'token string'
             SQL
     );
 };

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -863,6 +863,65 @@ $deleteOldCommandsTopologies = function () use ($pearDB, &$errorMessage, $versio
     );
 };
 
+/** -------------------------------------- Poller tokens -------------------------------------- */
+$updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = "Unable to update and rename jwt_tokens table";
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Updating jwt_tokens table",
+    );
+    $tableExistWithOldName = $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT true FROM INFORMATION_SCHEMA.TABLES
+            WHERE table_schema = 'db_name' AND table_name LIKE 'jwt_tokens'
+            SQL
+    );
+    if (! $tableExistWithOldName) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: jwt_tokens table not found, skipping update",
+        );
+
+        return;
+    }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Renaming jwt_tokens table",
+    );
+    $pearDB->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `jwt_tokens` RENAME TO `authentication_tokens`, MODIFY COMMENT 'Table for tokens not used for api/ui login'
+            SQL
+    );
+
+    if ($pearDB->columnExists(
+            $pearDB->getConnectionConfig()->getDatabaseNameRealTime(),
+            'authentication_tokens',
+            'type'
+    )) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Nothing to update in authentication_tokens table",
+        );
+
+        return;
+    }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Updating authentication_tokens table",
+    );
+    $pearDB->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `authentication_tokens`
+            ADD COLUMN `type` enum('cma','poller') DEFAULT 'cma' COMMENT 'Define token usage',
+            ALTER COLUMN `token_string` SET COMMENT 'token string',
+            SQL
+    );
+};
+
+
 try {
     // DDL statements for real time database
     $pearDBO->executeStatement(
@@ -872,7 +931,7 @@ try {
     );
 
     // DDL statements for configuration database
-    // TODO add your function calls to update the configuration database structure here
+    $updateAuthenticationTable();
 
     // Transactional queries for configuration database
     if (! $pearDB->isTransactionActive()) {


### PR DESCRIPTION
## Description

Add a new `poller` token type alongside the existing `api` and `cma` types, backed by a unified `authentication_tokens` table (replacing the old `jwt_tokens` table for CMA tokens).                                                                                                            
                                                            
  ## Changes                                                                                                                                     
                                                            
  ### Domain                                                                                                                                     
  - Add `TokenTypeEnum::POLLER` enum case
  - Add `PollerToken` and `NewPollerToken` domain models                                                                                         
                                                            
  ### Application                                                                                                                                
  - `GetToken`: accept `POLLER` type in addition to `CMA`   
  - `TokenFactory`: handle `POLLER` case in `create()` and `createNew()`                                                                         
                                                                                                                                                 
  ### Infrastructure                                                                                                                             
  - `AddTokenInput` / `AddTokenRequestTransformer`: support `poller` as a valid input type; `userId` is now optional for poller tokens                                                                                       
  - `DbReadTokenRepository`: query from `authentication_tokens` instead of `jwt_tokens`; resolve token type dynamically from the `type` column                                                                          
  - `DbWriteTokenRepository`: route writes through `addAuthenticationToken` / `updateAuthenticationToken` for both CMA and poller tokens; store a null `encoding_key` for poller tokens                                                                                                             
                                                                                                                                                 
  ### Database                                                                                                                                   
  - `createTables.sql` / `Update-next.php`: create `authentication_tokens` table with a `type` column                                                                                                                         
                                                            
  ## Tests                                                                                                                                       
  - Unit tests for `PollerToken` and `NewPollerToken` domain models
  - `GetTokenTest`: add POLLER success case, update NotFoundResponse description                                                                 
  - `AddTokenTest`: add POLLER success case            

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Introduced POLLER token type and new Poller domain models

**⚡ Enhancements**
* Adapted Add/Get token use cases, validation, and API

**🔧 Refactors**
* Extended TokenFactory and NewToken to create poller tokens
* Replaced jwt_tokens with authentication_tokens and updated repositories queries


<sup>[More info](https://app.aikido.dev/featurebranch/scan/105042472?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->