### PR TITLE
fix(exporter): disable FK checks during table cleanup to prevent cascade deletes

### DIFF
--- a/centreon/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
+++ b/centreon/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
@@ -88,6 +88,9 @@ class ConfigurationExporter extends ExporterServiceAbstract
         // Phase 1: clear tables and reset auto_increment outside transaction.
         // ALTER TABLE (DDL) causes an implicit commit in MySQL/MariaDB, so it must
         // run before beginTransaction() to avoid breaking the import transaction.
+        // FK checks must be disabled to prevent CASCADE deletes on tables not in the
+        // export manifest (e.g. cfg_nagios_logger, acl_resources_*_relations).
+        $db->query('SET FOREIGN_KEY_CHECKS=0');
         $truncated = [];
         foreach ($import['data'] as $data) {
             if (! isset($truncated[$data['table']]) && isset($tables[$data['table']])) {
@@ -96,6 +99,7 @@ class ConfigurationExporter extends ExporterServiceAbstract
                 $truncated[$data['table']] = 1;
             }
         }
+        $db->query('SET FOREIGN_KEY_CHECKS=1');
 
         // Phase 2: import data inside a transaction.
         $db->beginTransaction();


### PR DESCRIPTION
## Description

Backport of #10491 for dev-25.10.x.

When exporting the configuration of a remote server from the Central, the import process deletes tables with FK checks enabled, causing CASCADE deletes on tables not in the export manifest (`cfg_nagios_logger`, `acl_resources_*_relations`). This disables FK checks around the Phase 1 cleanup loop.

**Fixes** MON-200066

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Set up a Central + Remote Server environment
2. Create hosts, services, users and ACL resources on the Remote Server
3. Export the configuration of the Remote (or a poller it manages) from the Central
4. Verify that `cfg_nagios_logger` rows still exist on the Remote's database
5. Verify that ACL resource relations are preserved on the Remote
6. Export the configuration from the Remote Server itself — it should succeed without error

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).