### PR TITLE
fix(OpenTickets): handle engine encrypt prefix

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -159,7 +159,7 @@ $query = "SELECT SQL_CALC_FOUND_ROWS h.host_id,
         h.host_id = cv5.host_id AND (cv5.service_id IS NULL OR cv5.service_id = 0) AND cv5.name = '" . $macro_tickets['ticket_id'] . "'
     )
     LEFT JOIN mod_open_tickets mop1 ON (
-        cv5.value = mop1.ticket_value AND (
+        (cv5.value = mop1.ticket_value OR cv5.value = CONCAT('raw::', mop1.ticket_value)) AND (
             mop1.timestamp > h.last_time_up OR h.last_time_up IS NULL
         )
     )
@@ -174,7 +174,7 @@ $query = "SELECT SQL_CALC_FOUND_ROWS h.host_id,
         s.service_id = cv3.service_id AND s.host_id = cv3.host_id AND cv3.name = '" . $macro_tickets['ticket_id'] . "'
     )
     LEFT JOIN mod_open_tickets mop2 ON (
-        cv3.value REGEXP CONCAT('(raw::)?', mop2.ticket_value) AND (
+        (cv3.value = mop2.ticket_value OR cv3.value = CONCAT('raw::', mop2.ticket_value)) AND (
             mop2.timestamp > s.last_time_ok OR s.last_time_ok IS NULL
         )
     )

--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -174,7 +174,7 @@ $query = "SELECT SQL_CALC_FOUND_ROWS h.host_id,
         s.service_id = cv3.service_id AND s.host_id = cv3.host_id AND cv3.name = '" . $macro_tickets['ticket_id'] . "'
     )
     LEFT JOIN mod_open_tickets mop2 ON (
-        cv3.value = mop2.ticket_value AND (
+        cv3.value REGEXP CONCAT('(raw::)?', mop2.ticket_value) AND (
             mop2.timestamp > s.last_time_ok OR s.last_time_ok IS NULL
         )
     )

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -1095,7 +1095,7 @@ class Automatic
             LEFT JOIN customvariables cv ON (h.host_id = cv.host_id
             AND (cv.service_id IS NULL or cv.service_id = 0)
             AND cv.name = :macro_name)
-            LEFT JOIN mod_open_tickets mot ON cv.value = mot.ticket_value
+            LEFT JOIN mod_open_tickets mot ON cv.value REGEXP CONCAT("(raw::)?", mot.ticket_value)
             WHERE h.host_id = :host_id'
         );
         $stmt->bindParam(':macro_name', $macroName, PDO::PARAM_STR);
@@ -1119,7 +1119,7 @@ class Automatic
         $query = <<<'SQL'
                 SELECT mot.ticket_value AS ticket_id
                 FROM customvariables cv
-                LEFT JOIN mod_open_tickets mot ON cv.value = mot.ticket_value
+                LEFT JOIN mod_open_tickets mot ON cv.value REGEXP CONCAT('(raw::)?', mot.ticket_value)
                 WHERE cv.service_id = :service_id
                     AND cv.host_id = :host_id
                     AND cv.name = :macro_name

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -1095,7 +1095,10 @@ class Automatic
             LEFT JOIN customvariables cv ON (h.host_id = cv.host_id
             AND (cv.service_id IS NULL or cv.service_id = 0)
             AND cv.name = :macro_name)
-            LEFT JOIN mod_open_tickets mot ON cv.value REGEXP CONCAT("(raw::)?", mot.ticket_value)
+            LEFT JOIN mod_open_tickets mot ON (
+                cv.value = mot.ticket_value
+                OR cv.value = CONCAT("raw::", mot.ticket_value)
+            )
             WHERE h.host_id = :host_id'
         );
         $stmt->bindParam(':macro_name', $macroName, PDO::PARAM_STR);
@@ -1119,7 +1122,10 @@ class Automatic
         $query = <<<'SQL'
                 SELECT mot.ticket_value AS ticket_id
                 FROM customvariables cv
-                LEFT JOIN mod_open_tickets mot ON cv.value REGEXP CONCAT('(raw::)?', mot.ticket_value)
+                LEFT JOIN mod_open_tickets mot ON (
+                    cv.value = mot.ticket_value
+                    OR cv.value = CONCAT('raw::', mot.ticket_value)
+                )
                 WHERE cv.service_id = :service_id
                     AND cv.host_id = :host_id
                     AND cv.name = :macro_name


### PR DESCRIPTION
## Description

when you use CHANGE_CUSTOM_HOST_VAR or CHANGE_CUSTOM_SVC_VAR external command, it doesn't add the raw:: prefix in the customvariables table. This breaks open ticket because it search for a ticket id without the raw:: prefix

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Adjusted widget SQL to match ticket values with raw:: prefix
* Replaced REGEXP matching with exact equality for ticket values


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110277917?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->