### PR TITLE
fix(ci): use computed image_tag and additional_tag in dockerize meta step

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -999,7 +999,8 @@ jobs:
             docker.centreon.com/centreon/${{ env.project }}-${{ matrix.operating_system }}
             docker.centreon.com/centreon/${{ env.project }}-slim-${{ matrix.operating_system }}
           tags: |
-            type=raw,value=${{ github.head_ref || github.ref_name }}
+            type=raw,value=${{ steps.image_tag.outputs.tag }}
+            type=raw,value=${{ steps.image_tag.outputs.additional_tag }},enable=${{ steps.image_tag.outputs.additional_tag != '' }}
 
       - name: Build and push web image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0


### PR DESCRIPTION
## Summary

- The `meta` step in the `dockerize` job was using `type=raw,value=${{ github.head_ref || github.ref_name }}` (raw branch name) instead of the tags computed by the `image_tag` step
- On `develop`, the image was pushed with tag `develop` instead of `develop-26.10`, and `additional_tag=develop` was never pushed
- Fix uses `steps.image_tag.outputs.tag` as the primary tag and conditionally adds `steps.image_tag.outputs.additional_tag` when non-empty

## Test plan

- [ ] On `develop` branch: image pushed with both `develop-26.10` and `develop` tags
- [ ] On feature branch: image pushed with sanitized branch name only (no additional tag)

Refs: MON-198270

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed dockerize meta step to use computed primary and additional tags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107935023?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->