### PR TITLE
Mon 198977 fix warning messages for downtime popup

### DIFF
--- a/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -23,7 +23,7 @@ if (! isset($centreon)) {
     exit();
 }
 
-if (!defined('DOWNTIME_ON_HOST')) {
+if (! defined('DOWNTIME_ON_HOST')) {
     define('DOWNTIME_ON_HOST', 75);
 }
 

--- a/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -23,8 +23,8 @@ if (! isset($centreon)) {
     exit();
 }
 
-if (!isset(DOWNTIME_ON_HOST)) {
-    const DOWNTIME_ON_HOST = 75;
+if (!defined(DOWNTIME_ON_HOST)) {
+    define(DOWNTIME_ON_HOST, 75);
 }
 
 $select = [];

--- a/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -23,7 +23,9 @@ if (! isset($centreon)) {
     exit();
 }
 
-const DOWNTIME_ON_HOST = 75;
+if (!isset(DOWNTIME_ON_HOST)) {
+    const DOWNTIME_ON_HOST = 75;
+}
 
 $select = [];
 if (isset($_GET['select'])) {

--- a/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -23,8 +23,8 @@ if (! isset($centreon)) {
     exit();
 }
 
-if (!defined(DOWNTIME_ON_HOST)) {
-    define(DOWNTIME_ON_HOST, 75);
+if (!defined('DOWNTIME_ON_HOST')) {
+    define('DOWNTIME_ON_HOST', 75);
 }
 
 $select = [];

--- a/centreon/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
+++ b/centreon/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
@@ -13,10 +13,6 @@
 				<td class="FormRowValue" style='padding-left:15px;'>{$form.start.html}&nbsp;{$form.start_time.html}</td>
 			</tr>
 			<tr>
-				<td  class="FormRowField" style='padding-left:15px;'>{$form.host_or_centreon_time.label}</td>
-				<td  class="FormRowField" style='padding-left:15px;'>{$form.host_or_centreon_time.html}</td>
-			</tr>
-			<tr>
 				<td class="FormRowField" style='padding-left:15px;'>{$form.end.label}</td>
 				<td class="FormRowValue" style='padding-left:15px;'>{$form.end.html}&nbsp;{$form.end_time.html}</td>
 			</tr>

--- a/centreon/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
+++ b/centreon/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
@@ -43,7 +43,6 @@
 			{$form.hidden}
 		</table>
 		<div id="validForm">
-			<p>{$form.action.html}</p>
 			<p>{$form.submit.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
 		</div>
 	</div>


### PR DESCRIPTION
## Description

avoid warning messazges when you try to put a real time downtime on a host or service using old monitoring pages

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
