### PR TITLE
fix(graphs): add max_height param to cap graph image size

### DIFF
--- a/centreon/www/class/centreonGraph.class.php
+++ b/centreon/www/class/centreonGraph.class.php
@@ -1160,13 +1160,36 @@ class CentreonGraph
 
     /**
      * @throws Exception
-     * @return array|string|string[]|void|null
+     * @return string|void
      */
     public function displayImageFlow()
     {
-        $commandLine = '';
+        if ($this->checkcurve) {
+            return $this->getImageData();
+        }
 
-        // Send header
+        $imageData = $this->getImageData();
+        // Prevent PHP warnings from corrupting the binary image response (they still reach the error log).
+        ob_start();
+        $validImage = $imageData !== null && getimagesizefromstring($imageData) !== false;
+        ob_end_clean();
+        if ($validImage) {
+            // Force no compress for image
+            $this->setHeaders(false, mb_strlen($imageData, '8bit'));
+            echo $imageData;
+        } else {
+            self::displayError();
+        }
+    }
+
+    /**
+     * Generate the graph image and return its binary PNG data.
+     *
+     * @return string|null PNG binary data, or the RRDtool command line when checkcurve is set
+     */
+    public function getImageData()
+    {
+        $commandLine = '';
 
         $this->flushRrdcached($this->listMetricsId);
 
@@ -1216,7 +1239,6 @@ class CentreonGraph
             $gmt_export = 'export TZ=' . escapeshellarg($timezone) . '; ';
         }
         $this->log($commandLine);
-        // Send Binary Data
         if (! $this->checkcurve) {
             if (is_writable($this->generalOpt['debug_path'])) {
                 $stderr = ['file', $this->generalOpt['debug_path'] . '/rrdtool.log', 'a'];
@@ -1245,13 +1267,13 @@ class CentreonGraph
                 $str = stream_get_contents($pipes[1]);
                 $return_value = proc_close($process);
 
-                // Force no compress for image
-                $this->setHeaders(false, mb_strlen($str, '8bit'));
-                echo $str;
+                return ($return_value === 0 && $str !== false) ? $str : null;
             }
-        } else {
-            return $commandLine;
+
+            return null;
         }
+
+        return $commandLine;
     }
 
     /**

--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -276,7 +276,54 @@ $obj->setColor('ARROW', '#FF0000');
 /**
  * Display Images Binary Data
  */
-$obj->displayImageFlow();
+$maxHeight = filter_var($_GET['max_height'] ?? 0, FILTER_VALIDATE_INT);
+if ($maxHeight > 0 && ! $obj->checkcurve) {
+    // Cap to prevent memory exhaustion from aspect-ratio scaling in imagecreatetruecolor().
+    $maxHeight = min($maxHeight, 4096);
+
+    $imageData = $obj->getImageData();
+    if ($imageData === null) {
+        CentreonGraph::displayError();
+    }
+
+    // Prevent PHP warnings from corrupting the binary image response (they still reach the error log).
+    ob_start();
+    $imageSize = getimagesizefromstring($imageData);
+    ob_end_clean();
+    if ($imageSize === false) {
+        CentreonGraph::displayError();
+    }
+
+    [$width, $height] = $imageSize;
+    if ($height > $maxHeight) {
+        // See comment above about ob_start().
+        ob_start();
+        $image = imagecreatefromstring($imageData);
+        ob_end_clean();
+        if ($image === false) {
+            CentreonGraph::displayError();
+        }
+        unset($imageData);
+
+        $newWidth = max(1, (int) round($width * $maxHeight / $height));
+        $scaled = imagecreatetruecolor($newWidth, $maxHeight);
+        if ($scaled === false) {
+            imagedestroy($image);
+            CentreonGraph::displayError();
+        }
+        imagecopyresampled($scaled, $image, 0, 0, 0, 0, $newWidth, $maxHeight, $width, $height);
+        imagedestroy($image);
+
+        $obj->setHeaders(false);
+        imagepng($scaled);
+        imagedestroy($scaled);
+    } else {
+        $obj->setHeaders(false, mb_strlen($imageData, '8bit'));
+        echo $imageData;
+    }
+} else {
+    $obj->displayImageFlow();
+}
 
 /**
  * Closing session


### PR DESCRIPTION
## Description

When a service has many metrics, the graph image generated by `generateImage.php`
can be very tall due to the legend listing all metrics. This oversized image breaks
page layout in report exports (the image overflows the page).

This adds an optional `max_height` GET parameter to `generateImage.php` that scales
down the image using GD when it exceeds the specified height. A new `getImageData()`
method is extracted from `displayImageFlow()` in `CentreonGraph` to provide access
to the raw PNG data without output buffering.

Backport of #9999.

Fixes: [MON-200285](https://centreon.atlassian.net/browse/MON-200285)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [X] 25.10.x
- [ ] master

[MON-200285]: https://centreon.atlassian.net/browse/MON-200285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ