### PR TITLE
fix(packaging): allow encoded slashes in Apache URLs

### DIFF
--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -29,6 +29,7 @@ ServerTokens Prod
     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
     ServerSignature Off
     TraceEnable Off
+    AllowEncodedSlashes NoDecode
 
     Alias ${base_uri}/api ${install_dir}
     Alias ${base_uri} ${install_dir}/www/

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -11,6 +11,7 @@ ServerTokens Prod
     Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;SameSite=Strict
     ServerSignature Off
     TraceEnable Off
+    AllowEncodedSlashes NoDecode
 
     Alias ${base_uri}/api ${install_dir}
     Alias ${base_uri} ${install_dir}/www/


### PR DESCRIPTION
## Summary
Backport of [#10410](https://github.com/centreon/centreon/pull/10410) to `dev-24.10.x`.


## Change
Adds `AllowEncodedSlashes NoDecode` to both Centreon Apache VirtualHosts so URL path segments containing `%2F` reach PHP/Symfony instead of being rejected by Apache with a 404 — needed for metric-name path parameters that contain `/` (e.g. Linux Disk-Global metrics like `used_/usr`).

Clean cherry-pick from `develop` (`1cf0b33c46`), no conflicts, no code changes.

## Verification
End-to-end test performed on the original PR (`#10410`) against `centreon-web-alma9:develop`:
- Without patch → Apache 404 (HTML SPA fallback)
- With patch → Symfony 200 (`application/json`) with the metric payload

Same 2-line diff applies here; no version-specific concerns.

[MON-199530]: https://centreon.atlassian.net/browse/MON-199530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ