### PR TITLE
fix(ci): restrict open-tickets e2e lint scope to features directory (backport 24.10)

### DIFF
--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -281,6 +281,7 @@ jobs:
           module_name: ${{ env.module }}
           dependencies_lock_file: ${{ env.e2e_directory }}/pnpm-lock.yaml
           pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          lint_path: './features'
 
   package:
     needs:


### PR DESCRIPTION
## Context

Backport of MON-198749 / centreon#10353 to dev-24.10.x (MON-200148) — keep develop and the maintenance branches aligned.

The `open-tickets` `e2e-lint` job ran `frontend-lint` without a `lint_path`, so the linter scanned the whole e2e directory instead of just the Gherkin features. develop restricts it to `./features`; this aligns dev-24.10.x (same change as the 25.10 backport MON-198783).

## Change

`.github/workflows/open-tickets.yml` — add `lint_path: './features'` to the `e2e-lint` job's `frontend-lint` step (same value as develop). The `frontend-lint` action on this branch already supports the `lint_path` input.

## Notes

- Code-alignment backport. A separate, pre-existing `e2e-lint` failure (biome `self-installer exits with code 127`) affects develop and the maintenance branches and is **out of scope** of this ticket.

Refs: MON-200148, MON-198749