### PR TITLE
chore(tests): wire SymfonyExtension and enforce zero direct deprecations

### DIFF
--- a/centreon/phpunit.new.integration.xml
+++ b/centreon/phpunit.new.integration.xml
@@ -25,6 +25,7 @@
     </php>
 
     <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
         <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
     </extensions>
 

--- a/centreon/phpunit.new.xml
+++ b/centreon/phpunit.new.xml
@@ -24,4 +24,8 @@
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+
 </phpunit>

--- a/centreon/phpunit.xml
+++ b/centreon/phpunit.xml
@@ -24,6 +24,7 @@
     <!-- ###+ nelmio/cors-bundle ### -->
     <env name="CORS_ALLOW_ORIGIN" value="^https?://localhost(:[0-9]+)?$"/>
     <!-- ###- nelmio/cors-bundle ### -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;quiet[]=indirect&amp;quiet[]=other"/>
   </php>
   <testsuites>
     <testsuite name="Symfony Test Suite">
@@ -39,6 +40,9 @@
       <group>intl-data</group>
     </exclude>
   </groups>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
   <logging/>
   <source>
     <include>


### PR DESCRIPTION
## Description

`symfony/phpunit-bridge` v8.0.8 (shipped with Symfony 7.4) defaults to downloading
PHPUnit 9.6 and explicitly rejects PHPUnit 10.x when invoked via `simple-phpunit`.
Running `./vendor/bin/simple-phpunit` was causing a PHP fatal error because PHPUnit 9.6
(loaded by the bridge) and PHPUnit 10.5 (installed by Composer) were both present at
runtime, with incompatible `TestSuite::run()` signatures.

This PR fixes the test runner by:
- Declaring `Symfony\Bridge\PhpUnit\SymfonyExtension` in all three phpunit config files
  so that the bridge integrates correctly with PHPUnit 10+ (the extension replaces the
  old bootstrap/listener approach). Tests must now be run via `./vendor/bin/pest`.
- Adding `SYMFONY_DEPRECATIONS_HELPER=max[self]=0&quiet[]=indirect&quiet[]=other` to
  enforce zero self-authored deprecations while suppressing vendor noise.

**Fixes** MON-195027

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

Run the test suite — it must complete without fatal errors and show the deprecation summary:
```bash
./vendor/bin/pest --configuration phpunit.xml
./vendor/bin/pest --configuration phpunit.new.xml
```
Expected: all tests pass, `Tests: N passed` with no fatal error.