### PR TITLE
fix(remote-server): allow nullable dbUser and dbPassword in broker configuration

### DIFF
--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputUnifiedSql.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputUnifiedSql.php
@@ -29,14 +29,14 @@ class OutputUnifiedSql
     /**
      * Get template configuration.
      *
-     * @todo move it as yml
-     *
-     * @param string $dbUser the database user
-     * @param string $dbPassword the database password
+     * @param string $dbHost
+     * @param string|null $dbUser the database user
+     * @param string|null $dbPassword the database password
      *
      * @return array<int, string[]> the configuration template
+     * @todo move it as yml
      */
-    public static function getConfiguration(string $dbHost, string $dbUser, string $dbPassword): array
+    public static function getConfiguration(string $dbHost, ?string $dbUser, ?string $dbPassword): array
     {
         return [
             [

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/CfgCentreonBrokerInfo.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/CfgCentreonBrokerInfo.php
@@ -38,8 +38,8 @@ class CfgCentreonBrokerInfo
      * Get template configuration.
      *
      * @param string $serverName the poller name
-     * @param string $dbUser the database user
-     * @param string $dbPassword the database password
+     * @param string|null $dbUser the database user
+     * @param string|null $dbPassword the database password
      * @param string $dbHost
      *
      * @return array<string, array<string, array<int, array<string>>>> the configuration template
@@ -47,8 +47,8 @@ class CfgCentreonBrokerInfo
      */
     public static function getConfiguration(
         string $serverName,
-        string $dbUser,
-        string $dbPassword,
+        ?string $dbUser,
+        ?string $dbPassword,
         string $dbHost = 'localhost',
     ): array {
         $serverName = strtolower(str_replace(' ', '-', $serverName));


### PR DESCRIPTION
## Description

Fix regression introduced in #10243: `$dbUser` and `$dbPassword` parameters were typed as non-nullable `string` in `OutputUnifiedSql::getConfiguration()` and `CfgCentreonBrokerInfo::getConfiguration()`, causing failures when those values are `null` (e.g. in Docker environments where credentials are not set).

Both parameters are now typed as `?string` to allow `null` values.

**Fixes** MON-198325

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Go to `Configuration > Pollers > Pollers`, click the `Add` button and select ‘Add a Centreon poller’
2. Click Next, select `Create a new poller`, fill in the form, then click `Apply`
3. The poller should be created without any error messages appearing

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Allowed dbUser and dbPassword parameters to be nullable to prevent failures


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109354423?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->