### PR TITLE
fix(ci): do not fail translation-build if technique-ci cannot push

### DIFF
--- a/.github/scripts/translation/build-translations.sh
+++ b/.github/scripts/translation/build-translations.sh
@@ -41,7 +41,7 @@ if [[ "$(git diff --ignore-matching-lines="POT-Creation-Date" | wc -l)" != "0" ]
       git status
       git add .
       git commit -m "chore(lang): update translations"
-      git push
+      git push || echo "::warning::Failed to push translations commit (technique-ci may not have push access)."
     else
       echo "::notice::Last commit author is technique-ci. Skipping commit to avoid infinite loop."
       cd ..


### PR DESCRIPTION
## Description

fix(ci): do not fail translation-build if technique-ci cannot push

**Fixes** MON-197764

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Made translation-build tolerant when technique-ci lacked push permissions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106076969?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->