### PR TITLE
chore(packaging): handle php8.2 deprecation in preinstall script

### DIFF
--- a/centreon/packaging/scripts/centreon-web-preinstall.sh
+++ b/centreon/packaging/scripts/centreon-web-preinstall.sh
@@ -15,3 +15,11 @@ if systemctl --all --type service | grep -q "php8.1-fpm" ; then
   systemctl disable php8.1-fpm > /dev/null 2>&1 || :
   systemctl stop php8.1-fpm > /dev/null 2>&1 || :
 fi
+
+# Prepare php upgrade from 8.2
+if systemctl --all --type service | grep -q "php8.2-fpm" ; then
+  echo "Disabling and stopping php8.2-fpm to migrate to php@PHP_MIN_VERSION@-fpm ..."
+  a2dismod php8.2 > /dev/null 2>&1 || :
+  systemctl disable php8.2-fpm > /dev/null 2>&1 || :
+  systemctl stop php8.2-fpm > /dev/null 2>&1 || :
+fi


### PR DESCRIPTION
## Description

Add a PHP 8.2 FPM disabling block in the preinstall script to handle upgrades to PHP 8.4. When upgrading, the old `php8.2-fpm` service needs to be stopped and disabled before the new version takes over, following the same pattern already in place for PHP 8.0 and 8.1.

**Fixes** MON-200157

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

- Install Centreon with PHP 8.2 FPM running
- Upgrade the `centreon-web` package to a version using PHP 8.4
- Verify that `php8.2-fpm` is stopped and disabled after the preinstall phase
- Verify that `php8.4-fpm` is the active FPM service after upgrade

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).