### PR TITLE
fix(resource-status): do not empty search filter when reloading the page

### DIFF
--- a/centreon/www/front_src/src/Resources/Actions/Actions.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Actions.cypress.spec.tsx
@@ -558,7 +558,7 @@ describe('CSV export', () => {
     cy.get('@modal').should('not.be.visible');
     cy.contains(labelExportProcessingInProgress);
 
-    const expectedUrl = `${csvExportEndpoint}?page=1&limit=10&sort_by=%7B%22status_severity_code%22%3A%22desc%22%2C%22last_status_change%22%3A%22desc%22%7D&search=%7B%22%24and%22%3A%5B%5D%7D&all_pages=true&max_lines=10000&columns[]=status&columns[]=resource&columns[]=parent_resource&columns[]=duration&columns[]=last_check&columns[]=information&columns[]=tries&columns[]=severity&columns[]=notes_url&columns[]=action_url&columns[]=state&columns[]=alias&columns[]=parent_alias&columns[]=fqdn&columns[]=monitoring_server_name&columns[]=notification&columns[]=checks&format=csv`;
+    const expectedUrl = `${csvExportEndpoint}?page=1&limit=10&sort_by=%7B%22status_severity_code%22%3A%22desc%22%2C%22last_status_change%22%3A%22desc%22%7D&search=%7B%22%24and%22%3A%5B%5D%7D&states=%5B%22unhandled_problems%22%5D&statuses=%5B%22WARNING%22%2C%22DOWN%22%2C%22CRITICAL%22%2C%22UNKNOWN%22%5D&all_pages=true&max_lines=10000&columns[]=status&columns[]=resource&columns[]=parent_resource&columns[]=duration&columns[]=last_check&columns[]=information&columns[]=tries&columns[]=severity&columns[]=notes_url&columns[]=action_url&columns[]=state&columns[]=alias&columns[]=parent_alias&columns[]=fqdn&columns[]=monitoring_server_name&columns[]=notification&columns[]=checks&format=csv`;
     cy.get('@windowOpen').should(
       'be.calledWith',
       expectedUrl,

--- a/centreon/www/front_src/src/Resources/Actions/Actions.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Actions.cypress.spec.tsx
@@ -598,7 +598,7 @@ describe('CSV export', () => {
     cy.contains(labelExportProcessingInProgress);
     cy.get('@modal').should('not.be.visible');
 
-    const expectedUrl = `${csvExportEndpoint}?page=1&limit=10&sort_by=%7B%22status_severity_code%22%3A%22desc%22%2C%22last_status_change%22%3A%22desc%22%7D&search=%7B%22%24and%22%3A%5B%5D%7D&all_pages=false&max_lines=10000&columns[]=resource&columns[]=parent_resource&columns[]=duration&columns[]=last_check&columns[]=information&columns[]=tries&format=csv`;
+    const expectedUrl = `${csvExportEndpoint}?page=1&limit=10&sort_by=%7B%22status_severity_code%22%3A%22desc%22%2C%22last_status_change%22%3A%22desc%22%7D&search=%7B%22%24and%22%3A%5B%5D%7D&states=%5B%22unhandled_problems%22%5D&statuses=%5B%22WARNING%22%2C%22DOWN%22%2C%22CRITICAL%22%2C%22UNKNOWN%22%5D&all_pages=false&max_lines=10000&columns[]=resource&columns[]=parent_resource&columns[]=duration&columns[]=last_check&columns[]=information&columns[]=tries&format=csv`;
     cy.get('@windowOpen').should(
       'be.calledWith',
       expectedUrl,

--- a/centreon/www/front_src/src/Resources/Actions/Actions.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Actions.cypress.spec.tsx
@@ -586,6 +586,7 @@ describe('CSV export', () => {
     cy.get('@modal').contains(labelSelecetPages);
 
     cy.get('@modal').findByTestId(labelCurrentPageOnly).click();
+    cy.waitForRequest('@countResources');
     cy.get('@modal').findByTestId(labelAllPages).should('not.be.checked');
 
     cy.get('@modal').contains(labelWarningExportToCsv);

--- a/centreon/www/front_src/src/Resources/Filter/filterAtoms.ts
+++ b/centreon/www/front_src/src/Resources/Filter/filterAtoms.ts
@@ -76,7 +76,9 @@ export const appliedFilterAtom = atomWithDefault<Filter>((get) =>
   get(getDefaultFilterDerivedAtom)()
 );
 export const editPanelOpenAtom = atom(false);
-export const searchAtom = atom('');
+export const searchAtom = atomWithDefault<string>((get) =>
+  build(get(currentFilterAtom).criterias)
+);
 export const sendingFilterAtom = atom(false);
 
 export const criteriaValueNameByIdAtom = atom<Record<string, string>>({});


### PR DESCRIPTION
Bug fix — Resource Status: search filter was cleared on page reload

▶️ The searchAtom was initialized with an empty string (''), which caused the search input to be wiped on every page reload, even when a filter was already active.

**Fix**: searchAtom is now an atomWithDefault that derives its initial value by rebuilding the search string from the current filter's criterias (currentFilterAtom). This way, on reload, the displayed search field correctly reflects the state of the applied filter.

  Modified file:
  - centreon/www/front_src/src/Resources/Filter/filterAtoms.ts