### PR TITLE
fix(ci): handle alma8 OS in Xray test execution creation

### DIFF
--- a/.github/scripts/xray/create-test-execution.sh
+++ b/.github/scripts/xray/create-test-execution.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   IS_NIGHTLY        - "true" or "false"
 #   MAJOR_VERSION     - e.g. "24.10"
 #   MINOR_VERSION     - e.g. "3"
-#   OS                - e.g. "alma9", "bullseye", "bookworm"
+#   OS                - e.g. "alma8", "alma9", "bullseye", "bookworm"
 #   GITHUB_REF_NAME   - current git ref name (set by GitHub Actions)
 #   GITHUB_REPOSITORY - owner/repo (set by GitHub Actions)
 #   GITHUB_RUN_ID     - workflow run ID (set by GitHub Actions)
@@ -40,6 +40,10 @@ echo "The summary of the TE is: $input_summary"
 linux_distribution=''
 mariadb_version=''
 case "$OS" in
+  alma8)
+    linux_distribution="ALMA8"
+    mariadb_version="MARIADB_10_5"
+    ;;
   alma9)
     linux_distribution="ALMA9"
     mariadb_version="MARIADB_10_5"
@@ -53,7 +57,7 @@ case "$OS" in
     mariadb_version="MARIADB_10_11"
     ;;
   *)
-    echo "ERROR: Unknown OS value: '$OS'. Expected one of: alma9, bullseye, bookworm." >&2
+    echo "ERROR: Unknown OS value: '$OS'. Expected one of: alma8, alma9, bullseye, bookworm." >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Description

The nightly `web` workflow on `dev-25.10.x` fails on the `create-xray-test-plan-and-test-execution alma8` job:

```
ERROR: Unknown OS value: 'alma8'. Expected one of: alma9, bullseye, bookworm.
```

`.github/scripts/xray/create-test-execution.sh` only mapped `alma9`, `bullseye` and `bookworm` and exited 1 for any other OS. `alma8` is still part of the 25.10 OS matrix (`web.yml`), so its leg aborted every night.

Same root cause as MON-200249 (24.10), on the 25.10 branch.

## Fix

Add the missing `alma8` case to the `case "$OS"` block (plus the error message and header comment).

```sh
alma8)
  linux_distribution="ALMA8"
  mariadb_version="MARIADB_10_5"
  ;;
```

> Please confirm the exact Xray distribution custom-field value (`ALMA8`) and the MariaDB version (`MARIADB_10_5`, aligned with `alma9` on 25.10) match the Xray configuration.

Refs: MON-200329
Failing run: https://github.com/centreon/centreon/actions/runs/26886900262/job/79306638516