### PR TITLE
fix(broker): use injected DB connection instead of global variable

### DIFF
--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -662,8 +662,8 @@ class Broker extends AbstractObjectJSON
      */
     private function getCentreonPlatformUuid(): ?string
     {
-        global $pearDB;
-        $result = $pearDB->query("SELECT `value` FROM informations WHERE `key` = 'uuid'");
+        $db = $this->backend_instance->db;
+        $result = $db->query("SELECT `value` FROM informations WHERE `key` = 'uuid'");
 
         if (! $record = $result->fetch(PDO::FETCH_ASSOC)) {
             return null;
@@ -681,7 +681,7 @@ class Broker extends AbstractObjectJSON
      */
     private function generateAnomalyDetectionLuaParameters(): array
     {
-        global $pearDB;
+        $pearDB = $this->backend_instance->db;
 
         $sql = <<<'SQL'
             SELECT


### PR DESCRIPTION
## Description

Backport of #10412 for `dev-24.10.x`.

Replace `global $pearDB` usage with `$this->backend_instance->db` in Broker config-generate class to fix APPLYCFG failure when Anomaly Detection is configured.

**Fixes** MON-199568

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 24.10.x

## How this pull request can be tested ?

- Have a platform with Anomaly Detection configured
- Run `centreon -u <user> -p '<password>' -a APPLYCFG -v <poller_id>`
- Verify the command completes successfully

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).