### PR TITLE
fix(test): resolve biome lint errors in open-tickets dashboards commands

### DIFF
--- a/.github/actions/get-docker-from-image-version/action.yml
+++ b/.github/actions/get-docker-from-image-version/action.yml
@@ -4,7 +4,9 @@ description: |
   Resolution order:
     1. current_tag (e.g. develop-26.10 or branch name) if it exists in the registry
     2. major_version if the current branch is dev-XX.YY.x
-    3. (cloud only) develop-<major_version> if it exists in the registry (feature branches)
+    3. feature branches: probe the base-branch tag if it exists in the registry
+         - cloud:   develop-<major_version>
+         - on-prem: dev-<major_version>.x
     4. fallback: develop (cloud) or major_version (on-prem)
   Each resolved tag has tag_suffix appended (e.g. -alma9) when provided.
 
@@ -62,11 +64,19 @@ runs:
           FROM_IMAGE_VERSION="${CURRENT_TAG}${TAG_SUFFIX}"
         elif [[ "$BRANCH_NAME" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
           FROM_IMAGE_VERSION="${MAJOR_VERSION}${TAG_SUFFIX}"
-        elif [[ "$IS_CLOUD" == "true" && "$BRANCH_NAME" != "develop" ]]; then
-          DEVELOP_VERSION_TAG="develop-${MAJOR_VERSION}${TAG_SUFFIX}"
-          IMAGE_TAG_EXISTS=$(docker manifest inspect ${REGISTRY}/${FROM_IMAGE}:${DEVELOP_VERSION_TAG} >/dev/null 2>&1 && echo yes || echo no)
+        elif [[ "$BRANCH_NAME" != "develop" ]]; then
+          # Feature branch: probe the base-branch tag of the FROM image and use
+          # it if it exists. The web image is tagged dev-<major>.x on a dev branch
+          # while the dependencies image is tagged <major_version>, so probing
+          # keeps the right fallback for each image instead of assuming one.
+          if [[ "$IS_CLOUD" == "true" ]]; then
+            CANDIDATE_TAG="develop-${MAJOR_VERSION}${TAG_SUFFIX}"
+          else
+            CANDIDATE_TAG="dev-${MAJOR_VERSION}.x${TAG_SUFFIX}"
+          fi
+          IMAGE_TAG_EXISTS=$(docker manifest inspect ${REGISTRY}/${FROM_IMAGE}:${CANDIDATE_TAG} >/dev/null 2>&1 && echo yes || echo no)
           if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
-            FROM_IMAGE_VERSION="${DEVELOP_VERSION_TAG}"
+            FROM_IMAGE_VERSION="${CANDIDATE_TAG}"
           fi
         fi
 

--- a/.github/actions/get-docker-from-image-version/action.yml
+++ b/.github/actions/get-docker-from-image-version/action.yml
@@ -2,11 +2,9 @@ name: get-docker-from-image-version
 description: |
   Resolves the Docker image tag to use as FROM in a dockerize job.
   Resolution order:
-    1. current_tag (e.g. develop-26.10 or branch name) if it exists in the registry
-    2. major_version if the current branch is dev-XX.YY.x
-    3. feature branches: probe the base-branch tag if it exists in the registry
-         - cloud:   develop-<major_version>
-         - on-prem: dev-<major_version>.x
+    1. current_tag if it exists in the registry
+    2. major_version on a maintenance branch (dev-XX.YY.x)
+    3. otherwise probe the base branch tag (develop-<major> cloud, dev-<major>.x on-prem)
     4. fallback: develop (cloud) or major_version (on-prem)
   Each resolved tag has tag_suffix appended (e.g. -alma9) when provided.
 
@@ -65,10 +63,8 @@ runs:
         elif [[ "$BRANCH_NAME" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
           FROM_IMAGE_VERSION="${MAJOR_VERSION}${TAG_SUFFIX}"
         elif [[ "$BRANCH_NAME" != "develop" ]]; then
-          # Feature branch: probe the base-branch tag of the FROM image and use
-          # it if it exists. The web image is tagged dev-<major>.x on a dev branch
-          # while the dependencies image is tagged <major_version>, so probing
-          # keeps the right fallback for each image instead of assuming one.
+          # Probe the base maintenance branch tag (dev-<major>.x on-prem,
+          # develop-<major> cloud) and use it only if it exists.
           if [[ "$IS_CLOUD" == "true" ]]; then
             CANDIDATE_TAG="develop-${MAJOR_VERSION}${TAG_SUFFIX}"
           else

--- a/centreon-open-tickets/tests/e2e/features/Dashboards/commands.ts
+++ b/centreon-open-tickets/tests/e2e/features/Dashboards/commands.ts
@@ -1,4 +1,4 @@
-import { PAGES } from "fixtures/shared/constants/pages";
+import { PAGES } from 'fixtures/shared/constants/pages';
 
 Cypress.Commands.add('visitDashboards', () => {
   cy.intercept({
@@ -7,7 +7,7 @@ Cypress.Commands.add('visitDashboards', () => {
     url: '/centreon/api/latest/configuration/dashboards*'
   }).as('listAllDashboards');
 
-  const dashboardsUrl =  PAGES.monitoring.dashboardsLibrary;
+  const dashboardsUrl = PAGES.monitoring.dashboardsLibrary;
   cy.url().then((url) =>
     url.includes(dashboardsUrl)
       ? cy.visit(dashboardsUrl)
@@ -168,5 +168,3 @@ declare global {
     }
   }
 }
-
-export {};


### PR DESCRIPTION
## Description

The `e2e-lint` job in the `open-tickets` workflow was failing because Biome reported two violations in `centreon-open-tickets/tests/e2e/features/Dashboards/commands.ts`:

- `lint/complexity/noUselessEmptyExport` at line 172 — the `export {}` was unnecessary since the file already has imports
- Formatting issue (mixed quotes, double space)

Removed the useless empty export and let `biome --fix` normalize the formatting.

Fixes: [MON-200339](https://centreon.atlassian.net/browse/MON-200339)

[MON-200339]: https://centreon.atlassian.net/browse/MON-200339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ