### PR TITLE
[Backport release-24.10-next] fix(packaging): enable MariaDB local_infile in shipped config

### DIFF
--- a/centreon/packaging/src/centreon-database.cnf
+++ b/centreon/packaging/src/centreon-database.cnf
@@ -2,6 +2,10 @@
 # Custom MySQL/MariaDB server configuration for Centreon
 #
 [server]
+# Required for `LOAD DATA LOCAL INFILE` used by the central → remote topology link.
+# Defaults to OFF on recent MariaDB versions (>= 10.5.20 / 10.6.13 / 10.11 / 11.x).
+local_infile = ON
+
 innodb_file_per_table=1
 
 open_files_limit = 32000


### PR DESCRIPTION
Backport of #10391 to `release-24.10-next`.

Jira: MON-199145

> Note: Jira linking will need to be reconciled once the original ticket reaches "Ready for Release" and the automation creates the backport ticket.