### PR TITLE
docs(api): correct openapi doc of duplicate endpoint

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -4928,44 +4928,51 @@ paths:
       tags:
         - Command
       responses:
-        '403':
-          description: 'You are not allowed to duplicate commands'
         '200':
-          description: 'Command resource created'
+          description: 'A collection holding the duplication outcome for each requested command'
           content:
             application/ld+json:
               schema:
-                $ref: '#/components/schemas/DuplicateCommandResource.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DuplicateCommandResource'
+                type: object
+                properties:
+                  '@context': { type: string }
+                  '@id': { type: string }
+                  '@type': { type: string, example: Collection }
+                  totalItems: { type: integer }
+                  member: { type: array, items: { type: object, properties: { '@id': { type: string }, '@type': { type: string, example: DuplicateCommandResource }, command: { type: string, description: 'IRI of the duplicated command (absent when the duplication failed)' }, status: { type: integer }, message: { type: string } }, required: ['@id', '@type', status, message] } }
+              example:
+                '@context': /centreon/api/latest/contexts/Command
+                '@id': /centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8
+                '@type': Collection
+                totalItems: 2
+                member:
+                  - { '@id': /centreon/api/latest/.well-known/genid/c2afa2366f6f99491863, '@type': DuplicateCommandResource, command: /centreon/api/latest/configuration/commands/98, status: 204, message: 'Command duplicated successfully' }
+                  - { '@id': /centreon/api/latest/.well-known/genid/3fa305a034165257c384, '@type': DuplicateCommandResource, status: 404, message: 'Command with ID 99999 not found' }
           links: {  }
         '400':
-          description: 'Invalid input'
+          description: 'Invalid input — the request body failed validation'
           content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
+                type: object
+                properties:
+                  code: { type: integer, example: 400 }
+                  message: { type: string, description: 'One line per violation, formatted as "[propertyPath] message"', example: "[ids] IDs array cannot be empty\n" }
+                required:
+                  - code
+                  - message
+        '403':
+          description: 'You are not allowed to duplicate commands'
           content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
             application/json:
               schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
+                type: object
+                properties:
+                  code: { type: integer, example: 0 }
+                  message: { type: string, example: 'You are not allowed to duplicate commands' }
+                required:
+                  - code
+                  - message
       summary: 'Duplicate a Command resource'
       description: 'Duplicate a Command resource'
       parameters: []

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Command/DuplicateCommandResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Command/DuplicateCommandResource.php
@@ -35,10 +35,98 @@ use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Command\Duplica
     processor: DuplicateCommandsProcessor::class,
     input: DuplicateCommandInput::class,
     status: 200,
+    errors: [],
     openapi: new Model\Operation(
         summary: 'Duplicate a Command resource',
         responses: [
-            403 => new Model\Response('You are not allowed to duplicate commands'),
+            200 => new Model\Response(
+                description: 'A collection holding the duplication outcome for each requested command',
+                content: new \ArrayObject([
+                    'application/ld+json' => new Model\MediaType(
+                        schema: new \ArrayObject([
+                            'type' => 'object',
+                            'properties' => [
+                                '@context' => ['type' => 'string'],
+                                '@id' => ['type' => 'string'],
+                                '@type' => ['type' => 'string', 'example' => 'Collection'],
+                                'totalItems' => ['type' => 'integer'],
+                                'member' => [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            '@id' => ['type' => 'string'],
+                                            '@type' => ['type' => 'string', 'example' => 'DuplicateCommandResource'],
+                                            'command' => [
+                                                'type' => 'string',
+                                                'description' => 'IRI of the duplicated command (absent when the duplication failed)',
+                                            ],
+                                            'status' => ['type' => 'integer'],
+                                            'message' => ['type' => 'string'],
+                                        ],
+                                        'required' => ['@id', '@type', 'status', 'message'],
+                                    ],
+                                ],
+                            ],
+                        ]),
+                        example: [
+                            '@context' => '/centreon/api/latest/contexts/Command',
+                            '@id' => '/centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8',
+                            '@type' => 'Collection',
+                            'totalItems' => 2,
+                            'member' => [
+                                [
+                                    '@id' => '/centreon/api/latest/.well-known/genid/c2afa2366f6f99491863',
+                                    '@type' => 'DuplicateCommandResource',
+                                    'command' => '/centreon/api/latest/configuration/commands/98',
+                                    'status' => 204,
+                                    'message' => 'Command duplicated successfully',
+                                ],
+                                [
+                                    '@id' => '/centreon/api/latest/.well-known/genid/3fa305a034165257c384',
+                                    '@type' => 'DuplicateCommandResource',
+                                    'status' => 404,
+                                    'message' => 'Command with ID 99999 not found',
+                                ],
+                            ],
+                        ],
+                    ),
+                ]),
+            ),
+            400 => new Model\Response(
+                description: 'Invalid input — the request body failed validation',
+                content: new \ArrayObject([
+                    'application/json' => new Model\MediaType(
+                        schema: new \ArrayObject([
+                            'type' => 'object',
+                            'properties' => [
+                                'code' => ['type' => 'integer', 'example' => 400],
+                                'message' => [
+                                    'type' => 'string',
+                                    'description' => 'One line per violation, formatted as "[propertyPath] message"',
+                                    'example' => "[ids] IDs array cannot be empty\n",
+                                ],
+                            ],
+                            'required' => ['code', 'message'],
+                        ]),
+                    ),
+                ]),
+            ),
+            403 => new Model\Response(
+                description: 'You are not allowed to duplicate commands',
+                content: new \ArrayObject([
+                    'application/json' => new Model\MediaType(
+                        schema: new \ArrayObject([
+                            'type' => 'object',
+                            'properties' => [
+                                'code' => ['type' => 'integer', 'example' => 0],
+                                'message' => ['type' => 'string', 'example' => 'You are not allowed to duplicate commands'],
+                            ],
+                            'required' => ['code', 'message'],
+                        ]),
+                    ),
+                ]),
+            ),
         ],
     ),
 )]


### PR DESCRIPTION
## Description

Fix openapi doc for `POST configuration/commands/_duplicate` by adding proper examples for 200, 400 and 403 responses.

### 200
```json
{
  "@context": "/centreon/api/latest/contexts/Command",
  "@id": "/centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8",
  "@type": "Collection",
  "totalItems": 2,
  "member": [
    {
      "@id": "/centreon/api/latest/.well-known/genid/c2afa2366f6f99491863",
      "@type": "DuplicateCommandResource",
      "command": "/centreon/api/latest/configuration/commands/98",
      "status": 204,
      "message": "Command duplicated successfully"
    },
    {
      "@id": "/centreon/api/latest/.well-known/genid/3fa305a034165257c384",
      "@type": "DuplicateCommandResource",
      "status": 404,
      "message": "Command with ID 99999 not found"
    }
  ]
}
```

[MON-198689](https://centreon.atlassian.net/browse/MON-198689)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

check the api platform documentation on : `/docs`

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-198689]: https://centreon.atlassian.net/browse/MON-198689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ