### PR TITLE
fix(logging): drop RFC3339 date_format from new-kernel monolog handlers

### DIFF
--- a/centreon/config.new/packages/monolog.yaml
+++ b/centreon/config.new/packages/monolog.yaml
@@ -37,7 +37,6 @@ monolog:
             # (cf. MON-151077). Do NOT use `rotating_file` here —
             # the two would fight over filename / suffix.
             formatter: monolog.formatter.line
-            date_format: !php/const DateTimeInterface::RFC3339
 
 when@dev:
     monolog:
@@ -68,13 +67,11 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             console:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!console"]
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             deprecation:
                 type: rotating_file
                 channels: [deprecation]
@@ -82,7 +79,6 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             authentication:
                 type: rotating_file
                 channels: [authentication]
@@ -90,7 +86,6 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             token:
                 type: rotating_file
                 channels: [token]
@@ -98,7 +93,6 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             password:
                 type: rotating_file
                 channels: [password]
@@ -106,7 +100,6 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             upgrade:
                 type: rotating_file
                 channels: [upgrade]
@@ -114,7 +107,6 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             plugin-pack-manager:
                 type: rotating_file
                 channels: [plugin-pack-manager]
@@ -122,7 +114,6 @@ when@dev:
                 max_files: 14
                 level: debug
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
 
 when@test:
     monolog:
@@ -134,13 +125,11 @@ when@test:
                 excluded_http_codes: [404, 405]
                 channels: ["!event"]
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             nested:
                 type: stream
                 path: php://stderr
                 level: critical
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
 
 when@prod:
     monolog:
@@ -150,45 +139,38 @@ when@prod:
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!deprecation"]
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             deprecation:
                 type: stream
                 channels: [deprecation]
                 path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             authentication:
                 type: stream
                 channels: [authentication]
                 path: "%kernel.logs_dir%/%kernel.environment%.access.log"
                 level: info
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             token:
                 type: stream
                 channels: [token]
                 path: "%kernel.logs_dir%/%kernel.environment%.token.log"
                 level: info
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             password:
                 type: stream
                 channels: [password]
                 path: "%kernel.logs_dir%/%kernel.environment%.password.log"
                 level: info
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             upgrade:
                 type: stream
                 channels: [upgrade]
                 path: "%kernel.logs_dir%/%kernel.environment%.upgrade.log"
                 level: info
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339
             plugin-pack-manager:
                 type: stream
                 channels: [plugin-pack-manager]
                 path: "%kernel.logs_dir%/%kernel.environment%.plugin-pack-manager.log"
                 level: info
                 formatter: monolog.formatter.line
-                date_format: !php/const DateTimeInterface::RFC3339


### PR DESCRIPTION
JIRA Ticket : [MON-199096](https://centreon.atlassian.net/browse/MON-199096)

## Problem

Any command booting the new kernel (e.g. `bin/console.new assets:install`, run by container entrypoints) crashes with:

```
RotatingFileHandler.php line 199: Invalid date format - format must be one of … ("Y-m-d"/"Y-m"/"Y")
```

The new-kernel monolog handlers (`config.new/packages/monolog.yaml`) set `date_format: !php/const DateTimeInterface::RFC3339`. monolog-bundle forwards a handler's `date_format` to `RotatingFileHandler::setFilenameFormat()`, whose validation only accepts `Y` / `Y-m` / `Y-m-d` → RFC3339 throws, aborting the whole kernel boot.

## Fix

Remove `date_format` from the handlers. The RFC3339 timestamp is already set at the **formatter service** level (`monolog.formatter.line`, see the comment in `config.new/services/shared.php`), so the handler-level `date_format` was redundant for stream handlers and invalid for `rotating_file` ones.

Regression introduced by #10384.

> Draft — found while bringing up the dev-environment on `develop`; opening for review/CI. Jira ref to be attached.


[MON-199096]: https://centreon.atlassian.net/browse/MON-199096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ