### PR TITLE
fix(vault): cache vault auth token and GET responses to reduce HTTP calls

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
@@ -63,6 +63,8 @@ abstract class AbstractVaultRepository
 
     protected string $customPath = '';
 
+    private ?string $cachedAuthToken = null;
+
     public function __construct(
         protected ReadVaultConfigurationRepositoryInterface $configurationRepository,
         protected AmpHttpClient $httpClient,
@@ -99,6 +101,10 @@ abstract class AbstractVaultRepository
      */
     public function getAuthenticationToken(): string
     {
+        if ($this->cachedAuthToken !== null) {
+            return $this->cachedAuthToken;
+        }
+
         try {
             $vaultConfiguration = $this->vaultConfiguration ?? throw new \LogicException();
         } catch (\LogicException $exception) {
@@ -131,7 +137,9 @@ abstract class AbstractVaultRepository
             throw new \Exception('Unable to authenticate to Vault');
         }
 
-        return $content['auth']['client_token'];
+        $this->cachedAuthToken = $content['auth']['client_token'];
+
+        return $this->cachedAuthToken;
     }
 
     protected function buildUrl(string $uuid): string

--- a/centreon/src/Core/Common/Infrastructure/Repository/ReadVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/ReadVaultRepository.php
@@ -34,6 +34,9 @@ class ReadVaultRepository extends AbstractVaultRepository implements ReadVaultRe
     use LoggerTrait;
     use VaultTrait;
 
+    /** @var array<string, array<string, string>> */
+    private array $responseCache = [];
+
     /**
      * @inheritDoc
      */
@@ -53,9 +56,15 @@ class ReadVaultRepository extends AbstractVaultRepository implements ReadVaultRe
             . '/v1/' . $customPath;
         $url = sprintf('%s://%s', parent::DEFAULT_SCHEME, $url);
 
+        if (isset($this->responseCache[$url])) {
+            return $this->responseCache[$url];
+        }
+
         $responseContent = $this->sendRequest('GET', $url);
         if (is_array($responseContent) && isset($responseContent['data']['data'])) {
-            return $responseContent['data']['data'];
+            $this->responseCache[$url] = $responseContent['data']['data'];
+
+            return $this->responseCache[$url];
         }
 
         return [];


### PR DESCRIPTION
REF #https://github.com/centreon/centreon/pull/10322

## Description


**Fixes** MON-198644

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Set up a Centreon platform with Vault integration enabled
2. Configure multiple broker outputs with vault-stored credentials
3. Trigger a configuration export
4. Verify the export starts within a few seconds instead of 20+

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Cached Vault authentication token to avoid redundant login requests
* Cached Vault GET responses per URL to reduce HTTP calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112723653?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->