### PR TITLE
fix(ci): use major_version FROM image fallback for on-prem builds

### DIFF
--- a/.github/actions/get-docker-from-image-version/action.yml
+++ b/.github/actions/get-docker-from-image-version/action.yml
@@ -4,8 +4,8 @@ description: |
   Resolution order:
     1. current_tag (e.g. develop-26.10 or branch name) if it exists in the registry
     2. major_version if the current branch is dev-XX.YY.x
-    3. develop-<major_version> if it exists in the registry (feature branches)
-    4. develop (fallback)
+    3. (cloud only) develop-<major_version> if it exists in the registry (feature branches)
+    4. fallback: develop (cloud) or major_version (on-prem)
   Each resolved tag has tag_suffix appended (e.g. -alma9) when provided.
 
 inputs:
@@ -18,6 +18,10 @@ inputs:
   major_version:
     description: "Major version (e.g. 26.10)"
     required: true
+  is_cloud:
+    description: "Whether the build context is cloud ('true') or on-prem ('false'). Drives the default/fallback FROM tag."
+    required: false
+    default: "true"
   registry_url:
     description: "Docker registry URL (e.g. harbor.example.com)"
     required: true
@@ -41,30 +45,30 @@ runs:
         FROM_IMAGE: ${{ inputs.from_image }}
         CURRENT_TAG: ${{ inputs.current_tag }}
         MAJOR_VERSION: ${{ inputs.major_version }}
+        IS_CLOUD: ${{ inputs.is_cloud }}
         REGISTRY: ${{ inputs.registry_url }}
         TAG_SUFFIX: ${{ inputs.tag_suffix }}
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       run: |
-        FROM_IMAGE_VERSION="develop${TAG_SUFFIX}"
+        # Fallback tag: develop for cloud, major_version (e.g. 26.05) for on-prem.
+        if [[ "$IS_CLOUD" == "true" ]]; then
+          FROM_IMAGE_VERSION="develop${TAG_SUFFIX}"
+        else
+          FROM_IMAGE_VERSION="${MAJOR_VERSION}${TAG_SUFFIX}"
+        fi
 
         IMAGE_TAG_EXISTS=$(docker manifest inspect ${REGISTRY}/${FROM_IMAGE}:${CURRENT_TAG}${TAG_SUFFIX} >/dev/null 2>&1 && echo yes || echo no)
         if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
           FROM_IMAGE_VERSION="${CURRENT_TAG}${TAG_SUFFIX}"
-          echo "::notice::FROM image ${FROM_IMAGE}:${FROM_IMAGE_VERSION} will be used."
         elif [[ "$BRANCH_NAME" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
           FROM_IMAGE_VERSION="${MAJOR_VERSION}${TAG_SUFFIX}"
-          echo "::notice::FROM image ${FROM_IMAGE}:${FROM_IMAGE_VERSION} will be used."
-        elif [[ "$BRANCH_NAME" != "develop" ]]; then
+        elif [[ "$IS_CLOUD" == "true" && "$BRANCH_NAME" != "develop" ]]; then
           DEVELOP_VERSION_TAG="develop-${MAJOR_VERSION}${TAG_SUFFIX}"
           IMAGE_TAG_EXISTS=$(docker manifest inspect ${REGISTRY}/${FROM_IMAGE}:${DEVELOP_VERSION_TAG} >/dev/null 2>&1 && echo yes || echo no)
           if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
             FROM_IMAGE_VERSION="${DEVELOP_VERSION_TAG}"
-            echo "::notice::FROM image ${FROM_IMAGE}:${FROM_IMAGE_VERSION} will be used."
-          else
-            echo "::notice::FROM image ${FROM_IMAGE}:develop${TAG_SUFFIX} will be used."
           fi
-        else
-          echo "::notice::FROM image ${FROM_IMAGE}:develop${TAG_SUFFIX} will be used."
         fi
 
+        echo "::notice::FROM image ${FROM_IMAGE}:${FROM_IMAGE_VERSION} will be used."
         echo "from_image_version=${FROM_IMAGE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -457,6 +457,7 @@ jobs:
           from_image: centreon-web-${{ matrix.operating_system }}
           current_tag: ${{ steps.image_tag.outputs.tag }}
           major_version: ${{ needs.get-environment.outputs.major_version }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
 
       - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -991,6 +991,7 @@ jobs:
           from_image: centreon-web-dependencies-collect
           current_tag: ${{ steps.image_tag.outputs.tag }}
           major_version: ${{ needs.get-environment.outputs.major_version }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           registry_url: ghcr.io/${{ github.repository }}
           tag_suffix: -${{ matrix.operating_system }}
 


### PR DESCRIPTION
## Description

The `get-docker-from-image-version` action resolves the Docker image tag used as `FROM` in dockerize jobs. Its default/fallback tag was always `develop`, which only makes sense in a cloud context. On-prem (non-cloud) builds whose `FROM` image could not be resolved by branch name fell back to the cloud `develop` image, which is incorrect.

## Changes

- Add an `is_cloud` input to the action.
- The default/fallback `FROM` tag now matches the build context:
  - **cloud** → `develop`
  - **on-prem** → `major_version` (e.g. `26.05`), matching the dependency image tag built on `dev-XX.YY.x` branches.
- The `develop-<major_version>` lookup is now **cloud-only**.
- Wire `is_cloud` from `get-environment` in `web.yml` and `open-tickets.yml`.

When `is_cloud` is omitted, it defaults to `"true"`, preserving the previous behaviour.

## How it resolves now

| Context | Branch | Fallback FROM tag |
|---|---|---|
| cloud | `develop` / feature | `develop` (or `develop-<major_version>` if it exists) |
| on-prem | `dev-XX.YY.x` / feature | `<major_version>` (e.g. `26.05`) |

Refs: MON-151834