### PR TITLE
feat(token): create default poller token on install and upgrade

### DIFF
--- a/centreon/doc/API/latest/onPremise/Administration/Token/AddTokenAndFindTokens.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/AddTokenAndFindTokens.yaml
@@ -15,6 +15,7 @@ get:
     * creation_date
     * expiration_date
     * is_revoked
+    * type
   parameters:
     - $ref: '../../Common/QueryParameter/Limit.yaml'
     - $ref: '../../Common/QueryParameter/Page.yaml'
@@ -49,7 +50,7 @@ post:
       application/json:
         schema:
           allOf:
-            - required: ["name", "user_id", "expiration_date"]
+            - required: ["name", "expiration_date", "type"]
             - $ref: 'Schema/NewToken.yaml'
   responses:
     '201':

--- a/centreon/doc/API/latest/onPremise/Administration/Token/GetAndDeleteToken.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/GetAndDeleteToken.yaml
@@ -20,7 +20,7 @@ get:
     - Authentication token
   summary: "Get an API token"
   description: |
-    Get an API token (only if type is CMA)
+    Get an API token (only if type is CMA or POLLER)
   parameters:
     - $ref: 'QueryParameter/TokenName.yaml'
   responses:

--- a/centreon/doc/API/latest/onPremise/Administration/Token/GetAndPartialUpdateAndDeleteTokenByUser.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/GetAndPartialUpdateAndDeleteTokenByUser.yaml
@@ -3,7 +3,7 @@ get:
     - Authentication token
   summary: "Get an API token"
   description: |
-    Get an API token (only if type is CMA)
+    Get an API token (only if type is CMA or POLLER)
   parameters:
     - $ref: 'QueryParameter/TokenName.yaml'
     - $ref: 'QueryParameter/UserId.yaml'

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewToken.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewToken.yaml
@@ -6,10 +6,16 @@ properties:
     example: "my-api-token"
   user_id:
     type: integer
-    description: "User ID linked to the API authentication token"
+    description: "User ID linked to the authentication token (mandatory for type API)"
     example: 23
   expiration_date:
     type: string
-    description: "Expiration date of the API authentication token"
+    description: "Expiration date of the authentication token"
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
+    nullable: true
+  type:
+    type: string
+    enums: ["cma", "api", "poller"]
+    description: "Type of the token"
+    example: "cma"

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
@@ -42,7 +42,7 @@ properties:
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
-    nullalbe: true
+    nullable: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
@@ -10,6 +10,7 @@ properties:
     example: "xxxxxxx"
   user:
     type: object
+    nullable: true
     properties:
       id:
         type: integer
@@ -41,12 +42,13 @@ properties:
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
+    nullalbe: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"
     example: false
   type:
     type: string
-    enums: ["cma", "api"]
+    enums: ["cma", "api", "poller"]
     description: "Type of the token"
     example: "cma"

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/Token.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/Token.yaml
@@ -6,6 +6,7 @@ properties:
     example: "my-api-token"
   user:
     type: object
+    nullable: true
     properties:
       id:
         type: integer
@@ -37,7 +38,13 @@ properties:
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
+    nullable: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"
     example: false
+  type:
+    type: string
+    enums: ["cma", "api", "poller"]
+    description: "Type of the token"
+    example: "cma"

--- a/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewPollerToken.php
@@ -33,7 +33,7 @@ final class NewPollerToken extends NewToken
 
     /**
      * @param TrimmedString $name
-     * @param ?int $creatorId
+     * @param int $creatorId
      * @param TrimmedString $creatorName
      * @param \DateTimeInterface|null $expirationDate
      *
@@ -42,9 +42,9 @@ final class NewPollerToken extends NewToken
      */
     public function __construct(
         TrimmedString $name,
+        int $creatorId,
         TrimmedString $creatorName,
         ?\DateTimeInterface $expirationDate = null,
-        ?int $creatorId = null,
     ) {
         $this->shortName = (new \ReflectionClass($this))->getShortName();
 

--- a/centreon/src/Core/Security/Token/Domain/Model/PollerToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/PollerToken.php
@@ -30,7 +30,7 @@ final class PollerToken extends Token
 {
     /**
      * @param TrimmedString $name
-     * @param ?int $creatorId
+     * @param int $creatorId
      * @param TrimmedString $creatorName
      * @param \DateTimeInterface $creationDate
      * @param ?\DateTimeInterface $expirationDate
@@ -40,7 +40,7 @@ final class PollerToken extends Token
      */
     public function __construct(
         TrimmedString $name,
-        ?int $creatorId,
+        int $creatorId,
         TrimmedString $creatorName,
         \DateTimeInterface $creationDate,
         ?\DateTimeInterface $expirationDate,

--- a/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
@@ -55,7 +55,7 @@ use Respect\Validation\Exceptions\DateTimeException;
  *
  * @phpstan-type _PollerToken array{
  *      name: string,
- *      creator_id: ?int,
+ *      creator_id: int,
  *      creator_name: string,
  *      creation_date: int,
  *      expiration_date: ?int,
@@ -105,7 +105,7 @@ use Respect\Validation\Exceptions\DateTimeException;
  *
  * @phpstan-type _NewPollerToken array{
  *      name: string,
- *      creator_id: ?int,
+ *      creator_id: int,
  *      creator_name: ?string,
  *      expiration_date: ?DateTimeInterface,
  *  }

--- a/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/TokenFactory.php
@@ -143,7 +143,7 @@ final class TokenFactory
                 /** @var _PollerToken $data */
                 $token = new PollerToken(
                     new TrimmedString($data['name']),
-                    $data['creator_id'] ?? null,
+                    $data['creator_id'],
                     new TrimmedString($data['creator_name']),
                     (new DateTimeImmutable())->setTimestamp($data['creation_date']),
                     $data['expiration_date'] !== null
@@ -196,9 +196,9 @@ final class TokenFactory
                 /** @var _NewPollerToken $data */
                 $token = new NewPollerToken(
                     new TrimmedString($data['name']),
+                    $data['creator_id'],
                     $data['creator_name'] ? new TrimmedString($data['creator_name']) : new TrimmedString('system'),
                     $data['expiration_date'],
-                    $data['creator_id'] ?? null,
                 );
                 break;
             default:

--- a/centreon/tests/rest_api/collections/authentication/Tokens.postman_collection.json
+++ b/centreon/tests/rest_api/collections/authentication/Tokens.postman_collection.json
@@ -2039,7 +2039,7 @@
                   "const responseJson = pm.response.json();\r",
                   "\r",
                   "pm.test(\"5 tokens exist\", function () {\r",
-                  "    pm.expect(responseJson.result.length).to.eql5);\r",
+                  "    pm.expect(responseJson.result.length).to.eql(5);\r",
                   "});\r",
                   "\r",
                   "// Récupération par nom (robuste)\r",

--- a/centreon/tests/rest_api/collections/authentication/Tokens.postman_collection.json
+++ b/centreon/tests/rest_api/collections/authentication/Tokens.postman_collection.json
@@ -1836,8 +1836,8 @@
                 "exec": [
                   "const responseJson = pm.response.json();\r",
                   "\r",
-                  "pm.test(\"3 tokens exist\", function () {\r",
-                  "    pm.expect(responseJson.result.length).to.eql(3);\r",
+                  "pm.test(\"4 tokens exist\", function () {\r",
+                  "    pm.expect(responseJson.result.length).to.eql(4);\r",
                   "});\r",
                   "\r",
                   "// Récupération par nom (robuste)\r",
@@ -2038,8 +2038,8 @@
                 "exec": [
                   "const responseJson = pm.response.json();\r",
                   "\r",
-                  "pm.test(\"4 tokens exist\", function () {\r",
-                  "    pm.expect(responseJson.result.length).to.eql(4);\r",
+                  "pm.test(\"5 tokens exist\", function () {\r",
+                  "    pm.expect(responseJson.result.length).to.eql5);\r",
                   "});\r",
                   "\r",
                   "// Récupération par nom (robuste)\r",
@@ -2398,8 +2398,8 @@
                 "exec": [
                   "const responseJson = pm.response.json();\r",
                   "\r",
-                  "pm.test(\"3 tokens exist\", function () {\r",
-                  "    pm.expect(responseJson.result.length).to.eql(3);\r",
+                  "pm.test(\"4 tokens exist\", function () {\r",
+                  "    pm.expect(responseJson.result.length).to.eql(4);\r",
                   "});\r",
                   "\r",
                   "// Recherche robuste par nom\r",
@@ -3874,8 +3874,8 @@
                 "exec": [
                   "const responseJson = pm.response.json();\r",
                   "\r",
-                  "pm.test(\"5 tokens exist\", function () {\r",
-                  "    pm.expect(responseJson.result.length).to.eql(5);\r",
+                  "pm.test(\"6 tokens exist\", function () {\r",
+                  "    pm.expect(responseJson.result.length).to.eql(6);\r",
                   "});\r",
                   "\r",
                   "// Recherche par nom (robuste)\r",

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -955,6 +955,59 @@ $updateAuthenticationTable = function () use ($pearDB, &$errorMessage, $version)
     );
 };
 
+$createDefaultPollerToken = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to create default poller token';
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Creating default poller token",
+    );
+
+    if ($pearDB->fetchOne(
+        <<<'SQL'
+            SELECT 1 FROM `authentication_tokens` WHERE `token_name` = 'poller-default'
+            SQL
+    )) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Default poller token already exists, skipping creation",
+        );
+
+        return;
+    }
+
+    $adminInfos = $pearDB->fetchAssociative(
+        "SELECT `contact_id`, `contact_alias` FROM `contact` WHERE `contact_admin` = '1' LIMIT 1"
+    );
+    if ($adminInfos === false) {
+        CentreonLog::create()->warning(
+            CentreonLog::TYPE_BUSINESS_LOG,
+            'No admin contact found, skipping default poller token creation'
+        );
+
+        return;
+    }
+
+    $pearDB->insert(
+        <<<'SQL'
+            INSERT INTO `authentication_tokens`
+                (`token_string`, `token_name`, `creator_id`, `creator_name`, `encoding_key`, `is_revoked`, `creation_date`, `expiration_date`, `type`)
+            VALUES
+                (:token_string, 'poller-default', :creator_id, :creator_name, NULL, 0, :creation_date, NULL, 'poller')
+            SQL,
+        QueryParameters::create([
+            QueryParameter::string('token_string', \Security\Encryption::generateRandomString()),
+            QueryParameter::int('creator_id', (int) $adminInfos['contact_id']),
+            QueryParameter::string('creator_name', $adminInfos['contact_alias']),
+            QueryParameter::int('creation_date', time()),
+        ])
+    );
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Successfully created default poller token",
+    );
+};
+
 /** -------------------------------------- Log Actions -------------------------------------- */
 $updateLogActionTable = function () use ($pearDBO, &$errorMessage, $version): void {
     $errorMessage = "Unable to update 'log_action' table";
@@ -982,6 +1035,8 @@ try {
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
+
+    $createDefaultPollerToken();
 
     $createBrokerOutputEventScript();
     if ($isMachineACentral()) {

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -995,7 +995,7 @@ $createDefaultPollerToken = function () use ($pearDB, &$errorMessage, $version):
                 (:token_string, 'poller-default', :creator_id, :creator_name, NULL, 0, :creation_date, NULL, 'poller')
             SQL,
         QueryParameters::create([
-            QueryParameter::string('token_string', \Security\Encryption::generateRandomString()),
+            QueryParameter::string('token_string', Security\Encryption::generateRandomString()),
             QueryParameter::int('creator_id', (int) $adminInfos['contact_id']),
             QueryParameter::string('creator_name', $adminInfos['contact_alias']),
             QueryParameter::int('creation_date', time()),

--- a/centreon/www/install/steps/process/insertBaseConf.php
+++ b/centreon/www/install/steps/process/insertBaseConf.php
@@ -1,5 +1,7 @@
 <?php
 
+use Core\Security\Token\Domain\Model\PollerToken;
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -144,6 +146,27 @@ if ($row = $centralServerQuery->fetch()) {
             exception: $ex
         );
     }
+}
+
+// Create default poller token
+try {
+    $tokenStatement = $link->prepare(
+        <<<'SQL'
+            INSERT INTO `authentication_tokens`
+                (`token_string`, `token_name`, `creator_id`, `creator_name`, `encoding_key`, `is_revoked`, `creation_date`, `expiration_date`, `type`)
+            VALUES
+                (:token_string, 'poller-default', 1, 'admin', NULL, 0, :creation_date, NULL, 'poller')
+            SQL
+    );
+    $tokenStatement->bindValue(':token_string', \Security\Encryption::generateRandomString());
+    $tokenStatement->bindValue(':creation_date', time());
+    $tokenStatement->execute();
+} catch (Throwable $ex) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'An error occurred while creating the default poller token, skipping.',
+        exception: $ex
+    );
 }
 
 // Manage timezone

--- a/centreon/www/install/steps/process/insertBaseConf.php
+++ b/centreon/www/install/steps/process/insertBaseConf.php
@@ -1,7 +1,5 @@
 <?php
 
-use Core\Security\Token\Domain\Model\PollerToken;
-
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -158,7 +156,7 @@ try {
                 (:token_string, 'poller-default', 1, 'admin', NULL, 0, :creation_date, NULL, 'poller')
             SQL
     );
-    $tokenStatement->bindValue(':token_string', \Security\Encryption::generateRandomString());
+    $tokenStatement->bindValue(':token_string', Security\Encryption::generateRandomString());
     $tokenStatement->bindValue(':creation_date', time());
     $tokenStatement->execute();
 } catch (Throwable $ex) {


### PR DESCRIPTION
## Description

- makes `creatorId` mandatory (non-nullable) in the `PollerToken` and `NewPollerToken` domain models
- adds automatic creation of a default poller token (`poller-default`) during both fresh installs (`insertBaseConf.php`) and upgrades (`Update-next.php`)
- update api doc                                                 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Automatically created default poller token during install and upgrade processes

**⚡ Enhancements**
* Made creatorId mandatory in PollerToken and NewPollerToken constructors

**🔧 Refactors**
* Updated TokenFactory types and creation logic to require creator_id


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106942400?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->