### PR TITLE
fix(vault): cache vault auth token and GET responses to reduce HTTP calls

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
@@ -63,6 +63,8 @@ abstract class AbstractVaultRepository
 
     protected string $customPath = '';
 
+    private ?string $cachedAuthToken = null;
+
     public function __construct(
         protected ReadVaultConfigurationRepositoryInterface $configurationRepository,
         protected AmpHttpClient $httpClient,
@@ -99,6 +101,10 @@ abstract class AbstractVaultRepository
      */
     public function getAuthenticationToken(): string
     {
+        if ($this->cachedAuthToken !== null) {
+            return $this->cachedAuthToken;
+        }
+
         try {
             $vaultConfiguration = $this->vaultConfiguration ?? throw new \LogicException();
         } catch (\LogicException $exception) {
@@ -131,7 +137,9 @@ abstract class AbstractVaultRepository
             throw new \Exception('Unable to authenticate to Vault');
         }
 
-        return $content['auth']['client_token'];
+        $this->cachedAuthToken = $content['auth']['client_token'];
+
+        return $this->cachedAuthToken;
     }
 
     protected function buildUrl(string $uuid): string

--- a/centreon/src/Core/Common/Infrastructure/Repository/ReadVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/ReadVaultRepository.php
@@ -34,6 +34,9 @@ class ReadVaultRepository extends AbstractVaultRepository implements ReadVaultRe
     use LoggerTrait;
     use VaultTrait;
 
+    /** @var array<string, array<string, string>> */
+    private array $responseCache = [];
+
     /**
      * @inheritDoc
      */
@@ -53,9 +56,15 @@ class ReadVaultRepository extends AbstractVaultRepository implements ReadVaultRe
             . '/v1/' . $customPath;
         $url = sprintf('%s://%s', parent::DEFAULT_SCHEME, $url);
 
+        if (isset($this->responseCache[$url])) {
+            return $this->responseCache[$url];
+        }
+
         $responseContent = $this->sendRequest('GET', $url);
         if (is_array($responseContent) && isset($responseContent['data']['data'])) {
-            return $responseContent['data']['data'];
+            $this->responseCache[$url] = $responseContent['data']['data'];
+
+            return $this->responseCache[$url];
         }
 
         return [];

--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -445,7 +445,9 @@ class Broker extends AbstractObjectJSON
             }
 
             if ($this->isVaultEnabled && $this->readVaultRepository !== null) {
-                $this->resolveVaultOutputs($object);
+                foreach ($object['output'] as $outputIndex => $output) {
+                    $this->processVaultOutput($output, $outputIndex, $object);
+                }
             }
             $shouldBeEncrypted = $this->readMonitoringServerRepository->isEncryptionReady($pollerId);
             $dbSslEnabled = null;
@@ -825,55 +827,72 @@ class Broker extends AbstractObjectJSON
     }
 
     /**
-     * Collect all vault paths from broker outputs and resolve them in a single multiplexed request.
+     * Process vault output and update object with vault data.
      *
+     * @param array $output
+     * @param int $outputIndex
      * @param array $object
      * @return void
      */
-    private function resolveVaultOutputs(array &$object): void
+    private function processVaultOutput(array &$output, int $outputIndex, array &$object): void
     {
-        $vaultPaths = [];
-        foreach ($object['output'] as $outputIndex => $output) {
-            foreach ($output as $outputKey => $outputValue) {
-                if (is_string($outputValue) && $this->isAVaultPath($outputValue)) {
-                    $vaultPaths[$outputIndex . '::' . $outputKey] = $outputValue;
-                }
-                if ($outputKey === 'lua_parameter' && is_array($outputValue)) {
-                    foreach ($outputValue as $parameterIndex => $luaParameter) {
-                        if ($luaParameter['type'] === 'password'
-                            && is_string($luaParameter['value'])
-                            && $this->isAVaultPath($luaParameter['value'])
-                        ) {
-                            $vaultPaths[$outputIndex . '::lua::' . $parameterIndex] = $luaParameter['value'];
-                        }
-                    }
-                }
+        foreach ($output as $outputKey => $outputValue) {
+            if (is_string($outputValue) && $this->isAVaultPath($outputValue)) {
+                $this->updateVaultData($output, $outputKey, $outputValue, $object['output'][$outputIndex]);
+            }
+
+            if ($outputKey === 'lua_parameter' && is_array($outputValue)) {
+                $this->processLuaParameters($output, $outputKey, $outputValue, $object['output'][$outputIndex]);
             }
         }
+    }
 
-        if ($vaultPaths === []) {
-            return;
+    /**
+     * Update vault data for a given key.
+     *
+     * @param array $output
+     * @param string $outputKey
+     * @param string $outputValue
+     * @param array $outputReference
+     * @return void
+     */
+    private function updateVaultData(
+        array &$output,
+        string $outputKey,
+        string $outputValue,
+        array &$outputReference,
+    ): void {
+        $vaultData = $this->readVaultRepository->findFromPath($outputValue);
+        $vaultKey = $output['name'] . '_' . $outputKey;
+        if (array_key_exists($vaultKey, $vaultData)) {
+            $outputReference[$outputKey] = $vaultData[$vaultKey];
         }
+    }
 
-        $vaultData = $this->readVaultRepository->findFromPaths($vaultPaths);
-
-        foreach ($vaultData as $compositeKey => $data) {
-            $parts = explode('::', $compositeKey);
-            $outputIndex = (int) $parts[0];
-            $output = $object['output'][$outputIndex];
-
-            if (isset($parts[1]) && $parts[1] === 'lua') {
-                $parameterIndex = (int) $parts[2];
-                $luaParameter = $output['lua_parameter'][$parameterIndex];
-                $vaultKey = $output['name'] . '_lua_parameter_' . $luaParameter['name'];
-                if (array_key_exists($vaultKey, $data)) {
-                    $object['output'][$outputIndex]['lua_parameter'][$parameterIndex]['value'] = $data[$vaultKey];
-                }
-            } else {
-                $outputKey = $parts[1];
-                $vaultKey = $output['name'] . '_' . $outputKey;
-                if (array_key_exists($vaultKey, $data)) {
-                    $object['output'][$outputIndex][$outputKey] = $data[$vaultKey];
+    /**
+     * Process Lua parameters and update with vault data if applicable.
+     *
+     * @param array $output
+     * @param string $outputKey
+     * @param array $luaParameters
+     * @param array $outputReference
+     * @return void
+     */
+    private function processLuaParameters(
+        array &$output,
+        string $outputKey,
+        array $luaParameters,
+        array &$outputReference,
+    ): void {
+        foreach ($luaParameters as $parameterIndex => $luaParameter) {
+            if ($luaParameter['type'] === 'password'
+                && is_string($luaParameter['value'])
+                && $this->isAVaultPath($luaParameter['value'])
+            ) {
+                $vaultData = $this->readVaultRepository->findFromPath($luaParameter['value']);
+                $vaultKey = $output['name'] . '_' . $outputKey . '_' . $luaParameter['name'];
+                if (array_key_exists($vaultKey, $vaultData)) {
+                    $outputReference[$outputKey][$parameterIndex]['value'] = $vaultData[$vaultKey];
                 }
             }
         }

--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -445,9 +445,7 @@ class Broker extends AbstractObjectJSON
             }
 
             if ($this->isVaultEnabled && $this->readVaultRepository !== null) {
-                foreach ($object['output'] as $outputIndex => $output) {
-                    $this->processVaultOutput($output, $outputIndex, $object);
-                }
+                $this->resolveVaultOutputs($object);
             }
             $shouldBeEncrypted = $this->readMonitoringServerRepository->isEncryptionReady($pollerId);
             $dbSslEnabled = null;
@@ -827,72 +825,55 @@ class Broker extends AbstractObjectJSON
     }
 
     /**
-     * Process vault output and update object with vault data.
+     * Collect all vault paths from broker outputs and resolve them in a single multiplexed request.
      *
-     * @param array $output
-     * @param int $outputIndex
      * @param array $object
      * @return void
      */
-    private function processVaultOutput(array &$output, int $outputIndex, array &$object): void
+    private function resolveVaultOutputs(array &$object): void
     {
-        foreach ($output as $outputKey => $outputValue) {
-            if (is_string($outputValue) && $this->isAVaultPath($outputValue)) {
-                $this->updateVaultData($output, $outputKey, $outputValue, $object['output'][$outputIndex]);
-            }
-
-            if ($outputKey === 'lua_parameter' && is_array($outputValue)) {
-                $this->processLuaParameters($output, $outputKey, $outputValue, $object['output'][$outputIndex]);
+        $vaultPaths = [];
+        foreach ($object['output'] as $outputIndex => $output) {
+            foreach ($output as $outputKey => $outputValue) {
+                if (is_string($outputValue) && $this->isAVaultPath($outputValue)) {
+                    $vaultPaths[$outputIndex . '::' . $outputKey] = $outputValue;
+                }
+                if ($outputKey === 'lua_parameter' && is_array($outputValue)) {
+                    foreach ($outputValue as $parameterIndex => $luaParameter) {
+                        if ($luaParameter['type'] === 'password'
+                            && is_string($luaParameter['value'])
+                            && $this->isAVaultPath($luaParameter['value'])
+                        ) {
+                            $vaultPaths[$outputIndex . '::lua::' . $parameterIndex] = $luaParameter['value'];
+                        }
+                    }
+                }
             }
         }
-    }
 
-    /**
-     * Update vault data for a given key.
-     *
-     * @param array $output
-     * @param string $outputKey
-     * @param string $outputValue
-     * @param array $outputReference
-     * @return void
-     */
-    private function updateVaultData(
-        array &$output,
-        string $outputKey,
-        string $outputValue,
-        array &$outputReference,
-    ): void {
-        $vaultData = $this->readVaultRepository->findFromPath($outputValue);
-        $vaultKey = $output['name'] . '_' . $outputKey;
-        if (array_key_exists($vaultKey, $vaultData)) {
-            $outputReference[$outputKey] = $vaultData[$vaultKey];
+        if ($vaultPaths === []) {
+            return;
         }
-    }
 
-    /**
-     * Process Lua parameters and update with vault data if applicable.
-     *
-     * @param array $output
-     * @param string $outputKey
-     * @param array $luaParameters
-     * @param array $outputReference
-     * @return void
-     */
-    private function processLuaParameters(
-        array &$output,
-        string $outputKey,
-        array $luaParameters,
-        array &$outputReference,
-    ): void {
-        foreach ($luaParameters as $parameterIndex => $luaParameter) {
-            if ($luaParameter['type'] === 'password'
-                && is_string($luaParameter['value'])
-                && $this->isAVaultPath($luaParameter['value'])
-            ) {
-                $vaultData = $this->readVaultRepository->findFromPath($luaParameter['value']);
-                $vaultKey = $output['name'] . '_' . $outputKey . '_' . $luaParameter['name'];
-                if (array_key_exists($vaultKey, $vaultData)) {
-                    $outputReference[$outputKey][$parameterIndex]['value'] = $vaultData[$vaultKey];
+        $vaultData = $this->readVaultRepository->findFromPaths($vaultPaths);
+
+        foreach ($vaultData as $compositeKey => $data) {
+            $parts = explode('::', $compositeKey);
+            $outputIndex = (int) $parts[0];
+            $output = $object['output'][$outputIndex];
+
+            if (isset($parts[1]) && $parts[1] === 'lua') {
+                $parameterIndex = (int) $parts[2];
+                $luaParameter = $output['lua_parameter'][$parameterIndex];
+                $vaultKey = $output['name'] . '_lua_parameter_' . $luaParameter['name'];
+                if (array_key_exists($vaultKey, $data)) {
+                    $object['output'][$outputIndex]['lua_parameter'][$parameterIndex]['value'] = $data[$vaultKey];
+                }
+            } else {
+                $outputKey = $parts[1];
+                $vaultKey = $output['name'] . '_' . $outputKey;
+                if (array_key_exists($vaultKey, $data)) {
+                    $object['output'][$outputIndex][$outputKey] = $data[$vaultKey];
                 }
             }
         }


### PR DESCRIPTION
## Description

Optimizes vault HTTP calls by adding two caching layers:

- **Auth token cache** (`AbstractVaultRepository`): caches the vault authentication token per instance, eliminating redundant `POST /v1/auth/approle/login` calls (1 auth per config generation instead of N).
- **GET response cache** (`ReadVaultRepository`): caches `findFromPath` results by URL, so when the same vault secret (same UUID) is queried for different fields (db_host, db_name, db_password, etc.), only one HTTP GET is made (1 GET per unique UUID instead of N).

The broker config generation logic (`broker.class.php`) is left unchanged to preserve existing behavior.

**Fixes** MON-198456

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## How this pull request can be tested ?

- Configure a vault and store broker credentials (db_host, db_name, db_user, db_password) in it
- Export the poller configuration
- Verify that the broker config files are generated correctly with resolved vault values
- Check logs to confirm auth token is reused across requests and GET responses are cached per UUID
- Verify engine uptime (lastUpdateTime) keeps updating after config deployment

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Cached Vault authentication token per repository instance to reduce logins
* Cached GET responses by URL in ReadVaultRepository to avoid duplicate requests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112352490?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->