### PR TITLE
fix: auto use the correct response parsing method between text and json

### DIFF
--- a/centreon/packages/ui/src/Dashboard/DashboardLayout.stories.tsx
+++ b/centreon/packages/ui/src/Dashboard/DashboardLayout.stories.tsx
@@ -72,17 +72,19 @@ const DashboardTemplate = ({
   header,
   layout = dashboardLayout
 }: DashboardTemplateProps): ReactElement => (
-  <DashboardLayout.Layout<CustomLayout> layout={layout}>
-    {layout.map(({ i, content, shouldUseFluidTypography }) => (
-      <DashboardLayout.Item header={header} id={i} key={i}>
-        {shouldUseFluidTypography ? (
-          <FluidTypography text={content} />
-        ) : (
-          <Typography>{content}</Typography>
-        )}
-      </DashboardLayout.Item>
-    ))}
-  </DashboardLayout.Layout>
+  <div className="h-150 overflow-y-auto">
+    <DashboardLayout.Layout<CustomLayout> layout={layout}>
+      {layout.map(({ i, content, shouldUseFluidTypography }) => (
+        <DashboardLayout.Item header={header} id={i} key={i}>
+          {shouldUseFluidTypography ? (
+            <FluidTypography text={content} />
+          ) : (
+            <Typography>{content}</Typography>
+          )}
+        </DashboardLayout.Item>
+      ))}
+    </DashboardLayout.Layout>
+  </div>
 );
 
 const meta: Meta<typeof DashboardTemplate> = {

--- a/centreon/packages/ui/src/InputField/Select/Autocomplete/Connected/index.stories.tsx
+++ b/centreon/packages/ui/src/InputField/Select/Autocomplete/Connected/index.stories.tsx
@@ -36,6 +36,7 @@ const getEndpoint = ({ endpoint, parameters }): string =>
 
 const mockSearch = (page: number): object => ({
   delay: 1000,
+  headers: { 'Content-Type': 'application/json' },
   method: 'GET',
   response: (request): Listing<SelectEntry> => {
     const { searchParams } = request;

--- a/centreon/packages/ui/src/InputField/Select/Autocomplete/Connected/index.test.tsx
+++ b/centreon/packages/ui/src/InputField/Select/Autocomplete/Connected/index.test.tsx
@@ -1,129 +1,130 @@
 import {
-	act,
-	fireEvent,
-	getFetchCall,
-	mockResponse,
-	type RenderResult,
-	render,
-	resetMocks,
-	waitFor,
-} from "../../../../../test/testRenderer";
-import buildListingEndpoint from "../../../../api/buildListingEndpoint";
+  act,
+  fireEvent,
+  getFetchCall,
+  mockResponse,
+  type RenderResult,
+  render,
+  resetMocks,
+  waitFor
+} from '../../../../../test/testRenderer';
+import buildListingEndpoint from '../../../../api/buildListingEndpoint';
 import type {
-	BuildListingEndpointParameters,
-	ConditionsSearchParameter,
-} from "../../../../api/buildListingEndpoint/models";
-import TestQueryProvider from "../../../../api/TestQueryProvider";
+  BuildListingEndpointParameters,
+  ConditionsSearchParameter
+} from '../../../../api/buildListingEndpoint/models';
+import TestQueryProvider from '../../../../api/TestQueryProvider';
+import SingleConnectedAutocompleteField from './Single';
 
-import SingleConnectedAutocompleteField from "./Single";
-
-const label = "Connected Autocomplete";
-const placeholder = "Type here...";
+const label = 'Connected Autocomplete';
+const placeholder = 'Type here...';
 
 const optionsData = {
-	meta: {
-		limit: 2,
-		page: 1,
-		total: 20,
-	},
-	result: [
-		{ id: 0, name: "My Option 1" },
-		{ id: 1, name: "My Option 2" },
-	],
+  meta: {
+    limit: 2,
+    page: 1,
+    total: 20
+  },
+  result: [
+    { id: 0, name: 'My Option 1' },
+    { id: 1, name: 'My Option 2' }
+  ]
 };
 
-const baseEndpoint = "endpoint";
+const baseEndpoint = 'endpoint';
 
 const getEndpoint = (
-	parameters: BuildListingEndpointParameters["parameters"],
+  parameters: BuildListingEndpointParameters['parameters']
 ): string => {
-	return buildListingEndpoint({ baseEndpoint, parameters });
+  return buildListingEndpoint({ baseEndpoint, parameters });
 };
 
 interface Props {
-	searchConditions?: Array<ConditionsSearchParameter>;
+  searchConditions?: Array<ConditionsSearchParameter>;
 }
 
+const mockParams = { headers: { 'Content-Type': 'application/json' } };
+
 const renderSingleConnectedAutocompleteField = (
-	{ searchConditions }: Props = { searchConditions: undefined },
+  { searchConditions }: Props = { searchConditions: undefined }
 ): RenderResult =>
-	render(
-		<TestQueryProvider>
-			<SingleConnectedAutocompleteField
-				baseEndpoint=""
-				field="host.name"
-				getEndpoint={getEndpoint}
-				label={label}
-				placeholder="Type here..."
-				searchConditions={searchConditions}
-			/>
-		</TestQueryProvider>,
-	);
+  render(
+    <TestQueryProvider>
+      <SingleConnectedAutocompleteField
+        baseEndpoint=""
+        field="host.name"
+        getEndpoint={getEndpoint}
+        label={label}
+        placeholder="Type here..."
+        searchConditions={searchConditions}
+      />
+    </TestQueryProvider>
+  );
 
 describe(SingleConnectedAutocompleteField, () => {
-	beforeEach(() => {
-		resetMocks();
-		mockResponse({ data: optionsData });
-	});
+  beforeEach(() => {
+    resetMocks();
+    mockResponse({ data: optionsData, options: mockParams });
+  });
 
-	it("populates options with the first page result from the endpoint request", async () => {
-		const { getByLabelText, getByText } =
-			renderSingleConnectedAutocompleteField();
+  it('populates options with the first page result from the endpoint request', async () => {
+    const { getByLabelText, getByText } =
+      renderSingleConnectedAutocompleteField();
 
-		fireEvent.click(getByLabelText("Open"));
+    fireEvent.click(getByLabelText('Open'));
 
-		expect(getFetchCall(0)).toEqual(`${baseEndpoint}?page=1`);
+    expect(getFetchCall(0)).toEqual(`${baseEndpoint}?page=1`);
 
-		await waitFor(() => {
-			expect(getByText("My Option 1")).toBeInTheDocument();
-		});
-	});
+    await waitFor(() => {
+      expect(getByText('My Option 1')).toBeInTheDocument();
+    });
+  });
 
-	it("populates options with the first page result from the endpoint request after typing something in input field", async () => {
-		const { getByLabelText, getByPlaceholderText } =
-			renderSingleConnectedAutocompleteField();
+  it('populates options with the first page result from the endpoint request after typing something in input field', async () => {
+    const { getByLabelText, getByPlaceholderText } =
+      renderSingleConnectedAutocompleteField();
 
-		act(() => {
-			fireEvent.click(getByLabelText("Open"));
-		});
+    act(() => {
+      fireEvent.click(getByLabelText('Open'));
+    });
 
-		await waitFor(() => {
-			expect(getFetchCall(0)).toEqual(`${baseEndpoint}?page=1`);
-		});
+    await waitFor(() => {
+      expect(getFetchCall(0)).toEqual(`${baseEndpoint}?page=1`);
+    });
 
-		await waitFor(() => {
-			expect(getFetchCall(1)).toEqual(`${baseEndpoint}?page=2`);
-		});
+    await waitFor(() => {
+      expect(getFetchCall(1)).toEqual(`${baseEndpoint}?page=2`);
+    });
 
-		fireEvent.change(getByPlaceholderText(placeholder), {
-			target: { value: "My Option 2" },
-		});
+    fireEvent.change(getByPlaceholderText(placeholder), {
+      target: { value: 'My Option 2' }
+    });
 
-		await waitFor(() => {
-			expect(decodeURIComponent(getFetchCall(2) as string)).toEqual(
-				'endpoint?page=1&search={"$and":[{"$and":[{"host.name":{"$lk":"%My Option 2%"}}]}]}',
-			);
-		});
-	});
+    await waitFor(() => {
+      expect(decodeURIComponent(getFetchCall(2) as string)).toEqual(
+        'endpoint?page=1&search={"$and":[{"$and":[{"host.name":{"$lk":"%My Option 2%"}}]}]}'
+      );
+    });
+  });
 
-	it("adds search conditions to the endpoint request when the corresponding prop is passed", async () => {
-		const { getByLabelText } = renderSingleConnectedAutocompleteField({
-			searchConditions: [
-				{
-					field: "parent_name",
-					value: {
-						$eq: "Centreon-Server",
-					},
-				},
-			],
-		});
+  it('adds search conditions to the endpoint request when the corresponding prop is passed', async () => {
+    const { getByLabelText } = renderSingleConnectedAutocompleteField({
+      searchConditions: [
+        {
+          field: 'parent_name',
+          value: {
+            $eq: 'Centreon-Server'
+          }
+        }
+      ]
+    });
 
-		fireEvent.click(getByLabelText("Open"));
+    fireEvent.click(getByLabelText('Open'));
 
-		await waitFor(() => {
-			expect(getFetchCall(0)).toEqual(
-				`${baseEndpoint}?page=1&search=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22parent_name%22%3A%7B%22%24eq%22%3A%22Centreon-Server%22%7D%7D%5D%7D%5D%7D`,
-			);
-		});
-	});
+    await waitFor(() => {
+      expect(getFetchCall(0)).toEqual(
+        `${baseEndpoint}?page=1&search=%7B%22%24and%22%3A%5B%7B%22%24or%22%3A%5B%7B%22parent_name%22%3A%7B%22%24eq%22%3A%22Centreon-Server%22%7D%7D%5D%7D%5D%7D`
+      );
+    });
+  });
 });

--- a/centreon/packages/ui/src/InputField/Text/index.stories.tsx
+++ b/centreon/packages/ui/src/InputField/Text/index.stories.tsx
@@ -104,7 +104,13 @@ export const autoSizeWithEndAdornment = (): JSX.Element => (
     autoSize
     autoSizeCustomPadding={10}
     autoSizeDefaultWidth={60}
-    EndAdornment={AbcIcon}
     placeholder="Auto size"
+    textFieldSlotsAndSlotProps={{
+      slotProps: {
+        input: {
+          endAdornment: <AbcIcon />
+        }
+      }
+    }}
   />
 );

--- a/centreon/packages/ui/src/api/customFetch.ts
+++ b/centreon/packages/ui/src/api/customFetch.ts
@@ -74,8 +74,8 @@ export const customFetch = <T>({
         };
       }
 
-      const responseParsingMethod = headers
-        ?.get('Content-Type')
+      const responseParsingMethod = response.headers
+        .get('Content-Type')
         ?.startsWith('text')
         ? 'text'
         : 'json';

--- a/centreon/packages/ui/src/api/customFetch.ts
+++ b/centreon/packages/ui/src/api/customFetch.ts
@@ -74,8 +74,13 @@ export const customFetch = <T>({
         };
       }
 
-      return response
-        .json()
+      const responseParsingMethod = headers
+        ?.get('Content-Type')
+        ?.startsWith('text')
+        ? 'text'
+        : 'json';
+
+      return response[responseParsingMethod]()
         .then((data) => {
           if (!response.ok) {
             const defaultError = {

--- a/centreon/packages/ui/src/api/useFetchQuery/index.test.ts
+++ b/centreon/packages/ui/src/api/useFetchQuery/index.test.ts
@@ -37,6 +37,8 @@ const renderFetchQuery = <T extends object>(
     wrapper: TestQueryProvider
   }) as RenderHookResult<UseFetchQueryState<T>, unknown>;
 
+const mockParams = { headers: { 'Content-Type': 'application/json' } };
+
 describe('useFetchQuery', () => {
   beforeEach(() => {
     mockedShowErrorMessage.mockReset();
@@ -57,7 +59,7 @@ describe('useFetchQuery', () => {
   });
 
   it('retrieves data from an endpoint', async () => {
-    fetchMock.once(JSON.stringify(user));
+    fetchMock.once(JSON.stringify(user), mockParams);
     const { result } = renderFetchQuery<User>({
       getEndpoint: () => '/endpoint',
       getQueryKey: () => ['queryKey']
@@ -70,6 +72,7 @@ describe('useFetchQuery', () => {
 
   it("shows an error from the API via the Snackbar and inside the browser's console", async () => {
     fetchMock.once(JSON.stringify({ code: 2, message: 'custom message' }), {
+      ...mockParams,
       status: 400
     });
 
@@ -109,6 +112,7 @@ describe('useFetchQuery', () => {
 
   it('shows a default failure message via the Snackbar as fallback', async () => {
     fetchMock.once(JSON.stringify({}), {
+      ...mockParams,
       status: 400
     });
 
@@ -134,6 +138,7 @@ describe('useFetchQuery', () => {
 
   it('does not show any message via the Snackbar when the httpCodesBypassErrorSnackbar is passed', async () => {
     fetchMock.once(JSON.stringify({}), {
+      ...mockParams,
       status: 400
     });
 


### PR DESCRIPTION
## Description

fix: auto use the correct response parsing method betweeb text and json

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
