### PR TITLE
fix(ServiceTemplate): deduplicate host_templates before write in POST and PATCH

### DIFF
--- a/centreon/phpstan.core.baseline.neon
+++ b/centreon/phpstan.core.baseline.neon
@@ -913,12 +913,6 @@ parameters:
 			path: src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
 
 		-
-			message: '#^Parameter \#2 \$hostTemplateIds of method Core\\ServiceTemplate\\Application\\Repository\\WriteServiceTemplateRepositoryInterface\:\:linkToHosts\(\) expects list\<int\>, array\<int\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
-
-		-
 			message: '#^Parameter \#2 \$serviceCategoriesIds of method Core\\ServiceCategory\\Application\\Repository\\WriteServiceCategoryRepositoryInterface\:\:linkToService\(\) expects list\<int\>, array\<int\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/NewServiceTemplateFactory.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/NewServiceTemplateFactory.php
@@ -94,7 +94,7 @@ class NewServiceTemplateFactory
         $serviceTemplate->setRecoveryNotificationDelay($request->recoveryNotificationDelay);
         $serviceTemplate->setFirstNotificationDelay($request->firstNotificationDelay);
         $serviceTemplate->setAcknowledgementTimeout($request->acknowledgementTimeout);
-        $serviceTemplate->setHostTemplateIds($request->hostTemplateIds);
+        $serviceTemplate->setHostTemplateIds(array_values(array_unique($request->hostTemplateIds)));
 
         return $serviceTemplate;
     }

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -172,7 +172,7 @@ final class PartialUpdateServiceTemplate
             'service_template_id' => $request->id,
             'host_templates' => $request->hostTemplates,
         ]);
-        $this->writeRepository->linkToHosts($request->id, $request->hostTemplates);
+        $this->writeRepository->linkToHosts($request->id, array_values(array_unique($request->hostTemplates)));
     }
 
     /**

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateTest.php
@@ -898,3 +898,57 @@ it('should present an AddServiceTemplateResponse when everything has gone well',
         ]]
     );
 });
+
+it('should pass deduplicated host template IDs to add() when host_templates contains duplicates', function (): void {
+    $request = createAddServiceTemplateRequest();
+    $request->hostTemplateIds = [1, 1];
+    $newServiceTemplateId = 99;
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturnMap([[Contact::ROLE_CONFIGURATION_SERVICES_TEMPLATES_READ_WRITE, true]]);
+
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->writeServiceTemplateRepository
+        ->expects($this->once())
+        ->method('add')
+        ->with($this->callback(fn ($serviceTemplate) => $serviceTemplate->getHostTemplateIds() === [1]))
+        ->willReturn($newServiceTemplateId);
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->with($newServiceTemplateId)
+        ->willReturn(new ServiceTemplate($newServiceTemplateId, 'fake_name', 'fake_alias'));
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn([]);
+
+    $this->readServiceMacroRepository
+        ->expects($this->exactly(2))
+        ->method('findByServiceIds')
+        ->willReturn([]);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->with($newServiceTemplateId)
+        ->willReturn([]);
+
+    $this->readServiceGroupRepository
+        ->expects($this->once())
+        ->method('findByService')
+        ->with($newServiceTemplateId)
+        ->willReturn([]);
+
+    ($this->addUseCase)($request, $this->useCasePresenter);
+
+    expect($this->useCasePresenter->response)->toBeInstanceOf(AddServiceTemplateResponse::class);
+});

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -711,3 +711,45 @@ it('should load command macros from an inherited template command when the servi
 
     expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
 });
+
+it('should call linkToHosts once with deduplicated IDs when host_templates contains duplicates', function (): void {
+    $request = new PartialUpdateServiceTemplateRequest(1);
+    $request->hostTemplates = [1, 1];
+    $accessGroups = [9, 11];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturnMap([[Contact::ROLE_CONFIGURATION_SERVICES_TEMPLATES_READ_WRITE, true]]);
+
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->with($this->user)
+        ->willReturn($accessGroups);
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findByIdAndAccessGroups')
+        ->with($request->id)
+        ->willReturn(new ServiceTemplate(1, 'fake_name', 'fake_alias'));
+
+    $this->validation
+        ->expects($this->once())
+        ->method('assertHostTemplateIds')
+        ->with($request->hostTemplates);
+
+    $this->writeServiceTemplateRepository
+        ->expects($this->once())
+        ->method('unlinkHosts')
+        ->with($request->id);
+
+    $this->writeServiceTemplateRepository
+        ->expects($this->once())
+        ->method('linkToHosts')
+        ->with($request->id, [1]);
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});


### PR DESCRIPTION
## Description

`POST /configuration/services/templates` and `PATCH /configuration/services/templates/{id}` silently accepted duplicate IDs in `host_templates`, causing multiple identical rows to be inserted into `host_service_relation`. This diverged from CLAPI which rejects the duplicate explicitly.

The fix applies `array_values(array_unique(...))` before the write call in both flows, consistent with the existing deduplication already applied to `service_categories` in the same use case.

**Fixes** MON-199801

## Type of change
- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Create a host template and a service template via the REST API
2. `PATCH /configuration/services/templates/{id}` with `host_templates: [HT_ID, HT_ID]`
3. Verify the response is `204 No Content` and only **one** row exists in `host_service_relation` for that service template
4. Repeat with `POST /configuration/services/templates` sending `host_templates: [HT_ID, HT_ID]` — same expectation