### PR TITLE
enh(broker): add event_script log level to broker configuration form and export

### DIFF
--- a/centreon/src/CentreonRemote/Domain/Resources/DefaultConfig/CfgCentreonBrokerLog.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/DefaultConfig/CfgCentreonBrokerLog.php
@@ -59,6 +59,7 @@ class CfgCentreonBrokerLog
             $loggerIds['graphite'] => $loggerLevelIds['error'],
             $loggerIds['victoria_metrics'] => $loggerLevelIds['error'],
             $loggerIds['stats'] => $loggerLevelIds['error'],
+            $loggerIds['event_script'] => $loggerLevelIds['error'],
         ];
 
         foreach ($loggerConfigurations as $loggerId => $loggerLevel) {

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -490,7 +490,8 @@ INSERT INTO `cb_log` (`id`, `name`) VALUES
 (14, 'influxdb'),
 (15, 'graphite'),
 (16, 'victoria_metrics'),
-(17, 'stats');
+(17, 'stats'),
+(18, 'event_script');
 
 --
 -- Contenu de la table `cb_log_level`

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -246,6 +246,7 @@ $addVmwareUpdatedField = function () use ($pearDB, &$errorMessage, $version): vo
     );
 };
 
+/** -------------------------------------- Poller UUID to UID -------------------------------------- */
 $renamePollerUuidToUid = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Unable to rename uuid column to uid on nagios_server';
     CentreonLog::create()->info(
@@ -383,6 +384,64 @@ function generateMissingPollerUids(ConnectionInterface $pearDB, string $version)
     );
 }
 
+/** -------------------------------------- Broker event_script logger -------------------------------------- */
+$addEventScriptLogger = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to add event_script logger to broker configuration';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Adding 'event_script' logger to broker configuration",
+    );
+
+    if ($pearDB->fetchOne(
+        <<<'SQL'
+            SELECT 1 FROM `cb_log` WHERE `name` = 'event_script'
+            SQL
+    )) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Logger 'event_script' already exists in cb_log, skipping",
+        );
+
+        return;
+    }
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            INSERT INTO `cb_log` (`name`) VALUES ('event_script')
+            SQL
+    );
+
+    $logId = (int) $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT `id` FROM `cb_log` WHERE `name` = 'event_script'
+            SQL
+    );
+
+    $errorLevelId = (int) $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT `id` FROM `cb_log_level` WHERE `name` = 'error'
+            SQL
+    );
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`)
+            SELECT `config_id`, :id_log, :id_level
+            FROM `cfg_centreonbroker`
+            SQL,
+        QueryParameters::create([
+            QueryParameter::int('id_log', $logId),
+            QueryParameter::int('id_level', $errorLevelId),
+        ])
+    );
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: Successfully added 'event_script' logger to broker configuration",
+    );
+};
+
 try {
     // DDL statements for real time database
     $migrateInstanceIdToBigint();
@@ -391,6 +450,7 @@ try {
     $addVmwareUpdatedField();
     $migrateModuleTableInstanceIds();
     $renamePollerUuidToUid();
+    $addEventScriptLogger();
 
     // Transactional queries for configuration database
     if (! $pearDB->isTransactionActive()) {

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -393,14 +393,41 @@ $addEventScriptLogger = function () use ($pearDB, &$errorMessage, $version): voi
         message: "UPGRADE - {$version}: Adding 'event_script' logger to broker configuration",
     );
 
-    if ($pearDB->fetchOne(
+    if (! $pearDB->fetchOne(
         <<<'SQL'
             SELECT 1 FROM `cb_log` WHERE `name` = 'event_script'
             SQL
     )) {
-        CentreonLog::create()->info(
+        $pearDB->executeStatement(
+            <<<'SQL'
+                INSERT INTO `cb_log` (`name`) VALUES ('event_script')
+                SQL
+        );
+    }
+
+    $logId = $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT `id` FROM `cb_log` WHERE `name` = 'event_script'
+            SQL
+    );
+    if ($logId === false) {
+        CentreonLog::create()->error(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Logger 'event_script' already exists in cb_log, skipping",
+            message: "UPGRADE - {$version}: Failed to retrieve 'event_script' log id from cb_log, skipping cfg_centreonbroker_log population",
+        );
+
+        return;
+    }
+
+    $errorLevelId = $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT `id` FROM `cb_log_level` WHERE `name` = 'error'
+            SQL
+    );
+    if ($errorLevelId === false) {
+        CentreonLog::create()->error(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Failed to retrieve 'error' level id from cb_log_level, skipping cfg_centreonbroker_log population",
         );
 
         return;
@@ -408,27 +435,14 @@ $addEventScriptLogger = function () use ($pearDB, &$errorMessage, $version): voi
 
     $pearDB->executeStatement(
         <<<'SQL'
-            INSERT INTO `cb_log` (`name`) VALUES ('event_script')
-            SQL
-    );
-
-    $logId = (int) $pearDB->fetchOne(
-        <<<'SQL'
-            SELECT `id` FROM `cb_log` WHERE `name` = 'event_script'
-            SQL
-    );
-
-    $errorLevelId = (int) $pearDB->fetchOne(
-        <<<'SQL'
-            SELECT `id` FROM `cb_log_level` WHERE `name` = 'error'
-            SQL
-    );
-
-    $pearDB->executeStatement(
-        <<<'SQL'
             INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`)
             SELECT `config_id`, :id_log, :id_level
-            FROM `cfg_centreonbroker`
+            FROM `cfg_centreonbroker` cb
+            WHERE NOT EXISTS (
+                SELECT 1 FROM `cfg_centreonbroker_log` cbl
+                WHERE cbl.`id_centreonbroker` = cb.`config_id`
+                  AND cbl.`id_log` = :id_log
+            )
             SQL,
         QueryParameters::create([
             QueryParameter::int('id_log', $logId),

--- a/centreon/www/install/var/baseconf/centreon-broker.sql
+++ b/centreon/www/install/var/baseconf/centreon-broker.sql
@@ -138,6 +138,7 @@ INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`)
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (2,15,3);
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (2,16,3);
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (2,17,3);
+INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (2,18,3);
 --
 --  Creation and config of central module
 --
@@ -177,6 +178,7 @@ INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`)
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (3,15,3);
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (3,16,3);
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (3,17,3);
+INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (3,18,3);
 
 UPDATE `nagios_server` SET `centreonbroker_cfg_path` = '@broker_etc@' WHERE `id` = 1;
 UPDATE `nagios_server` SET `centreonbroker_module_path` = '@centreonbroker_lib@' WHERE `id` = 1;

--- a/centreon/www/install/var/baseconf/centreon-broker.sql
+++ b/centreon/www/install/var/baseconf/centreon-broker.sql
@@ -84,6 +84,8 @@ INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`)
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (1,15,3);
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (1,16,3);
 INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (1,17,3);
+INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`) VALUES (1,18,3);
+
 --
 --  Creation and config of central rrd
 --


### PR DESCRIPTION
## Summary

- Adds `event_script` as a configurable logger in the Broker configuration form (Log Options section), alongside the existing 17 loggers (`core`, `sql`, `bbdo`, etc.)
- New installations: seeds `cb_log` with `(18, 'event_script')` via `insertBaseConf.sql`
- Existing installations: upgrade migration (`Update-next.php`) inserts the logger into `cb_log` and backfills `cfg_centreonbroker_log` for all existing broker configurations with the `error` default level
- No PHP form or export code changes required — both are fully dynamic (read from `cb_log` at runtime)

## Test plan

- [ ] Fresh install: `SELECT * FROM cb_log WHERE name='event_script'` returns 1 row with id 18
- [ ] Upgrade: running `Update-next.php` inserts the row in `cb_log` and creates `cfg_centreonbroker_log` entries for all existing broker configs; re-running is idempotent
- [ ] Broker config form → Log Options section → `event_script` dropdown appears with all levels (disabled → trace), defaulting to `error`
- [ ] Generate broker config (`central-broker-master.json`) → `log.loggers` in the output JSON includes `"event_script": "<configured level>"`

Refs: MON-195786