### PR TITLE
refactor(contact): use prepared statements in contact and contactgroup queries

### DIFF
--- a/centreon/lib/Centreon/Object/Contact/Contact.php
+++ b/centreon/lib/Centreon/Object/Contact/Contact.php
@@ -55,10 +55,10 @@ class Centreon_Object_Contact extends Centreon_Object
         $placeholders = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
+            $key = trim(trim($key), '`');
             if ($key == $this->primaryKey) {
                 continue;
             }
-            $this->assertValidIdentifier($key);
             $fields[] = $key;
             $placeholders[] = ':' . $key;
             $bindParams[':' . $key] = trim($value);
@@ -102,9 +102,6 @@ class Centreon_Object_Contact extends Centreon_Object
         }
 
         if (is_array($parameterNames)) {
-            foreach ($parameterNames as $parameterName) {
-                $this->assertValidIdentifier($parameterName);
-            }
             if (($key = array_search('contact_id', $parameterNames)) !== false) {
                 $parameterNames[$key] = $this->table . '.contact_id';
             }
@@ -112,9 +109,6 @@ class Centreon_Object_Contact extends Centreon_Object
         } elseif ($parameterNames === 'contact_id') {
             $params = $this->table . '.contact_id';
         } else {
-            if ($parameterNames !== '*') {
-                $this->assertValidIdentifier($parameterNames);
-            }
             $params = $parameterNames;
         }
         $sql = "SELECT {$params} FROM {$this->table}";
@@ -122,7 +116,6 @@ class Centreon_Object_Contact extends Centreon_Object
         $filterIndex = 0;
         $whereClauses = [];
         foreach ($filters as $key => $rawvalue) {
-            $this->assertValidIdentifier($key);
             if (is_array($rawvalue)) {
                 if ($rawvalue === []) {
                     $whereClauses[] = '1 = 0';
@@ -149,7 +142,6 @@ class Centreon_Object_Contact extends Centreon_Object
             $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
         }
         if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
-            $this->assertValidIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
@@ -214,10 +206,10 @@ class Centreon_Object_Contact extends Centreon_Object
         $setClauses = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
+            $key = trim(trim($key), '`');
             if ($key == $this->primaryKey) {
                 continue;
             }
-            $this->assertValidIdentifier($key);
             $setClauses[] = $key . ' = :' . $key;
             if ($value === '' && ! isset($notNullAttributes[$key])) {
                 $value = null;

--- a/centreon/lib/Centreon/Object/Contact/Contact.php
+++ b/centreon/lib/Centreon/Object/Contact/Contact.php
@@ -46,43 +46,43 @@ class Centreon_Object_Contact extends Centreon_Object
      */
     public function insert($params = [])
     {
-        $sql = "INSERT INTO {$this->table} ";
-        $sqlFields = '';
-        $sqlValues = '';
-        $sqlParams = [];
-
-        // Store password value and remove it from the array to not inserting it in contact table.
         if (isset($params['contact_passwd'])) {
             $password = $params['contact_passwd'];
             unset($params['contact_passwd']);
         }
+
+        $fields = [];
+        $placeholders = [];
+        $bindParams = [];
         foreach ($params as $key => $value) {
             if ($key == $this->primaryKey) {
                 continue;
             }
-            if ($sqlFields != '') {
-                $sqlFields .= ',';
-            }
-            if ($sqlValues != '') {
-                $sqlValues .= ',';
-            }
-            $sqlFields .= $key;
-            $sqlValues .= '?';
-            $sqlParams[] = trim($value);
-        }
-        if ($sqlFields && $sqlValues) {
-            $sql .= '(' . $sqlFields . ') VALUES (' . $sqlValues . ')';
-            $this->db->query($sql, $sqlParams);
-            $contactId = $this->db->lastInsertId();
-            if (isset($password, $contactId)) {
-                $contact = new CentreonContact($this->db);
-                $contact->addPasswordByContactId($contactId, $password);
-            }
-
-            return $contactId;
+            $this->assertValidIdentifier($key);
+            $fields[] = $key;
+            $placeholders[] = ':' . $key;
+            $bindParams[':' . $key] = trim($value);
         }
 
-        return null;
+        if ($fields === []) {
+            return null;
+        }
+
+        $sql = "INSERT INTO {$this->table} (" . implode(',', $fields) . ') VALUES ('
+            . implode(',', $placeholders) . ')';
+        $statement = $this->db->prepare($sql);
+        foreach ($bindParams as $paramName => $paramValue) {
+            $statement->bindValue($paramName, $paramValue);
+        }
+        $statement->execute();
+
+        $contactId = $this->db->lastInsertId();
+        if (isset($password, $contactId)) {
+            $contact = new CentreonContact($this->db);
+            $contact->addPasswordByContactId($contactId, $password);
+        }
+
+        return $contactId;
     }
 
     /**
@@ -102,6 +102,9 @@ class Centreon_Object_Contact extends Centreon_Object
         }
 
         if (is_array($parameterNames)) {
+            foreach ($parameterNames as $parameterName) {
+                $this->assertValidIdentifier($parameterName);
+            }
             if (($key = array_search('contact_id', $parameterNames)) !== false) {
                 $parameterNames[$key] = $this->table . '.contact_id';
             }
@@ -109,38 +112,56 @@ class Centreon_Object_Contact extends Centreon_Object
         } elseif ($parameterNames === 'contact_id') {
             $params = $this->table . '.contact_id';
         } else {
+            if ($parameterNames !== '*') {
+                $this->assertValidIdentifier($parameterNames);
+            }
             $params = $parameterNames;
         }
         $sql = "SELECT {$params} FROM {$this->table}";
-        $filterTab = [];
-        if (count($filters)) {
-            foreach ($filters as $key => $rawvalue) {
-                if ($filterTab === []) {
-                    $sql .= " WHERE {$key} ";
-                } else {
-                    $sql .= " {$filterType} {$key} ";
+        $bindParams = [];
+        $filterIndex = 0;
+        $whereClauses = [];
+        foreach ($filters as $key => $rawvalue) {
+            $this->assertValidIdentifier($key);
+            if (is_array($rawvalue)) {
+                if ($rawvalue === []) {
+                    $whereClauses[] = '1 = 0';
+                    continue;
                 }
-                if (is_array($rawvalue)) {
-                    $sql .= ' IN (' . str_repeat('?,', count($rawvalue) - 1) . '?) ';
-                    $filterTab = array_merge($filterTab, $rawvalue);
-                } else {
-                    $sql .= ' LIKE ? ';
-                    $value = trim($rawvalue);
-                    $value = str_replace('\\', '\\\\', $value);
-                    $value = str_replace('_', "\_", $value);
-                    $value = str_replace(' ', "\ ", $value);
-                    $filterTab[] = $value;
+                $inPlaceholders = [];
+                foreach ($rawvalue as $inValue) {
+                    $paramName = ':filter_' . $filterIndex++;
+                    $inPlaceholders[] = $paramName;
+                    $bindParams[$paramName] = $inValue;
                 }
+                $whereClauses[] = "{$key} IN (" . implode(',', $inPlaceholders) . ')';
+            } else {
+                $paramName = ':filter_' . $filterIndex++;
+                $value = trim($rawvalue);
+                $value = str_replace('\\', '\\\\', $value);
+                $value = str_replace('_', "\_", $value);
+                $value = str_replace(' ', "\ ", $value);
+                $whereClauses[] = "{$key} LIKE {$paramName}";
+                $bindParams[$paramName] = $value;
             }
         }
-        if (isset($order, $sort)   && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+        if ($whereClauses !== []) {
+            $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
+        }
+        if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            $this->assertValidIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
             $sql = $this->db->limit($sql, $count, $offset);
         }
 
-        $contacts = $this->getResult($sql, $filterTab, 'fetchAll');
+        $statement = $this->db->prepare($sql);
+        foreach ($bindParams as $paramName => $paramValue) {
+            $statement->bindValue($paramName, $paramValue);
+        }
+        $statement->execute();
+        $contacts = $statement->fetchAll();
         foreach ($contacts as &$contact) {
             $statement = $this->db->prepare(
                 'SELECT password FROM contact_password WHERE contact_id = :contactId '
@@ -159,10 +180,7 @@ class Centreon_Object_Contact extends Centreon_Object
      */
     public function update($contactId, $params = []): void
     {
-        $sql = "UPDATE {$this->table} SET ";
-        $sqlUpdate = '';
-        $sqlParams = [];
-        $not_null_attributes = [];
+        $notNullAttributes = [];
 
         // Store password value and remove it from the array to not inserting it in contact table.
         if (isset($params['contact_passwd'])) {
@@ -184,37 +202,41 @@ class Centreon_Object_Contact extends Centreon_Object
             }
         }
 
-        if (array_search('', $params)) {
-            $sql_attr = "SHOW FIELDS FROM {$this->table}";
-            $res = $this->getResult($sql_attr, [], 'fetchAll');
+        if (array_search('', $params, true) !== false) {
+            $res = $this->getResult("SHOW FIELDS FROM {$this->table}", [], 'fetchAll');
             foreach ($res as $tab) {
                 if ($tab['Null'] == 'NO') {
-                    $not_null_attributes[$tab['Field']] = true;
+                    $notNullAttributes[$tab['Field']] = true;
                 }
             }
         }
 
+        $setClauses = [];
+        $bindParams = [];
         foreach ($params as $key => $value) {
             if ($key == $this->primaryKey) {
                 continue;
             }
-            if ($sqlUpdate != '') {
-                $sqlUpdate .= ',';
-            }
-            $sqlUpdate .= $key . ' = ? ';
-            if ($value === '' && ! isset($not_null_attributes[$key])) {
+            $this->assertValidIdentifier($key);
+            $setClauses[] = $key . ' = :' . $key;
+            if ($value === '' && ! isset($notNullAttributes[$key])) {
                 $value = null;
             }
             if (! is_null($value)) {
                 $value = str_replace('<br/>', "\n", $value);
             }
-            $sqlParams[] = $value;
+            $bindParams[':' . $key] = $value;
         }
 
-        if ($sqlUpdate) {
-            $sqlParams[] = $contactId;
-            $sql .= $sqlUpdate . " WHERE {$this->primaryKey} = ?";
-            $this->db->query($sql, $sqlParams);
+        if ($setClauses !== []) {
+            $sql = "UPDATE {$this->table} SET " . implode(',', $setClauses)
+                . " WHERE {$this->primaryKey} = :primaryKeyId";
+            $statement = $this->db->prepare($sql);
+            foreach ($bindParams as $paramName => $paramValue) {
+                $statement->bindValue($paramName, $paramValue);
+            }
+            $statement->bindValue(':primaryKeyId', $contactId, PDO::PARAM_INT);
+            $statement->execute();
         }
 
         if (isset($password, $contactId)) {

--- a/centreon/lib/Centreon/Object/Contact/Contact.php
+++ b/centreon/lib/Centreon/Object/Contact/Contact.php
@@ -55,7 +55,7 @@ class Centreon_Object_Contact extends Centreon_Object
         $placeholders = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
-            $key = trim(trim($key), '`');
+            $key = $this->sanitizeIdentifier($key);
             if ($key == $this->primaryKey) {
                 continue;
             }
@@ -102,6 +102,7 @@ class Centreon_Object_Contact extends Centreon_Object
         }
 
         if (is_array($parameterNames)) {
+            $parameterNames = array_map([$this, 'sanitizeIdentifier'], $parameterNames);
             if (($key = array_search('contact_id', $parameterNames)) !== false) {
                 $parameterNames[$key] = $this->table . '.contact_id';
             }
@@ -109,13 +110,14 @@ class Centreon_Object_Contact extends Centreon_Object
         } elseif ($parameterNames === 'contact_id') {
             $params = $this->table . '.contact_id';
         } else {
-            $params = $parameterNames;
+            $params = $parameterNames !== '*' ? $this->sanitizeIdentifier($parameterNames) : $parameterNames;
         }
         $sql = "SELECT {$params} FROM {$this->table}";
         $bindParams = [];
         $filterIndex = 0;
         $whereClauses = [];
         foreach ($filters as $key => $rawvalue) {
+            $key = $this->sanitizeIdentifier($key);
             if (is_array($rawvalue)) {
                 if ($rawvalue === []) {
                     $whereClauses[] = '1 = 0';
@@ -142,6 +144,7 @@ class Centreon_Object_Contact extends Centreon_Object
             $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
         }
         if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            $order = $this->sanitizeIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
@@ -206,7 +209,7 @@ class Centreon_Object_Contact extends Centreon_Object
         $setClauses = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
-            $key = trim(trim($key), '`');
+            $key = $this->sanitizeIdentifier($key);
             if ($key == $this->primaryKey) {
                 continue;
             }

--- a/centreon/lib/Centreon/Object/Contact/Contact.php
+++ b/centreon/lib/Centreon/Object/Contact/Contact.php
@@ -158,6 +158,9 @@ class Centreon_Object_Contact extends Centreon_Object
         $statement->execute();
         $contacts = $statement->fetchAll();
         foreach ($contacts as &$contact) {
+            if (! isset($contact['contact_id'])) {
+                continue;
+            }
             $statement = $this->db->prepare(
                 'SELECT password FROM contact_password WHERE contact_id = :contactId '
                 . 'ORDER BY creation_date DESC LIMIT 1'

--- a/centreon/lib/Centreon/Object/Object.php
+++ b/centreon/lib/Centreon/Object/Object.php
@@ -94,10 +94,10 @@ abstract class Centreon_Object
         $placeholders = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
+            $key = trim(trim($key), '`');
             if ($key == $this->primaryKey) {
                 continue;
             }
-            $this->assertValidIdentifier($key);
             $fields[] = $key;
             $placeholders[] = ':' . $key;
             $bindParams[':' . $key] = trim($value);
@@ -159,10 +159,10 @@ abstract class Centreon_Object
         $setClauses = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
+            $key = trim(trim($key), '`');
             if ($key == $this->primaryKey) {
                 continue;
             }
-            $this->assertValidIdentifier($key);
             $setClauses[] = $key . ' = :' . $key;
             if ($value === '' && ! isset($notNullAttributes[$key])) {
                 $value = null;
@@ -226,17 +226,7 @@ abstract class Centreon_Object
      */
     public function getParameters($objectId, $parameterNames)
     {
-        if (is_array($parameterNames)) {
-            foreach ($parameterNames as $parameterName) {
-                $this->assertValidIdentifier($parameterName);
-            }
-            $params = implode(',', $parameterNames);
-        } else {
-            if ($parameterNames !== '*') {
-                $this->assertValidIdentifier($parameterNames);
-            }
-            $params = $parameterNames;
-        }
+        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
         $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = :objectId";
         $statement = $this->db->prepare($sql);
         $statement->bindValue(':objectId', $objectId, PDO::PARAM_INT);
@@ -272,23 +262,12 @@ abstract class Centreon_Object
         if ($filterType != 'OR' && $filterType != 'AND') {
             throw new Exception('Unknown filter type');
         }
-        if (is_array($parameterNames)) {
-            foreach ($parameterNames as $parameterName) {
-                $this->assertValidIdentifier($parameterName);
-            }
-            $params = implode(',', $parameterNames);
-        } else {
-            if ($parameterNames !== '*') {
-                $this->assertValidIdentifier($parameterNames);
-            }
-            $params = $parameterNames;
-        }
+        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
         $sql = "SELECT {$params} FROM {$this->table} ";
         $bindParams = [];
         $filterIndex = 0;
         $whereClauses = [];
         foreach ($filters as $key => $rawvalue) {
-            $this->assertValidIdentifier($key);
             if (is_array($rawvalue)) {
                 if ($rawvalue === []) {
                     $whereClauses[] = '1 = 0';
@@ -315,7 +294,6 @@ abstract class Centreon_Object
             $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
         }
         if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
-            $this->assertValidIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
@@ -343,7 +321,6 @@ abstract class Centreon_Object
      */
     public function getIdByParameter($paramName, $paramValues = [])
     {
-        $this->assertValidIdentifier($paramName);
         if (! is_array($paramValues)) {
             $paramValues = [$paramValues];
         }
@@ -402,17 +379,6 @@ abstract class Centreon_Object
     public function getTableName()
     {
         return $this->table;
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    protected function assertValidIdentifier(string $name): void
-    {
-        $stripped = trim($name, '`');
-        if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_.]*$/', $stripped) !== 1) {
-            throw new InvalidArgumentException("Invalid identifier: {$name}");
-        }
     }
 
     /**

--- a/centreon/lib/Centreon/Object/Object.php
+++ b/centreon/lib/Centreon/Object/Object.php
@@ -94,7 +94,7 @@ abstract class Centreon_Object
         $placeholders = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
-            $key = trim(trim($key), '`');
+            $key = $this->sanitizeIdentifier($key);
             if ($key == $this->primaryKey) {
                 continue;
             }
@@ -159,7 +159,7 @@ abstract class Centreon_Object
         $setClauses = [];
         $bindParams = [];
         foreach ($params as $key => $value) {
-            $key = trim(trim($key), '`');
+            $key = $this->sanitizeIdentifier($key);
             if ($key == $this->primaryKey) {
                 continue;
             }
@@ -226,7 +226,11 @@ abstract class Centreon_Object
      */
     public function getParameters($objectId, $parameterNames)
     {
-        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
+        if (is_array($parameterNames)) {
+            $params = implode(',', array_map([$this, 'sanitizeIdentifier'], $parameterNames));
+        } else {
+            $params = $parameterNames !== '*' ? $this->sanitizeIdentifier($parameterNames) : $parameterNames;
+        }
         $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = :objectId";
         $statement = $this->db->prepare($sql);
         $statement->bindValue(':objectId', $objectId, PDO::PARAM_INT);
@@ -262,12 +266,17 @@ abstract class Centreon_Object
         if ($filterType != 'OR' && $filterType != 'AND') {
             throw new Exception('Unknown filter type');
         }
-        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
+        if (is_array($parameterNames)) {
+            $params = implode(',', array_map([$this, 'sanitizeIdentifier'], $parameterNames));
+        } else {
+            $params = $parameterNames !== '*' ? $this->sanitizeIdentifier($parameterNames) : $parameterNames;
+        }
         $sql = "SELECT {$params} FROM {$this->table} ";
         $bindParams = [];
         $filterIndex = 0;
         $whereClauses = [];
         foreach ($filters as $key => $rawvalue) {
+            $key = $this->sanitizeIdentifier($key);
             if (is_array($rawvalue)) {
                 if ($rawvalue === []) {
                     $whereClauses[] = '1 = 0';
@@ -294,6 +303,7 @@ abstract class Centreon_Object
             $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
         }
         if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            $order = $this->sanitizeIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
@@ -321,6 +331,7 @@ abstract class Centreon_Object
      */
     public function getIdByParameter($paramName, $paramValues = [])
     {
+        $paramName = $this->sanitizeIdentifier($paramName);
         if (! is_array($paramValues)) {
             $paramValues = [$paramValues];
         }
@@ -379,6 +390,19 @@ abstract class Centreon_Object
     public function getTableName()
     {
         return $this->table;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
     }
 
     /**

--- a/centreon/lib/Centreon/Object/Object.php
+++ b/centreon/lib/Centreon/Object/Object.php
@@ -90,32 +90,32 @@ abstract class Centreon_Object
      */
     public function insert($params = [])
     {
-        $sql = "INSERT INTO {$this->table} ";
-        $sqlFields = '';
-        $sqlValues = '';
-        $sqlParams = [];
+        $fields = [];
+        $placeholders = [];
+        $bindParams = [];
         foreach ($params as $key => $value) {
             if ($key == $this->primaryKey) {
                 continue;
             }
-            if ($sqlFields != '') {
-                $sqlFields .= ',';
-            }
-            if ($sqlValues != '') {
-                $sqlValues .= ',';
-            }
-            $sqlFields .= $key;
-            $sqlValues .= '?';
-            $sqlParams[] = trim($value);
-        }
-        if ($sqlFields && $sqlValues) {
-            $sql .= '(' . $sqlFields . ') VALUES (' . $sqlValues . ')';
-            $this->db->query($sql, $sqlParams);
-
-            return $this->db->lastInsertId();
+            $this->assertValidIdentifier($key);
+            $fields[] = $key;
+            $placeholders[] = ':' . $key;
+            $bindParams[':' . $key] = trim($value);
         }
 
-        return null;
+        if ($fields === []) {
+            return null;
+        }
+
+        $sql = "INSERT INTO {$this->table} (" . implode(',', $fields) . ') VALUES ('
+            . implode(',', $placeholders) . ')';
+        $statement = $this->db->prepare($sql);
+        foreach ($bindParams as $paramName => $paramValue) {
+            $statement->bindValue($paramName, $paramValue);
+        }
+        $statement->execute();
+
+        return $this->db->lastInsertId();
     }
 
     /**
@@ -127,8 +127,11 @@ abstract class Centreon_Object
      */
     public function delete($objectId): void
     {
-        $sql = "DELETE FROM  {$this->table} WHERE {$this->primaryKey} = ?";
-        $this->db->query($sql, [$objectId]);
+        $statement = $this->db->prepare(
+            "DELETE FROM {$this->table} WHERE {$this->primaryKey} = :objectId"
+        );
+        $statement->bindValue(':objectId', $objectId, PDO::PARAM_INT);
+        $statement->execute();
     }
 
     /**
@@ -142,42 +145,43 @@ abstract class Centreon_Object
      */
     public function update($objectId, $params = []): void
     {
-        $sql = "UPDATE {$this->table} SET ";
-        $sqlUpdate = '';
-        $sqlParams = [];
-        $not_null_attributes = [];
+        $notNullAttributes = [];
 
-        if (array_search('', $params)) {
-            $sql_attr = "SHOW FIELDS FROM {$this->table}";
-            $res = $this->getResult($sql_attr, [], 'fetchAll');
+        if (array_search('', $params, true) !== false) {
+            $res = $this->getResult("SHOW FIELDS FROM {$this->table}", [], 'fetchAll');
             foreach ($res as $tab) {
                 if ($tab['Null'] == 'NO') {
-                    $not_null_attributes[$tab['Field']] = true;
+                    $notNullAttributes[$tab['Field']] = true;
                 }
             }
         }
 
+        $setClauses = [];
+        $bindParams = [];
         foreach ($params as $key => $value) {
             if ($key == $this->primaryKey) {
                 continue;
             }
-            if ($sqlUpdate != '') {
-                $sqlUpdate .= ',';
-            }
-            $sqlUpdate .= $key . ' = ? ';
-            if ($value === '' && ! isset($not_null_attributes[$key])) {
+            $this->assertValidIdentifier($key);
+            $setClauses[] = $key . ' = :' . $key;
+            if ($value === '' && ! isset($notNullAttributes[$key])) {
                 $value = null;
             }
             if (! is_null($value)) {
                 $value = str_replace('<br/>', "\n", $value);
             }
-            $sqlParams[] = $value;
+            $bindParams[':' . $key] = $value;
         }
 
-        if ($sqlUpdate) {
-            $sqlParams[] = $objectId;
-            $sql .= $sqlUpdate . " WHERE {$this->primaryKey} = ?";
-            $this->db->query($sql, $sqlParams);
+        if ($setClauses !== []) {
+            $sql = "UPDATE {$this->table} SET " . implode(',', $setClauses)
+                . " WHERE {$this->primaryKey} = :primaryKeyId";
+            $statement = $this->db->prepare($sql);
+            foreach ($bindParams as $paramName => $paramValue) {
+                $statement->bindValue($paramName, $paramValue);
+            }
+            $statement->bindValue(':primaryKeyId', $objectId, PDO::PARAM_INT);
+            $statement->execute();
         }
     }
 
@@ -222,10 +226,23 @@ abstract class Centreon_Object
      */
     public function getParameters($objectId, $parameterNames)
     {
-        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
-        $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = ?";
+        if (is_array($parameterNames)) {
+            foreach ($parameterNames as $parameterName) {
+                $this->assertValidIdentifier($parameterName);
+            }
+            $params = implode(',', $parameterNames);
+        } else {
+            if ($parameterNames !== '*') {
+                $this->assertValidIdentifier($parameterNames);
+            }
+            $params = $parameterNames;
+        }
+        $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = :objectId";
+        $statement = $this->db->prepare($sql);
+        $statement->bindValue(':objectId', $objectId, PDO::PARAM_INT);
+        $statement->execute();
 
-        return $this->getResult($sql, [$objectId], 'fetch');
+        return $statement->fetch(PDO::FETCH_ASSOC);
     }
 
     /**
@@ -255,37 +272,63 @@ abstract class Centreon_Object
         if ($filterType != 'OR' && $filterType != 'AND') {
             throw new Exception('Unknown filter type');
         }
-        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
+        if (is_array($parameterNames)) {
+            foreach ($parameterNames as $parameterName) {
+                $this->assertValidIdentifier($parameterName);
+            }
+            $params = implode(',', $parameterNames);
+        } else {
+            if ($parameterNames !== '*') {
+                $this->assertValidIdentifier($parameterNames);
+            }
+            $params = $parameterNames;
+        }
         $sql = "SELECT {$params} FROM {$this->table} ";
-        $filterTab = [];
-        if (count($filters)) {
-            foreach ($filters as $key => $rawvalue) {
-                if ($filterTab === []) {
-                    $sql .= " WHERE {$key} ";
-                } else {
-                    $sql .= " {$filterType} {$key} ";
+        $bindParams = [];
+        $filterIndex = 0;
+        $whereClauses = [];
+        foreach ($filters as $key => $rawvalue) {
+            $this->assertValidIdentifier($key);
+            if (is_array($rawvalue)) {
+                if ($rawvalue === []) {
+                    $whereClauses[] = '1 = 0';
+                    continue;
                 }
-                if (is_array($rawvalue)) {
-                    $sql .= ' IN (' . str_repeat('?,', count($rawvalue) - 1) . '?) ';
-                    $filterTab = array_merge($filterTab, $rawvalue);
-                } else {
-                    $sql .= ' LIKE ? ';
-                    $value = trim($rawvalue);
-                    $value = str_replace('\\', '\\\\', $value);
-                    $value = str_replace('_', "\_", $value);
-                    $value = str_replace(' ', "\ ", $value);
-                    $filterTab[] = $value;
+                $inPlaceholders = [];
+                foreach ($rawvalue as $inValue) {
+                    $paramName = ':filter_' . $filterIndex++;
+                    $inPlaceholders[] = $paramName;
+                    $bindParams[$paramName] = $inValue;
                 }
+                $whereClauses[] = "{$key} IN (" . implode(',', $inPlaceholders) . ')';
+            } else {
+                $paramName = ':filter_' . $filterIndex++;
+                $value = trim($rawvalue);
+                $value = str_replace('\\', '\\\\', $value);
+                $value = str_replace('_', "\_", $value);
+                $value = str_replace(' ', "\ ", $value);
+                $whereClauses[] = "{$key} LIKE {$paramName}";
+                $bindParams[$paramName] = $value;
             }
         }
-        if (isset($order, $sort)   && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+        if ($whereClauses !== []) {
+            $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
+        }
+        if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            $this->assertValidIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
             $sql = $this->db->limit($sql, $count, $offset);
         }
 
-        return $this->getResult($sql, $filterTab, 'fetchAll');
+        $statement = $this->db->prepare($sql);
+        foreach ($bindParams as $paramName => $paramValue) {
+            $statement->bindValue($paramName, $paramValue);
+        }
+        $statement->execute();
+
+        return $statement->fetchAll();
     }
 
     /**
@@ -300,29 +343,35 @@ abstract class Centreon_Object
      */
     public function getIdByParameter($paramName, $paramValues = [])
     {
-        $sql = "SELECT {$this->primaryKey} FROM {$this->table} WHERE ";
-        $condition = '';
+        $this->assertValidIdentifier($paramName);
         if (! is_array($paramValues)) {
             $paramValues = [$paramValues];
         }
-        foreach ($paramValues as $val) {
-            if ($condition != '') {
-                $condition .= ' OR ';
-            }
-            $condition .= $paramName . ' = ? ';
-        }
-        if ($condition) {
-            $sql .= $condition;
-            $rows = $this->getResult($sql, $paramValues, 'fetchAll');
-            $tab = [];
-            foreach ($rows as $val) {
-                $tab[] = $val[$this->primaryKey];
-            }
-
-            return $tab;
+        if ($paramValues === []) {
+            return [];
         }
 
-        return [];
+        $conditions = [];
+        $bindParams = [];
+        foreach ($paramValues as $index => $val) {
+            $paramKey = ':val_' . $index;
+            $conditions[] = $paramName . ' = ' . $paramKey;
+            $bindParams[$paramKey] = $val;
+        }
+
+        $sql = "SELECT {$this->primaryKey} FROM {$this->table} WHERE " . implode(' OR ', $conditions);
+        $statement = $this->db->prepare($sql);
+        foreach ($bindParams as $paramKey => $paramValue) {
+            $statement->bindValue($paramKey, $paramValue);
+        }
+        $statement->execute();
+
+        $tab = [];
+        foreach ($statement->fetchAll() as $row) {
+            $tab[] = $row[$this->primaryKey];
+        }
+
+        return $tab;
     }
 
     /**
@@ -353,6 +402,17 @@ abstract class Centreon_Object
     public function getTableName()
     {
         return $this->table;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function assertValidIdentifier(string $name): void
+    {
+        $stripped = trim($name, '`');
+        if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_.]*$/', $stripped) !== 1) {
+            throw new InvalidArgumentException("Invalid identifier: {$name}");
+        }
     }
 
     /**

--- a/centreon/src/Centreon/Domain/Repository/ContactGroupRepository.php
+++ b/centreon/src/Centreon/Domain/Repository/ContactGroupRepository.php
@@ -86,8 +86,13 @@ class ContactGroupRepository extends AbstractRepositoryRDB implements Pagination
             }
         }
 
-        if ($ordering['field'] ?? false) {
-            $sql .= ' ORDER BY `' . $ordering['field'] . '` ' . $ordering['order'];
+        $allowedOrderColumns = ['cg_id', 'cg_name', 'cg_alias', 'cg_activate', 'cg_type'];
+        if (
+            ($ordering['field'] ?? false)
+            && in_array($ordering['field'], $allowedOrderColumns, true)
+        ) {
+            $order = isset($ordering['order']) && strtoupper($ordering['order']) === 'DESC' ? 'DESC' : 'ASC';
+            $sql .= ' ORDER BY `' . $ordering['field'] . '` ' . $order;
         }
 
         if ($limit !== null) {

--- a/centreon/www/class/centreonContact.class.php
+++ b/centreon/www/class/centreonContact.class.php
@@ -28,6 +28,16 @@ use Core\Security\ProviderConfiguration\Domain\Local\Model\SecurityPolicy;
  */
 class CentreonContact
 {
+    private const ALLOWED_CONTACT_FIELDS = [
+        'contact_id', 'contact_name', 'contact_alias', 'contact_email', 'contact_pager',
+        'contact_comment', 'contact_host_notification_options', 'contact_service_notification_options',
+        'contact_activate', 'contact_admin', 'contact_oreon', 'contact_auth_type',
+        'contact_lang', 'contact_template_id', 'contact_register', 'contact_location',
+        'timeperiod_tp_id', 'timeperiod_tp_id2', 'contact_enable_notifications',
+        'contact_type_msg', 'contact_ldap_dn', 'ar_id', 'contact_autologin_key',
+        'default_page', 'reach_api', 'reach_api_rt', 'show_deprecated_pages',
+    ];
+
     /** @var CentreonDB */
     protected $db;
 
@@ -56,27 +66,52 @@ class CentreonContact
     {
         $fieldStr = '*';
         if (count($fields)) {
-            $fieldStr = implode(', ', $fields);
+            $validFields = array_intersect($fields, self::ALLOWED_CONTACT_FIELDS);
+            $fieldStr = count($validFields) ? implode(', ', $validFields) : '*';
         }
+
         $filterStr = " WHERE contact_register = '0' ";
+        $bindParams = [];
+        $paramIndex = 0;
         foreach ($filters as $k => $v) {
-            $filterStr .= " AND {$k} LIKE '{$this->db->escape($v)}' ";
+            if (! in_array($k, self::ALLOWED_CONTACT_FIELDS, true)) {
+                continue;
+            }
+            $paramName = ':filter_' . $paramIndex++;
+            $filterStr .= " AND {$k} LIKE {$paramName} ";
+            $bindParams[$paramName] = $v;
         }
+
         $orderStr = '';
-        if (count($order) === 2) {
+        if (
+            count($order) === 2
+            && in_array($order[0], self::ALLOWED_CONTACT_FIELDS, true)
+            && in_array(strtoupper($order[1]), ['ASC', 'DESC'], true)
+        ) {
             $orderStr = " ORDER BY {$order[0]} {$order[1]} ";
         }
+
         $limitStr = '';
         if (count($limit) === 2) {
-            $limitStr = " LIMIT {$limit[0]},{$limit[1]}";
+            $limitStr = ' LIMIT :limitOffset, :limitCount';
+            $bindParams[':limitOffset'] = (int) $limit[0];
+            $bindParams[':limitCount'] = (int) $limit[1];
         }
-        $res = $this->db->query("SELECT SQL_CALC_FOUND_ROWS {$fieldStr} 
-                                FROM contact 
-                                {$filterStr}
-                                {$orderStr}
-                                {$limitStr}");
+
+        $statement = $this->db->prepare(
+            "SELECT SQL_CALC_FOUND_ROWS {$fieldStr} FROM contact {$filterStr} {$orderStr} {$limitStr}"
+        );
+        foreach ($bindParams as $paramName => $paramValue) {
+            $statement->bindValue(
+                $paramName,
+                $paramValue,
+                is_int($paramValue) ? PDO::PARAM_INT : PDO::PARAM_STR
+            );
+        }
+        $statement->execute();
+
         $arr = [];
-        while ($row = $res->fetchRow()) {
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
             $arr[] = $row;
         }
 
@@ -94,14 +129,17 @@ class CentreonContact
      */
     public static function getContactGroupsFromContact($db, $contactId)
     {
-        $sql = 'SELECT cg_id, cg_name
-            FROM contactgroup_contact_relation r, contactgroup cg 
+        $statement = $db->prepare(
+            'SELECT cg_id, cg_name
+            FROM contactgroup_contact_relation r, contactgroup cg
             WHERE cg.cg_id = r.contactgroup_cg_id
-            AND r.contact_contact_id = ' . $db->escape($contactId);
-        $stmt = $db->query($sql);
+            AND r.contact_contact_id = :contactId'
+        );
+        $statement->bindValue(':contactId', (int) $contactId, PDO::PARAM_INT);
+        $statement->execute();
 
         $cgs = [];
-        while ($row = $stmt->fetchRow()) {
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
             $cgs[$row['cg_id']] = $row['cg_name'];
         }
 

--- a/centreon/www/class/centreonContactgroup.class.php
+++ b/centreon/www/class/centreonContactgroup.class.php
@@ -267,43 +267,62 @@ class CentreonContactgroup
             }
 
             // Refresh Users Groups by deleting old relations and inserting new ones if needed.
-            $this->db->query('DELETE FROM contactgroup_contact_relation '
-                . 'WHERE contactgroup_cg_id = ' . (int) $cgRow['cg_id']);
+            $deleteStmt = $this->db->prepare(
+                'DELETE FROM contactgroup_contact_relation WHERE contactgroup_cg_id = :cgId'
+            );
+            $deleteStmt->bindValue(':cgId', (int) $cgRow['cg_id'], PDO::PARAM_INT);
+            $deleteStmt->execute();
 
             $members = $ldapConn->listUserForGroup($cgRow['cg_ldap_dn']);
-            $contact = '';
-            foreach ($members as $member) {
-                $contact .= $this->db->quote($member) . ',';
-            }
-            $contact = rtrim($contact, ',');
 
-            if (! $contact) {
-                // no need to continue. If there's no contact, there's no relation to insert.
+            if ($members === []) {
                 $msg[] = "Error : there's no contact to update for LDAP : " . $cgRow['ar_name'] . '.';
 
-                return $msg;
+                continue;
             }
             try {
-                $resContact = $this->db->query('SELECT contact_id FROM contact '
-                    . 'WHERE contact_ldap_dn IN (' . $contact . ')');
+                $memberValues = array_values($members);
+                $bindParams = [];
+                $placeholders = [];
+                foreach ($memberValues as $index => $memberDn) {
+                    $paramName = ':dn' . $index;
+                    $placeholders[] = $paramName;
+                    $bindParams[$paramName] = $memberDn;
+                }
+                $selectStmt = $this->db->prepare(
+                    'SELECT contact_id FROM contact WHERE contact_ldap_dn IN (' . implode(',', $placeholders) . ')'
+                );
+                foreach ($bindParams as $paramName => $paramValue) {
+                    $selectStmt->bindValue($paramName, $paramValue, PDO::PARAM_STR);
+                }
+                $selectStmt->execute();
 
-                while ($rowContact = $resContact->fetch()) {
+                $insertStmt = $this->db->prepare(
+                    'INSERT INTO contactgroup_contact_relation
+                    (contactgroup_cg_id, contact_contact_id) VALUES (:cgId, :contactId)'
+                );
+                while ($rowContact = $selectStmt->fetch()) {
                     try {
-                        // inserting the LDAP contactgroups relation between the cg and the user
-                        $this->db->query('INSERT INTO contactgroup_contact_relation '
-                            . '(contactgroup_cg_id, contact_contact_id) '
-                            . 'VALUES (' . (int) $cgRow['cg_id'] . ', ' . (int) $rowContact['contact_id'] . ')');
+                        $insertStmt->bindValue(':cgId', (int) $cgRow['cg_id'], PDO::PARAM_INT);
+                        $insertStmt->bindValue(':contactId', (int) $rowContact['contact_id'], PDO::PARAM_INT);
+                        $insertStmt->execute();
                     } catch (PDOException $e) {
-                        $stmt = $this->db->query('SELECT c.contact_name, cg_name FROM contact c '
-                            . 'INNER JOIN contactgroup_contact_relation cgr ON cgr.contact_contact_id = c.contact_id '
-                            . 'INNER JOIN contactgroup cg ON cg.cg_id = cgr.contactgroup_cg_id');
-                        $res = $stmt->fetch();
+                        $errorStmt = $this->db->prepare(
+                            'SELECT c.contact_name, cg.cg_name FROM contact c
+                            INNER JOIN contactgroup_contact_relation cgr ON cgr.contact_contact_id = c.contact_id
+                            INNER JOIN contactgroup cg ON cg.cg_id = cgr.contactgroup_cg_id
+                            WHERE c.contact_id = :contactId AND cg.cg_id = :cgId'
+                        );
+                        $errorStmt->bindValue(':contactId', (int) $rowContact['contact_id'], PDO::PARAM_INT);
+                        $errorStmt->bindValue(':cgId', (int) $cgRow['cg_id'], PDO::PARAM_INT);
+                        $errorStmt->execute();
+                        $res = $errorStmt->fetch();
                         $msg[] = 'Error inserting relation between contactgroup : ' . $res['cg_name']
                             . ' and contact : ' . $res['contact_name'] . '.';
                     }
                 }
             } catch (PDOException $e) {
-                $msg[] = "Error in getting contact ID's list : " . $contact . ' from members.';
+                $msg[] = "Error in getting contact ID's list from members.";
                 continue;
             }
         }
@@ -411,29 +430,36 @@ class CentreonContactgroup
                         );
                         $deleteStmt->bindValue(':cgId', $row['cg_id'], PDO::PARAM_INT);
                         $deleteStmt->execute();
-                        $contactDns = '';
-                        foreach ($members as $member) {
-                            $contactDns .= $this->db->quote($member) . ',';
-                        }
-                        $contactDns = rtrim($contactDns, ',');
-
-                        if ($contactDns !== '') {
+                        if ($members !== []) {
                             try {
-                                $resContact = $this->db->query(
-                                    'SELECT contact_id FROM contact WHERE contact_ldap_dn IN (' . $contactDns . ')'
+                                $memberValues = array_values($members);
+                                $bindParams = [];
+                                $placeholders = [];
+                                foreach ($memberValues as $index => $memberDn) {
+                                    $paramName = ':dn' . $index;
+                                    $placeholders[] = $paramName;
+                                    $bindParams[$paramName] = $memberDn;
+                                }
+                                $selectStmt = $this->db->prepare(
+                                    'SELECT contact_id FROM contact WHERE contact_ldap_dn IN ('
+                                    . implode(',', $placeholders) . ')'
                                 );
+                                foreach ($bindParams as $paramName => $paramValue) {
+                                    $selectStmt->bindValue($paramName, $paramValue, PDO::PARAM_STR);
+                                }
+                                $selectStmt->execute();
                             } catch (PDOException $e) {
                                 $msg[] = 'Error in getting contact id from members.';
 
                                 throw $e;
                             }
-                            while ($rowContact = $resContact->fetch()) {
+                            $insertStmt = $this->db->prepare(
+                                'INSERT INTO contactgroup_contact_relation
+                                (contactgroup_cg_id, contact_contact_id)
+                                VALUES (:cgId, :contactId)'
+                            );
+                            while ($rowContact = $selectStmt->fetch()) {
                                 try {
-                                    $insertStmt = $this->db->prepare(
-                                        'INSERT INTO contactgroup_contact_relation
-                                        (contactgroup_cg_id, contact_contact_id)
-                                        VALUES (:cgId, :contactId)'
-                                    );
                                     $insertStmt->bindValue(':cgId', $row['cg_id'], PDO::PARAM_INT);
                                     $insertStmt->bindValue(':contactId', $rowContact['contact_id'], PDO::PARAM_INT);
                                     $insertStmt->execute();
@@ -473,11 +499,10 @@ class CentreonContactgroup
      */
     public function getNameFromCgId($cgId)
     {
-        $query = 'SELECT cg_name FROM contactgroup WHERE cg_id = ' . CentreonDB::escape($cgId) . ' LIMIT 1';
-        $res = $this->db->query($query);
-        if ($res->rowCount()) {
-            $row = $res->fetch();
-
+        $statement = $this->db->prepare('SELECT cg_name FROM contactgroup WHERE cg_id = :cgId LIMIT 1');
+        $statement->bindValue(':cgId', (int) $cgId, PDO::PARAM_INT);
+        $statement->execute();
+        if ($row = $statement->fetch()) {
             return $row['cg_name'];
         }
 
@@ -503,9 +528,11 @@ class CentreonContactgroup
 
                 // Query test if exists
                 $query = 'SELECT COUNT(*) as nb FROM contactgroup '
-                    . "WHERE cg_name = '" . $pearDB->escape($cg_name) . "' AND cg_type != 'ldap' ";
+                    . "WHERE cg_name = :cgName AND cg_type != 'ldap' ";
                 try {
-                    $res = $pearDB->query($query);
+                    $res = $pearDB->prepare($query);
+                    $res->bindValue(':cgName', $cg_name, PDO::PARAM_STR);
+                    $res->execute();
                 } catch (PDOException $e) {
                     return false;
                 }

--- a/centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
@@ -102,11 +102,13 @@ foreach ($cgs as $cg) {
 
     // Contacts
     $ctNbr = [];
-    $rq = "SELECT COUNT(DISTINCT contact_contact_id) AS `nbr`
+    $rq = 'SELECT COUNT(DISTINCT contact_contact_id) AS `nbr`
            FROM `contactgroup_contact_relation` `cgr`
-           WHERE `cgr`.`contactgroup_cg_id` = '" . $cg['cg_id'] . "' "
+           WHERE `cgr`.`contactgroup_cg_id` = :cgId '
         . $acl->queryBuilder('AND', 'contact_contact_id', $contactstring);
-    $dbResult2 = $pearDB->query($rq);
+    $dbResult2 = $pearDB->prepare($rq);
+    $dbResult2->bindValue(':cgId', (int) $cg['cg_id'], PDO::PARAM_INT);
+    $dbResult2->execute();
     $ctNbr = $dbResult2->fetch();
     $elemArr[] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $cg['cg_name'], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&cg_id=' . $cg['cg_id'], 'RowMenu_desc' => $cg['cg_alias'], 'RowMenu_contacts' => $ctNbr['nbr'], 'RowMenu_status' => $cg['cg_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_badge' => $cg['cg_activate'] ? 'service_ok' : 'service_critical', 'RowMenu_options' => $moptions];
     $style = $style != 'two' ? 'two' : 'one';


### PR DESCRIPTION
## Description

Replace string concatenation and `escape()` calls with prepared statements (`prepare`/`bindValue`/`execute`)
across Contact and ContactGroup legacy files. Add identifier validation in `Centreon_Object` base class
to protect dynamic column names in query builders.

Also fix a pre-existing bug in `syncWithLdapConfigGen()` where the error handler query had no WHERE clause,
returning the first row instead of the specific contact/contactgroup pair that caused the insert failure.

**Fixes** MON-198820

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## How this pull request can be tested ?

- CLAPI: `centreon -u admin -p centreon -o CONTACT -a add/setparam/show/del`
- UI: Configuration > Users > Contact Groups > list, sort, paginate
- UI: Configuration > Users > Contact Templates > list, sort, filter
- LDAP sync if environment available

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).