### PR TITLE
Mon 198967 fix warning message status details

### DIFF
--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -366,12 +366,11 @@ if (! is_null($host_id)) {
 
         // Ajust data for beeing displayed in template
         $centreon->CentreonGMT->getMyGMTFromSession(session_id(), $pearDB);
-
-        // a service is forced to have a command line but if acl user is not allowed to see command line, the command_line "doesn't exist"
-        (isset($service_status['command_line']))
-            ? $service_status['command_line'] = str_replace(' -', "\n\t-", $service_status['command_line'])
-            : $service_status['command_line'] = "";
-
+        // A service is forced to have a command line, but if the ACL user is not allowed to
+        // see the command line, $service_status['command_line'] stays as the default empty string.
+        $service_status['command_line'] = isset($service_status['command_line'])
+            ? str_replace(' -', "\n\t-", $service_status['command_line'])
+            : '';
         $service_status['performance_data'] = CentreonUtils::escapeAll(
             str_replace(' \'', "\n'", $service_status['performance_data'])
         );

--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -369,7 +369,7 @@ if (! is_null($host_id)) {
 
         // a service is forced to have a command line but if acl user is not allowed to see command line, the command_line "doesn't exist"
         (isset($service_status['command_line']))
-            ? str_replace(' -', "\n\t-", $service_status['command_line'])
+            ? $service_status['command_line'] = str_replace(' -', "\n\t-", $service_status['command_line'])
             : $service_status['command_line'] = "";
 
         $service_status['performance_data'] = CentreonUtils::escapeAll(

--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -366,7 +366,12 @@ if (! is_null($host_id)) {
 
         // Ajust data for beeing displayed in template
         $centreon->CentreonGMT->getMyGMTFromSession(session_id(), $pearDB);
-        $service_status['command_line'] = str_replace(' -', "\n\t-", $service_status['command_line']);
+
+        // a service is forced to have a command line but if acl user is not allowed to see command line, the command_line "doesn't exist"
+        (isset($service_status['command_line']))
+            ? str_replace(' -', "\n\t-", $service_status['command_line'])
+            : $service_status['command_line'] = "";
+
         $service_status['performance_data'] = CentreonUtils::escapeAll(
             str_replace(' \'', "\n'", $service_status['performance_data'])
         );

--- a/centreon/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/centreon/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -407,35 +407,35 @@
                         <h4>{t}Host commands and shortcuts{/t}</h4>
                     </td>
                 </tr>
-                {if ($lcaTopo.60101 || $admin == 1) && !$isRemote}
+                {if (isset($lcaTopo.60101) || $admin == 1) && !$isRemote}
                 <tr class='list_two'>
                     <td class="ListColLeft ColPopup">
                         <a href='./main.php?p=60101&host_id={$host_id}&o=c'>{$lnk_host_config}</a>
                     </td>
                 </tr>
                 {/if}
-                {if $lcaTopo.20301 || $admin == 1}
+                {if isset($lcaTopo.20301) || $admin == 1}
                 <tr class='list_one'>
                     <td class="ListColLeft ColPopup">
                         <a href='./main.php?p=20301&h={$host_id}'>{$lnk_host_logs}</a>
                     </td>
                 </tr>
                 {/if}
-                {if $lcaTopo.20301 || $admin == 1}
+                {if isset($lcaTopo.20301) || $admin == 1}
                 <tr class='list_two'>
                     <td class="ListColLeft ColPopup">
                         <a href='./main.php?p=20201&o=svc&host_search={$host_data.host_name}&statusService=svc&statusFilter='>{$lnk_all_services}</a>
                     </td>
                 </tr>
                 {/if}
-                {if $lcaTopo.307 || $admin == 1}
+                {if isset($lcaTopo.307) || $admin == 1}
                 <tr class='list_one'>
                     <td class="ListColLeft ColPopup">
                         <a href='./main.php?p=307&host={$host_id}'>{$lnk_host_reports}</a>
                     </td>
                 </tr>
                 {/if}
-                {if $lcaTopo.20401 || $admin == 1}
+                {if isset($lcaTopo.20401) || $admin == 1}
                 <tr class='list_two'>
                     <td class="ListColLeft ColPopup">
                         <a href='./main.php?p=20401&mode=0&svc_id={$host_data.host_name}'>{$lnk_host_graphs}</a>

--- a/centreon/www/include/monitoring/objectDetails/template/serviceDetails.ihtml
+++ b/centreon/www/include/monitoring/objectDetails/template/serviceDetails.ihtml
@@ -224,21 +224,21 @@
                                 <td></td>
                             </tr>
                             {/if}
-                            {if ($lcaTopo.6 || $lcaTopo.602 || $admin == 1) && !$isRemote}
+                            {if (isset($lcaTopo.6) || isset($lcaTopo.602) || $admin == 1) && !$isRemote}
                             <tr>
                                 <td class="ColPopup">
-                                    {if $lcaTopo.6 || $admin == 1}
+                                    {if isset($lcaTopo.6) || $admin == 1}
                                         <a href='./main.php?p=60101&host_id={$h.host_id}&o=c'>{$lnk_host_config} {$h.host_name}</a>
                                     {/if}
                                 </td>
                                 <td class="ColPopup">
-                                    {if $lcaTopo.602 || $admin == 1}
+                                    {if isset($lcaTopo.602) || $admin == 1}
                                         <a href='./main.php?p=60201&service_id={$service_id}&o=c'>{$lnk_serv_config}</a>
                                     {/if}
                                 </td>
                             </tr>
                             {/if}
-                            {if $lcaTopo.20301 || $admin == 1}
+                            {if isset($lcaTopo.20301) || $admin == 1}
                             <tr>
                                 <td class="ColPopup">
                                         <a href='./main.php?p=20301&h={$h.host_id}'>{$lnk_host_logs}</a>
@@ -248,16 +248,16 @@
                                 </td>
                             </tr>
                             {/if}
-                            {if $lcaTopo.307 || $lcaTopo.30702 || $admin == 1}
+                            {if isset($lcaTopo.307) || isset($lcaTopo.30702) || $admin == 1}
                             <tr>
                                 <td class="ColPopup">
-                                    {if $lcaTopo.307 || $admin == 1}
+                                    {if isset($lcaTopo.307) || $admin == 1}
                                         <a href='./main.php?p=307&host={$h.host_id}'>{$lnk_host_reports}</a>
                                     {/if}
                                 </td>
 
                                 <td class="ColPopup">
-                                    {if $lcaTopo.30702 || $admin == 1}
+                                    {if isset($lcaTopo.30702) || $admin == 1}
                                         <a href='./main.php?p=30702&period=yesterday&start=&end=&host_id={$h.host_id}&item={$service_id}'>{$lnk_serv_reports}</a>
                                     {/if}
                                 </td>
@@ -277,7 +277,7 @@
                                     <h4>{$serv_shortcut}</h4>
                                 </td>
                             </tr>
-                            {if $lcaTopo.60204 || $admin == 1}
+                            {if isset($lcaTopo.60204) || $admin == 1}
                             <tr>
                                 <td class="ColPopup">
                                         <a href='./main.php?p=60204&o=c&meta_id={$meta_id}&o=c'>{$lnk_serv_config}</a>
@@ -285,7 +285,7 @@
                                 </td>
                             </tr>
                             {/if}
-                            {if $lcaTopo.20301 || $admin == 1}
+                            {if isset($lcaTopo.20301) || $admin == 1}
                             <tr>
                                 <td class="ColPopup">
                                         <a href='./main.php?p=20301&svc={$h.host_id}_{$service_id}'>{$lnk_serv_logs}</a>
@@ -297,7 +297,7 @@
                         </table>
                     </td>
                 </tr>
-                {if $is_meta == 'false' && ($lcaTopo.20201 || $admin == 1)}
+                {if $is_meta == 'false' && (isset($lcaTopo.20201) || $admin == 1)}
                 <tr>
                     <td style="vertical-align: top; padding-bottom: 8px !important;" nowrap="nowrap">
                         <table class="table linkList">
@@ -323,35 +323,35 @@
                                     <h4>{$m_mon_service_command}</h4>
                                 </td>
                             </tr>
-                                {if ($aclAct.service_schedule_check || $admin == true) && $service_data.active_checks_enabled}
+                                {if (isset($aclAct.service_schedule_check) || $admin == true) && $service_data.active_checks_enabled}
                                     <tr class='list_two'>
                                         <td class="ListColLeft ColPopup" id="service_schedule_check">
                                             <b><a href="#" onClick="send_command('service_schedule_check', '0');">{$m_mon_schedule}</a></b>
                                         </td>
                                     </tr>
                                 {/if}
-                                {if ($aclAct.service_schedule_forced_check || $admin == true) && $service_data.active_checks_enabled}
+                                {if (isset($aclAct.service_schedule_forced_check) || $admin == true) && $service_data.active_checks_enabled}
                                     <tr class='list_one'>
                                         <td class="ListColLeft ColPopup" id="service_schedule_check_forced">
                                             <b><a href="#" onClick="send_command('service_schedule_check', '1', '{$m_mon_schedule_force}');">{$m_mon_schedule_force}</a></b>
                                         </td>
                                     </tr>
                                 {/if}
-                                {if $aclAct.service_schedule_downtime || $admin == true}
+                                {if isset($aclAct.service_schedule_downtime) || $admin == true}
                                     <tr class='list_two'>
                                         <td class="ListColLeft ColPopup">
                                             <b><a href='./main.php?p=21001&o=a&host_id={$h.host_id}&service_id={$service_data.service_id}'>{$m_mon_schedule_downtime}</a></b>
                                         </td>
                                     </tr>
                                 {/if}
-                                {if $aclAct.service_comment || $admin == true}
+                                {if isset($aclAct.service_comment) || $admin == true}
                                     <tr class='list_one'>
                                         <td class="ListColLeft ColPopup">
                                             <b><a href='./main.php?p=21002&o=as&host_name={$h.host_name}&service_description={$svc_description}'>{$m_mon_schedule_comment}</a></b>
                                         </td>
                                     </tr>
                                 {/if}
-                                {if ($aclAct.service_submit_result || $admin == true) && $service_data.passive_checks_enabled}
+                                {if (isset($aclAct.service_submit_result) || $admin == true) && $service_data.passive_checks_enabled}
                                     <tr class='list_two'>
                                         <td class="ListColLeft ColPopup">
                                             <b><a href='./main.php?p={$p}&o=svcpc&cmd=16&host_name={$h.host_name}&service_description={$svc_description}&is_meta={$is_meta}'>{$m_mon_submit_passive}</a></b>
@@ -379,7 +379,7 @@
                                     {/if}
                                 </td>
                                 <td class="ListColRight ColPopup" id="service_checks">
-                                {if isset($service_data.active_checks_enabled) && in_array($service_data.active_checks_enabled, ['0', '1']) && ($aclAct.service_checks || $admin == true)}
+                                {if isset($service_data.active_checks_enabled) && in_array($service_data.active_checks_enabled, ['0', '1']) && (isset($aclAct.service_checks) || $admin == true)}
                                     <a href="#" onClick="send_command('service_checks', '{$en_inv[$service_data.active_checks_enabled]}');" title="{$en_inv_text[$service_data.active_checks_enabled]}">
                                     <img class="ico-16" src={$img_en[$service_data.active_checks_enabled]} />
 
@@ -395,7 +395,7 @@
                                     {/if}
                                 </td>
                                 <td class="ListColRight ColPopup" id="service_passive_checks">
-                                    {if isset($service_data.passive_checks_enabled) && in_array($service_data.passive_checks_enabled, ['0', '1']) && ( $aclAct.service_passive_checks || $admin == true)}
+                                    {if isset($service_data.passive_checks_enabled) && in_array($service_data.passive_checks_enabled, ['0', '1']) && ( isset($aclAct.service_passive_checks) || $admin == true)}
                                     <a href="#" onClick="send_command('service_passive_checks', '{$en_inv[$service_data.passive_checks_enabled]}');" title='{$en_inv_text[$service_data.passive_checks_enabled]} {$m_mon_accept_passive}'>
                                     <img class="ico-16" src={$img_en[$service_data.passive_checks_enabled]}
                                     alt="{$en_inv_text[$service_data.passive_checks_enabled]} {$m_mon_accept_passive}" />
@@ -411,7 +411,7 @@
                                     {/if}
                                 </td>
                                     <td class="ListColRight ColPopup" id="service_notifications">
-                                    {if isset($service_data.notifications_enabled) && in_array($service_data.notifications_enabled, ['0', '1']) && ($aclAct.service_notifications || $admin == true)}
+                                    {if isset($service_data.notifications_enabled) && in_array($service_data.notifications_enabled, ['0', '1']) && (isset($aclAct.service_notifications) || $admin == true)}
                                         <a href="#" onClick="send_command('service_notifications', '{$en_inv[$service_data.notifications_enabled]}');" title='{$en_inv_text[$service_data.notifications_enabled]} {$m_mon_notification_service}'>
                                         <img class="ico-16" src={$img_en[$service_data.notifications_enabled]}
                                         alt="{$en_inv_text[$service_data.notifications_enabled]} {$m_mon_notification_service}" />
@@ -427,7 +427,7 @@
                                     {/if}
                                 </td>
                                 <td class="ListColRight ColPopup" id="service_event_handler">
-                                {if isset($service_data.event_handler_enabled) && in_array($service_data.event_handler_enabled, ['0', '1']) && ($aclAct.service_event_handler || $admin == true)}
+                                {if isset($service_data.event_handler_enabled) && in_array($service_data.event_handler_enabled, ['0', '1']) && (isset($aclAct.service_event_handler) || $admin == true)}
                                     <a href="#" onClick="send_command('service_event_handler', '{$en_inv[$service_data.event_handler_enabled]}');" title='{$en_inv_text[$service_data.event_handler_enabled]} {$m_mon_event_handler}'>
                                     <img class="ico-16" src={$img_en[$service_data.event_handler_enabled]}
                                     alt="{$en_inv_text[$service_data.event_handler_enabled]} {$m_mon_event_handler}" />
@@ -443,7 +443,7 @@
                                     {/if}
                                 </td>
                                     <td class="ListColRight ColPopup" id="service_flap_detection">
-                                    {if isset($service_data.flap_detection_enabled) && in_array($service_data.flap_detection_enabled, ['0', '1']) && ($aclAct.service_flap_detection || $admin == true)}
+                                    {if isset($service_data.flap_detection_enabled) && in_array($service_data.flap_detection_enabled, ['0', '1']) && (isset($aclAct.service_flap_detection) || $admin == true)}
                                         <a href="#" onClick="send_command('service_flap_detection', '{$en_inv[$service_data.flap_detection_enabled]}');" title='{$en_inv_text[$service_data.flap_detection_enabled]} {$m_mon_flap_detection}'>
                                         <img class="ico-16" src={$img_en[$service_data.flap_detection_enabled]}
                                         alt="{$en_inv_text[$service_data.flap_detection_enabled]} {$m_mon_flap_detection}" />
@@ -460,7 +460,7 @@
                                     {/if}
                                 </td>
                                 <td class="ListColRight ColPopup" id="global_service_obsess">
-                                {if isset($service_data.obsess_over_service) && in_array($service_data.obsess_over_service, ['0', '1']) && ($aclAct.global_service_obsess || $admin == 1)}
+                                {if isset($service_data.obsess_over_service) && in_array($service_data.obsess_over_service, ['0', '1']) && (isset($aclAct.global_service_obsess) || $admin == 1)}
                                     <a href="#" onClick="send_command('global_service_obsess', '{$en_inv[$service_data.obsess_over_service]}');" title='{$en_inv_text[$service_data.obsess_over_service]} {$m_mon_obsessing}'>
                                     <img class="ico-16" src={$img_en[$service_data.obsess_over_service]}
                                     alt="{$en_inv_text[$service_data.obsess_over_service]} {$m_mon_obsessing}" />
@@ -478,8 +478,8 @@
                                 </td>
                                 <td class="ListColRight ColPopup">
                                     {if
-                                        ($aclAct.service_acknowledgement && (isset($service_data.problem_has_been_acknowledged) && in_array($service_data.problem_has_been_acknowledged, ['0', '1'])))
-                                        || ($aclAct.service_disacknowledgement && (isset($service_data.problem_has_been_acknowledged) && in_array($service_data.problem_has_been_acknowledged, ['0', '1'])))
+                                        (isset($aclAct.service_acknowledgement) && (isset($service_data.problem_has_been_acknowledged) && in_array($service_data.problem_has_been_acknowledged, ['0', '1'])))
+                                        || (isset($aclAct.service_disacknowledgement) && (isset($service_data.problem_has_been_acknowledged) && in_array($service_data.problem_has_been_acknowledged, ['0', '1'])))
                                         || ($admin == true && (isset($service_data.problem_has_been_acknowledged) && in_array($service_data.problem_has_been_acknowledged, ['0', '1'])))
                                     }
                                         <a href='./main.php?p={$p}&o=svcak&cmd=15&host_name={$h.host_name|urlencode}&service_description={$svc_description|urlencode}&en={$en_acknowledge[$service_data.problem_has_been_acknowledged]}' title='{$en_acknowledge_text[$service_data.problem_has_been_acknowledged]}'>


### PR DESCRIPTION
## Description

avoid warning messages broker page when you try to reach the deprecated services/hosts status details pages (mainly happen with non-admin users

.ihtml conditions edited using claude

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
