### PR TITLE
fix(ci): use explicit alma9 lookup instead of array index for cloud distrib

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -834,8 +834,9 @@ jobs:
             }));
 
             const cloudDistrib = allDistribs.find(d => d.operating_system === 'alma9');
+            const onPremMainDistrib = allDistribs.filter(d => d.operating_system === 'alma10');
             const isCloudTestingOrStable = isCloud && ['testing', 'stable'].includes(stability);
-            const result = isCloudTestingOrStable ? [cloudDistrib] : isFullRun ? allDistribs : [cloudDistrib];
+            const result = isCloudTestingOrStable ? [cloudDistrib] : isFullRun ? allDistribs : isCloud ? [cloudDistrib] : [onPremMainDistrib];
 
             console.log('package_matrix', result);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -833,8 +833,9 @@ jobs:
               ...info,
             }));
 
+            const cloudDistrib = allDistribs.find(d => d.operating_system === 'alma9');
             const isCloudTestingOrStable = isCloud && ['testing', 'stable'].includes(stability);
-            const result = isCloudTestingOrStable ? [allDistribs[0]] : isFullRun ? allDistribs : [allDistribs[0]];
+            const result = isCloudTestingOrStable ? [cloudDistrib] : isFullRun ? allDistribs : [cloudDistrib];
 
             console.log('package_matrix', result);
 


### PR DESCRIPTION
## Summary

- Replace `allDistribs[0]` with an explicit `.find(d => d.operating_system === 'alma9')` to select the cloud distribution
- Eliminates implicit dependency on insertion order in `distribMap`
- Applies to both the cloud testing/stable path and the default (non-full-run) fallback

## Test plan

- [ ] Verify `get-environment` workflow still selects `alma9` for cloud builds
- [ ] Verify full-run still returns all distributions
- [ ] Verify non-cloud non-full-run still defaults to `alma9`