### PR TITLE
chore(packaging): add copyright file to Debian packages

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -167,7 +167,7 @@ runs:
             if [[ -n "$COPYRIGHT_SRC" ]]; then
               cp "$COPYRIGHT_SRC" ./copyright
               PACKAGE_NAME=$(grep '^name:' "$BASENAME" | head -1 | sed 's/^name: *//;s/"//g' | xargs)
-              awk -v pkg="$PACKAGE_NAME" 'BEGIN{injected=0} (/^scripts:/ || /^overrides:/ || /^rpm:/ || /^deb:/) && !injected { print "  - src: ./copyright"; print "    dst: /usr/share/doc/" pkg "/copyright"; print "    packager: deb"; injected=1 } { print }' "$BASENAME" > "${BASENAME}.tmp" && mv "${BASENAME}.tmp" "$BASENAME"
+              awk -v pkg="$PACKAGE_NAME" 'BEGIN{in_contents=0;injected=0} /^contents:/{in_contents=1} in_contents && /^[a-z]/ && !/^contents:/ && !injected{print "  - src: ./copyright"; print "    dst: /usr/share/doc/" pkg "/copyright"; print "    packager: deb"; injected=1; in_contents=0} {print} END{if(!injected){if(!in_contents){print "contents:"} print "  - src: ./copyright"; print "    dst: /usr/share/doc/" pkg "/copyright"; print "    packager: deb"}}' "$BASENAME" > "${BASENAME}.tmp" && mv "${BASENAME}.tmp" "$BASENAME"
             fi
           fi
           nfpm package --config $BASENAME --packager "$INPUT_PACKAGE_EXTENSION"

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -167,7 +167,7 @@ runs:
             if [[ -n "$COPYRIGHT_SRC" ]]; then
               cp "$COPYRIGHT_SRC" ./copyright
               PACKAGE_NAME=$(grep '^name:' "$BASENAME" | head -1 | sed 's/^name: *//;s/"//g' | xargs)
-              python3 -c "import yaml; f=open('${BASENAME}'); c=yaml.safe_load(f); f.close(); c.setdefault('contents',[]).append({'src':'./copyright','dst':'/usr/share/doc/${PACKAGE_NAME}/copyright','packager':'deb'}); f=open('${BASENAME}','w'); yaml.dump(c,f,default_flow_style=False,allow_unicode=True,sort_keys=False); f.close()"
+              awk -v pkg="$PACKAGE_NAME" 'BEGIN{injected=0} (/^scripts:/ || /^overrides:/ || /^rpm:/ || /^deb:/) && !injected { print "  - src: ./copyright"; print "    dst: /usr/share/doc/" pkg "/copyright"; print "    packager: deb"; injected=1 } { print }' "$BASENAME" > "${BASENAME}.tmp" && mv "${BASENAME}.tmp" "$BASENAME"
             fi
           fi
           nfpm package --config $BASENAME --packager "$INPUT_PACKAGE_EXTENSION"

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -139,6 +139,7 @@ runs:
         export RPM_SIGNING_KEY_ID="$RPM_GPG_SIGNING_KEY_ID"
         export NFPM_RPM_PASSPHRASE="$RPM_GPG_SIGNING_PASSPHRASE"
 
+        REPO_ROOT=$(pwd)
         for FILE in $INPUT_NFPM_FILE_PATTERN; do
           DIRNAME=$(dirname $FILE)
           BASENAME=$(basename $FILE)
@@ -153,6 +154,21 @@ runs:
           sed -i "s/@COMMIT_HASH@/$INPUT_COMMIT_HASH/g" $BASENAME
           if [[ -n "$PHP_MIN_VERSION" ]]; then
             grep -rl "@PHP_MIN_VERSION@" . 2>/dev/null | xargs -r sed -i "s/@PHP_MIN_VERSION@/$PHP_MIN_VERSION/g" || true
+          fi
+          if [[ "$INPUT_PACKAGE_EXTENSION" == "deb" ]]; then
+            COPYRIGHT_SRC=""
+            for candidate in "${REPO_ROOT}/LICENSE.md" "${REPO_ROOT}/LICENSE"; do
+              [[ -f "$candidate" ]] && COPYRIGHT_SRC="$candidate" && break
+            done
+            if [[ -z "$COPYRIGHT_SRC" ]]; then
+              PKG_LICENSE=$(grep '^license:' "$BASENAME" | head -1 | sed 's/^license: *//;s/"//g' | xargs)
+              [[ -f "${REPO_ROOT}/copyright.${PKG_LICENSE}" ]] && COPYRIGHT_SRC="${REPO_ROOT}/copyright.${PKG_LICENSE}"
+            fi
+            if [[ -n "$COPYRIGHT_SRC" ]]; then
+              cp "$COPYRIGHT_SRC" ./copyright
+              PACKAGE_NAME=$(grep '^name:' "$BASENAME" | head -1 | sed 's/^name: *//;s/"//g' | xargs)
+              python3 -c "import yaml; f=open('${BASENAME}'); c=yaml.safe_load(f); f.close(); c.setdefault('contents',[]).append({'src':'./copyright','dst':'/usr/share/doc/${PACKAGE_NAME}/copyright','packager':'deb'}); f=open('${BASENAME}','w'); yaml.dump(c,f,default_flow_style=False,allow_unicode=True,sort_keys=False); f.close()"
+            fi
           fi
           nfpm package --config $BASENAME --packager "$INPUT_PACKAGE_EXTENSION"
           cd -

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -156,13 +156,14 @@ runs:
             grep -rl "@PHP_MIN_VERSION@" . 2>/dev/null | xargs -r sed -i "s/@PHP_MIN_VERSION@/$PHP_MIN_VERSION/g" || true
           fi
           if [[ "$INPUT_PACKAGE_EXTENSION" == "deb" ]]; then
+            PKG_LICENSE=$(grep '^license:' "$BASENAME" | head -1 | sed 's/^license: *//;s/"//g' | xargs)
             COPYRIGHT_SRC=""
-            for candidate in "${REPO_ROOT}/LICENSE.md" "${REPO_ROOT}/LICENSE"; do
-              [[ -f "$candidate" ]] && COPYRIGHT_SRC="$candidate" && break
-            done
-            if [[ -z "$COPYRIGHT_SRC" ]]; then
-              PKG_LICENSE=$(grep '^license:' "$BASENAME" | head -1 | sed 's/^license: *//;s/"//g' | xargs)
-              [[ -f "${REPO_ROOT}/copyright.${PKG_LICENSE}" ]] && COPYRIGHT_SRC="${REPO_ROOT}/copyright.${PKG_LICENSE}"
+            if [[ -f "${REPO_ROOT}/copyright.${PKG_LICENSE}" ]]; then
+              COPYRIGHT_SRC="${REPO_ROOT}/copyright.${PKG_LICENSE}"
+            else
+              for candidate in "${REPO_ROOT}/LICENSE.md" "${REPO_ROOT}/LICENSE"; do
+                [[ -f "$candidate" ]] && COPYRIGHT_SRC="$candidate" && break
+              done
             fi
             if [[ -n "$COPYRIGHT_SRC" ]]; then
               cp "$COPYRIGHT_SRC" ./copyright

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2008-2022 CENTREON - contact@centreon.com
+   Copyright (C) 2008-2026 CENTREON - contact@centreon.com
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Modify `.github/actions/package-nfpm/action.yml` to automatically inject the copyright file into each Debian package at `/usr/share/doc/<package>/copyright`
- The injection is driven by the `license:` field in each nfpm YAML, keeping consistency with the RPM `License:` tag
- RPM packages are not affected (guarded by `INPUT_PACKAGE_EXTENSION == deb`)

Fixes: MON-32954

## Test plan

- [x] Trigger a DEB packaging job and inspect the produced `.deb`: `dpkg -c <pkg>.deb | grep copyright`
- [x] Extract and read the copyright file: `dpkg -x <pkg>.deb /tmp/extract && cat /tmp/extract/usr/share/doc/<pkg>/copyright`
- [x] Verify RPM packages are unaffected
- [x] Optionally run `lintian <pkg>.deb` — no `no-copyright-file` warning expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)