### PR TITLE
chore(release) bump oss 24.10 2026-06-01

### DIFF
--- a/.version.centreon-awie
+++ b/.version.centreon-awie
@@ -1,1 +1,1 @@
-MINOR=6
+MINOR=7

--- a/.version.centreon-dsm
+++ b/.version.centreon-dsm
@@ -1,1 +1,1 @@
-MINOR=6
+MINOR=7

--- a/.version.centreon-open-tickets
+++ b/.version.centreon-open-tickets
@@ -1,1 +1,1 @@
-MINOR=12
+MINOR=13

--- a/centreon-awie/www/modules/centreon-awie/conf.php
+++ b/centreon-awie/www/modules/centreon-awie/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-awie']['rname'] = 'Centreon Api Web Import Export';
 $module_conf['centreon-awie']['name'] = 'centreon-awie';
-$module_conf['centreon-awie']['mod_release'] = '24.10.6';
+$module_conf['centreon-awie']['mod_release'] = '24.10.7';
 $module_conf['centreon-awie']['infos'] = 'The Centreon AWIE (Application Web Import Export) module has been '
     . 'designed to help users configure several Centreon Web platforms in a faster and easier way, thanks to its '
     . 'import/export mechanism.
@@ -35,7 +35,7 @@ Centreon AWIE is based on CLAPI commands but its added value is to allow using C
 $module_conf['centreon-awie']['is_removeable'] = '1';
 $module_conf['centreon-awie']['author'] = 'Centreon';
 $module_conf['centreon-awie']['stability'] = 'stable';
-$module_conf['centreon-awie']['last_update'] = '2026-03-24';
+$module_conf['centreon-awie']['last_update'] = '2026-06-01';
 $module_conf['centreon-awie']['images'] = [
     'images/image1.png',
 ];

--- a/centreon-dsm/www/modules/centreon-dsm/conf.php
+++ b/centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -22,7 +22,7 @@
 // Be Careful with internal_name, it's case sensitive (with directory module name)
 $module_conf['centreon-dsm']['name'] = 'centreon-dsm';
 $module_conf['centreon-dsm']['rname'] = 'Dynamic Services Management';
-$module_conf['centreon-dsm']['mod_release'] = '24.10.6';
+$module_conf['centreon-dsm']['mod_release'] = '24.10.7';
 $module_conf['centreon-dsm']['infos'] = 'Centreon Dynamic Service Management (Centreon-DSM) is a module to manage '
     . 'alarms with an event logs system. With DSM, Centreon can receive events such as SNMP traps resulting from the '
     . 'detection of a problem and assign events dynamically to a slot defined in Centreon, like a tray events.
@@ -37,7 +37,7 @@ The goal of this module is to overhead the basic trap management system of Centr
 $module_conf['centreon-dsm']['is_removeable'] = '1';
 $module_conf['centreon-dsm']['author'] = 'Centreon';
 $module_conf['centreon-dsm']['stability'] = 'stable';
-$module_conf['centreon-dsm']['last_update'] = '2026-03-24';
+$module_conf['centreon-dsm']['last_update'] = '2026-06-01';
 $module_conf['centreon-dsm']['images'] = [
     'images/dsm_snmp_events_tray.png',
 ];

--- a/centreon-open-tickets/widgets/open-tickets/configs.xml
+++ b/centreon-open-tickets/widgets/open-tickets/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>This widget is associated to the Open Tickets Module and allows for selecting hosts or services events for which to create tickets in your favorite ITSM tools. This widget can also list already created tickets with their ID and datetime.</description>
-  <version>24.10.12</version>
+  <version>24.10.13</version>
   <keywords>centreon, widget, tickets</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/open-tickets/resources/centreon-logo.png</thumbnail>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-open-tickets']['rname'] = 'Centreon Open Tickets';
 $module_conf['centreon-open-tickets']['name'] = 'centreon-open-tickets';
-$module_conf['centreon-open-tickets']['mod_release'] = '24.10.12';
+$module_conf['centreon-open-tickets']['mod_release'] = '24.10.13';
 $module_conf['centreon-open-tickets']['infos'] = 'Centreon Open Tickets is a community module developed to '
     . 'create tickets to your favorite ITSM tools using API.
 
@@ -36,7 +36,7 @@ Regarding the widget configuration, it is possible to see the created tickets by
 $module_conf['centreon-open-tickets']['is_removeable'] = '1';
 $module_conf['centreon-open-tickets']['author'] = 'Centreon';
 $module_conf['centreon-open-tickets']['stability'] = 'stable';
-$module_conf['centreon-open-tickets']['last_update'] = '2026-04-21';
+$module_conf['centreon-open-tickets']['last_update'] = '2026-06-01';
 $module_conf['centreon-open-tickets']['images'] = [
     'images/image1.png',
     'images/image2.png',


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-199689

Bump OSS versions to 24.10 (2026-06-01):
- centreon-awie: 24.10.7
- centreon-dsm: 24.10.7
- centreon-open-tickets: 24.10.13
