### PR TITLE
chore: use gitleaks protect --staged in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,4 +9,4 @@ if ! command -v gitleaks >/dev/null 2>&1; then
 fi
 
 # scan for secrets before commit
-gitleaks detect --no-git --verbose
+gitleaks protect -v --staged


### PR DESCRIPTION
## Description

Replace `gitleaks detect --no-git --verbose` with `gitleaks protect -v --staged` in the pre-commit hook to only scan staged changes instead of the entire working directory.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master