### PR TITLE
chore(release) bump oss 25.10 2026-06-01

### DIFF
--- a/.version.centreon-awie
+++ b/.version.centreon-awie
@@ -1,1 +1,1 @@
-MINOR=6
+MINOR=7

--- a/.version.centreon-dsm
+++ b/.version.centreon-dsm
@@ -1,1 +1,1 @@
-MINOR=3
+MINOR=4

--- a/centreon-awie/www/modules/centreon-awie/conf.php
+++ b/centreon-awie/www/modules/centreon-awie/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-awie']['rname'] = 'Centreon Api Web Import Export';
 $module_conf['centreon-awie']['name'] = 'centreon-awie';
-$module_conf['centreon-awie']['mod_release'] = '25.10.6';
+$module_conf['centreon-awie']['mod_release'] = '25.10.7';
 $module_conf['centreon-awie']['infos'] = 'The Centreon AWIE (Application Web Import Export) module has been '
     . 'designed to help users configure several Centreon Web platforms in a faster and easier way, thanks to its '
     . 'import/export mechanism.
@@ -35,7 +35,7 @@ Centreon AWIE is based on CLAPI commands but its added value is to allow using C
 $module_conf['centreon-awie']['is_removeable'] = '1';
 $module_conf['centreon-awie']['author'] = 'Centreon';
 $module_conf['centreon-awie']['stability'] = 'stable';
-$module_conf['centreon-awie']['last_update'] = '2026-03-24';
+$module_conf['centreon-awie']['last_update'] = '2026-06-01';
 $module_conf['centreon-awie']['images'] = [
     'images/image1.png',
 ];

--- a/centreon-dsm/www/modules/centreon-dsm/conf.php
+++ b/centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -22,7 +22,7 @@
 // Be Careful with internal_name, it's case sensitive (with directory module name)
 $module_conf['centreon-dsm']['name'] = 'centreon-dsm';
 $module_conf['centreon-dsm']['rname'] = 'Dynamic Services Management';
-$module_conf['centreon-dsm']['mod_release'] = '25.10.3';
+$module_conf['centreon-dsm']['mod_release'] = '25.10.4';
 $module_conf['centreon-dsm']['infos'] = 'Centreon Dynamic Service Management (Centreon-DSM) is a module to manage '
     . 'alarms with an event logs system. With DSM, Centreon can receive events such as SNMP traps resulting from the '
     . 'detection of a problem and assign events dynamically to a slot defined in Centreon, like a tray events.
@@ -37,7 +37,7 @@ The goal of this module is to overhead the basic trap management system of Centr
 $module_conf['centreon-dsm']['is_removeable'] = '1';
 $module_conf['centreon-dsm']['author'] = 'Centreon';
 $module_conf['centreon-dsm']['stability'] = 'stable';
-$module_conf['centreon-dsm']['last_update'] = '2026-03-24';
+$module_conf['centreon-dsm']['last_update'] = '2026-06-01';
 $module_conf['centreon-dsm']['images'] = [
     'images/dsm_snmp_events_tray.png',
 ];


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-199683

Bump OSS versions to 25.10 (2026-06-01):
- centreon-dsm: 25.10.4
- centreon-awie: 25.10.7
