### PR TITLE
enh(ci): extract inline workflow scripts to dedicated shell files

### DIFF
--- a/.github/scripts/translation/build-translations.sh
+++ b/.github/scripts/translation/build-translations.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build translations for centreon-web.
+#
+# Expected environment variables (set via workflow env block):
+#   IS_NIGHTLY                    - "true" or "false"
+#   STABILITY                     - "stable" or "unstable"
+#   EVENT_NAME                    - github.event_name
+#   HAS_UPDATE_TRANSLATIONS_LABEL - "true" or "false"
+#   GITHUB_WORKSPACE              - GitHub Actions workspace root
+#   GITHUB_OUTPUT                 - GitHub Actions step output file
+
+TRANSLATIONS_PATCH_FILE=""
+
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+cd centreon
+
+for i in lang/*.UTF-8 ; do
+  localefull="$(basename "$i")"
+  langName="$(echo "$localefull" | cut -d . -f 1)"
+  langShortName="$(echo "$localefull" | cut -d _ -f 1)"
+  mkdir -p "www/locale/$localefull/LC_MESSAGES"
+  bash -e ../.github/scripts/translation/make_translation.sh centreon "$langName"
+  msgfmt "lang/$localefull/LC_MESSAGES/messages.po" -o "www/locale/$localefull/LC_MESSAGES/messages.mo" || exit 1
+  msgfmt "lang/$localefull/LC_MESSAGES/help.po" -o "www/locale/$localefull/LC_MESSAGES/help.mo" || exit 1
+  php bin/centreon-translations.php "$langShortName" "lang/$localefull/LC_MESSAGES/messages.po" "www/locale/$localefull/LC_MESSAGES/messages.ser"
+done
+
+mkdir -p www/locale/en_US.UTF-8/LC_MESSAGES
+php bin/centreon-translations.php en lang/fr_FR.UTF-8/LC_MESSAGES/messages.po www/locale/en_US.UTF-8/LC_MESSAGES/messages.ser
+
+if [[ "$(git diff --ignore-matching-lines="POT-Creation-Date" | wc -l)" != "0" ]]; then
+  # avoid to always update POT-Creation-Date field
+  find -type f -regex '.+\.pot?' -exec sed -i -e 's/"POT-Creation-Date.*$/"POT-Creation-Date: 2025-01-01 00:00+0000\\n"/g' {} \;
+  if [[ ( "$IS_NIGHTLY" == "false" && "$STABILITY" == "unstable" ) || ( "$EVENT_NAME" == 'pull_request' && "$HAS_UPDATE_TRANSLATIONS_LABEL" == "true" ) ]]; then
+    if [[ "$(git log -1 --pretty=format:'%an')" != "technique-ci" ]]; then
+      git config user.name "technique-ci"
+      git config user.email "technique+ci@centreon.com"
+      git status
+      git add .
+      git commit -m "chore(lang): update translations"
+      git push
+    else
+      echo "::notice::Last commit author is technique-ci. Skipping commit to avoid infinite loop."
+      cd ..
+      git diff > translations.patch
+      TRANSLATIONS_PATCH_FILE="translations.patch"
+    fi
+  else
+    echo "::notice::Translations have been updated, but the workflow is a nightly run or does not have the update-translations label. Skipping commit. Git patch will be available as artifact."
+    cd ..
+    git diff > translations.patch
+    TRANSLATIONS_PATCH_FILE="translations.patch"
+  fi
+else
+  echo "No changes in translations"
+fi
+
+echo "translations_patch_file=$TRANSLATIONS_PATCH_FILE" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/translation/build-translations.sh
+++ b/.github/scripts/translation/build-translations.sh
@@ -41,7 +41,7 @@ if [[ "$(git diff --ignore-matching-lines="POT-Creation-Date" | wc -l)" != "0" ]
       git status
       git add .
       git commit -m "chore(lang): update translations"
-      git push
+      git push || echo "::warning::Failed to push translations commit (technique-ci may not have push access)."
     else
       echo "::notice::Last commit author is technique-ci. Skipping commit to avoid infinite loop."
       cd ..

--- a/.github/scripts/xray/associate-test-cases.sh
+++ b/.github/scripts/xray/associate-test-cases.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+set -euo pipefail
+
+# Associate Xray test cases with a test plan and test execution.
+#
+# Expected environment variables:
+#   XRAY_TOKEN        - Xray API bearer token
+#   TEST_PLAN_ID      - Xray test plan issue ID
+#   TEST_EXECUTION_ID - Xray test execution issue ID
+#   JIRA_USER_EMAIL   - Jira user email for API auth
+#   JIRA_API_TOKEN    - Jira API token for API auth
+#   GITHUB_OUTPUT     - step output file (set by GitHub Actions)
+#
+# Must be run from centreon/tests/rest_api/ directory (set via working-directory in workflow).
+
+get_test_ids() {
+  start=0
+  test_issue_ids=()
+
+  while true; do
+      xray_graphql_getTests='{
+          "query": "query getTests($jql: String, $limit: Int!, $start: Int) { getTests(jql: $jql, limit: $limit, start: $start) { total results { issueId } } }",
+          "variables": {
+              "jql": "reporter = \"712020:093f82f0-b0f1-4498-8369-fbe72fb50bcb\" AND project = MON AND type = \"Test\" AND testType = \"API\"",
+              "limit": 100,
+              "start": '$start'
+          }
+      }'
+
+      response=$(curl -X POST \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer $XRAY_TOKEN" \
+          --data "$xray_graphql_getTests" \
+          "https://xray.cloud.getxray.app/api/v2/graphql")
+
+      echo "Response from getTests:"
+      echo "$response"
+
+      # Parsing and processing test IDs
+      current_test_issue_ids=($(echo "$response" | jq -r '.data.getTests.results[].issueId'))
+
+      echo "Current Test Issue IDs: ${current_test_issue_ids[*]}"
+
+      # Check if there are no more test issues
+      if [ ${#current_test_issue_ids[@]} -eq 0 ]; then
+          echo "No more test issues. Exiting loop."
+          break
+      fi
+
+      # Concatenate the current batch of results to the overall test_issue_ids array
+      test_issue_ids+=("${current_test_issue_ids[@]}")
+
+      # Increment the start value for the next iteration
+      start=$((start + 100))
+  done
+
+  # Display all retrieved test issue IDs
+  echo "All Test Issue IDs: ${test_issue_ids[*]}"
+}
+
+get_test_ids
+
+formatted_getTest_issue_ids_str="["
+for issue_id in "${test_issue_ids[@]}"; do
+  formatted_getTest_issue_ids_str+="\"$issue_id\","
+done
+formatted_getTest_issue_ids_str="${formatted_getTest_issue_ids_str%,}"
+formatted_getTest_issue_ids_str+="]"
+echo "$formatted_getTest_issue_ids_str"
+
+# Display the retrieved test issue IDs
+echo "Test Issue IDs: ${test_issue_ids[*]}"
+
+# Mutation to add tests to the test plan
+xray_graphql_addTestsToTestPlan='{
+  "query": "mutation AddTestsToTestPlan($issueId: String!, $testIssueIds: [String]!) { addTestsToTestPlan(issueId: $issueId, testIssueIds: $testIssueIds) { addedTests warning } }",
+  "variables": {
+    "issueId": "'"$TEST_PLAN_ID"'",
+    "testIssueIds": '"$formatted_getTest_issue_ids_str"'
+  }
+}'
+
+# Execute the mutation to add tests to the test plan
+response_addTestsToTestPlan=$(curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $XRAY_TOKEN" \
+  --data "$xray_graphql_addTestsToTestPlan" \
+  "https://xray.cloud.getxray.app/api/v2/graphql")
+
+echo "Response from Add Tests to Test Plan:"
+echo "$response_addTestsToTestPlan"
+if echo "$response_addTestsToTestPlan" | jq -e '.errors' > /dev/null 2>&1; then
+  echo "GraphQL error on addTestsToTestPlan:" >&2
+  echo "$response_addTestsToTestPlan" >&2
+  exit 1
+fi
+
+get_test_plan_issue_ids() {
+  start=0
+  issue=()
+  api_issue_ids=()
+
+  while true; do
+      xray_graphql_getTestPlan='{
+          "query": "query GetTestPlan($issueId: String, $start: Int) { getTestPlan(issueId: $issueId) { issueId tests(limit: 100, start: $start) { results { issueId testType { name } } } } }",
+          "variables": {
+              "issueId": "'"$TEST_PLAN_ID"'",
+              "start": '$start'
+          }
+      }'
+
+      response=$(curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $XRAY_TOKEN" --data "${xray_graphql_getTestPlan}" "https://xray.cloud.getxray.app/api/v2/graphql")
+
+      echo "Response from Get Test Plan:"
+      echo "$response"
+
+      # Parsing and processing test IDs
+      current_issue_ids=($(echo "$response" | jq -r '.data.getTestPlan.tests.results[] | .issueId'))
+      echo "Current Issue IDs: ${current_issue_ids[*]}"
+
+      # Concatenate the current batch of results to the overall issue_ids array
+      issue+=("${current_issue_ids[@]}")
+
+      # Parsing and processing test IDs for API tests and adding them to api_issue_ids
+      current_api_issue_ids=($(echo "$response" | jq -r '.data.getTestPlan.tests.results[] | select(.testType.name == "API") | .issueId'))
+      api_issue_ids+=("${current_api_issue_ids[@]}")
+
+      # Increment the start value for the next iteration
+      start=$((start + 100))
+
+      # Check if there are more results
+      if [ -z "$response" ] || [ ${#current_issue_ids[@]} -eq 0 ]; then
+          echo "No more results. Exiting loop."
+          break
+      fi
+  done
+
+  # Display results
+  echo "API Issue IDs: ${api_issue_ids[*]}"
+  echo "api-issue-ids=${api_issue_ids[*]}" >> "$GITHUB_OUTPUT"
+}
+
+get_test_plan_issue_ids
+issue_ids=("${api_issue_ids[@]}")
+
+summaries=()
+
+for issue_id in "${issue_ids[@]}"; do
+  echo "Processing issue ID: $issue_id"
+  jira_issue_url="https://centreon.atlassian.net/rest/api/2/issue/$issue_id"
+
+  response_body=$(mktemp)
+  response_code=$(curl --request GET \
+    --url "$jira_issue_url" \
+    --user "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+    --header 'Accept: application/json' \
+    --silent --output "$response_body" --write-out "%{http_code}")
+  response=$(cat "$response_body")
+  rm -f "$response_body"
+
+  if [[ "$response_code" -lt 200 || "$response_code" -ge 300 ]]; then
+    echo "Failed to fetch Jira issue $issue_id (HTTP $response_code)." >&2
+    echo "$response" >&2
+    exit 1
+  fi
+
+  summary=$(echo "$response" | jq -r '.fields.summary // empty')
+  if [[ -z "$summary" ]]; then
+    echo "Jira issue $issue_id returned no summary." >&2
+    echo "$response" >&2
+    exit 1
+  fi
+
+  echo "The issue with ID $issue_id exists."
+  summaries+=("$summary")
+done
+
+mapfile -t collections < <(find ./collections -type f -name "*.postman_collection.json")
+test_case_ids=()
+
+xray_graphql_AddingTestsToTestPlan='{
+  "query": "mutation AddTestsToTestPlan($issueId: String!, $testIssueIds: [String]!) { addTestsToTestPlan(issueId: $issueId, testIssueIds: $testIssueIds) { addedTests warning } }",
+  "variables": {
+    "issueId":"'"$TEST_PLAN_ID"'",
+    "testIssueIds": []
+  }
+}'
+
+existing_test_case_ids=("${issue_ids[@]}")
+
+for collection_file in "${collections[@]}"; do
+  collection_name=$(basename "$collection_file" .postman_collection.json)
+  collection_name_sanitized="${collection_name//[^a-zA-Z0-9]/_}"
+
+  if [[ " ${summaries[*]} " =~ " ${collection_name_sanitized} " ]]; then
+    echo "The test case for $collection_name_sanitized already exists in the test plan."
+  else
+    # Adding a new test case
+    create_body=$(mktemp)
+    create_status=$(curl --request POST \
+      --url 'https://centreon.atlassian.net/rest/api/2/issue' \
+      --user "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+      --header 'Accept: application/json' \
+      --header 'Content-Type: application/json' \
+      --data '{
+        "fields": {
+          "project": {
+            "key": "MON"
+          },
+          "summary": "'"$collection_name_sanitized"'",
+          "components": [{"name": "centreon-web"}],
+          "priority":{"name":"Low"},
+          "description": "Test case for '"$collection_name_sanitized"'",
+          "issuetype": {
+            "name": "Test"
+          }
+        }
+      }' \
+      --silent --output "$create_body" --write-out "%{http_code}" \
+      --max-time 20)
+    response=$(cat "$create_body")
+    rm -f "$create_body"
+
+    if [[ -z "$response" || "$create_status" -lt 200 || "$create_status" -ge 300 ]]; then
+      echo "Failed to create the test case for $collection_name_sanitized (HTTP $create_status)." >&2
+    else
+      test_case_id=$(echo "$response" | jq -r '.id // empty')
+      if [[ -z "$test_case_id" ]]; then
+        echo "Failed to extract test case ID from response:" >&2
+        echo "$response" >&2
+      else
+        # Checking if the test case is a new one
+        if [[ ! " ${existing_test_case_ids[*]} " =~ " ${test_case_id} " ]]; then
+          echo "New Test Case with ID: $test_case_id"
+          summaries+=("$collection_name_sanitized")
+
+          # Update GraphQL query to add this test to the test plan
+          xray_graphql_AddingTestsToTestPlan_variables=$(echo "$xray_graphql_AddingTestsToTestPlan" | jq --arg test_case_id "$test_case_id" '.variables.testIssueIds += [$test_case_id]')
+
+          # Execute the GraphQL mutation to update the testType only for new test cases
+          testType_mutation_response=$(curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $XRAY_TOKEN" --data '{"query": "mutation { updateTestType(issueId: \"'$test_case_id'\", testType: {name: \"API\"} ) { issueId testType { name kind } } }"}' "https://xray.cloud.getxray.app/api/v2/graphql")
+
+          # Checking if the mutation was successful
+          if [ "$(echo "$testType_mutation_response" | jq -r '.data.updateTestType')" != "null" ]; then
+            echo "Successfully updated testType to API for Test Case with ID: $test_case_id"
+          else
+            echo "Failed to update testType for Test Case with ID: $test_case_id" >&2
+            echo "$testType_mutation_response" >&2
+            exit 1
+          fi
+
+          # Execute the GraphQL mutation to add tests to the test plan
+          response=$(curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $XRAY_TOKEN" --data "$xray_graphql_AddingTestsToTestPlan_variables" "https://xray.cloud.getxray.app/api/v2/graphql")
+          if echo "$response" | jq -e '.errors' > /dev/null 2>&1; then
+            echo "GraphQL error on addTestsToTestPlan (loop) for test case $test_case_id:" >&2
+            echo "$response" >&2
+            exit 1
+          fi
+        else
+          echo "Test Case with ID $test_case_id already exists in the test plan."
+        fi
+      fi
+    fi
+  fi
+done
+
+get_test_plan_issue_ids
+issue_list_ids=("${issue[@]}")
+echo "issue_list_ids=("${issue[*]}")" >> "$GITHUB_OUTPUT"
+
+test_issue_ids=("${issue_list_ids[@]}")
+formatted_test_issue_ids_str="["
+for issue_id in "${issue_list_ids[@]}"; do
+  formatted_test_issue_ids_str+="\"$issue_id\","
+done
+formatted_test_issue_ids_str="${formatted_test_issue_ids_str%,}"
+formatted_test_issue_ids_str+="]"
+echo "$formatted_test_issue_ids_str"
+
+xray_graphql_addTestsToTestExecution='{
+  "query": "mutation AddTestsToTestExecution($issueId: String!, $testIssueIds: [String]) { addTestsToTestExecution(issueId: $issueId, testIssueIds: $testIssueIds) { addedTests warning } }",
+  "variables": {
+    "issueId": "'"$TEST_EXECUTION_ID"'",
+    "testIssueIds": '$formatted_test_issue_ids_str'
+  }
+}'
+
+response_addTestsToTestExecution=$(curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $XRAY_TOKEN" --data "${xray_graphql_addTestsToTestExecution}" "https://xray.cloud.getxray.app/api/v2/graphql")
+
+echo "Response from Add Tests to Test Execution:"
+echo "$response_addTestsToTestExecution"
+if echo "$response_addTestsToTestExecution" | jq -e '.errors' > /dev/null 2>&1; then
+  echo "GraphQL error on addTestsToTestExecution:" >&2
+  echo "$response_addTestsToTestExecution" >&2
+  exit 1
+fi

--- a/.github/scripts/xray/create-or-get-test-plan-key.sh
+++ b/.github/scripts/xray/create-or-get-test-plan-key.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create or get the Xray TestPlan key for a given major version and OS.
+#
+# Expected environment variables:
+#   XRAY_TOKEN      - Xray API bearer token
+#   IS_NIGHTLY      - "true" or "false"
+#   MAJOR_VERSION   - e.g. "24.10"
+#   OS              - e.g. "alma9", "bullseye", "bookworm"
+#   GITHUB_REF_NAME - current git ref name (set by GitHub Actions)
+#   GITHUB_OUTPUT   - step output file (set by GitHub Actions)
+
+# Determine the summary's prefix
+summary_prefix=''
+if [[ "${IS_NIGHTLY:-}" == 'true' ]]; then
+  summary_prefix="NIGHTLY"
+else
+  echo "The github_ref_name is: $GITHUB_REF_NAME"
+  case "$GITHUB_REF_NAME" in
+    hotfix*)
+      summary_prefix="HOTFIX"
+      ;;
+    release*)
+      summary_prefix="RLZ"
+      ;;
+  esac
+fi
+
+input_summary="$summary_prefix OSS $MAJOR_VERSION"
+echo "The summary to search is: $input_summary"
+
+# Paginate through all test plans to find an existing match
+start=0
+test_plan_key=""
+
+while true; do
+  graphql_query='{
+    "query":"query GetTestPlans($jql: String, $limit: Int!, $start: Int) { getTestPlans(jql: $jql, limit: $limit, start: $start) { total results { issueId jira(fields: [\"summary\", \"key\"]) } } }",
+    "variables":{"jql": "project = MON","limit": 100, "start": '"$start"'}}'
+
+  response=$(curl -sS -H "Content-Type: application/json" -X POST -H "Authorization: Bearer $XRAY_TOKEN" --data "$graphql_query" "https://xray.cloud.getxray.app/api/v2/graphql")
+
+  test_plans=$(echo "$response" | jq -c '.data.getTestPlans.results[].jira')
+
+  if [ -z "$test_plans" ]; then
+    echo "No more test plans found."
+    break
+  fi
+
+  echo "These are the existing TPs: $test_plans"
+
+  while read row; do
+    summary=$(echo "$row" | jq -r '.summary')
+    if [[ "$summary" == "$input_summary" ]]; then
+      test_plan_key=$(echo "$row" | jq -r '.key')
+      echo "The test_plan_key is $test_plan_key and the summary is $summary"
+      break
+    fi
+  done <<< "$test_plans"
+
+  if [[ -n "$test_plan_key" ]]; then
+    echo "Found existing TestPlan: $test_plan_key"
+    break
+  fi
+
+  start=$((start + 100))
+done
+
+# If no matching test plan was found after full pagination, create one
+if [[ -z "$test_plan_key" ]]; then
+  echo "TestPlan doesn't exist yet — creating it."
+
+  create_test_plan_mutation="{
+    \"query\": \"mutation CreateTestPlan(\$testIssueIds: [String], \$jira: JSON!) { createTestPlan(testIssueIds: \$testIssueIds, jira: \$jira) { testPlan { issueId jira(fields: [\\\"key\\\"]) }warnings } }\",
+    \"variables\": {
+      \"testIssueIds\": [],
+      \"jira\": {
+        \"fields\": {
+          \"summary\": \"$input_summary\",
+          \"project\": { \"key\": \"MON\" }
+        }
+      }
+    }
+  }"
+  create_result=$(curl -sS -H "Content-Type: application/json" -X POST -H "Authorization: Bearer $XRAY_TOKEN" -d "$create_test_plan_mutation" "https://xray.cloud.getxray.app/api/v2/graphql")
+  echo "API response: $create_result"
+
+  # Validate the creation response
+  if echo "$create_result" | jq -e '(.errors // []) | length > 0' > /dev/null 2>&1; then
+    echo "ERROR: GraphQL errors in create TestPlan response:" >&2
+    echo "$create_result" >&2
+    exit 1
+  fi
+
+  test_plan_key=$(echo "$create_result" | jq -r '.data.createTestPlan.testPlan.jira.key')
+
+  if [[ -z "$test_plan_key" || "$test_plan_key" == "null" ]]; then
+    echo "ERROR: TestPlan creation returned null key. Full response:" >&2
+    echo "$create_result" >&2
+    exit 1
+  fi
+
+  echo "New TP created with key: $test_plan_key"
+fi
+
+# Set the testPlanKey as an output
+echo "test_plan_key_${OS}=${test_plan_key}" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/xray/create-test-execution.sh
+++ b/.github/scripts/xray/create-test-execution.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create an Xray TestExecution and output its ID.
+#
+# Expected environment variables:
+#   XRAY_TOKEN        - Xray API bearer token
+#   IS_NIGHTLY        - "true" or "false"
+#   MAJOR_VERSION     - e.g. "24.10"
+#   MINOR_VERSION     - e.g. "3"
+#   OS                - e.g. "alma9", "bullseye", "bookworm"
+#   GITHUB_REF_NAME   - current git ref name (set by GitHub Actions)
+#   GITHUB_REPOSITORY - owner/repo (set by GitHub Actions)
+#   GITHUB_RUN_ID     - workflow run ID (set by GitHub Actions)
+#   GITHUB_OUTPUT     - step output file (set by GitHub Actions)
+
+# Determine the summary's prefix
+summary_prefix=''
+if [[ "${IS_NIGHTLY:-}" == 'true' ]]; then
+  summary_prefix="NIGHTLY"
+else
+  echo "The github_ref_name is: $GITHUB_REF_NAME"
+  case "$GITHUB_REF_NAME" in
+    hotfix*)
+      summary_prefix="HOTFIX"
+      ;;
+    release*)
+      summary_prefix="RLZ"
+      ;;
+  esac
+fi
+
+current_date=$(date +'%d/%m/%Y')
+
+workflow_run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+input_summary="$summary_prefix WEB ${MAJOR_VERSION}.${MINOR_VERSION} $current_date"
+echo "The summary of the TE is: $input_summary"
+
+linux_distribution=''
+mariadb_version=''
+case "$OS" in
+  alma9)
+    linux_distribution="ALMA9"
+    mariadb_version="MARIADB_10_5"
+    ;;
+  bullseye)
+    linux_distribution="DEBIAN11"
+    mariadb_version="MARIADB_10_5"
+    ;;
+  bookworm)
+    linux_distribution="DEBIAN12"
+    mariadb_version="MARIADB_10_11"
+    ;;
+  *)
+    echo "ERROR: Unknown OS value: '$OS'. Expected one of: alma9, bullseye, bookworm." >&2
+    exit 1
+    ;;
+esac
+
+xray_graphql_createTestExecution="{
+  \"query\": \"mutation CreateTestExecution(\$testEnvironments: [String], \$jira: JSON!) { createTestExecution(testEnvironments: \$testEnvironments, jira: \$jira) { testExecution { issueId jira(fields: [\\\"key\\\"]) } warnings createdTestEnvironments } }\",
+  \"variables\": {
+    \"testEnvironments\": [\"$linux_distribution\",\"$mariadb_version\",\"CHROME\"],
+    \"jira\": {
+      \"fields\": {
+        \"summary\": \"$input_summary\",
+        \"description\": \"$workflow_run_url\",
+        \"project\": { \"key\": \"MON\" },
+        \"components\": [{\"name\": \"centreon-web\"}],
+        \"priority\":{\"name\":\"Low\"}
+      }
+    }
+  }
+}"
+
+echo "this is the graphql mutation : $xray_graphql_createTestExecution"
+
+response=$(curl -sS -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $XRAY_TOKEN" --data "$xray_graphql_createTestExecution" "https://xray.cloud.getxray.app/api/v2/graphql")
+
+echo -e "Response from Create Test Execution:\n$response"
+
+# Validate the response
+if [ -z "$response" ]; then
+  echo "ERROR: Empty response from Xray API." >&2
+  exit 1
+fi
+
+if echo "$response" | jq -e '(.errors // []) | length > 0' > /dev/null 2>&1; then
+  echo "ERROR: GraphQL errors in response:" >&2
+  echo "$response" >&2
+  exit 1
+fi
+
+if [ "$(echo "$response" | jq -r '.data.createTestExecution.testExecution')" = "null" ]; then
+  echo "ERROR: TestExecution creation returned null. Full response:" >&2
+  echo "$response" >&2
+  exit 1
+fi
+
+# Extract the ID of the created TE
+test_execution_id=$(echo "$response" | jq -r '.data.createTestExecution.testExecution.issueId')
+echo "test_execution_id_${OS}=$test_execution_id" >> "$GITHUB_OUTPUT"
+
+echo "TestExecution created with ID:  $test_execution_id"

--- a/.github/workflows/create-xray-test-plan-and-test-execution.yml
+++ b/.github/workflows/create-xray-test-plan-and-test-execution.yml
@@ -81,6 +81,10 @@ jobs:
       test_execution_id_bookworm: ${{ steps.get_test_execution_id.outputs.test_execution_id_bookworm }}
 
     steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/scripts/xray
+
       - name: Generate Xray Token
         id: generate_xray_token
         run: |
@@ -91,93 +95,12 @@ jobs:
 
       - name: Create or Get the TestPlanKey
         id: get_test_plan_key
-        run: |
-          # Initialize start value
-          start=0
-
-          # Loop to fetch all test plans
-          while true; do
-            # Execute the GraphQL query with the current start value
-            graphql_query='{
-              "query":"query GetTestPlans($jql: String, $limit: Int!, $start: Int) { getTestPlans(jql: $jql, limit: $limit, start: $start) { total results { issueId jira(fields: [\"summary\", \"key\"]) } } }",
-              "variables":{"jql": "project = MON","limit": 100, "start": '"$start"'}}'
-
-            response=$(curl -sS -H "Content-Type: application/json" -X POST -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" --data "$graphql_query" "https://xray.cloud.getxray.app/api/v2/graphql")
-
-            # Parse the response and extract test plans
-            test_plans=$(echo "$response" | jq -c '.data.getTestPlans.results[].jira')
-
-            # Check if test_plans is empty
-            if [ -z "$test_plans" ]; then
-              echo "No more test plans found. Exiting loop."
-              break
-            fi
-
-            echo "These are the existing TPs: $test_plans"
-
-            # Determine the summary's prefix
-            summary_prefix=''
-            if [[ ${{ inputs.is_nightly || '' }} == 'true' ]]; then
-              summary_prefix="NIGHTLY"
-            else
-              echo "The github_ref_name is: $GITHUB_REF_NAME"
-              case "$GITHUB_REF_NAME" in
-                hotfix*)
-                  summary_prefix="HOTFIX"
-                  ;;
-                release*)
-                  summary_prefix="RLZ"
-                  ;;
-              esac
-            fi
-
-            input_summary="$summary_prefix OSS ${{ inputs.major_version }}"
-            echo "The summary to search is: $input_summary"
-
-            # Extract the key of the existent test plan
-            while read row; do
-              summary=$(echo "$row" | jq -r '.summary')
-              if [[ "$summary" == "$input_summary" ]]; then
-                test_plan_key=$(echo "$row" | jq -r '.key')
-                echo "The test_plan_key is $test_plan_key and the summary is $summary"
-                break
-              fi
-            done <<< "$test_plans"
-
-            echo "The test plan key for now is: $test_plan_key"
-
-            # If no matching test plan was found, create one
-            if [[ -z "$test_plan_key" ]]; then
-              echo "TestPlan doesn't exist yet"
-
-              # Create the test plan using a GraphQL mutation
-              create_test_plan_mutation="{
-                \"query\": \"mutation CreateTestPlan(\$testIssueIds: [String], \$jira: JSON!) { createTestPlan(testIssueIds: \$testIssueIds, jira: \$jira) { testPlan { issueId jira(fields: [\\\"key\\\"]) }warnings } }\",
-                \"variables\": {
-                  \"testIssueIds\": [],
-                  \"jira\": {
-                    \"fields\": {
-                      \"summary\": \"$input_summary\",
-                      \"project\": { \"key\": \"MON\" }
-                    }
-                  }
-                }
-              }"
-              create_result=$(curl -sS -H "Content-Type: application/json" -X POST -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" -d "$create_test_plan_mutation" "https://xray.cloud.getxray.app/api/v2/graphql")
-              echo "API response: $create_result "
-
-              # Extract the key of the created test plan
-              test_plan_key=$(echo "$create_result" | jq -r '.data.createTestPlan.testPlan.jira.key')
-              echo "New TP created with key: $test_plan_key"
-            fi
-
-            # Update start value for the next iteration
-            start=$((start + 100))
-          done
-
-          # Set the testPlanKey as an output
-          echo "test_plan_key_${{ inputs.os }}=$test_plan_key" >> $GITHUB_OUTPUT
-
+        env:
+          XRAY_TOKEN: ${{ steps.generate_xray_token.outputs.xray_token }}
+          IS_NIGHTLY: ${{ inputs.is_nightly || '' }}
+          MAJOR_VERSION: ${{ inputs.major_version }}
+          OS: ${{ inputs.os }}
+        run: bash .github/scripts/xray/create-or-get-test-plan-key.sh
         shell: bash
 
       - name: Get TestPlanID
@@ -194,77 +117,13 @@ jobs:
 
       - name: Create TestExecution and Get the TestExecutionID
         id: get_test_execution_id
-        run: |
-          # Determine the summary's prefix
-          summary_prefix=''
-          if [[ ${{ inputs.is_nightly || '' }} == 'true' ]]; then
-            summary_prefix="NIGHTLY"
-          else
-            echo "The github_ref_name is: $GITHUB_REF_NAME"
-            case "$GITHUB_REF_NAME" in
-              hotfix*)
-                summary_prefix="HOTFIX"
-                ;;
-              release*)
-                summary_prefix="RLZ"
-                ;;
-            esac
-          fi
-
-          current_date=$(date +'%d/%m/%Y')
-
-          workflow_run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-          input_summary="$summary_prefix WEB ${{ inputs.major_version }}.${{ inputs.minor_version }} $current_date"
-          echo "The summary of the TE is: $input_summary"
-
-          linux_distribution=''
-          case "${{ inputs.os }}" in
-            alma8)
-              linux_distribution="ALMA8"
-              mariadb_version="MARIADB_10_5"
-              ;;
-            alma9)
-              linux_distribution="ALMA9"
-              mariadb_version="MARIADB_10_5"
-              ;;
-            bullseye)
-              linux_distribution="DEBIAN11"
-              mariadb_version="MARIADB_10_5"
-              ;;
-            bookworm)
-              linux_distribution="DEBIAN12"
-              mariadb_version="MARIADB_10_11"
-            ;;
-          esac
-
-          xray_graphql_createTestExecution="{
-            \"query\": \"mutation CreateTestExecution(\$testEnvironments: [String], \$jira: JSON!) { createTestExecution(testEnvironments: \$testEnvironments, jira: \$jira) { testExecution { issueId jira(fields: [\\\"key\\\"]) } warnings createdTestEnvironments } }\",
-            \"variables\": {
-              \"testEnvironments\": [\"$linux_distribution\",\"$mariadb_version\",\"CHROME\"],
-              \"jira\": {
-                \"fields\": {
-                  \"summary\": \"$input_summary\",
-                  \"description\": \"$workflow_run_url\",
-                  \"project\": { \"key\": \"MON\" },
-                  \"components\": [{\"name\": \"centreon-web\"}],
-                  \"priority\":{\"name\":\"Low\"}
-                }
-              }
-            }
-          }"
-
-          echo "this is the graphql mutation : $xray_graphql_createTestExecution"
-
-          response=$(curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" --data "$xray_graphql_createTestExecution" "https://xray.cloud.getxray.app/api/v2/graphql")
-
-          echo -e "Response from Create Test Execution:\n$response"
-
-          # Extract the ID of the created TE
-          test_execution_id=$(echo "$response" | jq -r '.data.createTestExecution.testExecution.issueId')
-          echo "test_execution_id_${{ inputs.os }}=$test_execution_id" >> $GITHUB_OUTPUT
-
-          echo "TestExecution created with ID:  $test_execution_id"
+        env:
+          XRAY_TOKEN: ${{ steps.generate_xray_token.outputs.xray_token }}
+          IS_NIGHTLY: ${{ inputs.is_nightly || '' }}
+          MAJOR_VERSION: ${{ inputs.major_version }}
+          MINOR_VERSION: ${{ inputs.minor_version }}
+          OS: ${{ inputs.os }}
+        run: bash .github/scripts/xray/create-test-execution.sh
         shell: bash
 
       - name: Get TestExecutionKey

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -79,6 +79,55 @@ jobs:
           echo "GITHUB_OUTPUT contents:"
           cat $GITHUB_OUTPUT
 
+  associate-test-cases:
+    runs-on: ubuntu-24.04
+    if: |
+      inputs.os == 'alma9' && contains(fromJson('["testing", "unstable"]'), inputs.stability) &&
+      inputs.is_nightly == 'true'
+    outputs:
+      test_execution_id: ${{ steps.get-test-ids.outputs.test_execution_id }}
+      test_plan_id: ${{ steps.get-test-ids.outputs.test_plan_id }}
+      issue_list_ids: ${{ steps.xray-newman.outputs.issue_list_ids }}
+      api-issue-ids: ${{ steps.xray-newman.outputs.api-issue-ids }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: centreon/tests/rest_api
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Test Execution and test plan Keys
+        id: get-test-ids
+        run: |
+          test_execution_id=$(echo '${{ inputs.xray_keys_and_ids }}' | jq -r '.test_execution_id_'${{ inputs.os }})
+          test_plan_id=$(echo '${{ inputs.xray_keys_and_ids }}' | jq -r '.test_plan_id_'${{ inputs.os }})
+          echo "The Test Execution ID : $test_execution_id"
+          echo "The Test Plan ID : $test_plan_id"
+          echo "test_plan_id=$test_plan_id" >> $GITHUB_OUTPUT
+          echo "test_execution_id=$test_execution_id" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Generate Xray Token
+        id: generate-xray-token
+        run: |
+          token_response=$(curl -H "Content-Type: application/json" -X POST --data "{\"client_id\": \"${{ secrets.client_id }}\", \"client_secret\": \"${{ secrets.client_secret }}\"}" "https://xray.cloud.getxray.app/api/v1/authenticate")
+          xray_token=$(echo "$token_response" | sed -n 's/.*"\(.*\)".*/\1/p')
+          echo "xray_token=$xray_token" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Associate Test Cases with Test plan
+        id: xray-newman
+        env:
+          XRAY_TOKEN: ${{ steps.generate-xray-token.outputs.xray_token }}
+          TEST_PLAN_ID: ${{ steps.get-test-ids.outputs.test_plan_id }}
+          TEST_EXECUTION_ID: ${{ steps.get-test-ids.outputs.test_execution_id }}
+          JIRA_USER_EMAIL: ${{ secrets.jira_user_email }}
+          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/xray/associate-test-cases.sh"
+
+
   newman-test-run:
     needs: [newman-test-list]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -346,55 +346,7 @@ jobs:
           STABILITY: ${{ needs.get-environment.outputs.stability }}
           EVENT_NAME: ${{ github.event_name }}
           HAS_UPDATE_TRANSLATIONS_LABEL: ${{ contains(needs.get-environment.outputs.labels, 'update-translations') }}
-        run: |
-          TRANSLATIONS_PATCH_FILE=""
-
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-
-          cd centreon
-
-          for i in lang/*.UTF-8 ; do
-            localefull="$(basename "$i")"
-            langName="$(echo "$localefull" | cut -d . -f 1)"
-            langShortName="$(echo "$localefull" | cut -d _ -f 1)"
-            mkdir -p "www/locale/$localefull/LC_MESSAGES"
-            bash -e ../.github/scripts/translation/make_translation.sh centreon $langName
-            msgfmt "lang/$localefull/LC_MESSAGES/messages.po" -o "www/locale/$localefull/LC_MESSAGES/messages.mo" || exit 1
-            msgfmt "lang/$localefull/LC_MESSAGES/help.po" -o "www/locale/$localefull/LC_MESSAGES/help.mo" || exit 1
-            php bin/centreon-translations.php "$langShortName" "lang/$localefull/LC_MESSAGES/messages.po" "www/locale/$localefull/LC_MESSAGES/messages.ser"
-          done
-
-          mkdir -p www/locale/en_US.UTF-8/LC_MESSAGES
-          php bin/centreon-translations.php en lang/fr_FR.UTF-8/LC_MESSAGES/messages.po www/locale/en_US.UTF-8/LC_MESSAGES/messages.ser
-
-          if [[ "$(git diff --ignore-matching-lines="POT-Creation-Date" | wc -l)" != "0" ]]; then
-            # avoid to always update POT-Creation-Date field
-            find -type f -regex '.+\.pot?' -exec sed -i -e 's/"POT-Creation-Date.*$/"POT-Creation-Date: 2025-01-01 00:00+0000\\n"/g' {} \;
-            if [[ ( "$IS_NIGHTLY" == "false" && "$STABILITY" == "unstable" ) || ( "$EVENT_NAME" == 'pull_request' && "$HAS_UPDATE_TRANSLATIONS_LABEL" == "true" ) ]]; then
-              if [[ "$(git log -1 --pretty=format:'%an')" != "technique-ci" ]]; then
-                git config user.name "technique-ci"
-                git config user.email "technique+ci@centreon.com"
-                git status
-                git add .
-                git commit -m "chore(lang): update translations"
-                git push || echo "::warning::Failed to push translations commit (technique-ci may not have push access)."
-              else
-                echo "::notice::Last commit author is technique-ci. Skipping commit to avoid infinite loop."
-                cd ..
-                git diff > translations.patch
-                TRANSLATIONS_PATCH_FILE="translations.patch"
-              fi
-            else
-              echo "::notice::Translations have been updated, but the workflow is a nightly run or does not have the update-translations label. Skipping commit. Git patch will be available as artifact."
-              cd ..
-              git diff > translations.patch
-              TRANSLATIONS_PATCH_FILE="translations.patch"
-            fi
-          else
-            echo "No changes in translations"
-          fi
-
-          echo "translations_patch_file=$TRANSLATIONS_PATCH_FILE" >> $GITHUB_OUTPUT
+        run: bash .github/scripts/translation/build-translations.sh
         shell: bash
 
       - name: Upload translations patch


### PR DESCRIPTION
## Description
Backport of #10257 to `dev-24.10.x`.

Extract long inline `run:` blocks from 3 workflow files into standalone shell scripts under `.github/scripts/`, enabling IDE syntax highlighting, local script execution, and better readability. GitHub Actions context is passed via `env:` blocks.

Scripts created:
- `scripts/translation/build-translations.sh` (from `web.yml`)
- `scripts/xray/create-or-get-test-plan-key.sh` (from `create-xray-test-plan-and-test-execution.yml`)
- `scripts/xray/create-test-execution.sh` (from `create-xray-test-plan-and-test-execution.yml`)
- `scripts/xray/associate-test-cases.sh` (from `newman.yml`)

Ref: MON-198051

**Fixes** MON-198051

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Same testing procedure as #10257 — verify nightly run completes successfully (translation-build, xray test plan/execution creation, associate-test-cases step).

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 2 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added .github/scripts/xray and translation shell scripts for workflows

**⚡ Enhancements**
* Updated workflows to call scripts, pass contexts via env and outputs

**🔧 Refactors**
* Extracted long inline workflow run blocks into dedicated shell files


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106076450?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->