### PR TITLE
chore(ci): migrate bruno-api-test list job from node20 to node24 (backport 24.10)

### DIFF
--- a/.github/workflows/bruno-api-test.yml
+++ b/.github/workflows/bruno-api-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: List Bruno collections by workspace
         id: set_collections

--- a/centreon/tests/api/README.md
+++ b/centreon/tests/api/README.md
@@ -7,8 +7,8 @@ This documentation covers the Bruno CLI v3 implementation for the `web-api-works
 ## Prerequisites
 
 - Bruno CLI v3 installed
-- Node.js environment
-- Access to the Centreon Web API instance
+- Node.js 24 or later
+- A running Centreon instance exposing the Web API (typically a Centreon Web Docker container) reachable at the configured base URL
 
 ## Installation
 


### PR DESCRIPTION
Backport to dev-24.10.x of MON-196949 / centreon#10535.

- `.github/workflows/bruno-api-test.yml` — `bruno-test-list-collections-workspace` job moved from `node-version: 20` to `24` (run job already on 24).
- `centreon/tests/api/README.md` — Node 24+ prerequisite + clarified "running Centreon instance" wording.

Clean cherry-pick of 2d08526cfbe8.

Refs: MON-200153, MON-196949