### PR TITLE
fix(error-handling): clamp exception code to valid HTTP status

### DIFF
--- a/centreon/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/centreon/src/EventSubscriber/CentreonEventSubscriber.php
@@ -333,9 +333,10 @@ class CentreonEventSubscriber implements EventSubscriberInterface
                     $message = 'The data sent does not comply with the defined validation constraints';
                 }
             } else {
-                $errorCode = $event->getThrowable()->getCode();
-                $statusCode = $event->getThrowable()->getCode()
-                    ?: Response::HTTP_INTERNAL_SERVER_ERROR;
+                $statusCode = ($event->getThrowable()->getCode() >= 100 && $event->getThrowable()->getCode() < 600)
+                    ? (int) $event->getThrowable()->getCode()
+                    : Response::HTTP_INTERNAL_SERVER_ERROR;
+                $errorCode = $statusCode;
             }
             // Manage exception outside controllers
             $event->setResponse(


### PR DESCRIPTION
## Summary

- Fix `InvalidArgumentException: The HTTP status code "10" is not valid.` raised when a DB `ConnectionException` (code 10) propagates before the controller, e.g. when the auth firewall's user load fails because the database is unreachable.
- Mirror the `[100, 600)` guard already present in the post-controller branch of `CentreonEventSubscriber::onKernelException`, so out-of-range exception codes fall back to HTTP 500.
- 24.10-only: `develop` / `dev-25.10.x` no longer hit this code path thanks to the API Platform migration (#7626), but cleaning the "code" part in the response can be forward-ported.

## Jira

MON-176597

## Test plan

- [ ] Break the DB credentials in `/etc/centreon/centreon.conf.php` (e.g. wrong password) so the connection fails immediately
- [ ] Hit any authenticated API endpoint (e.g. `GET /centreon/api/latest/configuration/proxy`)
- [ ] Response is HTTP 500 with body `{"code": 500, "message": "Error while connecting to the database: …"}`
- [ ] `/var/log/php-fpm/centreon-error.log` no longer contains `The HTTP status code "10" is not valid.`
- [ ] Restore credentials and confirm normal API responses still work