### PR TITLE
enh(broker): add poller UID to generated broker configuration

### DIFF
--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -257,7 +257,7 @@ class Broker extends AbstractObjectJSON
             $object['broker_name'] = $row['config_name'];
             $object['poller_id'] = (int) $this->engine['id'];
             if ($this->engine['uid'] !== null) {
-                $object['poller_uid'] = (int) $this->engine['uid'];
+                $object['uid'] = (int) $this->engine['uid'];
             }
             $object['poller_name'] = $this->engine['name'];
             $object['module_directory'] = (string) $this->engine['broker_modules_path'];

--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -86,6 +86,7 @@ class Broker extends AbstractObjectJSON
     /** @var string */
     protected $attributes_engine_parameters = '
         id,
+        uid,
         name,
         centreonbroker_module_path,
         centreonbroker_cfg_path,
@@ -255,6 +256,9 @@ class Broker extends AbstractObjectJSON
             $object['broker_id'] = (int) $row['config_id'];
             $object['broker_name'] = $row['config_name'];
             $object['poller_id'] = (int) $this->engine['id'];
+            if ($this->engine['uid'] !== null) {
+                $object['poller_uid'] = (int) $this->engine['uid'];
+            }
             $object['poller_name'] = $this->engine['name'];
             $object['module_directory'] = (string) $this->engine['broker_modules_path'];
             $object['log_timestamp'] = filter_var($row['config_write_timestamp'], FILTER_VALIDATE_BOOLEAN);
@@ -582,6 +586,7 @@ class Broker extends AbstractObjectJSON
         try {
             $row = $this->stmt_engine_parameters->fetch(PDO::FETCH_ASSOC);
             $this->engine['id'] = $row['id'];
+            $this->engine['uid'] = $row['uid'];
             $this->engine['name'] = $row['name'];
             $this->engine['broker_modules_path'] = $row['centreonbroker_module_path'];
             $this->engine['broker_cfg_path'] = $row['centreonbroker_cfg_path'];


### PR DESCRIPTION
## Description

Add the poller snowflake UID (`nagios_server.uid`) to the generated `*-module.json` broker configuration files. The `poller_uid` field is only included when the UID is not NULL, ensuring backward compatibility with pollers created before the snowflake UID feature.

**Fixes** MON-198663

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## How this pull request can be tested ?

- Export a poller configuration (Configuration > Pollers > Export)
- Check the generated `*-module.json` file in `/etc/centreon-broker/`
- Verify that `poller_uid` is present with the correct snowflake UID value
- For pollers without a UID (legacy), verify that `poller_uid` is absent from the JSON

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).