### PR TITLE
feat(dev): enable Symfony DebugBundle in dev/test environments

### DIFF
--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -89,6 +89,7 @@
     "pestphp/pest": "1.23.*",
     "php-vfs/php-vfs": "1.4.*",
     "robertfausk/mink-panther-driver": "1.1.*",
+    "symfony/debug-bundle": "6.4.*",
     "symfony/phpunit-bridge": "6.4.*",
     "symfony/stopwatch": "6.4.*",
     "symfony/twig-bundle": "6.4.*",

--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d07eb0653bb6cf3e14e0b330a65f391",
+    "content-hash": "6fe39dffcfbdf2e2ceef200d517c3efe",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -11390,6 +11390,84 @@
             "time": "2024-05-31T14:57:53+00:00"
         },
         {
+            "name": "symfony/debug-bundle",
+            "version": "v6.4.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug-bundle.git",
+                "reference": "eb79084c2c9778559b21f61cb1507cbd580cc6e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug-bundle/zipball/eb79084c2c9778559b21f61cb1507cbd580cc6e1",
+                "reference": "eb79084c2c9778559b21f61cb1507cbd580cc6e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xml": "*",
+                "php": ">=8.1",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/twig-bridge": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "conflict": {
+                "symfony/config": "<5.4",
+                "symfony/dependency-injection": "<5.4"
+            },
+            "require-dev": {
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/web-profiler-bundle": "^5.4|^6.0|^7.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\DebugBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of the Symfony VarDumper component and the ServerLogCommand from MonologBridge into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/debug-bundle/tree/v6.4.35"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-02T09:25:10+00:00"
+        },
+        {
             "name": "symfony/dom-crawler",
             "version": "v7.1.5",
             "source": {
@@ -12280,7 +12358,7 @@
         "ext-xmlwriter": "*",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },

--- a/centreon/config/bundles.php
+++ b/centreon/config/bundles.php
@@ -29,6 +29,7 @@ return [
     Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
 ];

--- a/centreon/config/routes/dev/web_profiler.yaml
+++ b/centreon/config/routes/dev/web_profiler.yaml
@@ -1,7 +1,7 @@
 web_profiler_wdt:
     resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
-    prefix: /centreon/api/beta/_wdt
+    prefix: /centreon/api/latest/_wdt
 
 web_profiler_profiler:
     resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
-    prefix: /centreon/api/beta/_profiler
+    prefix: /centreon/api/latest/_profiler


### PR DESCRIPTION
> Branch renamed to follow the MON-<id> convention. Replaces #10434 (closed automatically when the previous branch was deleted).
>
> Jira: [MON-199634](https://centreon.atlassian.net/browse/MON-199634)

## Summary

Activate the **Symfony `DebugBundle`** in `dev` / `test` environments. Until now only `WebProfilerBundle` was registered in `config/bundles.php`, which gives the toolbar and the profiler UI but **not** `dump()` / `dd()`. Adding `DebugBundle` brings the standard `VarDumper` integration: working `dump()` / `dd()` and a dedicated "Debug" panel in the Web Profiler.

This is the standard pair on a Symfony 6.4 stack and matches what `develop` / `25.10` already do via `config.new/bundles.php`.

## Changes

| File | Change |
|---|---|
| `composer.json` | `+ "symfony/debug-bundle": "6.4.*"` in `require-dev`, next to the already-present `symfony/web-profiler-bundle` |
| `composer.lock` | Regenerated by `composer require --dev symfony/debug-bundle:6.4.*` |
| `config/bundles.php` | `+ Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true]`, same scope as `WebProfilerBundle` |

No new `config/packages/dev/debug.yaml` is created. With no `dump_destination` set, dumps render inline in the response, which is the default Symfony behaviour and matches what we want for interactive debug.

## Effects

- ✅ `dump(\$x)` / `dd(\$x)` available everywhere in the codebase when `APP_ENV=dev` or `test`.
- ✅ A **Debug** tab appears in the Web Profiler with the captured dumps (timing, file:line).
- ✅ **prod is untouched** — the bundle is not loaded under `'all'`.

## Test plan

- [ ] `composer install` on a fresh clone of this branch
- [ ] `APP_ENV=dev` `bin/console cache:clear --env=dev` → exit 0 (kernel boots with the new bundle)
- [ ] In a dev request, `dump('hello')` shows the rendered dump in the response or in the profiler panel
- [ ] `APP_ENV=prod` `bin/console cache:clear --env=prod` → exit 0 (no regression: DebugBundle not loaded)
- [ ] Boot the stack in `centreon-dev-environment` with `DEV_PROFILE=backend`, `APP_ENV=dev`, `APP_DEBUG=1`, image `24.10` → the profiler is reachable and now exposes the Debug panel

## Related

- centreon-dev-environment companion PR (Makefile banner + doc): https://github.com/centreon/centreon-dev-environment/pull/127 (also renamed and replaced; new PR coming next)

[MON-199634]: https://centreon.atlassian.net/browse/MON-199634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ