### PR TITLE
test(e2e): fix 05-agent-configuration-check-permissions.feature

### DIFF
--- a/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions.feature
+++ b/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions.feature
@@ -65,5 +65,5 @@ Feature: Check permissions on Agent Configuration
   Scenario: Delete an agent configuration with a non-admin user with filters on Pollers
     Given a non-admin user is in the Agents Configuration page
     And an already existing agent configuration is displayed
-    When the user deletes the Agents Configuration
-    Then the first Agents Configuration is no longer displayed in the listing page
+    When the non-admin user deletes an Agent Configuration
+    Then the deleted agent Configuration is no longer displayed in the listing page

--- a/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions/index.ts
+++ b/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions/index.ts
@@ -201,15 +201,17 @@ Then(
 );
 
 When('the user deletes the Agents Configuration', () => {
-  cy.getByTestId({ testId: 'Delete' }).eq(1).click();
+  cy.contains('[role="row"]', agentsConfiguration.telegraf2.name).within(() => {
+    cy.getByTestId({ testId: 'Delete' }).click();
+  });
   cy.contains('button', 'Delete').click();
-  cy.wait('@deleteAgents');
+  cy.wait('@deleteAgents').its('response.statusCode').should('eq', 204);
 });
 
 Then(
   'the Agents Configuration is no longer displayed in the listing page',
   () => {
-    cy.contains('telegraf-001-updated').should('not.exist');
+    cy.contains(agentsConfiguration.telegraf2.name).should('not.exist');
   }
 );
 
@@ -427,7 +429,8 @@ Given('a non-admin user is in the Agents Configuration page', () => {
     loginViaApi: false
   });
   cy.visit(PAGES.configuration.agentConfigurations);
-  cy.wait('@getAgentsPage');
+  cy.wait('@getNavigationList');
+  cy.wait('@getAgentsPage').its('response.statusCode').should('eq', 200);
 });
 
 Given('an already existing agent configuration is displayed', () => {
@@ -480,14 +483,17 @@ Then(
   }
 );
 
+When('the non-admin user deletes an Agent Configuration', () => {
+  cy.contains('[role="row"]', agentsConfiguration.telegraf2.name).within(() => {
+    cy.getByTestId({ testId: 'Delete' }).click();
+  });
+  cy.contains('button', 'Delete').click();
+  cy.wait('@deleteAgents').its('response.statusCode').should('eq', 204);
+});
+
 Then(
-  'the first Agents Configuration is no longer displayed in the listing page',
+  'the deleted agent Configuration is no longer displayed in the listing page',
   () => {
-    cy.contains('telegraf-001-updated').should('not.exist');
-    cy.get('*[role="rowgroup"]').should(
-      'contain',
-      agentsConfiguration.telegraf2.name
-    );
-    cy.get('*[role="rowgroup"]').should('contain', 'Telegraf');
+    cy.contains(agentsConfiguration.telegraf2.name).should('not.exist');
   }
 );


### PR DESCRIPTION
## Description

This PR improves the stability of the E2E test suite on the `develop` branch by fixing flaky behavior in the `05-agent-configuration-check-permissions.feature` test on Trixie OS.

The test has been stabilized by:
- removing dependencies on element indexes
- using more reliable selectors
- waiting for API requests to complete successfully before continuing test execution

These changes reduce timing-related issues and make the test behavior more deterministic across environments.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2>How this pull request can be tested?</h2>

1. Run the E2E test suite on a Trixie OS environment.
2. Execute the following test multiple times:

```bash
05-agent-configuration-check-permissions.feature