### PR TITLE
chore(ci): migrate bruno-api-test list job from node20 to node24 (MON-196949)

### DIFF
--- a/.github/workflows/bruno-api-test.yml
+++ b/.github/workflows/bruno-api-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: List Bruno collections by workspace
         id: set_collections

--- a/centreon/tests/api/README.md
+++ b/centreon/tests/api/README.md
@@ -7,8 +7,8 @@ This documentation covers the Bruno CLI v3 implementation for the `web-api-works
 ## Prerequisites
 
 - Bruno CLI v3 installed
-- Node.js environment
-- Access to the Centreon Web API instance
+- Node.js 24 or later
+- A running Centreon instance exposing the Web API (typically a Centreon Web Docker container) reachable at the configured base URL
 
 ## Installation
 


### PR DESCRIPTION
## Context

MON-196949 — GitHub Actions forces Node.js 24 by default from June 2nd, 2026 and removes Node.js 20 on September 16th, 2026. QA workflows (E2E / API) using a custom Node 20 runtime must be migrated.

## Change

`.github/workflows/bruno-api-test.yml` — the `bruno-test-list-collections-workspace` job (`List Bruno collections by workspace`) used `setup-node` with `node-version: 20`, while the `Run Bruno collection tests` job is already on `node-version: 24`. This aligns the list job to Node 24.

This item was not in the ticket's `centreon` table (only listed for `centreon-modules`); the `bruno-api-test.yml` workflow was added to `centreon` by the recent Postman→Bruno migration, after the ticket was written.

## Notes

- The other `centreon` items from the ticket are already done on `develop`: `code-coverage-gate-keeper/action.yml` is already `using: 'node24'` and `publish-cypress-report/action.yml` is already `node-version: 24`.
- Backports to `dev-25.10.x` / `dev-24.10.x` to follow once merged.

Ref: MON-196949