### PR TITLE
fix(ci): restrict open-tickets e2e lint scope to features directory

### DIFF
--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -274,6 +274,7 @@ jobs:
           module_name: ${{ env.module }}
           dependencies_lock_file: ${{ env.e2e_directory }}/pnpm-lock.yaml
           pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          lint_path: ./features/
 
   package:
     needs:


### PR DESCRIPTION
## Summary

- The `e2e-lint` job in the open-tickets workflow was running Biome on the entire `centreon-open-tickets/tests/e2e` directory (`.`) via reviewdog, causing errors in `common.ts` to surface that were not caught locally
- Local `pnpm lint:ci` only scans `./features`, creating a discrepancy with CI
- Add `lint_path: ./features/` to align the reviewdog scope with the local lint command

linked with this change : https://github.com/centreon/centreon/pull/10270

## Test plan

- [ ] Verify `e2e-lint` job passes on `release-25.10-next`