### PR TITLE
feat(test): api: add host name unauthorized characters check (backport 24.10)

### DIFF
--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/DELETE -hosts - Delete host - HTTP 204.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/DELETE -hosts - Delete host - HTTP 204.bru
@@ -1,7 +1,7 @@
 meta {
   name: DELETE /hosts - Delete host - HTTP 204
   type: http
-  seq: 20
+  seq: 21
 }
 
 delete {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: GET /logout - Logout administrator - HTTP 200
   type: http
-  seq: 21
+  seq: 22
 }
 
 get {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/PATCH -hosts - Change host name - HTTP 204.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/PATCH -hosts - Change host name - HTTP 204.bru
@@ -1,7 +1,7 @@
 meta {
   name: PATCH /hosts - Change host name - HTTP 204
   type: http
-  seq: 19
+  seq: 20
 }
 
 patch {

--- a/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/POST -hosts - Add host with unauthorized characters in name - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Host/Administrator profile/POST -hosts - Add host with unauthorized characters in name - HTTP 400.bru
@@ -1,0 +1,73 @@
+meta {
+  name: POST /hosts - Add host with unauthorized characters in name - HTTP 400
+  type: http
+  seq: 19
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/hosts
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "host~3!",
+    "alias": "{{Host1Alias}}",
+    "address": "127.0.0.1",
+    "monitoring_server_id": 1,
+    "snmp_version": "2c",
+    "timezone_id": 1,
+    "severity_id": {{HostSeverity1Id}},
+    "check_timeperiod_id": 1,
+    "note_url": "noteUrl-value",
+    "note": "note-value",
+    "action_url": "actionUrl-value",
+    "max_check_attempts": 3,
+    "normal_check_interval": 5,
+    "retry_check_interval": 2,
+    "icon_id": 1,
+    "categories": [ {{HostCategory1Id}}
+    ],
+    "templates": [ {{HostTemplate1Id}}
+    ],
+    "geo_coords": "48.51,2.20",
+    "groups": [ {{HostGroup1Id}}
+    ],
+    "macros": [
+      {
+        "name": "nameC",
+        "value": "valueC",
+        "is_password": false,
+        "description": "some text"
+      },
+      {
+        "name": "nameD",
+        "value": "valueD",
+        "is_password": true,
+        "description": null
+      }
+    ],
+    "is_activated": true
+  }
+}
+
+assert {
+  res.status: eq 400
+}
+
+tests {
+  test("host name with unauthorized characters is rejected", function () {
+    const body = res.getBody();
+
+    expect(body).to.be.an("object");
+    expect(body).to.have.property("code").that.is.a("number");
+    expect(body).to.have.property("message").that.includes("unauthorized characters");
+  });
+
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}


### PR DESCRIPTION
Backport to dev-24.10.x of MON-184125 / centreon#10530.

Adds the Bruno `Host` test asserting a host name with unauthorized characters (`~!\$%^&*"|'<>?,()=`) is rejected with HTTP 400, placed with the other add-host validations before the admin logout.

Cherry-pick of 8d7b568361 with conflict resolution for the 24.10 collection layout: the `GET /hosts/{id}` request does not exist on 24.10 (kept removed), and the new test is sequenced at 19 with PATCH/DELETE/logout shifted to 20/21/22.

Refs: MON-200150, MON-184125