### PR TITLE
fix(web): restore cloud poller install command

### DIFF
--- a/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
+++ b/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
@@ -6,6 +6,7 @@ import { useAtomValue } from 'jotai';
 import { isEmpty } from 'ramda';
 import { ReactElement } from 'react';
 
+import FederatedComponent from '../../../components/FederatedComponents';
 import CloudInstallCommand from './CloudInstallCommand/CloudInstallCommand';
 import ExportConfiguration from './ExportConfiguration';
 
@@ -83,6 +84,12 @@ export const PollerSubMenu = ({
       {exportConfig.isExportButtonEnabled && (
         <ListItem className="p-2 [&:not(:last-child)]:border-b [&:not(:last-child)]:border-divider">
           <ExportConfiguration closeSubMenu={closeSubMenu} />
+        </ListItem>
+      )}
+
+      {platformFeatures?.isCloudPlatform && (
+        <ListItem className="p-2 [&:not(:last-child)]:border-b [&:not(:last-child)]:border-divider">
+          <FederatedComponent path="/cloud-extensions" />
         </ListItem>
       )}
 


### PR DESCRIPTION
## Description

Fixes: [MON-200005](https://centreon.atlassian.net/browse/MON-200005)
Backport of: #10477 (original ticket: [MON-199856](https://centreon.atlassian.net/browse/MON-199856))

PR #10272 silently removed the `<FederatedComponent path="/cloud-extensions" />` that rendered the "copy install command" button on cloud platforms, while introducing a new local `CloudInstallCommand` modal. That modal is intentionally disabled (`isCreatePollerDisplayed = false`) because its backing install script ([MON-198407](https://centreon.atlassian.net/browse/MON-198407)) is still **BLOCKED** and not yet shipped — so cloud users on 26.05 lost the feature with no replacement (QA blocker).

## Fix

Restore the `FederatedComponent` rendering at the same spot it lived before #10272, gated on `platformFeatures?.isCloudPlatform`.

- **Cloud**: button comes back via the `centreon-cloud-extensions` module (still deployed) — restores the 26.04 behavior.
- **On-prem**: condition is false → strictly no DOM rendered, no-op.

The new `CloudInstallCommand` stays disabled and will be flipped on in a follow-up once MON-198407 lands.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.05.x

## How to test

1. **Cloud 26.05**: open the top-bar Poller submenu → the "copy install command" entry is back.
2. **On-prem**: open the top-bar Poller submenu → no new entry, no empty/broken item.
3. Confirm no JS error in console on either env.

[MON-200005]: https://centreon.atlassian.net/browse/MON-200005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-199856]: https://centreon.atlassian.net/browse/MON-199856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-198407]: https://centreon.atlassian.net/browse/MON-198407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ