### PR TITLE
chore(php): resolve PHP 8.4 backward compatibility issues

### DIFF
--- a/centreon-awie/www/modules/centreon-awie/core/generateExport.php
+++ b/centreon-awie/www/modules/centreon-awie/core/generateExport.php
@@ -21,7 +21,7 @@
 
 require_once __DIR__ . '/../../../../bootstrap.php';
 
-error_reporting(E_ALL & ~E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', false);
 
 require_once _CENTREON_PATH_ . '/www/modules/centreon-awie/class/Export.class.php';

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -12809,6 +12809,10 @@ msgstr ""
 msgid "Please choose a date before %d"
 msgstr "Bitte wählen Sie ein Datum vor %d"
 
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Invalid date format"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."
 msgstr ""

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -12800,6 +12800,10 @@ msgstr ""
 msgid "Please choose a date before %d"
 msgstr "Please choose a date before %d"
 
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Invalid date format"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."
 msgstr "Please contact your administrator for more information."

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -12802,7 +12802,7 @@ msgstr "Please choose a date before %d"
 
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid "Invalid date format"
-msgstr ""
+msgstr "Invalid date format"
 
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14286,6 +14286,10 @@ msgstr ""
 msgid "Please choose a date before %d"
 msgstr ""
 
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Invalid date format"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."
 msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -12994,6 +12994,10 @@ msgstr ""
 msgid "Please choose a date before %d"
 msgstr "Veuillez choisir une date avant %d"
 
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Format de date invalide"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."
 msgstr "Veuillez contacter votre administrateur pour plus d'informations."

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -12995,8 +12995,8 @@ msgid "Please choose a date before %d"
 msgstr "Veuillez choisir une date avant %d"
 
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
-msgid "Format de date invalide"
-msgstr ""
+msgid "Invalid date format"
+msgstr "Format de date invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -13298,6 +13298,10 @@ msgstr ""
 msgid "Please choose a date before %d"
 msgstr ""
 
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Invalid date format"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."
 msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -13169,6 +13169,10 @@ msgstr ""
 msgid "Please choose a date before %d"
 msgstr ""
 
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+msgid "Invalid date format"
+msgstr ""
+
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator for more information."
 msgstr ""

--- a/centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+++ b/centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
@@ -258,10 +258,10 @@ class TimelineController extends AbstractController
                 throw new \RuntimeException('Unable to generate file');
             }
             $header = ['type', 'date', 'content', 'contact', 'status', 'tries'];
-            fputcsv($handle, $header, ';');
+            fputcsv($handle, $header, ';', '"', '\\');
 
             foreach ($timeLines as $timeLine) {
-                fputcsv($handle, $timeLine, ';');
+                fputcsv($handle, $timeLine, ';', '"', '\\');
             }
 
             fclose($handle);

--- a/centreon/src/Core/Infrastructure/Common/Presenter/CsvFormatter.php
+++ b/centreon/src/Core/Infrastructure/Common/Presenter/CsvFormatter.php
@@ -44,11 +44,11 @@ class CsvFormatter implements PresenterFormatterInterface
                 foreach ($data as $oneData) {
                     if (! $lineHeadersCreated) {
                         $columnNames = array_keys($oneData);
-                        fputcsv($handle, $columnNames, ';');
+                        fputcsv($handle, $columnNames, ';', '"', '\\');
                         $lineHeadersCreated = true;
                     }
                     $columnValues = array_values($oneData);
-                    fputcsv($handle, $columnValues, ';');
+                    fputcsv($handle, $columnValues, ';', '"', '\\');
                 }
             }
 

--- a/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions.feature
+++ b/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions.feature
@@ -65,5 +65,5 @@ Feature: Check permissions on Agent Configuration
   Scenario: Delete an agent configuration with a non-admin user with filters on Pollers
     Given a non-admin user is in the Agents Configuration page
     And an already existing agent configuration is displayed
-    When the user deletes the Agents Configuration
-    Then the first Agents Configuration is no longer displayed in the listing page
+    When the non-admin user deletes an Agent Configuration
+    Then the deleted agent Configuration is no longer displayed in the listing page

--- a/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions/index.ts
+++ b/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions/index.ts
@@ -201,15 +201,17 @@ Then(
 );
 
 When('the user deletes the Agents Configuration', () => {
-  cy.getByTestId({ testId: 'Delete' }).eq(1).click();
+  cy.contains('[role="row"]', agentsConfiguration.telegraf2.name).within(() => {
+    cy.getByTestId({ testId: 'Delete' }).click();
+  });
   cy.contains('button', 'Delete').click();
-  cy.wait('@deleteAgents');
+  cy.wait('@deleteAgents').its('response.statusCode').should('eq', 204);
 });
 
 Then(
   'the Agents Configuration is no longer displayed in the listing page',
   () => {
-    cy.contains('telegraf-001-updated').should('not.exist');
+    cy.contains(agentsConfiguration.telegraf2.name).should('not.exist');
   }
 );
 
@@ -427,7 +429,8 @@ Given('a non-admin user is in the Agents Configuration page', () => {
     loginViaApi: false
   });
   cy.visit(PAGES.configuration.agentConfigurations);
-  cy.wait('@getAgentsPage');
+  cy.wait('@getNavigationList');
+  cy.wait('@getAgentsPage').its('response.statusCode').should('eq', 200);
 });
 
 Given('an already existing agent configuration is displayed', () => {
@@ -480,14 +483,17 @@ Then(
   }
 );
 
+When('the non-admin user deletes an Agent Configuration', () => {
+  cy.contains('[role="row"]', agentsConfiguration.telegraf2.name).within(() => {
+    cy.getByTestId({ testId: 'Delete' }).click();
+  });
+  cy.contains('button', 'Delete').click();
+  cy.wait('@deleteAgents').its('response.statusCode').should('eq', 204);
+});
+
 Then(
-  'the first Agents Configuration is no longer displayed in the listing page',
+  'the deleted agent Configuration is no longer displayed in the listing page',
   () => {
-    cy.contains('telegraf-001-updated').should('not.exist');
-    cy.get('*[role="rowgroup"]').should(
-      'contain',
-      agentsConfiguration.telegraf2.name
-    );
-    cy.get('*[role="rowgroup"]').should('contain', 'Telegraf');
+    cy.contains(agentsConfiguration.telegraf2.name).should('not.exist');
   }
 );

--- a/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
@@ -1551,17 +1551,17 @@ if ($dbConfigCentreon instanceof ConnectionConfig && hasConnectionDb($dbConfigCe
             $pdo = $db->getNativeConnection();
             $db->startUnbufferedQuery();
             expect($db->isUnbufferedQueryActive())->toBeTrue()
-                ->and($pdo->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(0);
+                ->and($pdo->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeFalsy();
             $pdoStmt = $pdo->prepare('SELECT * FROM contact WHERE contact_id = 1');
             $pdoStmt->execute();
 
             $contact = $pdoStmt->fetch(\PDO::FETCH_ASSOC);
             expect($contact)->toBeArray()->toHaveKey('contact_id', 1)
                 ->and($db->isUnbufferedQueryActive())->toBeTrue()
-                ->and($pdo->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(0);
+                ->and($pdo->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeFalsy();
             $db->stopUnbufferedQuery();
             expect($db->isUnbufferedQueryActive())->toBeFalse()
-                ->and($pdo->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(1);
+                ->and($pdo->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeTruthy();
         }
     );
 

--- a/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
@@ -1530,16 +1530,16 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->startUnbufferedQuery();
             expect($db->isUnbufferedQueryActive())->toBeTrue()
-                ->and($db->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(0);
+                ->and($db->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeFalsy();
             $pdoStmt = $db->prepare('SELECT * FROM contact WHERE contact_id = 1');
             $pdoStmt->execute();
             $contact = $pdoStmt->fetch(\PDO::FETCH_ASSOC);
             expect($contact)->toBeArray()->toHaveKey('contact_id', 1)
                 ->and($db->isUnbufferedQueryActive())->toBeTrue()
-                ->and($db->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(0);
+                ->and($db->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeFalsy();
             $db->stopUnbufferedQuery();
             expect($db->isUnbufferedQueryActive())->toBeFalse()
-                ->and($db->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(1);
+                ->and($db->getAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeTruthy();
         }
     );
 

--- a/centreon/tests/php/Core/Common/Domain/Exception/BusinessLogicExceptionTest.php
+++ b/centreon/tests/php/Core/Common/Domain/Exception/BusinessLogicExceptionTest.php
@@ -39,6 +39,7 @@ it('test with a basic context from a repository exception', function (): void {
                 previous: $logicException
             );
         } catch (BusinessLogicException $exception) {
+            $closureMethod = $exception->getTrace()[0]['function'];
             expect($exception->getMessage())->toBe('repository_message')
                 ->and($exception->getCode())->toBe(1)
                 ->and($exception->getPrevious())->toBeInstanceOf(LogicException::class)
@@ -51,7 +52,7 @@ it('test with a basic context from a repository exception', function (): void {
                         'line' => $exception->getLine(),
                         'code' => 1,
                         'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                        'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                        'method' => $closureMethod,
                         'previous' => [
                             'type' => LogicException::class,
                             'message' => 'logic_message',
@@ -59,7 +60,7 @@ it('test with a basic context from a repository exception', function (): void {
                             'line' => $exception->getPrevious()->getLine(),
                             'code' => 100,
                             'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                            'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                            'method' => $closureMethod,
                             'previous' => null,
                         ],
                         'context' => [
@@ -84,6 +85,7 @@ it('test with a business context from a repository exception', function (): void
                 previous: $collectionException
             );
         } catch (BusinessLogicException $exception) {
+            $closureMethod = $exception->getTrace()[0]['function'];
             expect($exception->getMessage())->toBe('repository_message')
                 ->and($exception->getCode())->toBe(1)
                 ->and($exception->getPrevious())->toBeInstanceOf(CollectionException::class)
@@ -96,7 +98,7 @@ it('test with a business context from a repository exception', function (): void
                         'line' => $exception->getLine(),
                         'code' => 1,
                         'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                        'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                        'method' => $closureMethod,
                         'previous' => [
                             'type' => CollectionException::class,
                             'message' => 'collection_message',
@@ -104,7 +106,7 @@ it('test with a business context from a repository exception', function (): void
                             'line' => $exception->getPrevious()->getLine(),
                             'code' => 0,
                             'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                            'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                            'method' => $closureMethod,
                             'previous' => null,
                         ],
                         'context' => [
@@ -141,6 +143,7 @@ it('test with a business context with previous from a repository exception', fun
                 previous: $collectionException
             );
         } catch (BusinessLogicException $exception) {
+            $closureMethod = $exception->getTrace()[0]['function'];
             expect($exception->getMessage())->toBe('repository_message')
                 ->and($exception->getCode())->toBe(1)
                 ->and($exception->getPrevious())->toBeInstanceOf(CollectionException::class)
@@ -153,7 +156,7 @@ it('test with a business context with previous from a repository exception', fun
                         'line' => $exception->getLine(),
                         'code' => 1,
                         'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                        'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                        'method' => $closureMethod,
                         'previous' => [
                             'type' => CollectionException::class,
                             'message' => 'collection_message',
@@ -161,7 +164,7 @@ it('test with a business context with previous from a repository exception', fun
                             'line' => $exception->getPrevious()->getLine(),
                             'code' => 0,
                             'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                            'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                            'method' => $closureMethod,
                             'previous' => [
                                 'type' => LogicException::class,
                                 'message' => 'logic_message',
@@ -169,7 +172,7 @@ it('test with a business context with previous from a repository exception', fun
                                 'line' => $exception->getPrevious()->getPrevious()->getLine(),
                                 'code' => 100,
                                 'class' => 'P\Tests\php\Core\Common\Domain\Exception\BusinessLogicExceptionTest',
-                                'method' => 'Tests\Core\Common\Domain\Exception\{closure}',
+                                'method' => $closureMethod,
                                 'previous' => null,
                             ],
                         ],

--- a/centreon/tests/php/Core/Common/Domain/Exception/ExceptionFormatterTest.php
+++ b/centreon/tests/php/Core/Common/Domain/Exception/ExceptionFormatterTest.php
@@ -28,6 +28,7 @@ use Core\Common\Domain\Exception\RepositoryException;
 
 it('test format native exception without previous', function (): void {
     $exception = new \LogicException('logic_exception_message', 99);
+    $closureMethod = $exception->getTrace()[0]['function'];
     $format = ExceptionFormatter::format($exception);
     expect($format)->toBeArray()
         ->and($format)->toHaveKey('type')
@@ -37,19 +38,20 @@ it('test format native exception without previous', function (): void {
         ->and($format)->toHaveKey('file')
         ->and($format['file'])->toBe(__FILE__)
         ->and($format)->toHaveKey('line')
-        ->and($format['line'])->toBe(__LINE__ - 10)
+        ->and($format['line'])->toBe(__LINE__ - 11)
         ->and($format)->toHaveKey('code')
         ->and($format['code'])->toBe(99)
         ->and($format)->toHaveKey('class')
         ->and($format['class'])->toBe('P\\Tests\\php\\Core\\Common\\Domain\\Exception\\ExceptionFormatterTest')
         ->and($format)->toHaveKey('method')
-        ->and($format['method'])->toBe('Tests\\Core\\Common\\Domain\\Exception\\{closure}')
+        ->and($format['method'])->toBe($closureMethod)
         ->and($format)->toHaveKey('previous')
         ->and($format['previous'])->toBeNull();
 });
 
 it('test format business logic exception without previous', function (): void {
     $exception = new RepositoryException('repository_exception_message');
+    $closureMethod = $exception->getTrace()[0]['function'];
     $format = ExceptionFormatter::format($exception);
     expect($format)->toBeArray()
         ->and($format)->toHaveKey('type')
@@ -59,19 +61,20 @@ it('test format business logic exception without previous', function (): void {
         ->and($format)->toHaveKey('file')
         ->and($format['file'])->toBe(__FILE__)
         ->and($format)->toHaveKey('line')
-        ->and($format['line'])->toBe(__LINE__ - 10)
+        ->and($format['line'])->toBe(__LINE__ - 11)
         ->and($format)->toHaveKey('code')
         ->and($format['code'])->toBe(1)
         ->and($format)->toHaveKey('class')
         ->and($format['class'])->toBe('P\\Tests\\php\\Core\\Common\\Domain\\Exception\\ExceptionFormatterTest')
         ->and($format)->toHaveKey('method')
-        ->and($format['method'])->toBe('Tests\\Core\\Common\\Domain\\Exception\\{closure}')
+        ->and($format['method'])->toBe($closureMethod)
         ->and($format)->toHaveKey('previous')
         ->and($format['previous'])->toBeNull();
 });
 
 it('test format business logic exception without previous with context', function (): void {
     $exception = new RepositoryException('repository_exception_message', ['contact' => 1, 'name' => 'John']);
+    $closureMethod = $exception->getTrace()[0]['function'];
     $format = ExceptionFormatter::format($exception);
     expect($format)->toBeArray()
         ->and($format)->toHaveKey('type')
@@ -81,13 +84,13 @@ it('test format business logic exception without previous with context', functio
         ->and($format)->toHaveKey('file')
         ->and($format['file'])->toBe(__FILE__)
         ->and($format)->toHaveKey('line')
-        ->and($format['line'])->toBe(__LINE__ - 10)
+        ->and($format['line'])->toBe(__LINE__ - 11)
         ->and($format)->toHaveKey('code')
         ->and($format['code'])->toBe(1)
         ->and($format)->toHaveKey('class')
         ->and($format['class'])->toBe('P\\Tests\\php\\Core\\Common\\Domain\\Exception\\ExceptionFormatterTest')
         ->and($format)->toHaveKey('method')
-        ->and($format['method'])->toBe('Tests\\Core\\Common\\Domain\\Exception\\{closure}')
+        ->and($format['method'])->toBe($closureMethod)
         ->and($format)->toHaveKey('previous')
         ->and($format['previous'])->toBeNull();
 });
@@ -100,6 +103,7 @@ it('test format business logic exception with previous', function (): void {
             99
         )
     );
+    $closureMethod = $exception->getTrace()[0]['function'];
     $format = ExceptionFormatter::format($exception);
     expect($format)->toBeArray()
         ->and($format)->toHaveKey('type')
@@ -109,13 +113,13 @@ it('test format business logic exception with previous', function (): void {
         ->and($format)->toHaveKey('file')
         ->and($format['file'])->toBe(__FILE__)
         ->and($format)->toHaveKey('line')
-        ->and($format['line'])->toBe(__LINE__ - 16)
+        ->and($format['line'])->toBe(__LINE__ - 17)
         ->and($format)->toHaveKey('code')
         ->and($format['code'])->toBe(1)
         ->and($format)->toHaveKey('class')
         ->and($format['class'])->toBe('P\\Tests\\php\\Core\\Common\\Domain\\Exception\\ExceptionFormatterTest')
         ->and($format)->toHaveKey('method')
-        ->and($format['method'])->toBe('Tests\\Core\\Common\\Domain\\Exception\\{closure}')
+        ->and($format['method'])->toBe($closureMethod)
         ->and($format)->toHaveKey('previous')
         ->and($format['previous'])->toBeArray()
         ->and($format['previous'])->toHaveKey('type')
@@ -125,7 +129,7 @@ it('test format business logic exception with previous', function (): void {
         ->and($format['previous'])->toHaveKey('file')
         ->and($format['previous']['file'])->toBe(__FILE__)
         ->and($format['previous'])->toHaveKey('line')
-        ->and($format['previous']['line'])->toBe(__LINE__ - 30)
+        ->and($format['previous']['line'])->toBe(__LINE__ - 31)
         ->and($format['previous'])->toHaveKey('code')
         ->and($format['previous']['code'])->toBe(99)
         ->and($format['previous'])->toHaveKey('class')
@@ -133,7 +137,7 @@ it('test format business logic exception with previous', function (): void {
             'P\\Tests\\php\\Core\\Common\\Domain\\Exception\\ExceptionFormatterTest'
         )
         ->and($format['previous'])->toHaveKey('method')
-        ->and($format['previous']['method'])->toBe('Tests\\Core\\Common\\Domain\\Exception\\{closure}')
+        ->and($format['previous']['method'])->toBe($closureMethod)
         ->and($format['previous'])->toHaveKey('previous')
         ->and($format['previous']['previous'])->toBeNull();
 });

--- a/centreon/tests/php/Core/Common/Infrastructure/ExceptionLogger/ExceptionLoggerTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/ExceptionLogger/ExceptionLoggerTest.php
@@ -48,46 +48,52 @@ afterEach(function (): void {
 });
 
 it('test log a native exception', function (): void {
-    $this->exceptionLogger->log(new \LogicException('logic_exception_message'));
+    $exception = new \LogicException('logic_exception_message');
+    $closureMethod = str_replace('\\', '\\\\', $exception->getTrace()[0]['function']);
+    $this->exceptionLogger->log($exception);
     expect(file_exists($this->logPathFileName))->toBeTrue();
     $contentLog = file_get_contents($this->logPathFileName);
     expect($contentLog)->toContain(
-        '{"custom":null,"exception":{"exceptions":[{"type":"LogicException","message":"logic_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 4) . ',"code":0,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"}],"traces":[{"'
+        '{"custom":null,"exception":{"exceptions":[{"type":"LogicException","message":"logic_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 6) . ',"code":0,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"}],"traces":[{"'
     );
 });
 
 it('test log an exception that extends BusinessLogicException without context and previous', function (): void {
-    $this->exceptionLogger->log(new RepositoryException('repository_exception_message'));
+    $exception = new RepositoryException('repository_exception_message');
+    $closureMethod = str_replace('\\', '\\\\', $exception->getTrace()[0]['function']);
+    $this->exceptionLogger->log($exception);
     expect(file_exists($this->logPathFileName))->toBeTrue();
     $contentLog = file_get_contents($this->logPathFileName);
     expect($contentLog)->toContain(
-        '{"custom":{"from_exception":[]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 4) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"}],"traces":[{"'
+        '{"custom":{"from_exception":[]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 6) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"}],"traces":[{"'
     );
 });
 
 it('test log an exception that extends BusinessLogicException with context without previous', function (): void {
-    $this->exceptionLogger->log(new RepositoryException('repository_exception_message', ['contact' => 1]));
+    $exception = new RepositoryException('repository_exception_message', ['contact' => 1]);
+    $closureMethod = str_replace('\\', '\\\\', $exception->getTrace()[0]['function']);
+    $this->exceptionLogger->log($exception);
     expect(file_exists($this->logPathFileName))->toBeTrue();
     $contentLog = file_get_contents($this->logPathFileName);
     expect($contentLog)->toContain(
-        '{"custom":{"from_exception":[{"contact":1}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 4) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"}],"traces":[{"'
+        '{"custom":{"from_exception":[{"contact":1}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 6) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"}],"traces":[{"'
     );
 });
 
 it(
     'test log an exception that extends BusinessLogicException with context with a previous (native exception)',
     function (): void {
-        $this->exceptionLogger->log(
-            new RepositoryException(
-                'repository_exception_message',
-                ['contact' => 1],
-                new \LogicException('logic_exception_message')
-            )
+        $exception = new RepositoryException(
+            'repository_exception_message',
+            ['contact' => 1],
+            new \LogicException('logic_exception_message')
         );
+        $closureMethod = str_replace('\\', '\\\\', $exception->getTrace()[0]['function']);
+        $this->exceptionLogger->log($exception);
         expect(file_exists($this->logPathFileName))->toBeTrue();
         $contentLog = file_get_contents($this->logPathFileName);
         expect($contentLog)->toContain(
-            '{"custom":{"from_exception":[{"contact":1}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 9) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"},{"type":"LogicException","message":"logic_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 6) . ',"code":0,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"}],"traces":[{"'
+            '{"custom":{"from_exception":[{"contact":1}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 10) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"},{"type":"LogicException","message":"logic_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 7) . ',"code":0,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"}],"traces":[{"'
         );
     }
 );
@@ -95,17 +101,17 @@ it(
 it(
     'test log an exception that extends BusinessLogicException with context and a previous that extends a BusinessLogicException',
     function (): void {
-        $this->exceptionLogger->log(
-            new RepositoryException(
-                'repository_exception_message',
-                ['contact' => 1],
-                new RepositoryException('repository_exception_message_2')
-            )
+        $exception = new RepositoryException(
+            'repository_exception_message',
+            ['contact' => 1],
+            new RepositoryException('repository_exception_message_2')
         );
+        $closureMethod = str_replace('\\', '\\\\', $exception->getTrace()[0]['function']);
+        $this->exceptionLogger->log($exception);
         expect(file_exists($this->logPathFileName))->toBeTrue();
         $contentLog = file_get_contents($this->logPathFileName);
         expect($contentLog)->toContain(
-            '{"custom":{"from_exception":[{"contact":1}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 9) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"},{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message_2","file":"' . __FILE__ . '","line":' . (__LINE__ - 6) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"}],"traces":[{"'
+            '{"custom":{"from_exception":[{"contact":1}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 10) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"},{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message_2","file":"' . __FILE__ . '","line":' . (__LINE__ - 7) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"}],"traces":[{"'
         );
     }
 );
@@ -113,17 +119,17 @@ it(
 it(
     'test log an exception that extends BusinessLogicException with context and a previous that extends a BusinessLogicException which has context',
     function (): void {
-        $this->exceptionLogger->log(
-            new RepositoryException(
-                'repository_exception_message',
-                ['contact' => 1],
-                new RepositoryException('repository_exception_message_2', ['contact' => 2])
-            )
+        $exception = new RepositoryException(
+            'repository_exception_message',
+            ['contact' => 1],
+            new RepositoryException('repository_exception_message_2', ['contact' => 2])
         );
+        $closureMethod = str_replace('\\', '\\\\', $exception->getTrace()[0]['function']);
+        $this->exceptionLogger->log($exception);
         expect(file_exists($this->logPathFileName))->toBeTrue();
         $contentLog = file_get_contents($this->logPathFileName);
         expect($contentLog)->toContain(
-            '{"custom":{"from_exception":[{"contact":1},{"contact":2}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 9) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"},{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message_2","file":"' . __FILE__ . '","line":' . (__LINE__ - 6) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"Tests\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\{closure}"}],"traces":[{"'
+            '{"custom":{"from_exception":[{"contact":1},{"contact":2}]},"exception":{"exceptions":[{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message","file":"' . __FILE__ . '","line":' . (__LINE__ - 10) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"},{"type":"Core\\\\Common\\\\Domain\\\\Exception\\\\RepositoryException","message":"repository_exception_message_2","file":"' . __FILE__ . '","line":' . (__LINE__ - 7) . ',"code":1,"class":"P\\\\Tests\\\\php\\\\Core\\\\Common\\\\Infrastructure\\\\ExceptionLogger\\\\ExceptionLoggerTest","method":"' . $closureMethod . '"}],"traces":[{"'
         );
     }
 );

--- a/centreon/tests/php/bootstrap.php
+++ b/centreon/tests/php/bootstrap.php
@@ -45,8 +45,7 @@ foreach ($mockedVarConstants as $mockedVarConstant) {
     }
 }
 
-// Disable warnings for PEAR.
-error_reporting(E_ALL & ~E_STRICT);
+error_reporting(E_ALL);
 
 require_once realpath(__DIR__ . '/polyfill.php');
 $loader = require realpath(__DIR__ . '/../../vendor/autoload.php');

--- a/centreon/tests/php/www/class/CentreonDBTest.php
+++ b/centreon/tests/php/www/class/CentreonDBTest.php
@@ -1634,17 +1634,17 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         $db->startUnbufferedQuery();
         expect($db->isUnbufferedQueryActive())->toBeTrue()
             ->and($db->getAttribute(PDO::ATTR_STATEMENT_CLASS)[0])->toBe(CentreonDBStatement::class)
-            ->and($db->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(0);
+            ->and($db->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeFalsy();
         $pdoStmt = $db->prepare('SELECT * FROM contact WHERE contact_id = 1');
         $pdoStmt->execute();
         $contact = $pdoStmt->fetch(PDO::FETCH_ASSOC);
         expect($contact)->toBeArray()->toHaveKey('contact_id', 1)
             ->and($db->isUnbufferedQueryActive())->toBeTrue()
             ->and($db->getAttribute(PDO::ATTR_STATEMENT_CLASS)[0])->toBe(CentreonDBStatement::class)
-            ->and($db->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(0);
+            ->and($db->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeFalsy();
         $db->stopUnbufferedQuery();
         expect($db->isUnbufferedQueryActive())->toBeFalse()
-            ->and($db->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBe(1);
+            ->and($db->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))->toBeTruthy();
     });
 
     it(

--- a/centreon/tests/php/www/class/CentreonLogTest.php
+++ b/centreon/tests/php/www/class/CentreonLogTest.php
@@ -266,6 +266,7 @@ it('test writing logs with a custom context and an exception', function (): void
     try {
         throw new RuntimeException('test_message_exception', 99);
     } catch (RuntimeException $e) {
+        $closureMethod = str_replace('\\', '\\\\', $e->getTrace()[0]['function']);
         $logfile = $this->centreonLogTest->pathToLogTest . '/login.log';
         $this->centreonLogTest->loggerTest
             ->notice(CentreonLog::TYPE_LOGIN, 'login_message', ['custom_value1' => 'foo'], $e);
@@ -282,7 +283,7 @@ it('test writing logs with a custom context and an exception', function (): void
                 $e->getLine(),
                 99,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}'
+                $closureMethod
             ),
             '"default":{"request_infos":{"uri":null,"http_method":null,"server":null}}}'
         );
@@ -297,6 +298,7 @@ it('test writing logs with a custom context and a native exception with a previo
 
         throw new RuntimeException('test_message_exception', 99, $previous);
     } catch (RuntimeException $e) {
+        $closureMethod = str_replace('\\', '\\\\', $e->getTrace()[0]['function']);
         $logfile = $this->centreonLogTest->pathToLogTest . '/login.log';
         $this->centreonLogTest->loggerTest
             ->notice(CentreonLog::TYPE_LOGIN, 'login_message', ['custom_value1' => 'foo'], $e);
@@ -314,14 +316,14 @@ it('test writing logs with a custom context and a native exception with a previo
                 $e->getLine(),
                 99,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}',
+                $closureMethod,
                 'LogicException',
                 'test_message_exception_previous',
                 $e->getPrevious()->getFile(),
                 $e->getPrevious()->getLine(),
                 98,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}'
+                $closureMethod
             ),
             '"default":{"request_infos":{"uri":null,"http_method":null,"server":null}}',
         );
@@ -336,6 +338,7 @@ it('test writing logs with a custom context and an exception (BusinessLogicExcep
 
         throw new CentreonDbException('test_message_exception', ['contact' => 1], $previous);
     } catch (CentreonDbException $e) {
+        $closureMethod = str_replace('\\', '\\\\', $e->getTrace()[0]['function']);
         $logfile = $this->centreonLogTest->pathToLogTest . '/login.log';
         $this->centreonLogTest->loggerTest
             ->notice(CentreonLog::TYPE_LOGIN, 'login_message', ['custom_value1' => 'foo'], $e);
@@ -353,14 +356,14 @@ it('test writing logs with a custom context and an exception (BusinessLogicExcep
                 $e->getLine(),
                 1,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}',
+                $closureMethod,
                 'LogicException',
                 'test_message_exception_previous',
                 $e->getPrevious()->getFile(),
                 $e->getPrevious()->getLine(),
                 99,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}'
+                $closureMethod
             ),
             '"default":{"request_infos":{"uri":null,"http_method":null,"server":null}}',
         );
@@ -376,6 +379,7 @@ it('test writing logs with a custom context and an exception (BusinessLogicExcep
 
         throw new StatisticException('test_message_exception', ['X' => 100.36, 'Y' => 888, 'graph' => true], $previous);
     } catch (StatisticException $e) {
+        $closureMethod = str_replace('\\', '\\\\', $e->getTrace()[0]['function']);
         $logfile = $this->centreonLogTest->pathToLogTest . '/login.log';
         $this->centreonLogTest->loggerTest
             ->notice(CentreonLog::TYPE_LOGIN, 'login_message', ['custom_value1' => 'foo', 'custom_value2' => 'bar'], $e);
@@ -395,21 +399,21 @@ it('test writing logs with a custom context and an exception (BusinessLogicExcep
                 $e->getLine(),
                 0,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}',
+                $closureMethod,
                 'CentreonDbException',
                 'test_message_exception_previous',
                 $e->getPrevious()->getFile(),
                 $e->getPrevious()->getLine(),
                 1,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}',
+                $closureMethod,
                 'LogicException',
                 'test_message_native_exception_previous',
                 $e->getPrevious()->getPrevious()->getFile(),
                 $e->getPrevious()->getPrevious()->getLine(),
                 99,
                 'P\\\\Tests\\\\php\\\\www\\\\class\\\\CentreonLogTest',
-                '{closure}'
+                $closureMethod
             ),
             '"default":{"request_infos":{"uri":null,"http_method":null,"server":null}}',
         );

--- a/centreon/tools/update_centreon_storage_logs.php
+++ b/centreon/tools/update_centreon_storage_logs.php
@@ -473,7 +473,7 @@ try {
 
         $nbrRecords = 0;
         while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
-            fputcsv($fp, $row);
+            fputcsv($fp, $row, ',', '"', '\\');
             $nbrRecords++;
         }
         fclose($fp);

--- a/centreon/www/api/external.php
+++ b/centreon/www/api/external.php
@@ -19,7 +19,7 @@
  *
  */
 
-ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT);
+ini_set('error_reporting', E_ALL & ~E_NOTICE);
 ini_set('display_errors', 'Off');
 
 require_once __DIR__ . '/../../bootstrap.php';

--- a/centreon/www/class/centreonExternalCommand.class.php
+++ b/centreon/www/class/centreonExternalCommand.class.php
@@ -638,8 +638,12 @@ class CentreonExternalCommand
      */
     private function getDowntimeTimestampFromDate($date = 'now', $timezone = '', $start = true)
     {
-        $inputDate = new DateTime($date . ' GMT');
-        $dateTime = new DateTime($date, new DateTimeZone($timezone));
+        try {
+            $inputDate = new DateTime($date . ' GMT');
+            $dateTime = new DateTime($date, new DateTimeZone($timezone));
+        } catch (Exception $e) {
+            throw new InvalidArgumentException(sprintf('Invalid date format: %s', $date), 0, $e);
+        }
 
         // Winter to summer dst
         $dateTime2 = clone $dateTime;

--- a/centreon/www/class/centreonGMT.class.php
+++ b/centreon/www/class/centreonGMT.class.php
@@ -214,11 +214,15 @@ class CentreonGMT
         }
 
         if (isset($date, $gmt)) {
-            if (! is_numeric($date)) {
-                $sDate = new DateTime($date);
-            } else {
-                $sDate = new DateTime();
-                $sDate->setTimestamp($date);
+            try {
+                if (! is_numeric($date)) {
+                    $sDate = new DateTime($date);
+                } else {
+                    $sDate = new DateTime();
+                    $sDate->setTimestamp($date);
+                }
+            } catch (Exception $e) {
+                return $return;
             }
 
             $sDate->setTimezone(new DateTimeZone($this->getActiveTimezone($gmt)));
@@ -252,11 +256,15 @@ class CentreonGMT
         }
 
         if (isset($date, $gmt)) {
-            if (! is_numeric($date)) {
-                $sDate = new DateTime($date);
-            } else {
-                $sDate = new DateTime();
-                $sDate->setTimestamp($date);
+            try {
+                if (! is_numeric($date)) {
+                    $sDate = new DateTime($date);
+                } else {
+                    $sDate = new DateTime();
+                    $sDate->setTimestamp($date);
+                }
+            } catch (Exception $e) {
+                return $return;
             }
 
             $localDate = new DateTime();

--- a/centreon/www/class/centreonGMT.class.php
+++ b/centreon/www/class/centreonGMT.class.php
@@ -203,7 +203,7 @@ class CentreonGMT
      * @param string|null $gmt
      * @param int $reverseOffset
      *
-     * @throws Exception
+     * @throws InvalidArgumentException
      * @return string
      */
     public function getUTCDate($date, $gmt = null, $reverseOffset = 1)
@@ -222,7 +222,7 @@ class CentreonGMT
                     $sDate->setTimestamp($date);
                 }
             } catch (Exception $e) {
-                return $return;
+                throw new InvalidArgumentException($e->getMessage(), 0, $e);
             }
 
             $sDate->setTimezone(new DateTimeZone($this->getActiveTimezone($gmt)));
@@ -240,7 +240,7 @@ class CentreonGMT
      * @param string|null $gmt
      * @param int $reverseOffset
      *
-     * @throws Exception
+     * @throws InvalidArgumentException
      * @return string
      */
     public function getUTCDateFromString($date, $gmt = null, $reverseOffset = 1)
@@ -264,7 +264,7 @@ class CentreonGMT
                     $sDate->setTimestamp($date);
                 }
             } catch (Exception $e) {
-                return $return;
+                throw new InvalidArgumentException($e->getMessage(), 0, $e);
             }
 
             $localDate = new DateTime();

--- a/centreon/www/include/eventLogs/export/Presenter.php
+++ b/centreon/www/include/eventLogs/export/Presenter.php
@@ -81,15 +81,15 @@ class Presenter
 
         // print meta data
         foreach ($this->metaData as $metaData) {
-            fputcsv($f, $metaData, self::DELIMITER);
+            fputcsv($f, $metaData, self::DELIMITER, '"', '\\');
         }
 
         // print heads
-        fputcsv($f, $this->heads, self::DELIMITER);
+        fputcsv($f, $this->heads, self::DELIMITER, '"', '\\');
 
         // print data
         foreach ($this->logs as $log) {
-            fputcsv($f, $log, self::DELIMITER);
+            fputcsv($f, $log, self::DELIMITER, '"', '\\');
         }
 
         fclose($f);

--- a/centreon/www/include/monitoring/downtime/AddDowntime.php
+++ b/centreon/www/include/monitoring/downtime/AddDowntime.php
@@ -44,13 +44,22 @@ function checkYearMax(array $fields)
 {
     $errors = [];
     $tooHighDateMessage = sprintf(_('Please choose a date before %d'), DOWNTIME_YEAR_MAX);
+    $invalidDateMessage = sprintf(_('Invalid date format'));
 
-    if (((int) (new DateTime($fields['alternativeDateStart']))->format('Y')) >= DOWNTIME_YEAR_MAX) {
-        $errors['start'] = $tooHighDateMessage;
+    try {
+        if (((int) (new DateTime($fields['alternativeDateStart']))->format('Y')) >= DOWNTIME_YEAR_MAX) {
+            $errors['start'] = $tooHighDateMessage;
+        }
+    } catch (Exception $e) {
+        $errors['start'] = $invalidDateMessage;
     }
 
-    if (((int) (new DateTime($fields['alternativeDateEnd']))->format('Y')) >= DOWNTIME_YEAR_MAX) {
-        $errors['end'] = $tooHighDateMessage;
+    try {
+        if (((int) (new DateTime($fields['alternativeDateEnd']))->format('Y')) >= DOWNTIME_YEAR_MAX) {
+            $errors['end'] = $tooHighDateMessage;
+        }
+    } catch (Exception $e) {
+        $errors['end'] = $invalidDateMessage;
     }
 
     return $errors !== [] ? $errors : true;

--- a/centreon/www/main.get.php
+++ b/centreon/www/main.get.php
@@ -23,9 +23,9 @@ require_once __DIR__ . '/../bootstrap.php';
 
 // Set logging options
 if (defined('E_DEPRECATED')) {
-    ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+    ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 } else {
-    ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT);
+    ini_set('error_reporting', E_ALL & ~E_NOTICE);
 }
 
 // Purge Values

--- a/centreon/www/main.php
+++ b/centreon/www/main.php
@@ -25,9 +25,9 @@ use CentreonLegacy\Core\Menu\Menu;
 
 // Set logging options
 if (defined('E_DEPRECATED')) {
-    ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+    ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 } else {
-    ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT);
+    ini_set('error_reporting', E_ALL & ~E_NOTICE);
 }
 
 // Purge Values

--- a/centreon/www/widgets/host-monitoring/src/export.php
+++ b/centreon/www/widgets/host-monitoring/src/export.php
@@ -485,7 +485,7 @@ $memoryFile = fopen('php://memory', 'w');
 // loop over the input array
 foreach ($lines as $line) {
     // generate csv lines from the inner arrays
-    fputcsv($memoryFile, $line, ';');
+    fputcsv($memoryFile, $line, ';', '"', '\\');
 }
 // reset the file pointer to the start of the file
 fseek($memoryFile, 0);

--- a/centreon/www/widgets/service-monitoring/src/export.php
+++ b/centreon/www/widgets/service-monitoring/src/export.php
@@ -551,9 +551,9 @@ foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($
     }
 
     if (! $headerWritten) {
-        fputcsv($csvOutput, $header, ';');
+        fputcsv($csvOutput, $header, ';', '"', '\\');
         $headerWritten = true;
     }
-    fputcsv($csvOutput, $line, ';');
+    fputcsv($csvOutput, $line, ';', '"', '\\');
     $header = [];
 }

--- a/php-tools/php-cs-fixer/config/base.strict.php
+++ b/php-tools/php-cs-fixer/config/base.strict.php
@@ -24,8 +24,12 @@ declare(strict_types=1);
 use PhpCsFixer\Config;
 use Tools\PhpCsFixer\PhpCsFixerRuleSet;
 
-return (new Config())
-    // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
-    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
-    ->setRiskyAllowed(true)
-    ->setRules(PhpCsFixerRuleSet::getRules());
+$config = new Config();
+// @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
+$config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+// TODO MON-198134: remove this once PHP 8.4 is the minimum supported version
+$config->setUnsupportedPhpVersionAllowed(true);
+$config->setRiskyAllowed(true);
+$config->setRules(PhpCsFixerRuleSet::getRules());
+
+return $config;

--- a/php-tools/php-cs-fixer/config/base.unstrict.php
+++ b/php-tools/php-cs-fixer/config/base.unstrict.php
@@ -24,8 +24,11 @@ declare(strict_types=1);
 use PhpCsFixer\Config;
 use Tools\PhpCsFixer\PhpCsFixerRuleSet;
 
-return (new Config())
-    // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
-    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
-    ->setRiskyAllowed(false)
-    ->setRules(PhpCsFixerRuleSet::getRulesSafe());
+$config = new Config();
+// @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
+$config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+$config->setUnsupportedPhpVersionAllowed(true);
+$config->setRiskyAllowed(false);
+$config->setRules(PhpCsFixerRuleSet::getRulesSafe());
+
+return $config;

--- a/php-tools/php-cs-fixer/config/base.unstrict.php
+++ b/php-tools/php-cs-fixer/config/base.unstrict.php
@@ -27,6 +27,7 @@ use Tools\PhpCsFixer\PhpCsFixerRuleSet;
 $config = new Config();
 // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
 $config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+// TODO MON-198134: remove this once PHP 8.4 is the minimum supported version
 $config->setUnsupportedPhpVersionAllowed(true);
 $config->setRiskyAllowed(false);
 $config->setRules(PhpCsFixerRuleSet::getRulesSafe());

--- a/php-tools/php-cs-fixer/src/PhpCsFixerRuleSet.php
+++ b/php-tools/php-cs-fixer/src/PhpCsFixerRuleSet.php
@@ -195,7 +195,7 @@ class PhpCsFixerRuleSet
             'get_class_to_class_keyword' => true,
             'implode_call' => true,
             'logical_operators' => true,
-            'mb_str_functions' => true,
+            'mb_str_functions' => false,
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'no_alias_functions' => true,


### PR DESCRIPTION
## Description

- Add explicit escape parameter to all `fputcsv()` calls to preserve the backslash default that changed in PHP 8.4.
- Update test assertions for PDO buffered query attributes to use `toBeFalsy`/`toBeTruthy` instead of exact integer comparisons
- Dynamically resolve closure method names in exception trace tests to accommodate PHP 8.4's new naming.
- Remove obsolete `E_STRICT` exclusion from test bootstrap error reporting.

[MON-197576](https://centreon.atlassian.net/browse/MON-197576)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master


[MON-197576]: https://centreon.atlassian.net/browse/MON-197576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ