### PR TITLE
fix(packaging): allow php-fpm to write in centreon directory

### DIFF
--- a/centreon/packaging/src/php-fpm-systemd.conf
+++ b/centreon/packaging/src/php-fpm-systemd.conf
@@ -1,2 +1,4 @@
 [Service]
 LimitNOFILE=4096
+ProtectSystem=true
+ReadWritePaths=/usr/share/centreon/


### PR DESCRIPTION
## Summary

Hardens the php-fpm systemd service by enabling filesystem protection while explicitly allowing write access to the Centreon application directory.

## Changes

- **`ProtectSystem=true`**: Mounts `/usr` and `/boot` as read-only for the php-fpm service, restricting it from writing to system directories it does not need access to.
- **`ReadWritePaths=/usr/share/centreon/`**: Grants an explicit write exception to the Centreon application directory so that php-fpm can still generate cache files, compiled templates, and other runtime artifacts.

## Why

Without `ProtectSystem=true`, php-fpm had unrestricted write access to system paths. Adding this protection reduces the attack surface in case of a compromise.
Without the `ReadWritePaths` exception, php-fpm would fail to write to `/usr/share/centreon/`, which is required for normal Centreon operations (Smarty cache, generated configuration, etc.).

## Testing

- Verify php-fpm starts correctly after the change: `systemctl restart php-fpm`
- Confirm Centreon pages load without filesystem permission errors in `/var/log/php-fpm/` or `/var/log/centreon/`
- Confirm write operations to `/usr/share/centreon/` succeed (e.g., cache generation)

**Fixes** MON-199301 MON-199146