### PR TITLE
fix(notifications): temporary files not removed (26.04 backport - #10288)

### DIFF
--- a/centreon/lua/centreon-cloud-notifications.lua
+++ b/centreon/lua/centreon-cloud-notifications.lua
@@ -59,7 +59,7 @@ local function login()
     end
   }
 
-  ok, err = c:perform()
+  local ok, err = c:perform()
   if not ok then
     broker_log:error(0, "Unable to get a token for the '" .. data.user .. "' user")
   end
@@ -81,7 +81,7 @@ local function update_conf(full_conf)
   broker_log:info(1, "Reading notification configuration: " .. tostring(full_conf))
   local content = broker.json_decode(full_conf)
   if not content then
-    broker_log:error(0, "Unable to decode '" .. tostring(resp) .. "'. Is the URL still accessible?")
+    broker_log:error(0, "[update_conf] Unable to decode '" .. tostring(full_conf) .. "'. Is the URL still accessible?")
     return
   end
   local uid = content.uid
@@ -94,9 +94,9 @@ local function update_conf(full_conf)
   data.current_uid = uid
 
   data.host = {}
-  for i, n in ipairs(content.result) do
+  for _, n in ipairs(content.result) do
     -- For each notification defined in result
-    for ii, h in ipairs(n.hosts) do
+    for _, h in ipairs(n.hosts) do
       -- For each host defined in the notification
       local host_id = h.id
       if not data.host[host_id] then
@@ -106,7 +106,7 @@ local function update_conf(full_conf)
       local hnotif = {events = h.events, notification_id = n.notification_id, service = {}}
       host_conf.notification[#host_conf.notification + 1] = hnotif
       if #h.services > 0 then
-        for iii, s in ipairs(h.services) do
+        for _, s in ipairs(h.services) do
           if s.events > 0 then
             -- Some notifications are configured on this service
             hnotif.service[s.id] = {
@@ -130,6 +130,7 @@ end
 --  configuration in data.host.
 local function get_configuration()
   local loop = true
+  local resp_code = -1
   while loop do
     data.last_refresh = os.time()
     local c = cURL.easy {
@@ -143,11 +144,11 @@ local function get_configuration()
     }
     local full = {resp = ""}
     c:setopt_writefunction(fill_conf, full)
-    ok, err = c:perform()
+    local ok, err = c:perform()
     if not ok then
       broker_log:error(0, "Unable to call the API to get the configuration.: " .. tostring(err))
     end
-    local resp_code = c:getinfo(cURL.INFO_RESPONSE_CODE)
+    resp_code = c:getinfo(cURL.INFO_RESPONSE_CODE)
     broker_log:info(2, "Response code: " .. resp_code)
     if resp_code == 200 then
       update_conf(full.resp)
@@ -165,11 +166,12 @@ local function get_configuration()
     broker_log:info(1, "No change in the configuration")
   elseif resp_code == 200 then
     broker_log:info(1, "Changes available in the configuration")
+  else
+    broker_log:error(0, "[get_configuration] Unexpected response code " .. tostring(resp_code) .. " (API unreachable or perform() failed)")
   end
 end
 
---- Get the notification configuration from the API. The parameter is the
---  notification ID.
+--- Get the notification configuration from the API. The parameter is the notification ID.
 --  @param id The notification ID we know from the first API configuration.
 --  @return A table with the notification content.
 local function get_notification_rule(id)
@@ -184,15 +186,16 @@ local function get_notification_rule(id)
         "x-AUTH-TOKEN: " .. tostring(data.token)
       },
       writefunction = function(resp)
-        content = broker.json_decode(resp)
-        if content then
+        local decoded = broker.json_decode(resp)
+        if decoded then
+          content = decoded
           broker_log:info(2, resp)
         else
-          broker_log:error(0, "Unable to decode the message '" .. tostring(resp) .. "'")
+          broker_log:error(0, "[get_notification_rule] Unable to decode the message: " .. tostring(resp))
         end
       end
     }
-    ok, err = c:perform()
+    local ok, err = c:perform()
     if not ok then
       broker_log:error(0, "Unable to call the API to get the notification " .. id .. ": " .. tostring(err))
     end
@@ -209,10 +212,9 @@ local function get_notification_rule(id)
   return content
 end
 
---- Get the notification configuration from the API. The parameter is the
---  notification ID.
+--- Get the notification details from the API (timeperiod, name, etc.).
 --  @param id The notification ID we know from the first API configuration.
---  @return A table with the notification content.
+--  @return A table with the notification details (including timeperiod).
 local function get_notification(id)
   local content = {}
   local loop = true
@@ -225,15 +227,16 @@ local function get_notification(id)
         "x-AUTH-TOKEN: " .. tostring(data.token)
       },
       writefunction = function(resp)
-        content = broker.json_decode(resp)
-        if content then
+        local decoded = broker.json_decode(resp)
+        if decoded then
+          content = decoded
           broker_log:info(2, resp)
         else
-          broker_log:error(0, "Unable to decode the message '" .. tostring(resp) .. "'")
+          broker_log:error(0, "[get_notification] Unable to decode the message: " .. tostring(resp))
         end
       end
     }
-    ok, err = c:perform()
+    local ok, err = c:perform()
     if not ok then
       broker_log:error(0, "Unable to call the API to get the notif " .. id .. ": " .. tostring(err))
     end
@@ -264,15 +267,16 @@ local function get_time_period(id)
         "x-AUTH-TOKEN: " .. tostring(data.token)
       },
       writefunction = function(resp)
-        content = broker.json_decode(resp)
-        if content then
+        local decoded = broker.json_decode(resp)
+        if decoded then
+          content = decoded
           broker_log:info(2, resp)
         else
-          broker_log:error(0, "Unable to decode the message '" .. tostring(resp) .. "'")
+          broker_log:error(0, "[get_time_period] Unable to decode the message: " .. tostring(resp))
         end
       end
     }
-    ok, err = c:perform()
+    local ok, err = c:perform()
     if not ok then
       broker_log:error(0, "Unable to call the API to get time period : " .. tostring(err))
     end
@@ -324,7 +328,7 @@ local function get_macros(event, conf, hostname)
     id = tostring(event.host_id)
   end
 
-  retval = {
+  local retval = {
     NOTIFICATIONTYPE = notif_type,
     NAME = name,
     STATE = tostring(states[event.state + 1]),
@@ -343,7 +347,7 @@ end
 --  @param macros The table containing the key/value.
 --  @return The resulting text.
 local function replace_macros(text, macros)
-  retval = text
+  local retval = text
   for k, v in pairs(macros) do
     broker_log:info(2, "replacing {{" .. k .. "}} by its value <<" .. v .. ">>")
     -- '%' is a specific character in gsub, we must escape it.
@@ -354,7 +358,7 @@ local function replace_macros(text, macros)
 end
 
 --- Escape shell characters in a string to prevent command injection.
----  This function escapes only what expands inside double quotes: \, ", $, `, '.
+---  This function escapes only what expands inside double quotes: \, ", $, `.
 --- Keep content (spaces/HTML) intact.
 --- @param str The string to escape.
 local function escape_shell_chars(str)
@@ -366,7 +370,6 @@ local function escape_shell_chars(str)
            :gsub('"', '\\"')
            :gsub("%$", "\\$")
            :gsub("`", "\\`")
-           :gsub("'", "\\'")
   return str
 end
 
@@ -408,20 +411,22 @@ local function send_mail(notif, event, conf, hostname)
   }
 
   --- Create temporary files for destination and message json files
-  local dest_tmpname = os.tmpname() .. ".json"
+  local dest_tmpname = os.tmpname()
   local dest_file = io.open(dest_tmpname, "w")
   if not dest_file then
-    broker_log:error(0, "Unable to create destination file: " .. dest_tmpname)
+    broker_log:error(0, "Unable to open destination file: " .. dest_tmpname)
+    os.remove(dest_tmpname)
     return
   end
   dest_file:write(broker.json_encode(destination_json))
   dest_file:close()
 
-  local msg_tmpname = os.tmpname() .. ".json"
+  local msg_tmpname = os.tmpname()
   local msg_file = io.open(msg_tmpname, "w")
   if not msg_file then
-    broker_log:error(0, "Unable to create message file: " .. msg_tmpname)
+    broker_log:error(0, "Unable to open message file: " .. msg_tmpname)
     os.remove(dest_tmpname)
+    os.remove(msg_tmpname)
     return
   end
   msg_file:write(broker.json_encode(message_json))
@@ -434,14 +439,22 @@ local function send_mail(notif, event, conf, hostname)
   cmd = string.gsub(cmd, "{{MESSAGE_FILE}}", escape_shell_chars(msg_tmpname))
 
   broker_log:info(1, "command content: " .. cmd)
-  -- Execution of the command
-  local f = io.popen(cmd, "r")
-  if f then
-    local s = f:read("*a")
-    f:close()
-    broker_log:info(0, "Sending notification -- output: " .. tostring(s))
+  -- Execution of the command; stderr is merged into stdout so aws errors are captured.
+  local f = io.popen(cmd .. " 2>&1", "r")
+  if not f then
+    broker_log:error(0, "Unable to start mail command: " .. cmd)
   else
-    broker_log:error(0, "Unable to get '" .. cmd .. "' output.")
+    local output = f:read("*a")
+    local ok, exit_type, exit_code = f:close()
+    output = output and output:gsub("%s+$", "") or ""
+    if ok then
+      broker_log:info(0, "Notification sent" .. (#output > 0 and (": " .. output) or ""))
+    else
+      broker_log:error(0, "Mail command failed"
+        .. " (exit_type=" .. tostring(exit_type)
+        .. " code=" .. tostring(exit_code) .. ")"
+        .. (#output > 0 and (" -- " .. output) or ""))
+    end
   end
 
   -- Removing temporary files
@@ -476,11 +489,13 @@ function init(conf)
       local content = f:read("*a")
       f:close()
       local j = broker.json_decode(content)
-      if j.user and j.password then
+      if not j then
+        broker_log:error(0, "The file '" .. data.authfile .. "' is not valid JSON")
+      elseif not j.user or not j.password then
+        broker_log:error(0, "The file '" .. data.authfile .. "' doesn't contain the good entries")
+      else
         data.user = j.user
         data.password = j.password
-      else
-        broker_log:error(0, "The file '" .. data.authfile .. "' doesn't contain the good entries")
       end
     else
       broker_log:error(0, "The specified file '" .. data.authfile .. "' doesn't exist")
@@ -507,7 +522,19 @@ function init(conf)
 end
 
 local function is_notifiable(notification)
+  if not notification or not notification.notification_id then
+    broker_log:error(0, "is_notifiable: missing notification_id (API call may have failed)")
+    return false
+  end
   local notif = get_notification(notification.notification_id)
+  if not notif.timeperiod then
+    broker_log:error(0, "is_notifiable: notification " .. tostring(notification.notification_id) .. " has no timeperiod (API call may have failed)")
+    return false
+  end
+  if notif.timeperiod.id == nil then
+    broker_log:error(0, "is_notifiable: notification " .. tostring(notification.notification_id) .. " has a timeperiod with no id")
+    return false
+  end
   local time_period = get_time_period(notif.timeperiod.id)
   return time_period.in_period == true
 end


### PR DESCRIPTION

(cherry picked from commit 04a6634c866683dc85105206b88f6fde7e89db6c)

## Description

- temporary files not removed
- add more logs on sendMail
- various fixes (variables names, missing local declarations, errors handling)

**Fixes** MON-198371

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Send multiple notifications and check that all notifications are sent and /tmp directory doesn't contains any lua_xxx files.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added additional logging around sendMail and API response handling

**🐛 Bugfixes**
* Removed leftover temporary files to ensure /tmp cleanup occurred

**🔧 Refactors**
* Made variables local and simplified iteration variables for clarity


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109522507?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->