### PR TITLE
fix(wizard): skip engine-context write when file already has content

### DIFF
--- a/centreon/src/Core/Installation/Infrastructure/InstallationHelper.php
+++ b/centreon/src/Core/Installation/Infrastructure/InstallationHelper.php
@@ -49,4 +49,9 @@ final readonly class InstallationHelper
 
         $this->engineRepository->writeEngineSecrets($engineSecrets);
     }
+
+    public function engineContextHasContent(): bool
+    {
+        return $this->engineRepository->engineSecretsHasContent();
+    }
 }

--- a/centreon/www/install/steps/process/process_step9.php
+++ b/centreon/www/install/steps/process/process_step9.php
@@ -72,7 +72,9 @@ try {
 
     /** @var InstallationHelper $installationHelper */
     $installationHelper = $kernel->getContainer()->get(InstallationHelper::class);
-    $installationHelper->writeEngineContextFile();
+    if (! $installationHelper->engineContextHasContent()) {
+        $installationHelper->writeEngineContextFile();
+    }
     $backupDir = _CENTREON_VARLIB_ . '/installs/'
         . '/install-' . $version . '-' . date('Ymd_His');
     $installDir = realpath(__DIR__ . '/../..');


### PR DESCRIPTION
## Description

During the installation wizard (step 9), the `engine-context` file is always overwritten, even when it already contains valid content. This causes compliance scripts that pre-set the engine-context before running the wizard to fail with:

```
engine-context already has content, unable to write in the file
```

The fix checks whether the engine-context file already has content before writing. If the file is non-empty, the write is skipped, preserving the existing configuration.

**Fixes** MON-199563

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

- Pre-set the engine-context file with valid content before running the installation wizard
- Run the wizard through step 9
- Verify the wizard completes successfully without overwriting the existing engine-context file
- Verify a fresh install (empty engine-context file) still writes the file correctly

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).