### PR TITLE
fix(actionLog): use getContactId in deleteByHostIdAndServiceTemplateId

### DIFF
--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php
@@ -45,8 +45,6 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
 {
     use LoggerTrait;
 
-    public mixed $contact;
-
     /**
      * @param WriteServiceRepositoryInterface $writeServiceRepository
      * @param TokenStorageInterface $tokenStorage
@@ -239,7 +237,7 @@ class DbWriteServiceActionLogRepository extends AbstractRepositoryRDB implements
                     $service['id'],
                     $service['name'],
                     ActionLog::ACTION_TYPE_DELETE,
-                    $this->contact->getId()
+                    $this->getContactId()
                 );
                 $this->writeActionLogRepository->addAction($actionLog);
             }


### PR DESCRIPTION
## Description

`DbWriteServiceActionLogRepository::deleteByHostIdAndServiceTemplateId()` still referenced `$this->contact->getId()` after PR #10053 migrated the repository to a `TokenStorageInterface`-backed `getContactId()` helper. The property is declared `public mixed $contact;` without initialization, which throws a `must not be accessed before initialization` error on PHP 8+ whenever this method runs.

Symptom: removing a host template from an existing host fails with a 500 error, and the change is rolled back. `/var/log/centreon/centreon-web.log` shows:

```
Typed property Core\Service\Infrastructure\Repository\DbWriteServiceActionLogRepository::$contact must not be accessed before initialization
in src/Core/Service/Infrastructure/Repository/DbWriteServiceActionLogRepository.php:242
```

Replace the lone `$this->contact->getId()` call with `$this->getContactId()` to match the other 5 call sites in the class, and remove the dead `public mixed $contact;` property declaration.

PR #10053 is on `develop` but not on `dev-25.10.x`, so this regression only affects branches downstream of `develop`. No backport needed.

Fixes: [MON-198590](https://centreon.atlassian.net/browse/MON-198590)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1. Have a host that uses a host template with linked services.
2. Edit the host and remove the template from the templates field.
3. Save.
4. **Before this PR**: the save fails with a 500 error and `centreon-web.log` shows the typed-property error.
5. **After this PR**: the template is removed cleanly; services that came from the removed template are deleted; no error in logs.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-198590]: https://centreon.atlassian.net/browse/MON-198590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced direct contact property access with helper and removed dead property


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112342431?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->