### PR TITLE
feat(test): api: add host name unauthorized characters check (MON-184125)

### DIFF
--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/DELETE -hosts - Delete host - HTTP 204.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/DELETE -hosts - Delete host - HTTP 204.bru
@@ -1,7 +1,7 @@
 meta {
   name: DELETE /hosts - Delete host - HTTP 204
   type: http
-  seq: 21
+  seq: 22
 }
 
 delete {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/GET -hosts - Get specific host by id - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/GET -hosts - Get specific host by id - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: GET /hosts/{id} - Get specific host by id - HTTP 200
   type: http
-  seq: 19
+  seq: 20
 }
 
 get {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: GET /logout - Logout administrator - HTTP 200
   type: http
-  seq: 22
+  seq: 23
 }
 
 get {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/PATCH -hosts - Change host name - HTTP 204.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/PATCH -hosts - Change host name - HTTP 204.bru
@@ -1,7 +1,7 @@
 meta {
   name: PATCH /hosts - Change host name - HTTP 204
   type: http
-  seq: 20
+  seq: 21
 }
 
 patch {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/POST -hosts - Add host with unauthorized characters in name - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/POST -hosts - Add host with unauthorized characters in name - HTTP 400.bru
@@ -1,0 +1,73 @@
+meta {
+  name: POST /hosts - Add host with unauthorized characters in name - HTTP 400
+  type: http
+  seq: 23
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/hosts
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "host~3!",
+    "alias": "{{Host1Alias}}",
+    "address": "127.0.0.1",
+    "monitoring_server_id": 1,
+    "snmp_version": "2c",
+    "timezone_id": 1,
+    "severity_id": {{HostSeverity1Id}},
+    "check_timeperiod_id": 1,
+    "note_url": "noteUrl-value",
+    "note": "note-value",
+    "action_url": "actionUrl-value",
+    "max_check_attempts": 3,
+    "normal_check_interval": 5,
+    "retry_check_interval": 2,
+    "icon_id": 1,
+    "categories": [ {{HostCategory1Id}}
+    ],
+    "templates": [ {{HostTemplate1Id}}
+    ],
+    "geo_coords": "48.51,2.20",
+    "groups": [ {{HostGroup1Id}}
+    ],
+    "macros": [
+      {
+        "name": "nameC",
+        "value": "valueC",
+        "is_password": false,
+        "description": "some text"
+      },
+      {
+        "name": "nameD",
+        "value": "valueD",
+        "is_password": true,
+        "description": null
+      }
+    ],
+    "is_activated": true
+  }
+}
+
+assert {
+  res.status: eq 400
+}
+
+tests {
+  test("host name with unauthorized characters is rejected", function () {
+    const body = res.getBody();
+
+    expect(body).to.be.an("object");
+    expect(body).to.have.property("code").that.is.a("number");
+    expect(body).to.have.property("message").that.includes("unauthorized characters");
+  });
+
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/POST -hosts - Add host with unauthorized characters in name - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/POST -hosts - Add host with unauthorized characters in name - HTTP 400.bru
@@ -1,7 +1,7 @@
 meta {
   name: POST /hosts - Add host with unauthorized characters in name - HTTP 400
   type: http
-  seq: 23
+  seq: 19
 }
 
 post {


### PR DESCRIPTION
## Context

MON-184125 — port the CCE-side test for incorrect characters in host names over to Centreon WEB.

Following bug MON-183386 (RELEASED), the WEB API now rejects host names containing the hardcoded illegal characters `~!\$%^&*"|'<>?,()=` on the `POST`/`PATCH /configuration/hosts` endpoints, returning:

```
{ "code": 400, "message": "[Host::name] The value contains unauthorized characters: ~!" }
```

The existing Bruno `Host` collection only covered empty / missing / boolean name cases — there was no coverage for unauthorized characters, which is exactly the behaviour fixed by MON-183386.

## Change

Adds a Bruno request to the `Host` collection (Administrator profile):

- `POST /hosts - Add host with unauthorized characters in name - HTTP 400` — creates a host with name `host~3!` and asserts HTTP `400` with a body message containing `unauthorized characters`.

## Notes

- Targets `develop`; backports to `dev-25.10.x` / `dev-24.10.x` to follow once merged (the restriction is present on those branches too).

Ref: MON-184125, MON-183386