### PR TITLE
fix(api-tests): harden Bruno collection runner against path traversal

### DIFF
--- a/.github/scripts/bruno-test-api/bruno-collections-run-workspace.js
+++ b/.github/scripts/bruno-test-api/bruno-collections-run-workspace.js
@@ -4,6 +4,19 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+// Resolve `segments` under `root` and refuse any path that escapes it.
+// Defense-in-depth against path traversal: validates the resolved location,
+// so a malicious segment (e.g. "../../etc") is rejected instead of read.
+function resolveWithin(root, ...segments) {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...segments);
+  if (resolved !== resolvedRoot && !resolved.startsWith(resolvedRoot + path.sep)) {
+    console.error(`Refusing path outside of "${resolvedRoot}": ${resolved}`);
+    process.exit(1);
+  }
+  return resolved;
+}
+
 // ----------------------
 // Arguments
 // ----------------------
@@ -23,7 +36,10 @@ console.log("Collection name:", collection);
 // ----------------------
 // Paths
 // ----------------------
-const collectionPath = path.join(process.cwd(), "collections", collection);
+const collectionPath = resolveWithin(
+  path.join(process.cwd(), "collections"),
+  collection,
+);
 if (!fs.existsSync(collectionPath)) {
   console.error(`❌ Collection directory not found: ${collectionPath}`);
   process.exit(1);
@@ -40,7 +56,7 @@ const environmentFileWithoutExtension = getEnvironmentFile(collectionPath);
 
 // Helper function
 function getEnvironmentFile(collectionPath, extension) {
-  const envDir = path.join(collectionPath, "environments");
+  const envDir = resolveWithin(collectionPath, "environments");
   if (!fs.existsSync(envDir)) return false;
   const ext = extension ?? ".bru";
   const envFiles = fs.readdirSync(envDir).filter((f) => f.endsWith(ext));


### PR DESCRIPTION
Aligns `develop` with the hardening already applied on `dev-25.10.x` (PR #10478).

Aikido flagged a *potential file inclusion via ReadFile* (high) on the Bruno
collection runner `.github/scripts/bruno-test-api/bruno-collections-run-workspace.js`:
the collection path derived from the CLI argument flows into `fs.readdirSync`.

The collection name is already allowlist-validated (`^[A-Za-z0-9_-]+$`), so traversal
was not actually reachable, but this adds real defense-in-depth (and the sanitization
the scanner expects):

- New reusable `resolveWithin(root, ...segments)` helper that resolves the target and
  refuses any path escaping its root (a `..` segment or an absolute path is rejected,
  not read).
- Used both for the collection directory (derived from the CLI argument) and for the
  `environments` directory.

Note: the guard suggested inline by Aikido was a no-op (it checked the constant
`"environments"` suffix, which can never escape, instead of the actual input). This
patch guards the real tainted value.

This is the same change as the one merged on `dev-25.10.x`; it keeps the Bruno runner
identical across branches.

Refs: MON-194055

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master
