### PR TITLE
Mon 198960 fix is string usage for host service monitoring widgets

### DIFF
--- a/centreon/GPL_LIB/smarty-plugins/SmartyBC.php
+++ b/centreon/GPL_LIB/smarty-plugins/SmartyBC.php
@@ -45,6 +45,7 @@ class SmartyBC extends Smarty
         'json_encode',
         'strtotime',
         'number_format',
+        'is_string',
     ];
     /**
      * Forbidden tags in Smarty templates.

--- a/centreon/www/widgets/host-monitoring/src/table.ihtml
+++ b/centreon/www/widgets/host-monitoring/src/table.ihtml
@@ -90,7 +90,7 @@
             {if is_string($elem.last_check)}
                 <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_check}</td>
             {else}
-                <td class='ListColCenter isTimestamp' style='white-space:nowrap;'>{$elem.last_check}</>
+                <td class='ListColCenter isTimestamp' style='white-space:nowrap;'>{$elem.last_check}</td>
             {/if}
         {/if}
 

--- a/centreon/www/widgets/host-monitoring/src/table.ihtml
+++ b/centreon/www/widgets/host-monitoring/src/table.ihtml
@@ -87,21 +87,19 @@
         {if $preferences.display_ip}<td class='ListColRight' style='white-space:nowrap;'>{$elem.address}</td>{/if}
 
         {if $preferences.display_last_check}
-            {if is_string($elem.last_check)}<td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_check}</td>
-        {else}
-            <td class='ListColCenter isTimestamp' style='white-space:nowrap;'>{$elem.last_check}</td>{/if}
+            {if is_string($elem.last_check)}
+                <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_check}</td>
+            {else}
+                <td class='ListColCenter isTimestamp' style='white-space:nowrap;'>{$elem.last_check}</>
+            {/if}
         {/if}
 
         {if $preferences.display_duration}
-            {if is_string($elem.last_state_change)}<td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>
-        {else}
-            <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>{/if}
+            <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>
         {/if}
 
         {if $preferences.display_hard_state_duration}
-            {if is_string($elem.last_hard_state_change)}<td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_hard_state_change}</td>
-        {else}
-            <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_hard_state_change}</td>{/if}
+            <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_hard_state_change}</td>
         {/if}
 
         {if $preferences.display_tries}<td class='ListColCenter' style='white-space:nowrap;'>{$elem.check_attempt}</td>{/if}

--- a/centreon/www/widgets/service-monitoring/src/table.ihtml
+++ b/centreon/www/widgets/service-monitoring/src/table.ihtml
@@ -132,19 +132,11 @@
                 {/if}
 
                 {if $preferences.display_duration}
-                    {if is_string($elem.last_state_change)}
-                        <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>
-                    {else}
-                        <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>
-                    {/if}
+                    <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_state_change}</td>
                 {/if}
 
                 {if $preferences.display_hard_state_duration}
-                    {if is_string($elem.last_hard_state_change)}
-                        <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_hard_state_change}</td>
-                    {else}
-                        <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_hard_state_change}</td>
-                    {/if}
+                    <td class='ListColCenter' style='white-space:nowrap;'>{$elem.last_hard_state_change}</td>
                 {/if}
 
                 {if $preferences.display_last_check}


### PR DESCRIPTION
## Description

avoid warning messages with is_string smarty function not being declared

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
