### PR TITLE
refactor(core): use native PHP I/O for pipe writes and improve argument handling

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24856,3 +24856,11 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
+
+#: src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+msgid "Engine restart command does not match the expected format. Please check the monitoring server configuration."
+msgstr "La commande de redémarrage du moteur ne correspond pas au format attendu. Veuillez vérifier la configuration du serveur de supervision."
+
+#: www/class/centreonBroker.class.php
+msgid "Broker reload command does not match the expected format. Please check the monitoring server configuration."
+msgstr "La commande de rechargement du broker ne correspond pas au format attendu. Veuillez vérifier la configuration du serveur de supervision."

--- a/centreon/phpstan.legacy.src.baseline.neon
+++ b/centreon/phpstan.legacy.src.baseline.neon
@@ -378,11 +378,6 @@ parameters:
 			path: src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
 
 		-
-			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) fh must contain 3 or more characters\.$#'
-			count: 3
-			path: src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
-
-		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) cc must contain 3 or more characters\.$#'
 			count: 1
 			path: src/CentreonRemote/ServiceProvider.php

--- a/centreon/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
+++ b/centreon/src/Centreon/Infrastructure/RemoteServer/RemoteServerRepositoryFile.php
@@ -45,7 +45,7 @@ class RemoteServerRepositoryFile implements RemoteServerLocalConfigurationReposi
     {
         system(
             "sed -i -r 's/(\\\$instance_mode?\s+=?\s+\")([a-z]+)(\";)/\\1central\\3/' "
-            . $this->centreonConfFilePath
+            . escapeshellarg($this->centreonConfFilePath)
         );
     }
 
@@ -56,7 +56,7 @@ class RemoteServerRepositoryFile implements RemoteServerLocalConfigurationReposi
     {
         system(
             "sed -i -r 's/(\\\$instance_mode?\s+=?\s+\")([a-z]+)(\";)/\\1remote\\3/' "
-            . $this->centreonConfFilePath
+            . escapeshellarg($this->centreonConfFilePath)
         );
     }
 }

--- a/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -26,6 +26,7 @@ use Centreon\ServiceProvider;
 use CentreonBroker;
 use CentreonContactgroup;
 use CentreonDB;
+use Core\MonitoringServer\Model\MonitoringServer;
 use Exception;
 use Generate;
 use Pimple\Container;
@@ -117,7 +118,9 @@ class PollerInteractionService
     {
         $centreonBrokerPath = _CENTREON_CACHEDIR_ . '/config/broker/';
 
-        $centCorePipe = defined('_CENTREON_VARLIB_') ? _CENTREON_VARLIB_ . '/centcore.cmd' : '/var/lib/centreon/centcore.cmd';
+        $centCorePipe = defined('_CENTREON_VARLIB_')
+            ? _CENTREON_VARLIB_ . '/centcore.cmd'
+            : '/var/lib/centreon/centcore.cmd';
 
         $tabServer = [];
         $tabs = $this->centreon->user->access->getPollerAclConf([
@@ -139,9 +142,13 @@ class PollerInteractionService
 
         foreach ($tabServer as $host) {
             if (in_array($host['id'], $pollerIDs)) {
-                passthru("echo 'SENDCFGFILE:{$host['id']}' >> {$centCorePipe}", $return);
+                $written = file_put_contents(
+                    $centCorePipe,
+                    'SENDCFGFILE:' . (int) $host['id'] . "\n",
+                    FILE_APPEND | LOCK_EX
+                );
 
-                if ($return) {
+                if ($written === false) {
                     throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
                 }
             }
@@ -157,7 +164,9 @@ class PollerInteractionService
     {
         $tabServers = [];
 
-        $centCorePipe = defined('_CENTREON_VARLIB_') ? _CENTREON_VARLIB_ . '/centcore.cmd' : '/var/lib/centreon/centcore.cmd';
+        $centCorePipe = defined('_CENTREON_VARLIB_')
+            ? _CENTREON_VARLIB_ . '/centcore.cmd'
+            : '/var/lib/centreon/centcore.cmd';
 
         $tabs = $this->centreon->user->access->getPollerAclConf([
             'fields' => ['name', 'id', 'localhost', 'engine_restart_command'],
@@ -181,15 +190,18 @@ class PollerInteractionService
         }
 
         foreach ($tabServers as $poller) {
-            if (isset($poller['localhost']) && $poller['localhost'] == 1) {
-                if ($poller['engine_restart_command'] != '') {
-                    shell_exec(escapeshellcmd("sudo -n -- {$poller['engine_restart_command']}"));
-                }
-            } elseif ($fh = @fopen($centCorePipe, 'a+')) {
-                fwrite($fh, 'RESTART:' . $poller['id'] . "\n");
-                fclose($fh);
+            if (isset($poller['localhost']) && (int) $poller['localhost'] === 1) {
+                $this->restartEngine($poller['engine_restart_command']);
             } else {
-                throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
+                $written = file_put_contents(
+                    $centCorePipe,
+                    'RESTART:' . (int) $poller['id'] . "\n",
+                    FILE_APPEND | LOCK_EX
+                );
+
+                if ($written === false) {
+                    throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
+                }
             }
 
             $restartTimeQuery = "UPDATE `nagios_server`
@@ -207,6 +219,25 @@ class PollerInteractionService
                     include $fileName;
                 }
             }
+        }
+    }
+
+    /**
+     * @param string|null $engineRestartCommand
+     *
+     * @throws Exception
+     * @return void
+     */
+    private function restartEngine(?string $engineRestartCommand): void
+    {
+        if (! empty($engineRestartCommand)) {
+            if (preg_match(MonitoringServer::VALID_COMMAND_RESTART_REGEX, $engineRestartCommand) !== 1) {
+                throw new Exception(_(
+                    'Engine restart command does not match the expected format.'
+                    . ' Please check the monitoring server configuration.'
+                ));
+            }
+            shell_exec(escapeshellcmd('sudo -n -- ' . $engineRestartCommand));
         }
     }
 }

--- a/centreon/www/class/centreonBroker.class.php
+++ b/centreon/www/class/centreonBroker.class.php
@@ -47,7 +47,11 @@ class CentreonBroker
      */
     public function reload(): void
     {
-        if ($command = $this->getReloadCommand()) {
+        $command = $this->getReloadCommand();
+        if (! empty($command)) {
+            if (preg_match(Core\MonitoringServer\Model\MonitoringServer::VALID_COMMAND_RELOAD_REGEX, $command) !== 1) {
+                throw new RuntimeException(_('Broker reload command does not match the expected format. Please check the monitoring server configuration.'));
+            }
             shell_exec(escapeshellcmd("sudo -n -- {$command}"));
         }
     }

--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1213,7 +1213,7 @@ class CentreonGraph
         $commandLine = preg_replace('/(\\$|`)/', '', $commandLine);
         $timezone = $this->GMT->getMyTimezone();
         if (! empty($timezone)) {
-            $gmt_export = "export TZ='" . $timezone . "'; ";
+            $gmt_export = 'export TZ=' . escapeshellarg($timezone) . '; ';
         }
         $this->log($commandLine);
         // Send Binary Data

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -343,11 +343,12 @@ try {
                     ));
                 }
             } else {
-                passthru(
-                    escapeshellcmd("echo 'SENDCFGFILE:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                    $return
+                $written = file_put_contents(
+                    $centcore_pipe,
+                    'SENDCFGFILE:' . (int) $host['id'] . "\n",
+                    FILE_APPEND | LOCK_EX
                 );
-                if ($return) {
+                if ($written === false) {
                     throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
                 }
                 if (! isset($msg_restart[$host['id']])) {

--- a/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -125,7 +125,9 @@ if ($form->validate()) {
                 $output = [];
                 $returnVal = 0;
                 exec(
-                    escapeshellcmd(_CENTREON_PATH_ . "/bin/generateSqlLite '{$host['id']}' '{$filename}'") . ' 2>&1',
+                    _CENTREON_PATH_ . '/bin/generateSqlLite '
+                    . escapeshellarg((string) $host['id']) . ' '
+                    . escapeshellarg($filename) . ' 2>&1',
                     $output,
                     $returnVal
                 );
@@ -139,11 +141,12 @@ if ($form->validate()) {
         if (isset($ret['apply']) && $ret['apply'] && $returnVal == 0) {
             $msg_generate .= sprintf('<strong>%s</strong><br/>', _('Centcore commands'));
             foreach ($tab_server as $host) {
-                passthru(
-                    escapeshellcmd("echo 'SYNCTRAP:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                    $return
+                $return = file_put_contents(
+                    $centcore_pipe,
+                    'SYNCTRAP:' . (int) $host['id'] . "\n",
+                    FILE_APPEND | LOCK_EX
                 );
-                if ($return) {
+                if ($return === false) {
                     $msg_generate .= "Error while writing into {$centcore_pipe}<br/>";
                 } else {
                     $msg_generate .= "Poller (id:{$host['id']}): SYNCTRAP sent to centcore.cmd<br/>";
@@ -152,11 +155,12 @@ if ($form->validate()) {
         }
         if (isset($ret['signal']) && in_array($ret['signal'], ['RELOADCENTREONTRAPD', 'RESTARTCENTREONTRAPD'])) {
             foreach ($tab_server as $host) {
-                passthru(
-                    escapeshellcmd("echo '{$ret['signal']}:{$host['id']}'") . ' >> ' . escapeshellcmd($centcore_pipe),
-                    $return
+                $return = file_put_contents(
+                    $centcore_pipe,
+                    $ret['signal'] . ':' . (int) $host['id'] . "\n",
+                    FILE_APPEND | LOCK_EX
                 );
-                if ($return) {
+                if ($return === false) {
                     $msg_generate .= "Error while writing into {$centcore_pipe}<br/>";
                 } else {
                     $msg_generate .= "Poller (id:{$host['id']}): {$ret['signal']} sent to centcore.cmd<br/>";

--- a/centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+++ b/centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
@@ -87,8 +87,9 @@ if ($form->validate()) {
         $msg .= str_replace("\n", '<br />', $stdout);
         $msg .= '<br />Moving traps in database...';
 
-        $command = "@CENTREONTRAPD_BINDIR@/centFillTrapDB -f '" . $values['tmp_name']
-            . "' -m " . $manufacturerId . ' --severity=info 2>&1';
+        $command = '@CENTREONTRAPD_BINDIR@/centFillTrapDB -f '
+            . escapeshellarg((string) $values['tmp_name'])
+            . ' -m ' . $manufacturerId . ' --severity=info 2>&1';
 
         if ($debug) {
             echo $command;


### PR DESCRIPTION
## Description

🏷️ `dev-25.10.x` backport for #10005

**Fixes** MON-198102

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 3 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Switched concatenated shell commands to use escapeshellarg for safety.
* Added restartEngine method and validated restart command against regex.
* Validated broker reload command format before executing sudo reload.
* Prevented path traversal and sanitized trapd path when importing MIBs.

**🔧 Refactors**
* Replaced passthru/fopen pipe writes with file_put_contents and checks.
* Escaped configuration file path in system sed calls to prevent issues.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/108943216?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->