### PR TITLE
chore(php): cleanup PHP deprecations

### DIFF
--- a/.github/workflows/bruno-api-test.yml
+++ b/.github/workflows/bruno-api-test.yml
@@ -175,7 +175,7 @@ jobs:
               bash -c "mkdir -p /var/log/centreon/symfony.new && chown ${WEB_USER}:${WEB_USER} /var/log/centreon/symfony.new"
 
             docker compose -f ../../../../.github/docker/docker-compose.yml exec -e OS_INPUT="$OS_INPUT" web \
-              bash -c bash -c '
+              bash -c '
                 if [[ "$OS_INPUT" == "alma9" ]]; then
                   PHP_INI="/etc/php.ini"
                 else
@@ -288,7 +288,7 @@ jobs:
           feature="${{ matrix.feature }}"
           deprecation_file_for_archive="$feature-deprecation.log"
           found=false
-          deprecation_file_container=$(docker compose -f ../../../../.github/docker/docker-compose.yml exec -T web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | grep -m1 ." | tr -d '\r')
+          deprecation_file_container=$(docker compose -f ../../../../.github/docker/docker-compose.yml exec -T web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | head -1" | tr -d '\r')
           if [[ -n "$deprecation_file_container" ]]; then
             docker compose -f ../../../../.github/docker/docker-compose.yml exec -T web cat "$deprecation_file_container" >> ./$deprecation_file_for_archive
             echo "Appended deprecation log from $deprecation_file_container"

--- a/.github/workflows/bruno-api-test.yml
+++ b/.github/workflows/bruno-api-test.yml
@@ -172,7 +172,7 @@ jobs:
 
             # Necessary for collecting deprecation logs
             docker compose -f ../../../../.github/docker/docker-compose.yml exec web \
-              bash -c "mkdir -p /var/log/centreon/symfony.new && chown ${WEB_USER}:${WEB_USER} /var/log/centreon/symfony.new"
+              bash -c "mkdir -p /var/log/centreon && chown ${WEB_USER}:${WEB_USER} /var/log/centreon"
 
             docker compose -f ../../../../.github/docker/docker-compose.yml exec -e OS_INPUT="$OS_INPUT" web \
               bash -c '
@@ -288,7 +288,7 @@ jobs:
           feature="${{ matrix.feature }}"
           deprecation_file_for_archive="$feature-deprecation.log"
           found=false
-          deprecation_file_container=$(docker compose -f ../../../../.github/docker/docker-compose.yml exec -T web bash -c "find /var/log/centreon/symfony.new/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | head -1" | tr -d '\r')
+          deprecation_file_container=$(docker compose -f ../../../../.github/docker/docker-compose.yml exec -T web bash -c "find /var/log/centreon/ -maxdepth 1 -regex \".*deprecations.*\" 2>/dev/null | head -1" | tr -d '\r')
           if [[ -n "$deprecation_file_container" ]]; then
             docker compose -f ../../../../.github/docker/docker-compose.yml exec -T web cat "$deprecation_file_container" >> ./$deprecation_file_for_archive
             echo "Appended deprecation log from $deprecation_file_container"

--- a/centreon/config.new/packages/monolog.yaml
+++ b/centreon/config.new/packages/monolog.yaml
@@ -1,3 +1,4 @@
+# MON-198992: PHP 8.3 / 8.4 deprecations cleanup — tracking branch.
 monolog:
     channels:
         - deprecation

--- a/centreon/config.new/packages/monolog.yaml
+++ b/centreon/config.new/packages/monolog.yaml
@@ -1,4 +1,3 @@
-# MON-198992: PHP 8.3 / 8.4 deprecations cleanup — tracking branch.
 monolog:
     channels:
         - deprecation

--- a/centreon/config/packages/security_checker.yaml
+++ b/centreon/config/packages/security_checker.yaml
@@ -1,8 +1,0 @@
-services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
-
-    SensioLabs\Security\SecurityChecker: null
-
-    SensioLabs\Security\Command\SecurityCheckerCommand: null

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -94,9 +94,6 @@ services:
     Security\Domain\Authentication\Model\LocalProvider:
         arguments: [ "%session_expiration_delay%" ]
 
-    Security\Domain\Authentication\Model\ProviderFactory:
-        arguments: [!tagged_iterator 'authentication.providers']
-
     Core\Resources\Infrastructure\Repository\DbReadResourceRepository:
         arguments:
             $resourceTypes: !tagged_iterator 'monitoring.resource.type'

--- a/centreon/src/Core/Dashboard/Infrastructure/API/PartialUpdateDashboard/PartialUpdateDashboardInput.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/PartialUpdateDashboard/PartialUpdateDashboardInput.php
@@ -69,7 +69,7 @@ final readonly class PartialUpdateDashboardInput
                 'type' => [
                     new Assert\NotNull(),
                     new Assert\Type('string'),
-                    new Assert\Choice(['global', 'manual']),
+                    new Assert\Choice(choices: ['global', 'manual']),
                 ],
                 'interval' => new Assert\Optional([
                     new Assert\Type('numeric'),

--- a/centreon/src/Core/Dashboard/Infrastructure/API/ShareDashboard/ShareDashboardInput.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/ShareDashboard/ShareDashboardInput.php
@@ -40,10 +40,10 @@ final readonly class ShareDashboardInput
                 ],
                 'role' => [
                     new Assert\NotBlank(),
-                    new Assert\Choice([
-                        'choices' => ['editor', 'viewer'],
-                        'message' => 'Role provided for contact is not valid. Valid roles are: editor, viewer',
-                    ]),
+                    new Assert\Choice(
+                        choices: ['editor', 'viewer'],
+                        message: 'Role provided for contact is not valid. Valid roles are: editor, viewer',
+                    ),
                 ],
             ]),
         ])]
@@ -56,10 +56,10 @@ final readonly class ShareDashboardInput
                 ],
                 'role' => [
                     new Assert\NotBlank(),
-                    new Assert\Choice([
-                        'choices' => ['editor', 'viewer'],
-                        'message' => 'Role provided for contact group is not valid. Valid roles are: editor, viewer',
-                    ]),
+                    new Assert\Choice(
+                        choices: ['editor', 'viewer'],
+                        message: 'Role provided for contact group is not valid. Valid roles are: editor, viewer',
+                    ),
                 ],
             ]),
         ])]


### PR DESCRIPTION
## Description

Migrate Assert\Choice to named arguments in :
- `PartialUpdateDashboardInput.php`
- `ShareDashboardInput.php`

Delete `config/packages/security_checker.yaml`: SensioLabs SecurityChecker classes are not in vendor or composer.json (project deprecated 2021, replaced by composer audit).

Fix symfony deprecation log collection in bruno-api-test workflow 
	
[MON-198992](https://centreon.atlassian.net/browse/MON-198992)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1. Add or check the presence of the `upload-artifacts` label to this PR and re-run the CI.
  2. Download the merged `bruno-alma9-deprecation-logs` artifact from the
     `bruno-test alma9 mysql:8.0 / regroup-artifacts` job.                                                                                                                                                   
  3. Open `Notifications-deprecation.log` and verify the following entries                                                                                                                                   
     are no longer present:                                                                                                                                                                                  
     - `Since symfony/dependency-injection 7.4: Service id "SensioLabs\Security\SecurityChecker"`                                                                                                            
     - `Since symfony/validator 7.3: Passing an array of options to configure the "Symfony\Component\Validator\Constraints\Choice" constraint`                                                               
     - `Since symfony/validator 7.4: Support for passing the choices as the first argument to Symfony\Component\Validator\Constraints\Choice`                                                                
     - `Since symfony/validator 7.4: Support for evaluating options in the base Constraint class is deprecated. Initialize properties in the constructor of Symfony\Component\Validator\Constraints\Choice` 

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-198992]: https://centreon.atlassian.net/browse/MON-198992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ