### PR TITLE
fix(packaging): allow encoded slashes in Apache URLs

### DIFF
--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -29,6 +29,7 @@ ServerTokens Prod
     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
     ServerSignature Off
     TraceEnable Off
+    AllowEncodedSlashes NoDecode
 
     Alias ${base_uri}/api ${install_dir}
     Alias ${base_uri} ${install_dir}/www/

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -11,6 +11,7 @@ ServerTokens Prod
     Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;SameSite=Strict
     ServerSignature Off
     TraceEnable Off
+    AllowEncodedSlashes NoDecode
 
     Alias ${base_uri}/api ${install_dir}
     Alias ${base_uri} ${install_dir}/www/


### PR DESCRIPTION
## Summary
Adds `AllowEncodedSlashes NoDecode` to both Centreon Apache VirtualHosts so URL path segments containing `%2F` reach PHP/Symfony instead of being rejected by Apache with a 404.

Fixes [MON-195008](https://centreon.atlassian.net/browse/MON-195008).

## Bug
`GET /monitoring/hosts/{hostId}/services/{serviceId}/metrics/{metricName}` and `GET /monitoring/metaservice/{metaServiceId}/metrics/{metricName}` return `404 Not Found` whenever `metricName` contains a `/` (e.g. Linux SNMP `Disk-Global` / `Inodes-Global` metrics like `used_/usr`). The 404 is an HTML page from Apache's `ErrorDocument`, not a JSON response from Symfony — the request never reaches PHP.

## Root cause
Apache's default is `AllowEncodedSlashes Off`, which rejects any request URI containing `%2F` *before* it is proxied to PHP-FPM.

## Fix
Add `AllowEncodedSlashes NoDecode` inside the relevant VirtualHosts:
- `centreon/packaging/src/centreon-apache.conf` — `<VirtualHost *:80>`
- `centreon/packaging/src/centreon-apache-https.conf` — `<VirtualHost *:443>`

`NoDecode` (rather than `On`) keeps `%2F` *encoded* in `REQUEST_URI` and leaves decoding to the application layer, which is the recommended setting for REST APIs.

## Why no `urldecode()` in the controller
The initial ticket suggested adding `urldecode($metricName)` in `FindSingleMetricController`. **It is not needed and would cause a double decode**:
- `Symfony\Component\HttpFoundation\Request::preparePathInfo()` does not decode the path.
- `Symfony\Component\Routing\Matcher\UrlMatcher::match()` calls `rawurldecode()` on the full path before route matching ([UrlMatcher.php:74](https://github.com/symfony/routing/blob/7.3/Matcher/UrlMatcher.php#L74)).
- The controller therefore already receives `$metricName = "used_/usr"`. An extra `urldecode()` would re-decode any remaining `%XX` sequences, and would silently convert `+` → space (which `rawurldecode` does not), corrupting otherwise-valid metric names.

The same reasoning applies to `FindSingleMetaMetricController`; both controllers are unchanged.

## Verification
Tested live against the `centreon-web-alma9:develop` container (`centreon-dev-environment`):

1. Deployed host `SV-LINUX-PAR` (id 144, OS-Linux-SNMP-custom template) via `GET /configuration/monitoring-servers/1/generate-and-reload`.
2. Injected a synthetic `used_/usr` metric on the host's `Ping` service in `centreon_storage.metrics` (since the dataset does not include a Disk-Global service).
3. Hit `GET /monitoring/hosts/144/services/303/metrics/used_%2Fusr` with an admin token, before and after the patch.

| | Without patch | With patch |
|---|---|---|
| HTTP status | `404 Not Found` | `200 OK` |
| `Content-Type` | `text/html; charset=UTF-8` | `application/json` |
| `X-Debug-Token` header | absent | present |
| Body | Apache `ErrorDocument` SPA fallback | `{"metrics":[{"metric_id":279,"name":"used_/usr","unit":"B","current_value":1234570,...}]}` |

Synthetic metric removed after the test.

## Scope notes for reviewers
- `AllowEncodedSlashes NoDecode` is a VirtualHost-wide directive — every route in the app now accepts `%2F` in path segments. This matches how most modern REST APIs are deployed and brings Apache in line with what frameworks (Symfony, Laravel, …) already expect.
- Combined with the `metricName: '.+'` route requirement and Symfony's pre-match decode, the metric endpoints also accept un-encoded `/` in `metricName` (e.g. `…/metrics/foo/bar`). This was already the case for any URI the SPA fallback didn't catch; it's now reachable.
- No application code change. No migration. No new dependency.

[MON-195008]: https://centreon.atlassian.net/browse/MON-195008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ