### PR TITLE
fix(packaging): enable MariaDB local_infile in shipped config

### DIFF
--- a/centreon/packaging/src/centreon-database.cnf
+++ b/centreon/packaging/src/centreon-database.cnf
@@ -2,6 +2,10 @@
 # Custom MySQL/MariaDB server configuration for Centreon
 #
 [server]
+# Required for `LOAD DATA LOCAL INFILE` used by the central → remote topology link.
+# Defaults to OFF on recent MariaDB versions (>= 10.5.20 / 10.6.13 / 10.11 / 11.x).
+local_infile = ON
+
 innodb_file_per_table=1
 
 open_files_limit = 32000


### PR DESCRIPTION
## Summary

- Add `local_infile = ON` to `packaging/src/centreon-database.cnf`. This is required for `LOAD DATA LOCAL INFILE` used by the central → remote topology link to work on recent MariaDB versions, where `local_infile` defaults to `OFF` (>= 10.5.20 / 10.6.13 / 10.11 / 11.x).
- Without this, the topology link's import phase silently fails on the remote: Phase-1 `DELETE FROM nagios_server` commits, Phase-2 `LOAD DATA LOCAL INFILE` is rejected, and the remote is left with an empty `nagios_server` table.

## Jira

MON-199145

## Scope

- Covers **fresh installs** via the `centreon-mariadb` package (file installed at `/etc/my.cnf.d/centreon.cnf` for RPM, `/etc/mysql/mariadb.conf.d/80-centreon.cnf` for DEB).
- **Existing installs are out of scope of this PR** — the package ships the file with `config|noreplace`, so existing installs keep their old file on upgrade. They will need either to manually add `local_infile = ON` to their MariaDB configuration, or a follow-up upgrade mechanism (separate fragment file / postinstall script) to be discussed.
- Two related defensive issues uncovered during analysis are tracked separately as future tickets:
  - `ConfigurationExporter::import()` exception handling (`\ErrorException` catch doesn't match the actual `\Exception` thrown).
  - `pollersStatusList()` `IN ()` defensive guard.

## Test plan

- [ ] On a fresh Centreon install with `centreon-mariadb` package, verify `mysql -e "SHOW VARIABLES LIKE 'local_infile';"` returns `ON`.
- [ ] On a fresh Alma9 / Debian 12 install, run the central → remote topology link end-to-end and confirm the remote's `nagios_server` table is correctly populated after the link.
- [ ] On the remote, verify `findLocalServer` resolves correctly (poller registration via `registerServerTopology.sh` succeeds).
- [ ] On the remote, verify the top counter UI loads without 500 on `pollersListIssues` and the "Export configuration" / "Configure pollers" actions are present.