### PR TITLE
feat(internal-api-client): make URL resolution configurable via env and server vars

### DIFF
--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       CENTREON_LANG: ${CENTREON_LANG:-en_US}
       DATABASE_PARTITIONING: ${DATABASE_PARTITIONING:-1}
       DEBUG: ${DEBUG:-0}
+      CENTREON_INTERNAL_API_BASE_URL: ${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}
     healthcheck:
       test: bash -c "[ -f /tmp/docker.ready ]" && curl --fail http://localhost/centreon/api/latest/platform/versions || exit 1
       interval: 1s

--- a/centreon/config/packages/framework.yaml
+++ b/centreon/config/packages/framework.yaml
@@ -1,5 +1,18 @@
+parameters:
+    # Default value used when the TRUSTED_PROXIES environment variable is not set.
+    # REMOTE_ADDR is a Symfony keyword replaced at runtime by the actual client IP,
+    # so X-Forwarded-* headers are honoured for a local reverse proxy.
+    env(TRUSTED_PROXIES): '127.0.0.1,REMOTE_ADDR'
+
 framework:
     secret: '%env(APP_SECRET)%'
+
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
+    trusted_headers:
+        - 'x-forwarded-for'
+        - 'x-forwarded-host'
+        - 'x-forwarded-proto'
+        - 'x-forwarded-port'
 
     php_errors:
         log: true

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -31,6 +31,8 @@ parameters:
     required_mariadb_min_version: "%env(_CENTREON_MARIA_DB_MIN_VERSION_)%"
     env(IS_CLOUD_PLATFORM): false
     env(FILE_FEATURE_FLAGS): "%centreon_path%/config/features.json"
+    env(CENTREON_INTERNAL_API_BASE_URL): ''
+
 
 services:
     # Default configuration for services in *this* file

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -139,3 +139,10 @@ services:
     Core\Security\Token\Application\Repository\ReadTokenRepositoryInterface:
         class: Core\Security\Token\Infrastructure\Repository\DbReadTokenRepository
         public: true
+
+    legacy.service_locator:
+      class: Symfony\Component\DependencyInjection\ServiceLocator
+      public: true
+      arguments:
+        - internal_api_client: '@Core\Common\Infrastructure\Api\InternalApiClient'
+      tags: [ 'container.service_locator' ]

--- a/centreon/packaging/src/php-fpm.deb.conf
+++ b/centreon/packaging/src/php-fpm.deb.conf
@@ -13,3 +13,4 @@ php_admin_flag[log_errors] = on
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var/lib/php/sessions
 php_value[soap.wsdl_cache_dir]  = /var/lib/php/wsdlcache
+env[CENTREON_INTERNAL_API_BASE_URL] = $CENTREON_INTERNAL_API_BASE_URL

--- a/centreon/packaging/src/php-fpm.rpm.conf
+++ b/centreon/packaging/src/php-fpm.rpm.conf
@@ -13,3 +13,4 @@ php_admin_flag[log_errors] = on
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var/lib/php/session
 php_value[soap.wsdl_cache_dir]  = /var/lib/php/wsdlcache
+env[CENTREON_INTERNAL_API_BASE_URL] = $CENTREON_INTERNAL_API_BASE_URL

--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -27,6 +27,8 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 /**
@@ -68,6 +70,10 @@ class Kernel extends BaseKernel
                 : 'prod';
             self::$instance = new self($env, (bool) $_SERVER['APP_DEBUG']);
             self::$instance->boot();
+            $request = Request::createFromGlobals();
+            /** @var RequestStack $requestStack */
+            $requestStack = self::$instance->getContainer()->get('request_stack');
+            $requestStack->push($request);
         }
 
         return self::$instance;

--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -82,7 +82,7 @@ final class InternalApiClient
             $this->internalApiBaseUrl,
             $request?->server->get('REQUEST_SCHEME'),
             $request?->server->get('SERVER_ADDR'),
-            $request?->server->getInt('SERVER_PORT'),
+            $request?->server->getInt('SERVER_PORT') ?: null,
         );
         $headers = array_merge(
             [

--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -23,7 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Common\Infrastructure\Api;
 
-use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
@@ -36,17 +37,16 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class InternalApiClient
 {
-    private const DEFAULT_LOCAL_HOST = '127.0.0.1';
-    private const DEFAULT_LOCAL_SCHEME = 'http';
+    private readonly ?string $internalApiBaseUrl;
 
-    private HttpClientInterface $httpClient;
-
-    /**
-     * @param HttpClientInterface|null $httpClient HTTP client (defaults to CurlHttpClient with SSL verification disabled)
-     */
-    public function __construct(?HttpClientInterface $httpClient = null)
-    {
-        $this->httpClient = $httpClient ?? new CurlHttpClient([
+    public function __construct(
+        #[Autowire('%env(CENTREON_INTERNAL_API_BASE_URL)%')]
+        string $internalApiBaseUrl,
+        private readonly RequestStack $requestStack,
+        private HttpClientInterface $httpClient,
+    ) {
+        $this->internalApiBaseUrl = $internalApiBaseUrl ?: null;
+        $this->httpClient = $httpClient->withOptions([
             'verify_peer' => false,
             'verify_host' => false,
         ]);
@@ -76,8 +76,14 @@ final class InternalApiClient
         array $payload = [],
         array $additionalHeaders = [],
     ): array {
-        $localUrl = self::convertToLocalUrl($url);
-
+        $request = $this->requestStack->getCurrentRequest();
+        $url = self::convertToLocalUrl(
+            $url,
+            $this->internalApiBaseUrl,
+            $request?->server->get('REQUEST_SCHEME'),
+            $request?->server->get('SERVER_ADDR'),
+            $request?->server->getInt('SERVER_PORT'),
+        );
         $headers = array_merge(
             [
                 'Content-Type' => 'application/json',
@@ -92,7 +98,7 @@ final class InternalApiClient
             $options['body'] = json_encode($payload, JSON_THROW_ON_ERROR);
         }
 
-        $response = $this->httpClient->request($httpMethod, $localUrl, $options);
+        $response = $this->httpClient->request($httpMethod, $url, $options);
 
         return [
             'status_code' => $response->getStatusCode(),
@@ -107,20 +113,63 @@ final class InternalApiClient
      *
      * @param string $url The original URL (may contain external hostname)
      *
+     * @throws \RuntimeException When required parameters are null and cannot be resolved from the URL
+     *
      * @return string The localhost URL
      */
-    public static function convertToLocalUrl(string $url): string
-    {
+    public static function convertToLocalUrl(
+        string $url,
+        ?string $internalApiBaseUrl = null,
+        ?string $requestScheme = null,
+        ?string $serverAddress = null,
+        ?int $serverPort = null,
+    ): string {
+        if (str_contains($url, '://')) {
+            $scheme = parse_url($url, PHP_URL_SCHEME);
+            if (! is_string($scheme) || filter_var($url, FILTER_VALIDATE_URL) === false) {
+                return $url;
+            }
+            $requestScheme = $scheme;
+        } elseif (! str_starts_with($url, '/')) {
+            $url = '/' . $url;
+        }
+
         $parsedUrl = parse_url($url);
 
         if ($parsedUrl === false) {
             return $url;
         }
 
-        $scheme = (isset($parsedUrl['scheme']) && in_array($parsedUrl['scheme'], ['http', 'https'], true))
-            ? $parsedUrl['scheme']
-            : self::DEFAULT_LOCAL_SCHEME;
-        $localUrl = $scheme . '://' . self::DEFAULT_LOCAL_HOST;
+        $localUrl = null;
+        if (! empty($internalApiBaseUrl)) {
+            $localUrl = self::generateUrlWithoutScheme($internalApiBaseUrl);
+            if ($localUrl !== null) {
+                if ($serverPort !== null && ! str_contains($localUrl, ':')) {
+                    $localUrl .= ':' . $serverPort;
+                }
+                if ($requestScheme === null) {
+                    throw new \RuntimeException(
+                        'Cannot build local URL: request scheme is null.'
+                    );
+                }
+                $localUrl = $requestScheme . '://' . $localUrl;
+            }
+        }
+
+        if ($localUrl === null) {
+            if ($requestScheme === null) {
+                throw new \RuntimeException(
+                    'Cannot build local URL: request scheme is null.'
+                );
+            }
+            if ($serverAddress === null) {
+                throw new \RuntimeException(
+                    'Cannot build local URL: server address is null.'
+                );
+            }
+            $portSuffix = ($serverPort !== null) ? ':' . $serverPort : '';
+            $localUrl = $requestScheme . '://' . $serverAddress . $portSuffix;
+        }
 
         // Add path
         if (isset($parsedUrl['path'])) {
@@ -138,5 +187,31 @@ final class InternalApiClient
         }
 
         return $localUrl;
+    }
+
+    private static function generateUrlWithoutScheme(string $url): ?string
+    {
+        if (str_contains($url, '://')) {
+            $parsed = parse_url($url);
+            if ($parsed === false || ! isset($parsed['host'])) {
+                return null;
+            }
+            $host = $parsed['host'];
+            $port = $parsed['port'] ?? null;
+        } else {
+            $parts = explode(':', $url, 2);
+            $host = $parts[0];
+            $port = isset($parts[1]) ? (int) $parts[1] : null;
+        }
+
+        if (empty($host)) {
+            return null;
+        }
+
+        if ($port !== null && ($port < 1 || $port > 65535)) {
+            return null;
+        }
+
+        return $port !== null ? $host . ':' . $port : $host;
     }
 }

--- a/centreon/src/Core/Infrastructure/Common/Api/HttpUrlTrait.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/HttpUrlTrait.php
@@ -23,22 +23,18 @@ declare(strict_types=1);
 
 namespace Core\Infrastructure\Common\Api;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\ServerBag;
 use Symfony\Contracts\Service\Attribute\Required;
 
 trait HttpUrlTrait
 {
-    /** @var ServerBag|null */
-    private ?ServerBag $httpServerBag = null;
+    private ?Request $request = null;
 
-    /**
-     * @param RequestStack $requestStack
-     */
     #[Required]
     public function setHttpServerBag(RequestStack $requestStack): void
     {
-        $this->httpServerBag = $requestStack->getCurrentRequest()?->server;
+        $this->request = $requestStack->getCurrentRequest();
     }
 
     /**
@@ -48,12 +44,15 @@ trait HttpUrlTrait
      */
     public function getHost(bool $withScheme = false): string
     {
-        $httpHost = $_SERVER['HTTP_HOST'];
-        if ($withScheme) {
-            $scheme = $_SERVER['REQUEST_SCHEME'];
+        if ($this->request === null) {
+            throw new \RuntimeException(
+                'Unable to resolve HTTP host: no current request available in the request stack'
+            );
         }
 
-        return $withScheme ? sprintf('%s://%s', $scheme, $httpHost) : $httpHost;
+        return $withScheme
+            ? $this->request->getSchemeAndHttpHost()
+            : $this->request->getHttpHost();
     }
 
     /**
@@ -63,36 +62,9 @@ trait HttpUrlTrait
      */
     protected function getBaseUrl(): string
     {
-        if (! $this->httpServerBag?->has('SERVER_NAME')) {
-            return '';
-        }
-
-        $protocol = $this->httpServerBag->has('HTTPS') && $this->httpServerBag->get('HTTPS') !== 'off'
-            ? 'https'
-            : 'http';
-
-        $port = null;
-        if ($this->httpServerBag->get('SERVER_PORT')) {
-            if (
-                ($protocol === 'http' && $this->httpServerBag->get('SERVER_PORT') !== '80')
-                || ($protocol === 'https' && $this->httpServerBag->get('SERVER_PORT') !== '443')
-            ) {
-                /**
-                 * @var string
-                 */
-                $port = $this->httpServerBag->get('SERVER_PORT');
-                $port = (int) $port;
-            }
-        }
-
-        $serverName = $this->httpServerBag->get('SERVER_NAME');
-
         $baseUri = trim($this->getBaseUri(), '/');
 
-        return rtrim(
-            $protocol . '://' . $serverName . ($port !== null ? ':' . $port : '') . '/' . $baseUri,
-            '/'
-        );
+        return rtrim($this->getHost(true) . '/' . $baseUri, '/');
     }
 
     /**
@@ -109,14 +81,19 @@ trait HttpUrlTrait
             'main(\.get)?\.php',
             '(?<!administration\/)authentication\/.+',
         ];
-        if ($this->httpServerBag?->has('REQUEST_URI')) {
-            /**
-             * @var string
-             */
-            $requestUri = $this->httpServerBag->get('REQUEST_URI');
-            if (preg_match('/^(.+?)\/?(' . implode('|', $routeSuffixPatterns) . ')/', $requestUri, $matches)) {
-                $baseUri = $matches[1];
-            }
+
+        if ($this->request === null) {
+            throw new \RuntimeException(
+                'Unable to resolve HTTP base URI: no current request available in the request stack'
+            );
+        }
+
+        $requestUri = $this->request->getRequestUri();
+        if (
+            $requestUri !== ''
+            && preg_match('/^(.+?)\/?(' . implode('|', $routeSuffixPatterns) . ')/', $requestUri, $matches)
+        ) {
+            $baseUri = $matches[1];
         }
 
         return rtrim($baseUri, '/');

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -85,12 +85,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
         $doubleBaseUri = '';
         if (! empty($parameters['base_uri'])) {
             $doubleBaseUri = $parameters['base_uri'] . '/' . $parameters['base_uri'];
-            $doubleBaseUri = preg_replace('/(?<!:)(\/{2,})/', '$2/', $doubleBaseUri);
-
-            if ($doubleBaseUri === null) {
-                throw new \Exception('Error occured during regular expression search and replace.');
-            }
-
+            $doubleBaseUri = $this->cleanPrefixUrl($doubleBaseUri);
             $parameters['base_uri'] .= '/';
         }
 
@@ -107,30 +102,14 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
             $context->setScheme($_SERVER['REQUEST_SCHEME']);
         }
 
-        if ($_SERVER['SERVER_NAME'] !== 'localhost') {
-            $context->setHost($_SERVER['SERVER_NAME']);
-        }
-
         $generatedRoute = $this->router->generate($name, $parameters, $referenceType);
-
-        // remove double slashes
-        $generatedRoute = preg_replace('/(?<!:)(\/{2,})/', '$2/', $generatedRoute);
-
-        if ($generatedRoute === null) {
-            throw new \Exception('Error occured during regular expression search and replace.');
-        }
+        $generatedRoute = $this->cleanPrefixUrl($generatedRoute);
 
         // remove double identical prefixes due to progressive migration
         $generatedRoute = str_replace($doubleBaseUri, $parameters['base_uri'], $generatedRoute);
 
         // remove double slashes
-        $generatedRoute = preg_replace('/(?<!:)(\/{2,})/', '$2/', $generatedRoute);
-
-        if ($generatedRoute === null) {
-            throw new \Exception('Error occured during regular expression search and replace.');
-        }
-
-        return $generatedRoute;
+        return $this->cleanPrefixUrl($generatedRoute);
     }
 
     /**
@@ -243,5 +222,22 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
             $context->setScheme($originalScheme);
             $context->setHttpPort($originalHttpPort);
         }
+    }
+
+    /**
+     * @param string $url
+     *
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    private function cleanPrefixUrl(string $url): string
+    {
+        $result = preg_replace('/(?<!:)\.?(\/+)/', '/', $url);
+        if ($result === null) {
+            throw new \RuntimeException('Error occurred during regular expression search and replace.');
+        }
+
+        return $result;
     }
 }

--- a/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
@@ -24,7 +24,10 @@ declare(strict_types=1);
 namespace Tests\Core\Common\Infrastructure\Api;
 
 use Core\Common\Infrastructure\Api\InternalApiClient;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -40,10 +43,22 @@ class InternalApiClientTest extends TestCase
      *
      * @param string $inputUrl The original URL
      * @param string $expectedUrl The expected localhost URL
+     * @param array{
+     *     'CENTREON_INTERNAL_API_BASE_URL': ?string,
+     *     'requestScheme': ?string,
+     *     'serverAddress': ?string,
+     *     'serverPort': ?int,
+     * } $env
      */
-    public function testConvertToLocalUrl(string $inputUrl, string $expectedUrl): void
+    public function testConvertToLocalUrl(string $inputUrl, string $expectedUrl, array $env): void
     {
-        $result = InternalApiClient::convertToLocalUrl($inputUrl);
+        $result = InternalApiClient::convertToLocalUrl(
+            $inputUrl,
+            $env['CENTREON_INTERNAL_API_BASE_URL'] ?? null,
+            $env['requestScheme'] ?? null,
+            $env['serverAddress'] ?? null,
+            $env['serverPort'] ?? null,
+        );
 
         $this->assertSame($expectedUrl, $result);
     }
@@ -56,71 +71,203 @@ class InternalApiClientTest extends TestCase
         yield 'simple HTTPS URL' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'simple HTTP URL' => [
             'inputUrl' => 'http://centreon.example.com/centreon/api/latest/hosts',
             'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'URL with query string' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts?limit=10&page=1',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts?limit=10&page=1',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'URL with fragment' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts#section',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts#section',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'URL with query string and fragment' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts?id=5#details',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts?id=5#details',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
-        yield 'URL with port number' => [
-            'inputUrl' => 'https://centreon.example.com:8443/centreon/api/latest/hosts',
-            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
+        yield 'CENTREON_INTERNAL_API_BASE_URL contains host with port' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
+            'expectedUrl' => 'https://127.0.0.1:8443/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1:8443'],
         ];
 
-        yield 'localhost URL should remain localhost' => [
+        yield 'localhost hostname converted to 127.0.0.1' => [
             'inputUrl' => 'http://localhost/centreon/api/latest/hosts',
             'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
-        yield '127.0.0.1 URL should remain unchanged' => [
-            'inputUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
-            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+        yield 'server address and port used when CENTREON_INTERNAL_API_BASE_URL is null' => [
+            'inputUrl' => 'http://127.0.1.1/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.1.1:80/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => null, 'serverAddress' => '127.0.1.1', 'serverPort' => 80],
         ];
 
         yield 'URL with IP address' => [
             'inputUrl' => 'https://192.168.1.100/centreon/api/latest/hosts',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'URL with subdomain' => [
             'inputUrl' => 'https://monitoring.centreon.example.com/centreon/api/latest/hosts',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'URL with complex path' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/configuration/hosts/123/templates',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/configuration/hosts/123/templates',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
-        yield 'URL without path' => [
+        yield 'URL without port and path' => [
             'inputUrl' => 'https://centreon.example.com',
             'expectedUrl' => 'https://127.0.0.1',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
+        ];
+
+        yield 'URL with port and without path' => [
+            'inputUrl' => 'https://centreon.example.com:8080',
+            'expectedUrl' => 'https://127.0.0.1',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
+        ];
+
+        yield 'URL with port different of CENTREON_INTERNAL_API_BASE_URL and without path' => [
+            'inputUrl' => 'https://centreon.example.com:8080',
+            'expectedUrl' => 'https://127.0.0.1:4000',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1:4000'],
         ];
 
         yield 'URL with only query string' => [
             'inputUrl' => 'https://centreon.example.com?search=test',
             'expectedUrl' => 'https://127.0.0.1?search=test',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
         yield 'URL with encoded characters in query' => [
             'inputUrl' => 'https://centreon.example.com/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
             'expectedUrl' => 'https://127.0.0.1/api/hosts?name=host%20name&filter=%7B%22id%22%3A1%7D',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
+        ];
+
+        yield 'Relative URL without / at start' => [
+            'inputUrl' => 'api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:8080/api/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1', 'requestScheme' => 'https', 'serverPort' => 8080],
+        ];
+
+        yield 'Relative URL with leading slash' => [
+            'inputUrl' => '/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:80/api/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1', 'requestScheme' => 'https', 'serverPort' => 80],
+        ];
+
+        yield 'empty CENTREON_INTERNAL_API_BASE_URL falls back to server address and port' => [
+            'inputUrl' => 'https://centreon.example.com/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:80/api/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '', 'serverAddress' => '127.0.0.1', 'serverPort' => 80],
+        ];
+
+        yield 'serverPort ignored when CENTREON_INTERNAL_API_BASE_URL already contains a port' => [
+            'inputUrl' => 'https://centreon.example.com/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:9000/api/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1:9000', 'serverPort' => 8080],
+        ];
+
+        yield 'CENTREON_INTERNAL_API_BASE_URL with full scheme has its scheme stripped' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
+            'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => 'https://127.0.0.1'],
+        ];
+
+        yield 'Relative URL with leading slash and base URL with port ignores serverPort' => [
+            'inputUrl' => '/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:9000/api/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1:9000', 'requestScheme' => 'https', 'serverPort' => 8080],
+        ];
+
+        yield 'Relative URL without CENTREON_INTERNAL_API_BASE_URL' => [
+            'inputUrl' => '/api/hosts',
+            'expectedUrl' => 'http://localhost:8080/api/hosts',
+            'env' => ['requestScheme' => 'http', 'serverAddress' => 'localhost', 'serverPort' => 8080],
+        ];
+    }
+
+    /**
+     * @dataProvider provideConvertToLocalUrlExceptionCases
+     */
+    public function testConvertToLocalUrlThrowsRuntimeException(
+        string $url,
+        ?string $internalApiBaseUrl,
+        ?string $requestScheme,
+        ?string $serverAddress,
+        ?int $serverPort,
+        string $expectedMessage,
+    ): void {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        InternalApiClient::convertToLocalUrl($url, $internalApiBaseUrl, $requestScheme, $serverAddress, $serverPort);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: ?string, 2: ?string, 3: ?string, 4: ?int, 5: string}>
+     */
+    public static function provideConvertToLocalUrlExceptionCases(): iterable
+    {
+        // Path 1: valid internalApiBaseUrl + null requestScheme
+        // generateUrlWithoutScheme returns non-null but the scheme is missing
+        yield 'relative URL with valid base URL and null request scheme' => [
+            '/api/hosts', '127.0.0.1', null, null, null,
+            'Cannot build local URL: request scheme is null.',
+        ];
+
+        yield 'relative URL without leading slash, valid base URL and null request scheme' => [
+            'api/hosts', '127.0.0.1', null, null, null,
+            'Cannot build local URL: request scheme is null.',
+        ];
+
+        // Path 2: $localUrl is null (empty or null internalApiBaseUrl) + null requestScheme
+        yield 'relative URL with null base URL and null request scheme' => [
+            '/api/hosts', null, null, null, null,
+            'Cannot build local URL: request scheme is null.',
+        ];
+
+        yield 'relative URL with empty base URL and null request scheme' => [
+            '/api/hosts', '', null, null, null,
+            'Cannot build local URL: request scheme is null.',
+        ];
+
+        // Path 2 (variant): generateUrlWithoutScheme returns null + null requestScheme
+        yield 'relative URL with invalid base URL causing null host and null request scheme' => [
+            '/api/hosts', 'http://', null, '127.0.0.1', null,
+            'Cannot build local URL: request scheme is null.',
+        ];
+
+        // Path 3: $localUrl is null + defined requestScheme + null serverAddress
+        yield 'relative URL with null base URL, defined request scheme and null server address' => [
+            '/api/hosts', null, 'https', null, null,
+            'Cannot build local URL: server address is null.',
+        ];
+
+        // Path 3 (variant): absolute URL (scheme extracted from the URL) + null internalApiBaseUrl + null serverAddress
+        yield 'absolute URL with null base URL and null server address' => [
+            'https://example.com/api', null, null, null, null,
+            'Cannot build local URL: server address is null.',
         ];
     }
 
@@ -141,7 +288,7 @@ class InternalApiClientTest extends TestCase
     {
         $externalUrl = 'https://external-server.example.com/api/test';
 
-        $result = InternalApiClient::convertToLocalUrl($externalUrl);
+        $result = InternalApiClient::convertToLocalUrl($externalUrl, null, 'https', '127.0.0.1');
 
         $this->assertStringContainsString('127.0.0.1', $result);
         $this->assertStringNotContainsString('external-server.example.com', $result);
@@ -151,7 +298,7 @@ class InternalApiClientTest extends TestCase
     {
         $url = 'https://example.com/centreon/api/latest/configuration/hosts/42';
 
-        $result = InternalApiClient::convertToLocalUrl($url);
+        $result = InternalApiClient::convertToLocalUrl($url, null, 'https', '127.0.0.1', 80);
 
         $this->assertStringContainsString('/centreon/api/latest/configuration/hosts/42', $result);
     }
@@ -160,7 +307,7 @@ class InternalApiClientTest extends TestCase
     {
         $url = 'https://example.com/api?param1=value1&param2=value2&param3=value3';
 
-        $result = InternalApiClient::convertToLocalUrl($url);
+        $result = InternalApiClient::convertToLocalUrl($url, null, 'https', '127.0.0.1', 80);
 
         $this->assertStringContainsString('param1=value1', $result);
         $this->assertStringContainsString('param2=value2', $result);
@@ -168,10 +315,85 @@ class InternalApiClientTest extends TestCase
     }
 
     // =========================================================================
+    // Tests for generateUrlWithoutScheme() method
+    // =========================================================================
+
+    /**
+     * @dataProvider provideUrlsForGenerateUrlWithoutScheme
+     */
+    public function testGenerateUrlWithoutScheme(string $input, ?string $expected): void
+    {
+        $method = new \ReflectionMethod(InternalApiClient::class, 'generateUrlWithoutScheme');
+        $result = $method->invoke(null, $input);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string|null}>
+     */
+    public static function provideUrlsForGenerateUrlWithoutScheme(): iterable
+    {
+        yield 'host:port without scheme' => ['127.0.0.1:8080', '127.0.0.1:8080'];
+
+        yield 'host only without scheme' => ['127.0.0.1', '127.0.0.1'];
+
+        yield 'hostname:port without scheme' => ['myhost:9090', 'myhost:9090'];
+
+        yield 'hostname only without scheme' => ['myhost', 'myhost'];
+
+        yield 'http scheme with host and port' => ['http://127.0.0.1:8080', '127.0.0.1:8080'];
+
+        yield 'https scheme with host and port' => ['https://127.0.0.1:443', '127.0.0.1:443'];
+
+        yield 'http scheme with host only' => ['http://127.0.0.1', '127.0.0.1'];
+
+        yield 'https scheme with host only' => ['https://myhost', 'myhost'];
+
+        yield 'scheme with no host' => ['http://', null];
+
+        yield 'scheme with empty host and port' => ['http://:8080', null];
+
+        yield 'scheme empty' => ['', null];
+
+        yield 'host and port empty' => [':', null];
+
+        yield 'empty host with port without scheme' => [':8080', null];
+
+        yield 'port 0 is invalid without scheme' => ['127.0.0.1:0', null];
+
+        yield 'port 1 is the minimum valid port without scheme' => ['127.0.0.1:1', '127.0.0.1:1'];
+
+        yield 'port 65535 is the maximum valid port without scheme' => ['127.0.0.1:65535', '127.0.0.1:65535'];
+
+        yield 'port 65536 exceeds maximum without scheme' => ['127.0.0.1:65536', null];
+
+        yield 'port 0 is invalid with scheme' => ['http://127.0.0.1:0', null];
+
+        yield 'port 1 is the minimum valid port with scheme' => ['http://127.0.0.1:1', '127.0.0.1:1'];
+
+        yield 'port 65535 is the maximum valid port with scheme' => ['https://127.0.0.1:65535', '127.0.0.1:65535'];
+
+        yield 'port 65536 exceeds maximum with scheme' => ['http://127.0.0.1:65536', null];
+
+        yield 'non-numeric port without scheme casts to 0 and is invalid' => ['myhost:notaport', null];
+
+        yield 'negative port without scheme is invalid' => ['127.0.0.1:-5', null];
+
+        yield 'url with path and query is stripped leaving host and port only' => ['http://myhost:8080/some/path?q=1', 'myhost:8080'];
+
+        yield 'url with path and query and no port is stripped leaving host only' => ['https://myhost/path?query=value', 'myhost'];
+
+        yield 'IPv6 address without port preserves brackets from parse_url' => ['http://[::1]', '[::1]'];
+
+        yield 'IPv6 address with port preserves brackets from parse_url' => ['http://[::1]:8080', '[::1]:8080'];
+    }
+
+    // =========================================================================
     // Tests for request() method
     // =========================================================================
 
-    public function testRequestConvertsUrlToLocalhost(): void
+    public function testRequestConvertsUrlToLocalhostWithRelativeUrl(): void
     {
         $mockResponse = $this->createMock(ResponseInterface::class);
         $mockResponse->method('getStatusCode')->willReturn(200);
@@ -182,13 +404,13 @@ class InternalApiClientTest extends TestCase
             ->method('request')
             ->with(
                 'GET',
-                $this->callback(fn ($url) => str_contains($url, '127.0.0.1')),
+                $this->callback(fn ($url) => str_contains($url, 'localhost:80')),
                 $this->anything()
             )
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
-        $result = $client->request('https://external.example.com/api/test', 'GET', self::TEST_SESSION_COOKIE);
+        $client = $this->createClient($mockHttpClient);
+        $result = $client->request('/api/test', 'GET', self::TEST_SESSION_COOKIE);
 
         $this->assertEquals(200, $result['status_code']);
         $this->assertEquals(['success' => true], $result['content']);
@@ -210,7 +432,7 @@ class InternalApiClientTest extends TestCase
             )
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/test', 'POST', self::TEST_SESSION_COOKIE);
 
         $this->assertEquals(201, $result['status_code']);
@@ -234,7 +456,7 @@ class InternalApiClientTest extends TestCase
             )
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $client->request('http://localhost/api/test', 'POST', self::TEST_SESSION_COOKIE, $payload);
     }
 
@@ -254,7 +476,7 @@ class InternalApiClientTest extends TestCase
             )
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
     }
 
@@ -275,7 +497,7 @@ class InternalApiClientTest extends TestCase
             )
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
     }
 
@@ -296,7 +518,7 @@ class InternalApiClientTest extends TestCase
             )
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
     }
 
@@ -311,7 +533,7 @@ class InternalApiClientTest extends TestCase
         $mockHttpClient = $this->createMock(HttpClientInterface::class);
         $mockHttpClient->method('request')->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
 
         $this->assertEquals($responseData, $result['content']);
@@ -328,7 +550,7 @@ class InternalApiClientTest extends TestCase
         $mockHttpClient = $this->createMock(HttpClientInterface::class);
         $mockHttpClient->method('request')->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/test', 'GET', self::TEST_SESSION_COOKIE);
 
         // json_decode returns null for invalid JSON
@@ -347,7 +569,7 @@ class InternalApiClientTest extends TestCase
             ->with('DELETE', $this->anything(), $this->anything())
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/hosts/42', 'DELETE', self::TEST_SESSION_COOKIE);
 
         $this->assertEquals(204, $result['status_code']);
@@ -365,7 +587,7 @@ class InternalApiClientTest extends TestCase
             ->with('PATCH', $this->anything(), $this->anything())
             ->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/hosts/42', 'PATCH', self::TEST_SESSION_COOKIE, ['name' => 'new-name']);
 
         $this->assertEquals(200, $result['status_code']);
@@ -384,7 +606,7 @@ class InternalApiClientTest extends TestCase
         $mockHttpClient = $this->createMock(HttpClientInterface::class);
         $mockHttpClient->method('request')->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/hosts/9999', 'GET', self::TEST_SESSION_COOKIE);
 
         $this->assertEquals(404, $result['status_code']);
@@ -400,9 +622,39 @@ class InternalApiClientTest extends TestCase
         $mockHttpClient = $this->createMock(HttpClientInterface::class);
         $mockHttpClient->method('request')->willReturn($mockResponse);
 
-        $client = new InternalApiClient($mockHttpClient);
+        $client = $this->createClient($mockHttpClient);
         $result = $client->request('http://localhost/api/test', 'POST', self::TEST_SESSION_COOKIE);
 
         $this->assertEquals(500, $result['status_code']);
+    }
+
+    private function createRequestStack(
+        string $scheme = 'http',
+        string $serverAddr = 'localhost',
+        int $port = 80,
+    ): RequestStack {
+        $request = new Request([], [], [], [], [], [
+            'REQUEST_SCHEME' => $scheme,
+            'SERVER_ADDR' => $serverAddr,
+            'SERVER_PORT' => (string) $port,
+        ]);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return $requestStack;
+    }
+
+    private function createClient(
+        HttpClientInterface&MockObject $httpClient,
+        string $internalApiBaseUrl = '',
+        ?RequestStack $requestStack = null,
+    ): InternalApiClient {
+        $httpClient->method('withOptions')->willReturnSelf();
+
+        return new InternalApiClient(
+            $internalApiBaseUrl,
+            $requestStack ?? $this->createRequestStack(),
+            $httpClient,
+        );
     }
 }

--- a/centreon/tests/php/Core/Infrastructure/Common/Api/HttpUrlTraitTest.php
+++ b/centreon/tests/php/Core/Infrastructure/Common/Api/HttpUrlTraitTest.php
@@ -24,20 +24,67 @@ declare(strict_types=1);
 namespace Tests\Core\Infrastructure\Common\Api;
 
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
-use Symfony\Component\HttpFoundation\ServerBag;
+use Symfony\Component\HttpFoundation\Request;
 
 uses(HttpUrlTrait::class);
 
+/**
+ * Build a Symfony Request from raw server values, coming from a trusted proxy
+ * so that X-Forwarded-* headers are honoured by the framework.
+ *
+ * @param array<string, string|null> $server
+ */
+function makeHttpUrlRequest(array $server): Request
+{
+    return new Request(server: array_merge(['REMOTE_ADDR' => '127.0.0.1'], $server));
+}
+
 beforeEach(function (): void {
-    $this->httpServerBag = new ServerBag([]);
+    $this->server = $_SERVER;
+
+    // Trust the local proxy so Symfony resolves the X-Forwarded-* headers.
+    Request::setTrustedProxies(
+        ['127.0.0.1'],
+        Request::HEADER_X_FORWARDED_FOR
+        | Request::HEADER_X_FORWARDED_HOST
+        | Request::HEADER_X_FORWARDED_PROTO
+        | Request::HEADER_X_FORWARDED_PORT
+    );
 });
 
-it('returns empty base url when there is no current request', function (): void {
-    expect($this->getBaseUrl())->toBe('');
+afterEach(function (): void {
+    Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
+    $_SERVER = $this->server;
 });
 
-it('returns empty base uri when there is no current request', function (): void {
+it('throws RuntimeException from getHost when there is no current request', function (): void {
+    $this->request = null;
+
+    expect(fn () => $this->getHost(true))
+        ->toThrow(\RuntimeException::class, 'Unable to resolve HTTP host: no current request available in the request stack');
+});
+
+it('throws RuntimeException from getBaseUri when there is no current request', function (): void {
+    $this->request = null;
+
+    expect(fn () => $this->getBaseUri())
+        ->toThrow(\RuntimeException::class, 'Unable to resolve HTTP base URI: no current request available in the request stack');
+});
+
+it('returns empty base uri when the request uri has no recognizable prefix', function (): void {
+    $this->request = makeHttpUrlRequest(['REQUEST_URI' => '/']);
+
     expect($this->getBaseUri())->toBe('');
+});
+
+it('returns base url without trailing slash when base uri is empty', function (): void {
+    $this->request = makeHttpUrlRequest([
+        'HTTP_HOST' => 'localhost',
+        'HTTPS' => 'off',
+        'REQUEST_URI' => '/api/latest/test',
+    ]);
+
+    expect($this->getBaseUrl())->toBe('http://localhost');
 });
 
 it(
@@ -46,7 +93,7 @@ it(
         $requestUri,
         $baseUri,
     ): void {
-        $this->httpServerBag->replace(['REQUEST_URI' => $requestUri]);
+        $this->request = makeHttpUrlRequest(['REQUEST_URI' => $requestUri]);
 
         expect($this->getBaseUri())->toBe($baseUri);
     }
@@ -67,50 +114,124 @@ it(
         $requestParameters,
         $baseUrl,
     ): void {
-        $this->httpServerBag->replace([
-            'HTTPS' => $requestParameters[0],
-            'SERVER_NAME' => $requestParameters[1],
-            'SERVER_PORT' => $requestParameters[2],
-            'REQUEST_URI' => $requestParameters[3],
+        $this->request = makeHttpUrlRequest([
+            'HTTP_HOST' => $requestParameters[1],
+            'HTTPS' => $requestParameters[0] === 'https' ? 'on' : 'off',
+            'SERVER_PORT' => $requestParameters[3],
+            'REQUEST_URI' => $requestParameters[4],
         ]);
 
         expect($this->getBaseUrl())->toBe($baseUrl);
     }
 )->with([
-    [
+    'docker port mapping (HTTP_HOST contains external port)' => [
         [
-            'off',
+            'http',
+            'localhost:8082',
             '127.0.0.1',
             '8080',
             '/centreon/api/latest/test',
         ],
-        'http://127.0.0.1:8080/centreon',
+        'http://localhost:8082/centreon',
     ],
-    [
+    'standard https (HTTP_HOST without port)' => [
         [
-            'on',
+            'https',
             'my.monitoring',
+            '127.0.0.1',
+            '443',
+            '/api/latest/test',
+        ],
+        'https://my.monitoring',
+    ],
+    'https with non-standard port in HTTP_HOST' => [
+        [
+            'https',
+            'my.monitoring:4443',
+            '127.0.0.1',
             '4443',
             '/api/latest/test',
         ],
         'https://my.monitoring:4443',
     ],
-    [
+    'standard http (HTTP_HOST without port)' => [
         [
-            'on',
+            'https',
             'test',
-            '',
+            '127.0.0.1',
+            null,
             '/api/latest/test',
         ],
         'https://test',
     ],
-    [
+]);
+
+it(
+    'formats properly base url behind a reverse proxy',
+    function (
+        $requestParameters,
+        $baseUrl,
+    ): void {
+        $this->request = makeHttpUrlRequest([
+            'HTTP_HOST' => $requestParameters[1],
+            'HTTPS' => 'off',
+            'SERVER_PORT' => $requestParameters[3],
+            'REQUEST_URI' => $requestParameters[4],
+            'HTTP_X_FORWARDED_PROTO' => $requestParameters[5],
+            'HTTP_X_FORWARDED_HOST' => $requestParameters[6],
+        ]);
+
+        expect($this->getBaseUrl())->toBe($baseUrl);
+    }
+)->with([
+    'ssl termination with custom domain' => [
         [
-            'off',
-            '192.168.0.1',
-            '',
-            '/monitoring/centreon/authentication/logout',
+            'http',
+            'internal-host:8080',
+            '127.0.0.1',
+            '8080',
+            '/centreon/api/latest/test',
+            'https',
+            'centreon.company.com',
         ],
-        'http://192.168.0.1/monitoring/centreon',
+        'https://centreon.company.com/centreon',
     ],
+    'ssl termination with multiple forwarded hosts (first wins)' => [
+        [
+            'http',
+            'internal-host:8080',
+            '127.0.0.1',
+            '8080',
+            '/centreon/api/latest/test',
+            'https',
+            'centreon.company.com, proxy.internal',
+        ],
+        'https://centreon.company.com/centreon',
+    ],
+]);
+
+it(
+    'formats properly host with and without scheme',
+    function (string $httpHost, ?string $forwardedHost, ?string $forwardedProto, string $requestScheme, bool $withScheme, string $expected): void {
+        $server = [
+            'HTTP_HOST' => $httpHost,
+            'REQUEST_SCHEME' => $requestScheme,
+        ];
+        if ($forwardedHost !== null) {
+            $server['HTTP_X_FORWARDED_HOST'] = $forwardedHost;
+        }
+        if ($forwardedProto !== null) {
+            $server['HTTP_X_FORWARDED_PROTO'] = $forwardedProto;
+        }
+        $this->request = makeHttpUrlRequest($server);
+
+        expect($this->getHost($withScheme))->toBe($expected);
+    }
+)->with([
+    'host without scheme' => ['localhost:8082', null, null, 'http', false, 'localhost:8082'],
+    'host with scheme' => ['localhost:8082', null, null, 'http', true, 'http://localhost:8082'],
+    'forwarded host overrides HTTP_HOST' => ['internal:8080', 'centreon.company.com', null, 'http', false, 'centreon.company.com'],
+    'forwarded proto overrides REQUEST_SCHEME' => ['localhost:8080', null, 'https', 'http', true, 'https://localhost:8080'],
+    'forwarded host and proto combined' => ['internal:8080', 'centreon.company.com', 'https', 'http', true, 'https://centreon.company.com'],
+    'multiple forwarded hosts (first wins)' => ['internal:8080', 'centreon.company.com, proxy.internal', null, 'http', false, 'centreon.company.com'],
 ]);

--- a/centreon/tests/php/Core/Infrastructure/Common/Api/RouterTest.php
+++ b/centreon/tests/php/Core/Infrastructure/Common/Api/RouterTest.php
@@ -20,20 +20,99 @@
  */
 
 use Core\Infrastructure\Common\Api\Router;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RequestContext;
 
 beforeEach(function (): void {
+    $this->server = $_SERVER;
+
+    $_SERVER['REQUEST_SCHEME'] = 'http';
+    $_SERVER['HTTP_HOST'] = 'localhost';
+    $_SERVER['SERVER_ADDR'] = '127.0.0.1';
+    $_SERVER['SERVER_PORT'] = '80';
+
+    $request = new Request(server: [
+        'HTTP_HOST' => 'localhost',
+        'HTTPS' => 'off',
+        'SERVER_PORT' => '80',
+    ]);
+
     $this->router = new Router(
         $this->createMock(Symfony\Component\Routing\RouterInterface::class),
         $this->createMock(Symfony\Component\Routing\Matcher\RequestMatcherInterface::class)
     );
+    $requestStack = $this->createMock(Symfony\Component\HttpFoundation\RequestStack::class);
+    $requestStack->method('getCurrentRequest')->willReturn($request);
+    $this->router->setHttpServerBag($requestStack);
+});
+
+afterEach(function (): void {
+    $_SERVER = $this->server;
 });
 
 it('should return a legacy path without options', function (): void {
     $legacyHref = $this->router->generateLegacyHref(60202);
-    expect($legacyHref)->toBe('/main.php?p=60202');
+    expect($legacyHref)->toBe('http://localhost/main.php?p=60202');
 });
 
 it('should return a legacy path with options', function (): void {
     $legacyHref = $this->router->generateLegacyHref(60202, ['foo' => 'bar']);
-    expect($legacyHref)->toBe('/main.php?p=60202&foo=bar');
+    expect($legacyHref)->toBe('http://localhost/main.php?p=60202&foo=bar');
+});
+
+it('should generate a local URL using 127.0.0.1', function (): void {
+    $context = new RequestContext();
+    $context->setHost('my-server.example.com');
+    $context->setScheme('https');
+    $context->setHttpPort(443);
+
+    $mockRouter = $this->createMock(Symfony\Component\Routing\RouterInterface::class);
+    $mockRouter->method('getContext')->willReturn($context);
+    $mockRouter->method('generate')->willReturn('http://127.0.0.1/centreon/api/latest/my-route');
+
+    $request = new Request(server: [
+        'HTTP_HOST' => 'my-server.example.com',
+        'HTTPS' => 'off',
+    ]);
+
+    $router = new Router(
+        $mockRouter,
+        $this->createMock(Symfony\Component\Routing\Matcher\RequestMatcherInterface::class)
+    );
+    $requestStack = $this->createMock(Symfony\Component\HttpFoundation\RequestStack::class);
+    $requestStack->method('getCurrentRequest')->willReturn($request);
+    $router->setHttpServerBag($requestStack);
+
+    $url = $router->generateLocalUrl('my_route');
+    expect($url)->toBe('http://127.0.0.1/centreon/api/latest/my-route');
+});
+
+it('should restore the original routing context after generating a local URL', function (): void {
+    $context = new RequestContext();
+    $context->setHost('my-server.example.com');
+    $context->setScheme('https');
+    $context->setHttpPort(443);
+
+    $mockRouter = $this->createMock(Symfony\Component\Routing\RouterInterface::class);
+    $mockRouter->method('getContext')->willReturn($context);
+    $mockRouter->method('generate')->willReturn('http://127.0.0.1/api/latest/my-route');
+
+    $request = new Request(server: [
+        'HTTP_HOST' => 'my-server.example.com',
+        'HTTPS' => 'off',
+    ]);
+
+    $router = new Router(
+        $mockRouter,
+        $this->createMock(Symfony\Component\Routing\Matcher\RequestMatcherInterface::class)
+    );
+    $requestStack = $this->createMock(Symfony\Component\HttpFoundation\RequestStack::class);
+    $requestStack->method('getCurrentRequest')->willReturn($request);
+    $router->setHttpServerBag($requestStack);
+
+    $router->generateLocalUrl('my_route');
+
+    expect($context->getHost())->toBe('my-server.example.com')
+        ->and($context->getScheme())->toBe('https')
+        ->and($context->getHttpPort())->toBe(443);
 });

--- a/centreon/tests/php/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionControllerTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionControllerTest.php
@@ -29,31 +29,29 @@ use Core\Infrastructure\Common\Presenter\JsonFormatter;
 use Core\Security\Authentication\Application\UseCase\LogoutSession\LogoutSession;
 use Core\Security\Authentication\Infrastructure\Api\LogoutSession\LogoutSessionController;
 use Core\Security\Authentication\Infrastructure\Api\LogoutSession\LogoutSessionPresenter;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class LogoutSessionControllerTest extends TestCase
 {
-    /** @var Request&\PHPUnit\Framework\MockObject\MockObject */
-    private $request;
+    private Request $request;
 
-    /** @var LogoutSession&\PHPUnit\Framework\MockObject\MockObject */
-    private $useCase;
+    private RequestStack&MockObject $requestStack;
 
-    /** @var LogoutSessionPresenter */
-    private $logoutSessionPresenter;
+    private LogoutSession&MockObject $useCase;
 
-    /** @var UrlGeneratorInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private UrlGeneratorInterface $urlGenerator;
+    private LogoutSessionPresenter $logoutSessionPresenter;
 
     public function setUp(): void
     {
-        $this->request = $this->createMock(Request::class);
+        $this->request = Request::create('http://localhost/');
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->requestStack->method('getCurrentRequest')->willReturn($this->request);
         $this->useCase = $this->createMock(LogoutSession::class);
         $this->logoutSessionPresenter = new LogoutSessionPresenter(new JsonFormatter());
-        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
     }
 
     /**
@@ -62,6 +60,7 @@ class LogoutSessionControllerTest extends TestCase
     public function testLogout(): void
     {
         $logoutSessionController = new LogoutSessionController();
+        $logoutSessionController->setHttpServerBag($this->requestStack);
 
         $this->request->cookies = new InputBag([session_name() => 'token']);
 
@@ -73,7 +72,7 @@ class LogoutSessionControllerTest extends TestCase
 
         $response = $logoutSessionController($this->useCase, $this->request, $this->logoutSessionPresenter);
 
-        $this->assertEquals('/login', $response->headers->get('location'));
+        $this->assertEquals('http://localhost/login', $response->headers->get('location'));
     }
 
     /**
@@ -82,6 +81,7 @@ class LogoutSessionControllerTest extends TestCase
     public function testLogoutFailed(): void
     {
         $logoutSessionController = new LogoutSessionController();
+        $logoutSessionController->setHttpServerBag($this->requestStack);
 
         $this->request->cookies = new InputBag([]);
 
@@ -93,6 +93,6 @@ class LogoutSessionControllerTest extends TestCase
 
         $response = $logoutSessionController($this->useCase, $this->request, $this->logoutSessionPresenter);
 
-        $this->assertEquals('/login', $response->headers->get('location'));
+        $this->assertEquals('http://localhost/login', $response->headers->get('location'));
     }
 }

--- a/centreon/tests/php/www/class/CentreonLogTest.php
+++ b/centreon/tests/php/www/class/CentreonLogTest.php
@@ -20,10 +20,12 @@
  */
 
 beforeEach(function (): void {
+    $this->server = $_SERVER;
     $_SERVER['APP_ENV'] = 'test';
 });
 
 afterEach(function (): void {
+    $_SERVER = $this->server;
     foreach (centreonLogTestSlugs() as $slug) {
         $file = centreonLogPath($slug);
         if (file_exists($file)) {

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -30,6 +30,7 @@ use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
@@ -1310,7 +1311,17 @@ class CentreonConfigCentreonBroker
         /** @var Core\Infrastructure\Common\Api\Router $router */
         $router = $kernel->getContainer()->get(Core\Infrastructure\Common\Api\Router::class)
         ?? throw new LogicException('Router not found in container');
-        $client = new InternalApiClient();
+
+        /** @var ServiceLocator $serviceLocator */
+        $serviceLocator = $kernel->getContainer()->get('legacy.service_locator');
+
+        if (! $serviceLocator->has('internal_api_client')) {
+            throw new RuntimeException('internal_api_client service is not registered in the service locator');
+        }
+
+        /** @var InternalApiClient $client */
+        $client = $serviceLocator->get('internal_api_client');
+
         $sessionCookie = CentreonSession::resolveSessionCookie();
         $parameters = ['brokerId' => $configId];
         if ($basePath) {

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -40,6 +40,7 @@ use Core\Host\Application\Converter\HostEventConverter;
 use Core\Infrastructure\Common\Api\Router;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -2975,7 +2976,18 @@ function updateByApi(array $formData, bool $isCloudPlatform, string $basePath, b
  */
 function callHostApi(string $url, string $httpMethod, array $payload): array
 {
-    $client = new InternalApiClient();
+    $kernel = Kernel::createForWeb();
+
+    /** @var ServiceLocator $serviceLocator */
+    $serviceLocator = $kernel->getContainer()->get('legacy.service_locator');
+
+    if (! $serviceLocator->has('internal_api_client')) {
+        throw new RuntimeException('internal_api_client service is not registered in the service locator');
+    }
+
+    /** @var InternalApiClient $client */
+    $client = $serviceLocator->get('internal_api_client');
+
     $response = $client->request($url, $httpMethod, CentreonSession::resolveSessionCookie(), $payload);
 
     $status = $response['status_code'];

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -38,6 +38,7 @@ use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryI
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -4531,7 +4532,17 @@ function deleteServiceTemplateByApi(array $serviceTemplates = []): void
  */
 function callApi(string $url, string $httpMethod, array $payload): array
 {
-    $client = new InternalApiClient();
+    $kernel = Kernel::createForWeb();
+
+    /** @var ServiceLocator $serviceLocator */
+    $serviceLocator = $kernel->getContainer()->get('legacy.service_locator');
+
+    if (! $serviceLocator->has('internal_api_client')) {
+        throw new RuntimeException('internal_api_client service is not registered in the service locator');
+    }
+
+    /** @var InternalApiClient $client */
+    $client = $serviceLocator->get('internal_api_client');
 
     return $client->request($url, $httpMethod, CentreonSession::resolveSessionCookie(), $payload);
 }

--- a/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/DB-Func.php
@@ -28,6 +28,7 @@ if (! isset($centreon)) {
 use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Infrastructure\Common\Api\Router;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 function includeExcludeTimeperiods($tpId, $includeTab = [], $excludeTab = [])
@@ -446,7 +447,16 @@ function insertTimeperiodByApi(array $formData, string $basePath): int
         UrlGeneratorInterface::ABSOLUTE_URL,
     );
 
-    $client = new InternalApiClient();
+    /** @var ServiceLocator $serviceLocator */
+    $serviceLocator = $kernel->getContainer()->get('legacy.service_locator');
+
+    if (! $serviceLocator->has('internal_api_client')) {
+        throw new RuntimeException('internal_api_client service is not registered in the service locator');
+    }
+
+    /** @var InternalApiClient $client */
+    $client = $serviceLocator->get('internal_api_client');
+
     $response = $client->request($url, 'POST', CentreonSession::resolveSessionCookie(), $payload);
 
     if ($response['status_code'] !== 201) {
@@ -516,7 +526,16 @@ function updateTimeperiodByApi(array $formData, string $basePath): void
         UrlGeneratorInterface::ABSOLUTE_URL,
     );
 
-    $client = new InternalApiClient();
+    /** @var ServiceLocator $serviceLocator */
+    $serviceLocator = $kernel->getContainer()->get('legacy.service_locator');
+
+    if (! $serviceLocator->has('internal_api_client')) {
+        throw new RuntimeException('internal_api_client service is not registered in the service locator');
+    }
+
+    /** @var InternalApiClient $client */
+    $client = $serviceLocator->get('internal_api_client');
+
     $response = $client->request($url, 'PUT', CentreonSession::resolveSessionCookie(), $payload);
 
     if ($response['status_code'] !== 204) {
@@ -564,7 +583,17 @@ function deleteTimePeriodByAPI(string $basePath, array $timePeriodIds): void
     $kernel = Kernel::createForWeb();
     /** @var Router $router */
     $router = $kernel->getContainer()->get(Router::class);
-    $client = new InternalApiClient();
+
+    /** @var ServiceLocator $serviceLocator */
+    $serviceLocator = $kernel->getContainer()->get('legacy.service_locator');
+
+    if (! $serviceLocator->has('internal_api_client')) {
+        throw new RuntimeException('internal_api_client service is not registered in the service locator');
+    }
+
+    /** @var InternalApiClient $client */
+    $client = $serviceLocator->get('internal_api_client');
+
     $sessionCookie = CentreonSession::resolveSessionCookie();
 
     foreach ($timePeriodIds as $id) {


### PR DESCRIPTION
## Description

Make internal API URL resolution fully configurable and reliable across all execution contexts (reverse proxy, SSL termination, Docker port mapping, legacy pages).

### `InternalApiClient` — configurable URL resolution

`InternalApiClient::convertToLocalUrl()` previously used hardcoded constants (`127.0.0.1`, `http`). It now resolves the local URL from configurable parameters:
- `CENTREON_INTERNAL_API_BASE_URL` env var takes precedence;
- otherwise the request scheme, server address and port are used, resolved from `RequestStack` instead of reading the `$_SERVER` superglobal.

It also:
- adds a `generateUrlWithoutScheme()` helper and supports relative URLs (with or without a leading `/`);
- makes `HttpClientInterface` a mandatory constructor dependency (configured through `withOptions`) instead of self-instantiating a `CurlHttpClient`;
- throws a `RuntimeException` when the request scheme or server address cannot be resolved and no usable base URL is provided;
- registers the `CENTREON_INTERNAL_API_BASE_URL` env parameter default in `services.yaml`.

### `Router` — cleanup

`Router::generate()` is simplified:
- extract a `cleanPrefixUrl()` private helper to deduplicate the three inline `preg_replace` calls that normalise multiple/dot-prefixed slashes (the regex now also collapses dot-prefixed slashes, e.g. `./`);
- remove the `SERVER_NAME !== 'localhost'` guarded `$context->setHost()` call — the routing context host is no longer overridden from `$_SERVER`;
- throw `\RuntimeException` instead of `\Exception` on regex failure.

### `HttpUrlTrait` — proxy-aware URL building

URL building no longer parses `$_SERVER`/`ServerBag` manually. It now relies on Symfony's `Request` accessors (`getSchemeAndHttpHost()`, `getHttpHost()`, `getRequestUri()`), so it uses `HTTP_HOST`, which already carries the client-facing port (e.g. `localhost:8082` with Docker port mapping).

Symfony trusted proxies and trusted headers are configured in `framework.yaml` (new `TRUSTED_PROXIES` env var, defaulting to `127.0.0.1,REMOTE_ADDR`) so that `X-Forwarded-Host` and `X-Forwarded-Proto` are honoured behind a reverse proxy, correctly handling SSL termination and custom domains. A `RuntimeException` is thrown in `getHost()`/`getBaseUri()` when no current request is available.

### Kernel — request context on boot

A `Request` is created from globals and pushed onto the `request_stack` when the Kernel singleton is created, so the DI container has an active request context available immediately after boot — required for `InternalApiClient` and `HttpUrlTrait` to resolve scheme/host/address via `RequestStack`.

### Legacy code — ServiceLocator DI

`InternalApiClient` is no longer directly instantiated in legacy code (host, service, timeperiod and broker configuration pages). It is now resolved through the DI container via a dedicated Symfony `ServiceLocator`, ensuring the properly configured singleton is used everywhere.

### PHP-FPM — env var forwarding

PHP-FPM clears all environment variables by default (`clear_env = yes`). Explicit `env[]` directives have been added to the pool configuration (deb and rpm) to forward `CENTREON_INTERNAL_API_BASE_URL` from the container environment to the PHP process, making it available in both `$_ENV` and Symfony's `%env()%` resolution.

### Docker Compose

`CENTREON_INTERNAL_API_BASE_URL` has been added to the docker-compose environment (defaulting to `127.0.0.1:80`) so the variable is available in local development setups without manual override.

### Tests

- Expanded the `InternalApiClient`, `Router` and `HttpUrlTrait` test suites: base-URL/server-address resolution paths, relative URLs, scheme stripping, proxy headers (`X-Forwarded-*`), the Docker port-mapping case, `getHost()` with/without scheme, `generateUrlWithoutScheme()` and the `RuntimeException` paths; `LogoutSessionControllerTest` adapted to the `RequestStack` based wiring.
- `ExceptionLogger` assertion updated to include function args in traces.
- `CentreonLog` test cleanup fixed (`/*` glob suffix so residual log files are deleted on failure) and `$_SERVER` is snapshotted/restored around each test to isolate it from whatever `SymfonyExtension` or the CI environment may have populated.

**Fixes** MON-198741

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Set `CENTREON_INTERNAL_API_BASE_URL=127.0.0.1:80` in the environment (or via docker-compose)
2. Trigger a workflow that calls `InternalApiClient::request()` with an internal API endpoint (e.g. export/generate configuration)
3. Verify the request is routed to the configured address
4. Remove the env var and verify fallback to `HTTP_HOST`-based resolution via `RequestStack`
5. Behind a reverse proxy, verify that `X-Forwarded-Host`/`X-Forwarded-Proto` are honoured (SSL termination, custom domain) once the proxy is listed in `TRUSTED_PROXIES`
6. On a legacy page (hosts, services, timeperiods, broker configuration), verify that `InternalApiClient` is correctly resolved through the `ServiceLocator` without direct instantiation
7. Verify that `CENTREON_INTERNAL_API_BASE_URL` is visible to PHP processes via `$_ENV` (PHP-FPM env forwarding)
