### PR TITLE
fix(upgrade): make SAML requested_authn_context migration idempotent

### DIFF
--- a/centreon/www/install/php/Update-25.10.11.php
+++ b/centreon/www/install/php/Update-25.10.11.php
@@ -19,8 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ConnectionInterface;
 use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use App\Kernel;
 use Core\AgentConfiguration\Application\UseCase\DeployDefaultAgentConfigurationForPoller\{
     DeployDefaultAgentConfigurationForPoller,
@@ -109,21 +111,89 @@ $deployDefaultAgentConfiguration = function () use ($pearDB, &$errorMessage, $ve
     );
 };
 
-// TODO add your functions here
+/** ------------------------------------- SAML ------------------------------------- */
+/**
+ * Recover SAML provider configurations whose requested_authn_context_comparison field was left in an
+ * invalid state by the non-idempotent 25.11.0 migration (MON-198174): a boolean, a missing value, or
+ * a string outside RequestedAuthnContextComparisonEnum breaks CustomConfiguration::createFromValues()
+ * and the login page. When detected, reset the value to 'exact'.
+ */
+$fixSamlRequestedAuthnContextComparison = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to recover SAML provider configuration';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: checking SAML provider configuration for invalid requested_authn_context_comparison"
+    );
+
+    $samlConfiguration = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT * FROM `provider_configuration`
+            WHERE `type` = 'saml'
+            SQL
+    );
+
+    if (! $samlConfiguration || ! isset($samlConfiguration['custom_configuration'])) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: no SAML provider configuration found, skipping"
+        );
+
+        return;
+    }
+
+    $customConfiguration = json_decode(
+        json: $samlConfiguration['custom_configuration'],
+        associative: true,
+        flags: JSON_THROW_ON_ERROR
+    );
+
+    $validComparisonValues = ['minimum', 'exact', 'better', 'maximum'];
+    $currentComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;
+
+    if (is_string($currentComparison) && in_array($currentComparison, $validComparisonValues, true)) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: requested_authn_context_comparison already valid, no recovery needed"
+        );
+
+        return;
+    }
+
+    $customConfiguration['requested_authn_context_comparison'] = 'exact';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: requested_authn_context_comparison was not a valid string, reset to 'exact'"
+    );
+
+    $query = <<<'SQL'
+            UPDATE `provider_configuration`
+            SET `custom_configuration` = :custom_configuration
+            WHERE `id` = :id
+        SQL;
+    $queryParameters = QueryParameters::create(
+        [
+            QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR)),
+            QueryParameter::int('id', (int) $samlConfiguration['id']),
+        ]
+    );
+    $pearDB->update($query, $queryParameters);
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: SAML provider configuration recovered successfully"
+    );
+};
 
 try {
-    // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
-
-    // DDL statements for configuration database
-    // TODO add your function calls to update the configuration database structure here
-
     // Transactional queries for configuration database
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
-    // TODO add your function calls to update the configuration database data here
+    // SAML recovery for platforms affected by MON-198174
+    $fixSamlRequestedAuthnContextComparison();
 
     if ($pearDB->isTransactionActive()) {
         $pearDB->commitTransaction();
@@ -132,6 +202,7 @@ try {
     try {
         $deployDefaultAgentConfiguration();
         $clearDefaultCurveTemplateLegend();
+
     } catch (Throwable $e) {
         CentreonLog::create()->warning(
             logTypeId: CentreonLog::TYPE_UPGRADE,

--- a/centreon/www/install/php/Update-25.10.6.php
+++ b/centreon/www/install/php/Update-25.10.6.php
@@ -44,8 +44,13 @@ $errorMessage = '';
 
 /**
  * Update SAML provider configuration:
- *      - If requested_authn_context exists, set requested_authn_context_comparison to its value and requested_authn_context to true
- *      - If requested_authn_context does not exist, set requested_authn_context_comparison to 'exact' and requested_authn_context to false
+ *      - If requested_authn_context_comparison is already a valid comparison value, keep it (idempotent rerun).
+ *      - Else if requested_authn_context is a valid legacy comparison value, move it to requested_authn_context_comparison.
+ *      - Else default requested_authn_context_comparison to 'exact' (recovers from a prior buggy run that stored a boolean or an invalid string).
+ *      - In all cases, force requested_authn_context to false.
+ *
+ * Valid comparison values mirror RequestedAuthnContextComparisonEnum and are whitelisted locally so the
+ * migration never writes a value that CustomConfiguration::createFromValues() would reject.
  */
 $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Unable to retrieve SAML provider configuration';
@@ -81,25 +86,38 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
         message: "UPGRADE - {$version}: SAML provider configuration found, checking for requested_authn_context"
     );
 
-    $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
+    $customConfiguration = json_decode(
+        json: $samlConfiguration['custom_configuration'],
+        associative: true,
+        flags: JSON_THROW_ON_ERROR
+    );
 
-    if (isset($customConfiguration['requested_authn_context'])) {
-        $customConfiguration['requested_authn_context_comparison'] = $customConfiguration['requested_authn_context'];
-        $customConfiguration['requested_authn_context'] = false;
+    $validComparisonValues = ['minimum', 'exact', 'better', 'maximum'];
+    $existingComparison = $customConfiguration['requested_authn_context_comparison'] ?? null;
+    $legacyValue = $customConfiguration['requested_authn_context'] ?? null;
+
+    if (is_string($existingComparison) && in_array($existingComparison, $validComparisonValues, true)) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: requested_authn_context_comparison already set to a valid value, keeping existing value"
+        );
+    } elseif (is_string($legacyValue) && in_array($legacyValue, $validComparisonValues, true)) {
+        $customConfiguration['requested_authn_context_comparison'] = $legacyValue;
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: requested_authn_context found, requested_authn_context_comparison takes the value of requested_authn_context, and requested_authn_context is set to true"
+            message: "UPGRADE - {$version}: requested_authn_context holds a valid legacy value, moved it to requested_authn_context_comparison"
         );
     } else {
         $customConfiguration['requested_authn_context_comparison'] = 'exact';
-        $customConfiguration['requested_authn_context'] = false;
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: requested_authn_context not found, setting requested_authn_context to false and requested_authn_context_comparison to 'exact'"
+            message: "UPGRADE - {$version}: requested_authn_context_comparison missing or invalid, defaulting to 'exact'"
         );
     }
+
+    $customConfiguration['requested_authn_context'] = false;
 
     CentreonLog::create()->info(
         logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -109,10 +127,13 @@ $updateSamlProviderConfiguration = function () use ($pearDB, &$errorMessage, $ve
     $query = <<<'SQL'
             UPDATE `provider_configuration`
             SET `custom_configuration` = :custom_configuration
-            WHERE `type` = 'saml'
+            WHERE `id` = :id
         SQL;
     $queryParameters = QueryParameters::create(
-        [QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR))]
+        [
+            QueryParameter::string('custom_configuration', json_encode($customConfiguration, JSON_THROW_ON_ERROR)),
+            QueryParameter::int('id', (int) $samlConfiguration['id']),
+        ]
     );
     $pearDB->update($query, $queryParameters);
 


### PR DESCRIPTION
backport of #10279

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made SAML requested_authn_context migration idempotent and validated comparison values
* Added recovery migration to reset invalid requested_authn_context_comparison values


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107957873?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->