### PR TITLE
fix(install): fix fresh install loading screen stuck on HTTP 500

### DIFF
--- a/centreon/config.new/packages/doctrine.yaml
+++ b/centreon/config.new/packages/doctrine.yaml
@@ -1,5 +1,12 @@
 parameters:
     env(DATABASE_SERVER_VERSION): 'mariadb-10.11.0'
+    env(hostCentreon): ''
+    env(hostCentstorage): ''
+    env(user): ''
+    env(password): ''
+    env(db): ''
+    env(dbcstg): ''
+    env(port): '3306'
 
 doctrine:
    dbal:

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -68,6 +68,10 @@ ServerTokens Prod
         Require all granted
     </Directory>
 
+    RewriteEngine On
+    RewriteCond /etc/centreon/centreon.conf.php !-f
+    RewriteRule ^${base_uri}/?$ ${base_uri}/install/install.php [R=302,L]
+
     <If "'${base_uri}' != '/'">
         RedirectMatch ^/$ ${base_uri}
     </If>

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -21,10 +21,6 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
-    <LocationMatch ^\${base_uri}/?(install/.*\.php(/.*)?)$>
-        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
-    </LocationMatch>
-
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>
@@ -53,6 +49,10 @@ ServerTokens Prod
         AllowOverride none
         Require all granted
     </Directory>
+
+    RewriteEngine On
+    RewriteCond /etc/centreon/centreon.conf.php !-f
+    RewriteRule ^${base_uri}/?$ ${base_uri}/install/install.php [R=302,L]
 
     <If "'${base_uri}' != '/'">
         RedirectMatch ^/$ ${base_uri}

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -21,6 +21,10 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
+    <LocationMatch ^\${base_uri}/?(install/.*\.php(/.*)?)$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
+    </LocationMatch>
+
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>


### PR DESCRIPTION
## Problem

On a fresh Centreon install (after `unattended.sh`, before the web wizard), the UI gets stuck on the loading screen. `GET /api/latest/platform/installation/status` returns HTTP 500 (`Environment variable not found: "hostCentreon"`) because `centreon.conf.php` does not yet exist, causing Symfony to throw `EnvNotFoundException` at DI container build time.

Additionally, navigating to `<ip>/` or `<ip>/centreon/` does not redirect to the install wizard — the React SPA tries to handle the redirect but the API 500 breaks the flow.

## Changes

### 1. Symfony env var defaults (`config.new/packages/doctrine.yaml`)
Added default values for all DB connection env vars. This prevents `EnvNotFoundException` on a fresh install where `centreon.conf.php` is absent. Both kernels are covered since `config/packages/doctrine.yaml` imports this file.

### 2. Apache redirect to install wizard (`packaging/src/centreon-apache.conf`, `centreon-apache-https.conf`)
Added a `RewriteRule` at VirtualHost scope that redirects `<base_uri>/` to `<base_uri>/install/install.php` when `centreon.conf.php` does not exist. This ensures the browser reaches the install wizard without depending on the React SPA or the API.

The condition `RewriteCond /etc/centreon/centreon.conf.php !-f` correctly handles all states:
- **Fresh install**: file absent → redirect fires ✓
- **Configured platform**: file present → redirect never fires ✓
- **Upgrade in progress**: file present → redirect never fires ✓

## Test plan
- [ ] Fresh install (after `unattended.sh`, `centreon.conf.php` absent): navigating to `<ip>/` redirects to `<ip>/centreon/install/install.php`
- [ ] Fresh install: `GET /api/latest/platform/installation/status` returns 200 (not 500)
- [ ] Configured platform: navigating to `<ip>/centreon/` loads the app normally, no redirect to install wizard
- [ ] Upgrade in progress (`centreon.conf.php` present, `www/install/` present): no redirect to install wizard

Fixes MON-199451