### PR TITLE
feat(docker): enable crond service by default in Alma9 container image

### DIFF
--- a/.github/docker/centreon-web/alma10/Dockerfile
+++ b/.github/docker/centreon-web/alma10/Dockerfile
@@ -54,6 +54,7 @@ systemctl stop cbd
 systemctl stop httpd
 systemctl stop php-fpm
 systemctl stop snmpd
+systemctl stop crond
 
 dnf clean all
 

--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/62-crond_background.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/62-crond_background.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting crond daemon..."
+systemctl start crond
+echo "crond daemon started."

--- a/.github/docker/centreon-web/alma9/Dockerfile
+++ b/.github/docker/centreon-web/alma9/Dockerfile
@@ -54,6 +54,7 @@ systemctl stop cbd
 systemctl stop httpd
 systemctl stop php-fpm
 systemctl stop snmpd
+systemctl stop crond
 
 dnf clean all
 

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/62-crond_background.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/62-crond_background.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting crond daemon..."
+systemctl start crond
+echo "crond daemon started."

--- a/.github/docker/centreon-web/trixie/Dockerfile
+++ b/.github/docker/centreon-web/trixie/Dockerfile
@@ -59,6 +59,7 @@ systemctl stop cbd
 systemctl stop apache2
 systemctl stop php${PHP_VERSION}-fpm
 systemctl stop snmpd
+systemctl stop cron
 
 apt-get clean
 

--- a/.github/docker/centreon-web/trixie/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/trixie/Dockerfile.dependencies
@@ -72,6 +72,7 @@ apt-get install -y \
   python3 \
   sed \
   snmpd \
+  cron \
   systemd \
   systemd-sysv \
   sudo

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/62-crond_background.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/62-crond_background.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting cron daemon..."
+systemctl start cron
+echo "cron daemon started."


### PR DESCRIPTION
## Summary

- Enables `crond` daemon by default in the Alma9 Docker container image for Centreon web
- Adds entrypoint script `62-crond_background.sh` to start `crond` at container startup
- Stops `crond` during image build to avoid dangling processes in image layers

## Context

Centreon Docker images rely on scheduled cron jobs for critical background operations (statistics computation, RRD cleanup, data purge). Without `crond` running, these tasks are silently skipped in containerized environments, causing inconsistent behavior vs bare-metal deployments.

## Scope

This PR targets **Alma9** only. Replication to `alma10` and `trixie` will follow once this is validated.

## Changes

- `.github/docker/centreon-web/alma9/Dockerfile`: added `systemctl stop crond` to build-time service cleanup
- `.github/docker/centreon-web/alma9/entrypoint/container.d/62-crond_background.sh`: new script to start crond at container init

## Jira

[MON-197369](https://centreon.atlassian.net/browse/MON-197369)

[MON-197369]: https://centreon.atlassian.net/browse/MON-197369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ