### PR TITLE
chore(release) bump oss 25.10 2026-04-21

### DIFF
--- a/.version.centreon-open-tickets
+++ b/.version.centreon-open-tickets
@@ -1,1 +1,1 @@
-MINOR=6
+MINOR=7

--- a/.version.centreon-web
+++ b/.version.centreon-web
@@ -1,1 +1,1 @@
-MINOR=11
+MINOR=12

--- a/centreon-open-tickets/widgets/open-tickets/configs.xml
+++ b/centreon-open-tickets/widgets/open-tickets/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>This widget is associated to the Open Tickets Module and allows for selecting hosts or services events for which to create tickets in your favorite ITSM tools. This widget can also list already created tickets with their ID and datetime.</description>
-  <version>25.10.6</version>
+  <version>25.10.7</version>
   <keywords>centreon, widget, tickets</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/open-tickets/resources/centreon-logo.png</thumbnail>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-open-tickets']['rname'] = 'Centreon Open Tickets';
 $module_conf['centreon-open-tickets']['name'] = 'centreon-open-tickets';
-$module_conf['centreon-open-tickets']['mod_release'] = '25.10.6';
+$module_conf['centreon-open-tickets']['mod_release'] = '25.10.7';
 $module_conf['centreon-open-tickets']['infos'] = 'Centreon Open Tickets is a community module developed to '
     . "create tickets to your favorite ITSM tools using API.
 
@@ -36,7 +36,7 @@ Regarding the widget configuration, it is possible to see the created tickets by
 $module_conf['centreon-open-tickets']['is_removeable'] = '1';
 $module_conf['centreon-open-tickets']['author'] = 'Centreon';
 $module_conf['centreon-open-tickets']['stability'] = 'stable';
-$module_conf['centreon-open-tickets']['last_update'] = '2026-03-24';
+$module_conf['centreon-open-tickets']['last_update'] = '2026-04-21';
 $module_conf['centreon-open-tickets']['images'] = [
     'images/image1.png',
     'images/image2.png',

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '25.10.11');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '25.10.12');
 
 --
 -- Contenu de la table `contact`


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-198106


Bump OSS versions to 25.10 (2026-04-21):
- centreon-open-tickets: 25.10.7
- centreon-web: 25.10.12


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated centreon-web default version to 25.10.12 in SQL
* Bumped centreon-open-tickets module release to 25.10.7 and date


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106462149?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->