### PR TITLE
fix(ci): fetch tags when input base sha is given

### DIFF
--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -80,6 +80,12 @@ jobs:
       trigger_delivery: ${{ github.event_name == 'workflow_dispatch' && steps.get_dispatch_triggers.outputs.trigger_delivery || steps.get_triggers.outputs.trigger_delivery || 'true' }}
 
     steps:
+      - name: Checkout sources
+        if: inputs.base_sha != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-tags: true
+
       - name: Convert inputs to yaml list
         if: github.event_name == 'pull_request' || inputs.base_sha != ''
         id: inline_inputs


### PR DESCRIPTION
## Description

fix(ci): fetch tags when input base sha is given

**Fixes** MON-198652

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added conditional checkout that fetched tags when base SHA provided
* Ran input conversion and changed-files logic when base SHA was present


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112778824?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->