### PR TITLE
fix(upgrade): make SAML requested_authn_context migration idempotent

### DIFF
--- a/centreon/www/install/php/Update-25.11.0.php
+++ b/centreon/www/install/php/Update-25.11.0.php
@@ -278,10 +278,13 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
     $query = <<<'SQL'
             UPDATE `provider_configuration`
             SET `custom_configuration` = :custom_configuration
-            WHERE `type` = 'saml'
+            WHERE `id` = :id
         SQL;
     $queryParameters = QueryParameters::create(
-        [QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR))]
+        [
+            QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR)),
+            QueryParameter::int('id', (int) $samlConfiguration['id']),
+        ]
     );
     $pearDB->update($query, $queryParameters);
 

--- a/centreon/www/install/php/Update-25.11.0.php
+++ b/centreon/www/install/php/Update-25.11.0.php
@@ -237,7 +237,11 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
         message: "UPGRADE - {$version}: SAML provider configuration found, checking for requested_authn_context"
     );
 
-    $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
+    $customConfiguration = json_decode(
+        json: $samlConfiguration['custom_configuration'],
+        associative: true,
+        flags: JSON_THROW_ON_ERROR
+    );
 
     $validComparisonValues = ['minimum', 'exact', 'better', 'maximum'];
     $existingComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;

--- a/centreon/www/install/php/Update-25.11.0.php
+++ b/centreon/www/install/php/Update-25.11.0.php
@@ -195,10 +195,13 @@ $fixTypoInStandardMacroName = function () use ($pearDB, &$errorMessage, $version
 
 /**
  * Update SAML provider configuration:
- *      - If requested_authn_context_comparison is already a string, keep it (idempotent rerun).
- *      - Else if requested_authn_context is a string, move that value to requested_authn_context_comparison.
- *      - Else default requested_authn_context_comparison to 'exact' (recovers from a prior buggy run that stored a boolean).
+ *      - If requested_authn_context_comparison is already a valid comparison value, keep it (idempotent rerun).
+ *      - Else if requested_authn_context is a valid legacy comparison value, move it to requested_authn_context_comparison.
+ *      - Else default requested_authn_context_comparison to 'exact' (recovers from a prior buggy run that stored a boolean or an invalid string).
  *      - In all cases, force requested_authn_context to false.
+ *
+ * Valid comparison values mirror RequestedAuthnContextComparisonEnum and are whitelisted locally so the
+ * migration never writes a value that CustomConfiguration::createFromValues() would reject.
  */
 $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Unable to retrieve SAML provider configuration';
@@ -236,20 +239,21 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
 
     $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
 
+    $validComparisonValues = ['minimum', 'exact', 'better', 'maximum'];
     $existingComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;
     $legacyValue = $customConfiguration['requested_authn_context'] ?? null;
 
-    if (is_string($existingComparison)) {
+    if (is_string($existingComparison) && in_array($existingComparison, $validComparisonValues, true)) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: requested_authn_context_comparison already set to a valid string, keeping existing value"
+            message: "UPGRADE - {$version}: requested_authn_context_comparison already set to a valid value, keeping existing value"
         );
-    } elseif (is_string($legacyValue)) {
+    } elseif (is_string($legacyValue) && in_array($legacyValue, $validComparisonValues, true)) {
         $customConfiguration['requested_authn_context_comparison'] = $legacyValue;
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: requested_authn_context found as string, moved its value to requested_authn_context_comparison"
+            message: "UPGRADE - {$version}: requested_authn_context holds a valid legacy value, moved it to requested_authn_context_comparison"
         );
     } else {
         $customConfiguration['requested_authn_context_comparison'] = 'exact';

--- a/centreon/www/install/php/Update-25.11.0.php
+++ b/centreon/www/install/php/Update-25.11.0.php
@@ -195,8 +195,10 @@ $fixTypoInStandardMacroName = function () use ($pearDB, &$errorMessage, $version
 
 /**
  * Update SAML provider configuration:
- *      - If requested_authn_context exists, set requested_authn_context_comparison to its value and requested_authn_context to true
- *      - If requested_authn_context does not exist, set requested_authn_context_comparison to 'exact' and requested_authn_context to false
+ *      - If requested_authn_context_comparison is already a string, keep it (idempotent rerun).
+ *      - Else if requested_authn_context is a string, move that value to requested_authn_context_comparison.
+ *      - Else default requested_authn_context_comparison to 'exact' (recovers from a prior buggy run that stored a boolean).
+ *      - In all cases, force requested_authn_context to false.
  */
 $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Unable to retrieve SAML provider configuration';
@@ -234,23 +236,31 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
 
     $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
 
-    if (isset($customConfiguration['requested_authn_context'])) {
-        $customConfiguration['requested_authn_context_comparison'] = $customConfiguration['requested_authn_context'];
-        $customConfiguration['requested_authn_context'] = false;
+    $existingComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;
+    $legacyValue = $customConfiguration['requested_authn_context'] ?? null;
+
+    if (is_string($existingComparison)) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: requested_authn_context_comparison already set to a valid string, keeping existing value"
+        );
+    } elseif (is_string($legacyValue)) {
+        $customConfiguration['requested_authn_context_comparison'] = $legacyValue;
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: requested_authn_context found, requested_authn_context_comparison takes the value of requested_authn_context, and requested_authn_context is set to true"
+            message: "UPGRADE - {$version}: requested_authn_context found as string, moved its value to requested_authn_context_comparison"
         );
     } else {
         $customConfiguration['requested_authn_context_comparison'] = 'exact';
-        $customConfiguration['requested_authn_context'] = false;
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: requested_authn_context not found, setting requested_authn_context to false and requested_authn_context_comparison to 'exact'"
+            message: "UPGRADE - {$version}: requested_authn_context_comparison missing or invalid, defaulting to 'exact'"
         );
     }
+
+    $customConfiguration['requested_authn_context'] = false;
 
     CentreonLog::create()->info(
         logTypeId: CentreonLog::TYPE_UPGRADE,

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -955,10 +955,13 @@ $fixSamlRequestedAuthnContextComparison = function () use ($pearDB, &$errorMessa
     $query = <<<'SQL'
             UPDATE `provider_configuration`
             SET `custom_configuration` = :custom_configuration
-            WHERE `type` = 'saml'
+            WHERE `id` = :id
         SQL;
     $queryParameters = QueryParameters::create(
-        [QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR))]
+        [
+            QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR)),
+            QueryParameter::int('id', (int) $samlConfiguration['id']),
+        ]
     );
     $pearDB->update($query, $queryParameters);
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -927,7 +927,11 @@ $fixSamlRequestedAuthnContextComparison = function () use ($pearDB, &$errorMessa
         return;
     }
 
-    $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
+    $customConfiguration = json_decode(
+        json: $samlConfiguration['custom_configuration'],
+        associative: true,
+        flags: JSON_THROW_ON_ERROR
+    );
 
     $validComparisonValues = ['minimum', 'exact', 'better', 'maximum'];
     $currentComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -896,6 +896,74 @@ $addPollerTypeColumn = function () use ($pearDB, &$errorMessage, $version): void
     );
 };
 
+/** ------------------------------------- SAML ------------------------------------- */
+/**
+ * Recover SAML provider configurations whose requested_authn_context_comparison field was left in an
+ * invalid state by the non-idempotent 25.11.0 migration (MON-198174): a boolean, a missing value, or
+ * a string outside RequestedAuthnContextComparisonEnum breaks CustomConfiguration::createFromValues()
+ * and the login page. When detected, reset the value to 'exact'.
+ */
+$fixSamlRequestedAuthnContextComparison = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to recover SAML provider configuration';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: checking SAML provider configuration for invalid requested_authn_context_comparison"
+    );
+
+    $samlConfiguration = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT * FROM `provider_configuration`
+            WHERE `type` = 'saml'
+            SQL
+    );
+
+    if (! $samlConfiguration || ! isset($samlConfiguration['custom_configuration'])) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: no SAML provider configuration found, skipping"
+        );
+
+        return;
+    }
+
+    $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
+
+    $validComparisonValues = ['minimum', 'exact', 'better', 'maximum'];
+    $currentComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;
+
+    if (is_string($currentComparison) && in_array($currentComparison, $validComparisonValues, true)) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: requested_authn_context_comparison already valid, no recovery needed"
+        );
+
+        return;
+    }
+
+    $customConfiguration['requested_authn_context_comparison'] = 'exact';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: requested_authn_context_comparison was not a valid string, reset to 'exact'"
+    );
+
+    $query = <<<'SQL'
+            UPDATE `provider_configuration`
+            SET `custom_configuration` = :custom_configuration
+            WHERE `type` = 'saml'
+        SQL;
+    $queryParameters = QueryParameters::create(
+        [QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR))]
+    );
+    $pearDB->update($query, $queryParameters);
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: SAML provider configuration recovered successfully"
+    );
+};
+
 try {
     // DDL statements for real time database
     $pearDBO->executeStatement(
@@ -906,6 +974,9 @@ try {
 
     // DDL statements for configuration database
     $addPollerTypeColumn();
+
+    // SAML recovery for platforms affected by MON-198174
+    $fixSamlRequestedAuthnContextComparison();
 
     // Transactional queries for configuration database
     if (! $pearDB->isTransactionActive()) {


### PR DESCRIPTION
## Summary

- Makes the SAML provider configuration migration in `Update-25.11.0.php` idempotent so it can safely run over already-migrated data.
- Validates `requested_authn_context_comparison` against the allowed enum (`minimum`, `exact`, `better`, `maximum`) to avoid preserving an invalid string that would still crash `CustomConfiguration::createFromValues()`.
- Adds a recovery step in `Update-next.php` that resets `requested_authn_context_comparison` to `'exact'` on platforms already broken by the initial non-idempotent migration (MON-198174).

## Context

In 25.11 we split the old `requested_authn_context` field: the string comparison value moved to a new `requested_authn_context_comparison`, and the legacy field was repurposed as a boolean (enable/disable). The upgrade script previously did:

```php
if (isset($customConfiguration['requested_authn_context'])) {
    $customConfiguration['requested_authn_context_comparison'] = $customConfiguration['requested_authn_context'];
    $customConfiguration['requested_authn_context'] = false;
}
```

This is not idempotent. If the migration runs a second time — or over a config whose `requested_authn_context` has already been flipped to `false` (boolean) by an earlier run — it copies `false` into `requested_authn_context_comparison`. The JSON schema then rejects the config at `GET /api/latest/authentication/providers/configurations` with:

> `[requested_authn_context_comparison] Boolean value found, but a string is required`

and the login page shows a red error banner. That is exactly the crash reported in MON-198174 on 25.10.11 (same code path, ported as `Update-25.10.6.php`).

## Fix

### 1. `Update-25.11.0.php` — idempotent migration

The closure now:

1. Leaves `requested_authn_context_comparison` untouched if it is already a valid value from `RequestedAuthnContextComparisonEnum` (`minimum`, `exact`, `better`, `maximum`) — idempotent rerun.
2. Otherwise, if `requested_authn_context` holds a valid legacy comparison value, moves it to `requested_authn_context_comparison`.
3. Otherwise defaults `requested_authn_context_comparison` to `'exact'` — recovers platforms whose JSON currently holds a boolean or an invalid string.
4. Always forces `requested_authn_context` to `false` (its new boolean semantics).

The allowed enum values are whitelisted locally in the migration so it never writes a value that `CustomConfiguration::createFromValues()` would reject.

### 2. `Update-next.php` — recovery for already-broken platforms

Platforms that already ran the original buggy 25.11.0 migration still carry an invalid `requested_authn_context_comparison` (boolean or invalid string) and will not re-enter `Update-25.11.0.php`. A new recovery closure `fixSamlRequestedAuthnContextComparison` is added to `Update-next.php`:

- If `requested_authn_context_comparison` is already a valid enum string → no-op.
- Otherwise reset it to `'exact'` and persist the JSON.

This runs once during the next upgrade and unblocks the login page automatically.

## Backport

The same idempotence fix is needed on `dev-25.10.x` and `release-25.10-next` in `Update-25.10.6.php` (the script shipping in 25.10.x has the exact same pattern). That will be done in dedicated backport PRs — this PR is on `develop` only.

## Jira

- [MON-198174](https://centreon.atlassian.net/browse/MON-198174) — includes a detailed HOW TO TEST comment with SQL helpers to seed each test state.

## Test plan

### `Update-25.11.0.php`

- [ ] Fresh SAML config where `requested_authn_context_comparison` is missing → becomes `'exact'`, `requested_authn_context = false`.
- [ ] Legacy SAML config where `requested_authn_context = 'minimum'` (valid string) → value moved to `requested_authn_context_comparison`, `requested_authn_context = false`.
- [ ] Run the upgrade twice in a row → second run leaves the valid string intact (idempotence).
- [ ] Config previously broken (`requested_authn_context_comparison = false`, boolean) → restored to `'exact'`.
- [ ] Config with an invalid string (`requested_authn_context_comparison = 'foobar'`) → reset to `'exact'` (enum whitelist).

### `Update-next.php`

- [ ] Platform whose `requested_authn_context_comparison` is still `false` (boolean) from the initial buggy migration → recovered to `'exact'`, login page clean, `/api/latest/authentication/providers/configurations` returns **200**.
- [ ] Platform with a valid `requested_authn_context_comparison` → recovery step logs "already valid, no recovery needed" and performs no UPDATE.
- [ ] Platform with no SAML configuration at all → recovery step logs "no SAML provider configuration found, skipping".

### Quality

- [x] `php -l` on `Update-25.11.0.php` and `Update-next.php`.
- [x] `composer rector:fix`, `composer cs:fix`, `composer stan` — no changes, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-198174]: https://centreon.atlassian.net/browse/MON-198174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made SAML migration idempotent and validated comparison values locally
* Added recovery step to reset invalid SAML comparison values to 'exact'
* Scoped SAML provider UPDATE to the fetched row id to prevent overwrite

**🔧 Refactors**
* Replaced positional json_decode flags with named arguments for correctness


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107489808?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->