### PR TITLE
feat(docker): enable crond service by default in Alma9 container image

### DIFF
--- a/.github/docker/centreon-web/alma8/Dockerfile
+++ b/.github/docker/centreon-web/alma8/Dockerfile
@@ -41,6 +41,7 @@ systemctl stop cbd
 systemctl stop httpd
 systemctl stop php-fpm
 systemctl stop snmpd
+systemctl stop crond
 
 dnf clean all
 

--- a/.github/docker/centreon-web/alma8/entrypoint/container.d/62-crond_background.sh
+++ b/.github/docker/centreon-web/alma8/entrypoint/container.d/62-crond_background.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting crond daemon..."
+systemctl start crond
+echo "crond daemon started."

--- a/.github/docker/centreon-web/alma9/Dockerfile
+++ b/.github/docker/centreon-web/alma9/Dockerfile
@@ -54,6 +54,7 @@ systemctl stop cbd
 systemctl stop httpd
 systemctl stop php-fpm
 systemctl stop snmpd
+systemctl stop crond
 
 dnf clean all
 rm -rf /usr/share/doc /usr/share/man /usr/share/info

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/62-crond_background.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/62-crond_background.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting crond daemon..."
+systemctl start crond
+echo "crond daemon started."

--- a/.github/docker/centreon-web/bookworm/Dockerfile
+++ b/.github/docker/centreon-web/bookworm/Dockerfile
@@ -58,6 +58,7 @@ systemctl stop cbd
 systemctl stop apache2
 systemctl stop php8.2-fpm
 systemctl stop snmpd
+systemctl stop cron
 
 apt-get clean
 rm -rf /usr/share/doc /usr/share/man /usr/share/info

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -73,6 +73,7 @@ apt-get install -y \
   python3 \
   sed \
   snmpd \
+  cron \
   software-properties-common \
   sudo
 

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/62-crond_background.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/62-crond_background.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting cron daemon..."
+systemctl start cron
+echo "cron daemon started."


### PR DESCRIPTION
## Description
Backport of #10359 to `dev-25.10.x`.

Enables the `crond` daemon by default in Centreon Docker container images. Without `crond` running, scheduled maintenance tasks (RRD cleanup, data purge, statistics) are silently skipped in containerized environments, causing inconsistent behavior vs bare-metal deployments.

Changes per distro:
- **alma8**: `systemctl stop crond` in Dockerfile + new `62-crond_background.sh` entrypoint
- **alma9**: `systemctl stop crond` in Dockerfile + new `62-crond_background.sh` entrypoint
- **bookworm**: `cron` package added in `Dockerfile.dependencies` + `systemctl stop cron` in Dockerfile + new `62-crond_background.sh` entrypoint (`systemctl start cron`)

Ref: MON-198901

**Fixes** MON-198901

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?
Same testing procedure as #10359.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).