### PR TITLE
fix(UI): prevent clock widget crash when user locale is null in playlist context (24.10 backport)

### DIFF
--- a/centreon/www/widgets/src/centreon-widget-clock/src/useGetLocaleAndTimezone.ts
+++ b/centreon/www/widgets/src/centreon-widget-clock/src/useGetLocaleAndTimezone.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useAtomValue } from 'jotai';
 
+import { useLocale } from '@centreon/ui';
 import { userAtom } from '@centreon/ui-context';
 
 import { PanelOptions } from './models';
@@ -14,14 +15,15 @@ export const useGetLocaleAndTimezone = ({
   timezone: string;
 } => {
   const user = useAtomValue(userAtom);
+  const userLocale = useLocale();
 
   const timezoneToUse = useMemo(
     () => (timezone?.id ?? user.timezone) as string,
     [user.timezone, timezone]
   );
   const localeToUse = useMemo(
-    () => (locale?.id ?? user.locale.replace('_', '-')) as string,
-    [user.locale, locale]
+    () => (locale?.id ?? userLocale.replace('_', '-')) as string,
+    [userLocale, locale]
   );
 
   return {


### PR DESCRIPTION
## Summary

- Backport of [#7599](https://github.com/centreon/centreon/pull/7599) (fix for MON-172751) to `dev-24.10.x`
- In `useGetLocaleAndTimezone.ts`, `user.locale` is `null` in playlist/unauthenticated contexts, causing `.replace()` to throw and preventing the Clock widget module from loading entirely
- Fix replaces `user.locale` with `useLocale()` from `@centreon/ui`, which falls back to browser locale when `user.locale` is null

## Root cause

```ts
// Before — crashes when user.locale is null (playlist / public context)
(locale?.id ?? user.locale.replace('_', '-'))

// After — useLocale() returns browser locale as fallback
(locale?.id ?? userLocale.replace('_', '-'))
```

## Test plan

- [ ] Add Clock widget to a dashboard
- [ ] Navigate to Playlist — module should load without "Impossible de charger le module" error
- [ ] Open a public playlist containing a dashboard with a Clock widget — widget should display correctly
- [ ] Verify Clock widget still works normally when user is authenticated

Fixes MON-196420

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Prevented clock widget crash when user locale was null


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107949496?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->