### PR TITLE
fix(trapd): fix sqlite db permission on creation

### DIFF
--- a/centreon/lib/perl/centreon/script/centreontrapd.pm
+++ b/centreon/lib/perl/centreon/script/centreontrapd.pm
@@ -1209,6 +1209,11 @@ sub run {
         );
     } elsif ($self->{centreontrapd_config}->{mode} == 1) {
         $self->{logger}->writeLogInfo('Mode: poller');
+        # If the sqlite database file does not exist, we create it and set permissions to 0664 to allow centreon-gorgone to update it
+        if ( $self->{centreontrapd_config}->{centreon_db} =~ /=(.*)/ and defined($1) and $1 ne '' and ! -e $1) {
+            open my $sdb_file, '>', $1 or die "Can't open the file $1: $!\n";
+            chmod 0664, $1 or die "Can't change permissions on $1: $!\n";
+        }
         $self->{cdb} = centreon::common::db->new(
             db => $self->{centreontrapd_config}->{centreon_db},
             type => $self->{centreontrapd_config}->{db_type},


### PR DESCRIPTION
## Description


Backport of MON-192523 to 24.10.

The centreontrapd tool was migrated to centreon-collect between 24.10 and 25.10.


**Fixes** # MON-198909

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [X] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

run the centreontrapd tool in poller mode without any sqlite db already created : the file should be created with 664 permission.


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
