### PR TITLE
chore(gitignore): ignore Symfony-generated config.new/reference.php

### DIFF
--- a/centreon/.gitignore
+++ b/centreon/.gitignore
@@ -48,6 +48,7 @@ var/
 bin/.phpunit/
 doc/en/_build/
 symfony/
+/config.new/reference.php
 
 src/Centreon*
 !src/Centreon/


### PR DESCRIPTION
## Summary

- Add `/config.new/reference.php` to `.gitignore`. The file is auto-generated by Symfony's DependencyInjection component to provide IDE autocompletion for `App::config([...])`; its own header states it is auto-generated and should not be tracked.

## Jira

[MON-199671](https://centreon.atlassian.net/browse/MON-199671)

## Test plan

- [ ] After pulling the branch, run `git status` in a working tree where `config.new/reference.php` has been generated locally — the file should no longer appear as untracked.
- [ ] Verify the other (hand-written) files in `config.new/` (`bootstrap.php`, `bundles.php`, `preload.php`, `packages/`, `routes/`, `services/`) are still tracked and unaffected.

[MON-199671]: https://centreon.atlassian.net/browse/MON-199671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ