### PR TITLE
enh(media): modernize Administration > Parameters > Images with an AJAX listing

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -638,6 +638,45 @@ msgid "Add Group"
 msgstr "Gruppe hinzufügen"
 
 #: centreon/www/include/options/media/images/formImg.php
+msgid "Drag and drop your images, or click to browse."
+msgstr "Ziehen Sie Ihre Bilder hierher oder klicken Sie zum Durchsuchen."
+
+msgid "\"%s\" already exists in this directory. Overwrite it?"
+msgstr "„%s“ existiert bereits in diesem Verzeichnis. Überschreiben?"
+
+msgid "Size"
+msgstr "Größe"
+
+msgid "Overwrite"
+msgstr "Überschreiben"
+
+msgid "Overwrite all"
+msgstr "Alle überschreiben"
+
+msgid "Skip"
+msgstr "Überspringen"
+
+msgid "Skip all"
+msgstr "Alle überspringen"
+
+msgid "New directory"
+msgstr "Neues Verzeichnis"
+
+msgid "Upload"
+msgstr "Hochladen"
+
+msgid "Allowed: JPG, PNG, GIF, SVG — max %s"
+msgstr "Erlaubt: JPG, PNG, GIF, SVG — max. %s"
+
+msgid "Drop images here"
+msgstr "Bilder hier ablegen"
+
+msgid "or click to browse"
+msgstr "oder zum Durchsuchen klicken"
+
+msgid "Please choose or enter a directory."
+msgstr "Bitte wählen oder geben Sie ein Verzeichnis ein."
+
 msgid "Add Image(s)"
 msgstr "Bild(er) hinzufügen"
 
@@ -16119,6 +16158,15 @@ msgid "Synchronize LDAP"
 msgstr "LDAP synchronisieren"
 
 #: centreon/www/include/options/media/images/listImg.php
+msgid "Browse and manage the images available in Centreon."
+msgstr "Durchsuchen und verwalten Sie die in Centreon verfügbaren Bilder."
+
+msgid "No image found"
+msgstr "Kein Bild gefunden"
+
+msgid "Name or directory"
+msgstr "Name oder Verzeichnis"
+
 msgid "Synchronize Media Directory"
 msgstr "Medienverzeichnis synchronisieren"
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -635,6 +635,45 @@ msgid "Add Group"
 msgstr "Agregar un grupo"
 
 #: centreon/www/include/options/media/images/formImg.php
+msgid "Drag and drop your images, or click to browse."
+msgstr "Arrastre y suelte sus imágenes, o haga clic para explorar."
+
+msgid "\"%s\" already exists in this directory. Overwrite it?"
+msgstr "«%s» ya existe en este directorio. ¿Sobrescribirlo?"
+
+msgid "Size"
+msgstr "Tamaño"
+
+msgid "Overwrite"
+msgstr "Sobrescribir"
+
+msgid "Overwrite all"
+msgstr "Sobrescribir todo"
+
+msgid "Skip"
+msgstr "Omitir"
+
+msgid "Skip all"
+msgstr "Omitir todo"
+
+msgid "New directory"
+msgstr "Nuevo directorio"
+
+msgid "Upload"
+msgstr "Subir"
+
+msgid "Allowed: JPG, PNG, GIF, SVG — max %s"
+msgstr "Permitido: JPG, PNG, GIF, SVG — máx. %s"
+
+msgid "Drop images here"
+msgstr "Suelte las imágenes aquí"
+
+msgid "or click to browse"
+msgstr "o haga clic para explorar"
+
+msgid "Please choose or enter a directory."
+msgstr "Elija o introduzca un directorio."
+
 msgid "Add Image(s)"
 msgstr "Añadiendo imagen (es)"
 
@@ -17658,6 +17697,15 @@ msgid "Synchronize LDAP"
 msgstr ""
 
 #: centreon/www/include/options/media/images/listImg.php
+msgid "Browse and manage the images available in Centreon."
+msgstr "Explore y gestione las imágenes disponibles en Centreon."
+
+msgid "No image found"
+msgstr "No se encontró ninguna imagen"
+
+msgid "Name or directory"
+msgstr "Nombre o directorio"
+
 msgid "Synchronize Media Directory"
 msgstr "Sincronizar el directorio de imágenes."
 

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -648,6 +648,45 @@ msgid "Add Group"
 msgstr "Ajouter un groupe"
 
 #: centreon/www/include/options/media/images/formImg.php
+msgid "Drag and drop your images, or click to browse."
+msgstr "Glissez-déposez vos images, ou cliquez pour parcourir."
+
+msgid "\"%s\" already exists in this directory. Overwrite it?"
+msgstr "« %s » existe déjà dans ce répertoire. L'écraser ?"
+
+msgid "Size"
+msgstr "Taille"
+
+msgid "Overwrite"
+msgstr "Écraser"
+
+msgid "Overwrite all"
+msgstr "Tout écraser"
+
+msgid "Skip"
+msgstr "Ignorer"
+
+msgid "Skip all"
+msgstr "Tout ignorer"
+
+msgid "New directory"
+msgstr "Nouveau répertoire"
+
+msgid "Upload"
+msgstr "Téléverser"
+
+msgid "Allowed: JPG, PNG, GIF, SVG — max %s"
+msgstr "Autorisé : JPG, PNG, GIF, SVG — max %s"
+
+msgid "Drop images here"
+msgstr "Déposez les images ici"
+
+msgid "or click to browse"
+msgstr "ou cliquez pour parcourir"
+
+msgid "Please choose or enter a directory."
+msgstr "Veuillez choisir ou saisir un répertoire."
+
 msgid "Add Image(s)"
 msgstr "Ajout d'image(s)"
 
@@ -16306,6 +16345,15 @@ msgid "Synchronize LDAP"
 msgstr "Synchroniser avec le LDAP"
 
 #: centreon/www/include/options/media/images/listImg.php
+msgid "Browse and manage the images available in Centreon."
+msgstr "Parcourez et gérez les images disponibles dans Centreon."
+
+msgid "No image found"
+msgstr "Aucune image trouvée"
+
+msgid "Name or directory"
+msgstr "Nom ou répertoire"
+
 msgid "Synchronize Media Directory"
 msgstr "Synchroniser le répertoire des images"
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -634,6 +634,45 @@ msgid "Add Group"
 msgstr "Adicionar Grupo"
 
 #: centreon/www/include/options/media/images/formImg.php
+msgid "Drag and drop your images, or click to browse."
+msgstr "Arraste e solte suas imagens, ou clique para procurar."
+
+msgid "\"%s\" already exists in this directory. Overwrite it?"
+msgstr "«%s» já existe neste diretório. Substituir?"
+
+msgid "Size"
+msgstr "Tamanho"
+
+msgid "Overwrite"
+msgstr "Substituir"
+
+msgid "Overwrite all"
+msgstr "Substituir tudo"
+
+msgid "Skip"
+msgstr "Ignorar"
+
+msgid "Skip all"
+msgstr "Ignorar tudo"
+
+msgid "New directory"
+msgstr "Novo diretório"
+
+msgid "Upload"
+msgstr "Enviar"
+
+msgid "Allowed: JPG, PNG, GIF, SVG — max %s"
+msgstr "Permitido: JPG, PNG, GIF, SVG — máx. %s"
+
+msgid "Drop images here"
+msgstr "Solte as imagens aqui"
+
+msgid "or click to browse"
+msgstr "ou clique para procurar"
+
+msgid "Please choose or enter a directory."
+msgstr "Escolha ou informe um diretório."
+
 msgid "Add Image(s)"
 msgstr "Adiciona imagem(s)"
 
@@ -16609,6 +16648,15 @@ msgid "Synchronize LDAP"
 msgstr ""
 
 #: centreon/www/include/options/media/images/listImg.php
+msgid "Browse and manage the images available in Centreon."
+msgstr "Navegue e gerencie as imagens disponíveis no Centreon."
+
+msgid "No image found"
+msgstr "Nenhuma imagem encontrada"
+
+msgid "Name or directory"
+msgstr "Nome ou diretório"
+
 msgid "Synchronize Media Directory"
 msgstr "Sincronizar Diretorio de Media"
 

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -634,6 +634,45 @@ msgid "Add Group"
 msgstr "Adicionar Grupo"
 
 #: centreon/www/include/options/media/images/formImg.php
+msgid "Drag and drop your images, or click to browse."
+msgstr "Arraste e solte as suas imagens, ou clique para procurar."
+
+msgid "\"%s\" already exists in this directory. Overwrite it?"
+msgstr "«%s» já existe neste diretório. Substituir?"
+
+msgid "Size"
+msgstr "Tamanho"
+
+msgid "Overwrite"
+msgstr "Substituir"
+
+msgid "Overwrite all"
+msgstr "Substituir tudo"
+
+msgid "Skip"
+msgstr "Ignorar"
+
+msgid "Skip all"
+msgstr "Ignorar tudo"
+
+msgid "New directory"
+msgstr "Novo diretório"
+
+msgid "Upload"
+msgstr "Carregar"
+
+msgid "Allowed: JPG, PNG, GIF, SVG — max %s"
+msgstr "Permitido: JPG, PNG, GIF, SVG — máx. %s"
+
+msgid "Drop images here"
+msgstr "Largue as imagens aqui"
+
+msgid "or click to browse"
+msgstr "ou clique para procurar"
+
+msgid "Please choose or enter a directory."
+msgstr "Escolha ou introduza um diretório."
+
 msgid "Add Image(s)"
 msgstr "Adiciona imagem(s)"
 
@@ -16480,6 +16519,15 @@ msgid "Synchronize LDAP"
 msgstr ""
 
 #: centreon/www/include/options/media/images/listImg.php
+msgid "Browse and manage the images available in Centreon."
+msgstr "Navegue e faça a gestão das imagens disponíveis no Centreon."
+
+msgid "No image found"
+msgstr "Nenhuma imagem encontrada"
+
+msgid "Name or directory"
+msgstr "Nome ou diretório"
+
 msgid "Synchronize Media Directory"
 msgstr "Sincronizar Diretorio de Media"
 

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
@@ -1,0 +1,82 @@
+Feature: Modern AJAX listing common features
+    As a Centreon admin
+    I want the modernized listing pages to work correctly
+    So that I can manage configuration objects efficiently
+
+  Background:
+    Given a user is logged in Centreon
+    And some service templates exist
+
+  @TEST_LISTING-001
+  Scenario: AJAX listing loads data without page reload
+    When the user navigates to the service templates listing
+    Then the listing table is rendered via AJAX
+    And the table contains service template rows
+
+  @TEST_LISTING-002
+  Scenario: Search filters listing results
+    When the user navigates to the service templates listing
+    And the user types a search term in the search field
+    And the user clicks the search button
+    Then only matching service templates are displayed
+    And the pagination reflects the filtered count
+
+  @TEST_LISTING-003
+  Scenario: Pagination navigates between pages
+    When the user navigates to the service templates listing
+    Then the pagination shows the total number of items
+    When the user clicks page 2
+    Then the listing shows the second page of results
+    And the current page indicator shows page 2
+
+  @TEST_LISTING-004
+  Scenario: Rows per page selector changes limit
+    When the user navigates to the service templates listing
+    And the user changes the rows per page to 10
+    Then the listing shows at most 10 rows
+    And the pagination is recalculated
+
+  @TEST_LISTING-005
+  Scenario: Locked elements checkbox toggles locked templates visibility
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked service templates are visible in the listing
+    When the user unchecks the locked checkbox and searches
+    Then locked service templates are hidden from the listing
+
+  @TEST_LISTING-006
+  Scenario: Locked templates have disabled checkboxes and dup inputs
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked rows have disabled selection checkboxes
+    And locked rows have disabled duplication inputs
+
+  @TEST_LISTING-007
+  Scenario: Bulk duplication works via the More actions dropdown
+    When the user navigates to the service templates listing
+    And the user selects a service template checkbox
+    And the user selects Duplicate from the More actions dropdown
+    Then a duplicated service template appears in the listing
+
+  @TEST_LISTING-008
+  Scenario: Bulk deletion works via the More actions dropdown
+    When the user navigates to the service templates listing
+    And the user selects a service template checkbox
+    And the user selects Delete from the More actions dropdown
+    Then the service template is removed from the listing
+
+  @TEST_LISTING-009
+  Scenario: Clicking a service template name navigates to the edit form
+    When the user navigates to the service templates listing
+    And the user clicks on a service template name
+    Then the service template edit form is displayed
+
+  @TEST_LISTING-010
+  Scenario: Session state persists search and pagination across navigation
+    When the user navigates to the service templates listing
+    And the user types a search term in the search field
+    And the user clicks the search button
+    And the user clicks on a service template name
+    And the user navigates back to the service templates listing
+    Then the search field still contains the search term
+    And the listing shows the same filtered results

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
@@ -1,0 +1,344 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const serviceTemplatesPage = PAGES.configuration.servicesTemplatesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('a user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('some service templates exist', () => {
+  // The default Centreon install includes many service templates (generic-active-service, etc.)
+  // Add a custom one for targeted testing
+  cy.addServiceTemplate({
+    name: 'test_listing_template',
+    template: 'generic-active-service'
+  });
+  cy.addServiceTemplate({
+    name: 'test_listing_other',
+    template: 'generic-active-service'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitListingAndWait(): void {
+  cy.visit(serviceTemplatesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  // Wait for AJAX data to load (tbody should have real rows, not just loading)
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  // Wait for table body to be populated after an AJAX call
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: AJAX listing loads data without page reload
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service templates listing', () => {
+  visitListingAndWait();
+});
+
+Then('the listing table is rendered via AJAX', () => {
+  // The modern listing uses cl-listing-table class and #clTableBody
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .should('exist');
+});
+
+Then('the table contains service template rows', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+  // Verify our test template is visible
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search filters listing results
+// ---------------------------------------------------------------------------
+
+When('the user types a search term in the search field', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('test_listing_template');
+});
+
+When('the user clicks the search button', () => {
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only matching service templates are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_other')
+    .should('not.exist');
+});
+
+Then('the pagination reflects the filtered count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .should('contain', '1-');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination navigates between pages
+// ---------------------------------------------------------------------------
+
+Then('the pagination shows the total number of items', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user clicks page 2', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop a.cl-page-num')
+    .contains('2')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('the listing shows the second page of results', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('the current page indicator shows page 2', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop span.cl-page-current')
+    .should('contain', '2');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Rows per page selector changes limit
+// ---------------------------------------------------------------------------
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('the listing shows at most 10 rows', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+Then('the pagination is recalculated', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /1-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked elements checkbox
+// ---------------------------------------------------------------------------
+
+When('the locked checkbox is checked', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .then($cb => {
+      if (!$cb.is(':checked')) {
+        cy.wrap($cb).click();
+        cy.getIframeBody().find('#clSearchBtn').click();
+        waitForAjaxRefresh();
+      }
+    });
+});
+
+Then('locked service templates are visible in the listing', () => {
+  // With locked checked, count the total rows
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .as('countWithLocked');
+});
+
+When('the user unchecks the locked checkbox and searches', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .uncheck();
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('locked service templates are hidden from the listing', () => {
+  // Without locked, the count should be less or equal
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .then(countWithoutLocked => {
+      cy.get('@countWithLocked').then(countWithLocked => {
+        expect(countWithoutLocked).to.be.at.most(countWithLocked as unknown as number);
+      });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked templates have disabled checkboxes and dup inputs
+// ---------------------------------------------------------------------------
+
+Then('locked rows have disabled selection checkboxes', () => {
+  // Find a row with a disabled checkbox (locked row)
+  cy.getIframeBody()
+    .find('#clTableBody .cl-col-picker input[type="checkbox"][disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('locked rows have disabled duplication inputs', () => {
+  cy.getIframeBody()
+    .find('#clTableBody input.cl-dup-input[disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a service template checkbox', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+});
+
+When('the user selects Duplicate from the More actions dropdown', () => {
+  // Override onchange to avoid confirm dialog
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated service template appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects Delete from the More actions dropdown', () => {
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the service template is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a service template name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'test_listing_template')
+    .click();
+});
+
+Then('the service template edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="service_description"]');
+  cy.getIframeBody()
+    .find('input[name="service_description"]')
+    .should('have.value', 'test_listing_template');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the service templates listing', () => {
+  cy.visit(serviceTemplatesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'test_listing_template');
+});
+
+Then('the listing shows the same filtered results', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+});

--- a/centreon/www/include/common/listing/AjaxListingHelper.php
+++ b/centreon/www/include/common/listing/AjaxListingHelper.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * Helper class for AJAX listing endpoints.
+ *
+ * Provides boilerplate: session validation, parameter parsing,
+ * Centreon autoloader registration, and JSON response helpers.
+ *
+ * Usage in an AJAX endpoint:
+ *
+ *   $helper = AjaxListingHelper::boot();
+ *   $params = $helper->getParams();
+ *   $centreon = $helper->getCentreon();  // may be null
+ *   $db = $helper->getDb();
+ *   // ... run your query ...
+ *   $helper->jsonResponse($rows, $total, $params['num'], $params['limit']);
+ */
+class AjaxListingHelper
+{
+    private CentreonDB $db;
+    private mixed $centreon;
+
+    private function __construct(CentreonDB $db, mixed $centreon)
+    {
+        $this->db = $db;
+        $this->centreon = $centreon;
+    }
+
+    /**
+     * Bootstrap the AJAX endpoint: config, session, autoloader, JSON header.
+     * Exits with appropriate HTTP error on failure.
+     */
+    public static function boot(): self
+    {
+        require_once realpath(__DIR__ . '/../../../../config/centreon.config.php');
+        require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+        require_once _CENTREON_PATH_ . '/www/class/centreonSession.class.php';
+        require_once _CENTREON_PATH_ . '/www/include/common/common-Func.php';
+        require_once _CENTREON_PATH_ . '/www/class/HtmlAnalyzer.php';
+
+        header('Content-Type: application/json');
+
+        session_start();
+
+        $db = new CentreonDB();
+
+        try {
+            if (! CentreonSession::checkSession(session_id(), $db)) {
+                self::jsonError('Unauthorized', 401);
+            }
+        } catch (\Exception $e) {
+            self::jsonError('Internal error', 500);
+        }
+
+        // Register Centreon class autoloader for session deserialization
+        require_once _CENTREON_PATH_ . '/www/class/centreon.class.php';
+        require_once _CENTREON_PATH_ . '/www/class/centreonACL.class.php';
+
+        spl_autoload_register(function ($sClass): void {
+            $fileName = lcfirst($sClass);
+            $fileNameType1 = _CENTREON_PATH_ . '/www/class/' . $fileName . '.class.php';
+            $fileNameType2 = _CENTREON_PATH_ . '/www/class/' . $fileName . '.php';
+            if (file_exists($fileNameType1)) {
+                require_once $fileNameType1;
+            } elseif (file_exists($fileNameType2)) {
+                require_once $fileNameType2;
+            }
+        });
+
+        $centreon = $_SESSION['centreon'] ?? null;
+
+        return new self($db, $centreon);
+    }
+
+    /**
+     * Get sanitized listing parameters from the request.
+     *
+     * @return array{search: string, num: int, limit: int}
+     */
+    public function getParams(): array
+    {
+        return [
+            'search' => HtmlAnalyzer::sanitizeAndRemoveTags($_GET['search'] ?? ''),
+            'num'    => filter_var($_GET['num'] ?? 0, FILTER_VALIDATE_INT) ?: 0,
+            'limit'  => filter_var($_GET['limit'] ?? 30, FILTER_VALIDATE_INT) ?: 30,
+        ];
+    }
+
+    /**
+     * Get the Centreon session object (or null if deserialization failed).
+     */
+    public function getCentreon(): mixed
+    {
+        return $this->centreon;
+    }
+
+    /**
+     * Get the Centreon session object, or exit 403 if unavailable.
+     */
+    public function requireCentreon(): mixed
+    {
+        if (! $this->centreon) {
+            self::jsonError('Forbidden', 403);
+        }
+        return $this->centreon;
+    }
+
+    /**
+     * Get the database connection.
+     */
+    public function getDb(): CentreonDB
+    {
+        return $this->db;
+    }
+
+    /**
+     * Check if the current user is admin.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->centreon ? (bool) $this->centreon->user->admin : false;
+    }
+
+    /**
+     * Get the ACL object for the current user.
+     */
+    public function getAcl(): ?CentreonACL
+    {
+        return $this->centreon ? $this->centreon->user->access : null;
+    }
+
+    /**
+     * Require write access on a given topology page. Exits 403 if read-only or no access.
+     * Admins always pass.
+     *
+     * @param int $pageId The topology page number (e.g. 60101 for hosts, 60201 for servicegroups)
+     */
+    public function requireWriteAccess(int $pageId): void
+    {
+        if ($this->isAdmin()) {
+            return;
+        }
+        $acl = $this->getAcl();
+        if (! $acl || $acl->page($pageId) !== 1) {
+            self::jsonError('Write access denied', 403);
+        }
+    }
+
+    /**
+     * Validate and consume a CSRF token from POST. Exits 403 on failure.
+     * Returns a fresh token for the next request.
+     */
+    public function validateCsrfToken(): string
+    {
+        $token = $_POST['centreon_token'] ?? null;
+
+        if ($token === null || ! in_array($token, $_SESSION['x-centreon-token'] ?? [], true)) {
+            self::jsonError('Invalid CSRF token', 403);
+        }
+
+        $key = array_search($token, $_SESSION['x-centreon-token'], true);
+        unset($_SESSION['x-centreon-token'][$key], $_SESSION['x-centreon-token-generated-at'][$token]);
+
+        return createCSRFToken();
+    }
+
+    /**
+     * Log a toggle action (enable/disable) to the audit log.
+     * Uses direct SQL to avoid dependencies on CentreonLogAction.
+     *
+     * @param string $objectType Object type (e.g. 'servicegroup', 'host', 'contact')
+     * @param int $objectId Object ID
+     * @param string $objectName Object name for display
+     * @param string $actionType Action type ('enable' or 'disable')
+     */
+    public function logToggleAction(string $objectType, int $objectId, string $objectName, string $actionType): void
+    {
+        try {
+            $pearDBO = new CentreonDB('centstorage');
+
+            // Check if audit log is enabled
+            $optResult = $pearDBO->query("SELECT audit_log_option FROM `config` LIMIT 1");
+            $auditOpt = $optResult->fetchColumn();
+            if ($auditOpt != '1') {
+                return;
+            }
+
+            $userId = $this->centreon ? $this->centreon->user->get_id() : 0;
+
+            $stmt = $pearDBO->prepare(
+                "INSERT INTO `log_action` (action_log_date, object_type, object_id, object_name, action_type, log_contact_id)"
+                . " VALUES (:ts, :obj_type, :obj_id, :obj_name, :action, :uid)"
+            );
+            $stmt->bindValue(':ts', time(), PDO::PARAM_INT);
+            $stmt->bindValue(':obj_type', $objectType, PDO::PARAM_STR);
+            $stmt->bindValue(':obj_id', $objectId, PDO::PARAM_INT);
+            $stmt->bindValue(':obj_name', $objectName, PDO::PARAM_STR);
+            $stmt->bindValue(':action', $actionType, PDO::PARAM_STR);
+            $stmt->bindValue(':uid', $userId, PDO::PARAM_INT);
+            $stmt->execute();
+        } catch (\Throwable $e) {
+            // Silently fail logging — don't break the toggle
+        }
+    }
+
+    /**
+     * Send a successful JSON listing response and exit.
+     */
+    public function jsonResponse(array $rows, int $total, int $num, int $limit): void
+    {
+        echo json_encode([
+            'rows'           => $rows,
+            'total'          => $total,
+            'num'            => $num,
+            'limit'          => $limit,
+            'centreon_token' => createCSRFToken(),
+        ]);
+        exit;
+    }
+
+    /**
+     * Send a JSON error response and exit.
+     */
+    public static function jsonError(string $message, int $httpCode = 400): void
+    {
+        http_response_code($httpCode);
+        echo json_encode(['error' => $message]);
+        exit;
+    }
+}

--- a/centreon/www/include/common/listing/listing.css
+++ b/centreon/www/include/common/listing/listing.css
@@ -1,0 +1,1018 @@
+/*
+ * Centreon Modern Listing Styles
+ *
+ * Shared CSS for AJAX-based configuration listing pages.
+ * Prefix: cl- (centreon-listing)
+ *
+ * Usage: Include this file in any Smarty listing template, then use
+ * the CentreonListing JS module for AJAX data loading and rendering.
+ */
+
+/* ==========================================================================
+   Layout container
+   ========================================================================== */
+
+.cl-listing-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+/* ==========================================================================
+   Actions bar (top toolbar: add button, bulk actions, search, pagination)
+   ========================================================================== */
+
+.cl-actions-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    gap: 12px;
+}
+
+.cl-actions-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+/* "More actions" dropdown in actions bar */
+.cl-actions-left select {
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    background: var(--select-background, #fff);
+    cursor: pointer;
+    line-height: 1.4;
+    height: auto;
+}
+
+/* ==========================================================================
+   Add button (blue with "+" prefix)
+   ========================================================================== */
+
+.cl-btn-add {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #fff;
+    background-color: var(--color-primary-light, #2E68AA);
+    border: none;
+    border-radius: 4px;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+    line-height: 1.4;
+    transition: background-color 0.15s ease;
+}
+
+.cl-btn-add:hover {
+    background-color: var(--color-primary-hover, #255891);
+    color: #fff;
+    text-decoration: none;
+}
+
+.cl-btn-add::before {
+    content: '+';
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 1;
+}
+
+/* ==========================================================================
+   Search bar (centered between actions and pagination)
+   ========================================================================== */
+
+.cl-search-center {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 24px;
+}
+
+.cl-search-input {
+    width: 100%;
+    max-width: 400px;
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.cl-search-input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+.cl-search-input::placeholder {
+    color: var(--color-grey-chateau, #a7a9ac);
+}
+
+/* ==========================================================================
+   Pagination (page numbers, nav arrows, limit selector, row count)
+   ========================================================================== */
+
+.cl-pagination {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.cl-pagination a,
+.cl-pagination span.cl-page-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    font-size: 13px;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.cl-pagination a {
+    color: var(--color-primary-light, #2E68AA);
+}
+
+.cl-pagination a:hover {
+    background-color: var(--color-listing-hover, #E6EDF5);
+    text-decoration: none;
+}
+
+/* Navigation arrows (first, prev, next, last) */
+.cl-pagination a.cl-page-nav img {
+    width: 14px;
+    height: 14px;
+    opacity: 0.6;
+}
+
+.cl-pagination a.cl-page-nav:hover img {
+    opacity: 1;
+}
+
+/* Current page indicator */
+.cl-pagination span.cl-page-current {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    background-color: var(--color-primary-light, #2E68AA);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+/* "X-Y of Z" label */
+.cl-pagination .cl-page-info {
+    font-size: 13px;
+    color: var(--body-color, #555);
+    padding: 0 4px;
+}
+
+/* Rows-per-page selector */
+.cl-pagination .cl-limit-select {
+    padding: 4px 8px;
+    font-size: 13px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    background: var(--select-background, #fff);
+    cursor: pointer;
+    min-width: 50px;
+}
+
+/* ==========================================================================
+   Data table
+   ========================================================================== */
+
+.cl-listing-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    background: var(--select-background, #fff);
+    border: none;
+}
+
+/* -- Table header --------------------------------------------------------- */
+
+.cl-listing-table thead th {
+    padding: 6px 16px;
+    font-weight: 600;
+    font-size: 13px;
+    color: #fff;
+    text-align: left;
+    border-bottom: none;
+    background: #8C8C8C;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.cl-listing-table thead th.cl-col-center {
+    text-align: center;
+}
+
+.cl-listing-table thead th.cl-col-right {
+    text-align: right;
+}
+
+.cl-listing-table thead th.cl-col-picker {
+    width: 40px;
+    text-align: center;
+    padding: 6px 8px;
+    vertical-align: middle;
+}
+
+/* -- Table body rows ------------------------------------------------------ */
+
+.cl-listing-table tbody tr {
+    background: var(--select-background, #fff);
+    transition: background-color 0.15s ease;
+    cursor: pointer;
+}
+
+.cl-listing-table tbody tr:hover {
+    background-color: var(--color-listing-hover, #E6EDF5);
+}
+
+.cl-listing-table tbody td {
+    padding: 4px 16px;
+    font-size: 13px;
+    color: var(--body-color, #555);
+    border-bottom: 1px solid var(--color-divider, #E3E3E3);
+    vertical-align: middle;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 300px;
+}
+
+.cl-listing-table tbody td.cl-col-center {
+    text-align: center;
+}
+
+.cl-listing-table tbody td.cl-col-right {
+    text-align: right;
+}
+
+.cl-listing-table tbody td.cl-col-picker {
+    width: 40px;
+    text-align: center;
+    padding: 4px 8px;
+}
+
+/* -- Links inside rows ---------------------------------------------------- */
+
+.cl-listing-table tbody td a {
+    color: var(--color-primary-light, #2E68AA);
+    text-decoration: none;
+}
+
+.cl-listing-table tbody td a:hover {
+    text-decoration: underline;
+}
+
+.cl-listing-table tbody tr:hover td {
+    color: var(--color-charcoal, #444);
+}
+
+.cl-listing-table tbody tr:hover td a {
+    color: var(--color-primary-hover, #255891);
+}
+
+/* ==========================================================================
+   Options cell (actions column: toggle + duplication input)
+   ========================================================================== */
+
+.cl-options-cell {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.cl-dup-input {
+    width: 36px;
+    height: 22px;
+    text-align: center;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    font-size: 11px;
+    margin: 0;
+    padding: 0 2px;
+    line-height: 20px;
+}
+
+.cl-dup-input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+    outline: none;
+}
+
+/* ==========================================================================
+   Toggle switch (iPhone style enable/disable)
+   ========================================================================== */
+
+.cl-toggle {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.cl-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.cl-toggle-slider {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    border-radius: 20px;
+    transition: background-color 0.25s ease;
+}
+
+.cl-toggle-slider::before {
+    content: '';
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: #fff;
+    border-radius: 50%;
+    transition: transform 0.25s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.cl-toggle input:checked + .cl-toggle-slider {
+    background-color: var(--color-success, #88B922);
+}
+
+.cl-toggle input:checked + .cl-toggle-slider::before {
+    transform: translateX(16px);
+}
+
+.cl-toggle input:disabled + .cl-toggle-slider {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ==========================================================================
+   Bottom bar (bulk actions + pagination)
+   ========================================================================== */
+
+.cl-bottom-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+}
+
+/* ==========================================================================
+   Checkbox alignment (header and body rows)
+   ========================================================================== */
+
+.cl-listing-table .cl-col-picker .md-checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    height: 100%;
+}
+
+.cl-listing-table .cl-col-picker .md-checkbox input[type="checkbox"] {
+    margin: 0;
+}
+
+.cl-listing-table .cl-col-picker .md-checkbox label {
+    margin: 0;
+    padding: 0;
+    min-height: auto;
+    line-height: 1;
+}
+
+/* White checkbox border on dark header */
+.cl-listing-table thead th .md-checkbox label::before {
+    border-color: #fff;
+}
+
+/* ==========================================================================
+   States: loading, empty, fade-in animation
+   ========================================================================== */
+
+.cl-loading {
+    text-align: center;
+    padding: 24px;
+    color: var(--color-grey-chateau, #a7a9ac);
+    font-size: 14px;
+}
+
+.cl-listing-table tbody {
+    transition: opacity 0.2s ease;
+}
+
+.cl-listing-table tbody.cl-fade-in {
+    animation: clFadeIn 0.25s ease;
+}
+
+@keyframes clFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* ==========================================================================
+   Sub-listing header (e.g. meta service metric listing)
+   ========================================================================== */
+
+.cl-meta-header {
+    padding: 10px 16px;
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--body-color, #555);
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 4px;
+    margin-bottom: 8px;
+}
+
+/* ==========================================================================
+   Tooltip (instant, no-delay, fixed position in body)
+   ========================================================================== */
+
+.cl-tooltip-popup {
+    position: fixed;
+    z-index: 99999;
+    background: var(--body-background, #222);
+    color: var(--body-color, #eee);
+    border: 1px solid var(--listing-border-botom-color, #555);
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+.cl-tooltip-popup b {
+    margin-right: 4px;
+}
+
+/* ==========================================================================
+   Add button dropdown (two-level: Wizard / Advanced)
+   ========================================================================== */
+
+.cl-add-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.cl-add-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    min-width: 160px;
+    margin-top: 4px;
+    overflow: hidden;
+}
+
+.cl-add-dropdown.cl-open .cl-add-dropdown-menu {
+    display: block;
+}
+
+.cl-add-dropdown-menu a {
+    display: block;
+    padding: 8px 16px;
+    color: var(--body-color, #444);
+    text-decoration: none;
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.cl-add-dropdown-menu a:hover {
+    background: var(--list-hover-background-color, #E6EDF5);
+    text-decoration: none;
+}
+
+/* ==========================================================================
+   Filter box (advanced search with multiple fields)
+   ========================================================================== */
+
+.cl-filter-box {
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 6px;
+    padding: 10px 16px;
+    margin-bottom: 8px;
+}
+
+.cl-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.cl-filter-bar .cl-search-input {
+    max-width: none;
+    width: 200px;
+    height: 28px;
+    padding: 4px 8px;
+    font-size: 13px;
+}
+
+.cl-filter-bar .select2-container {
+    width: 180px !important;
+}
+
+.cl-filter-bar .select2-container .select2-selection {
+    height: 30px;
+    min-height: 30px;
+}
+
+.cl-filter-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--body-color, #555);
+    margin-right: 4px;
+}
+
+/* ==========================================================================
+   Clear button for individual select2 dropdowns
+   ========================================================================== */
+
+.cl-clear-select {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--color-danger, #FF4A4A);
+    padding: 0 2px;
+    margin-left: -2px;
+    margin-right: 4px;
+    opacity: 0.6;
+}
+
+.cl-clear-select:hover {
+    opacity: 1;
+}
+
+/* ==========================================================================
+   Monitoring status badges (real-time host/poller status)
+   ========================================================================== */
+
+.cl-mon-badge {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.cl-mon-up {
+    background: var(--color-success, #88B922);
+    box-shadow: 0 0 4px var(--color-success, #88B922);
+}
+
+.cl-mon-down {
+    background: var(--color-danger, #FF4A4A);
+    box-shadow: 0 0 4px var(--color-danger, #FF4A4A);
+}
+
+.cl-mon-unreach {
+    background: var(--color-aluminium, #818285);
+    box-shadow: 0 0 4px var(--color-aluminium, #818285);
+}
+
+.cl-mon-warning {
+    background: var(--color-warning, #FD9B27);
+    box-shadow: 0 0 4px var(--color-warning, #FD9B27);
+}
+
+.cl-mon-unknown {
+    background: var(--color-aluminium, #818285);
+    box-shadow: 0 0 4px var(--color-aluminium, #818285);
+}
+
+.cl-mon-pending {
+    background: var(--color-pending, #1EBEB3);
+    box-shadow: 0 0 4px var(--color-pending, #1EBEB3);
+}
+
+/* ==========================================================================
+   Stale last-update highlight (pollers)
+   ========================================================================== */
+
+.cl-stale {
+    background-color: #F7D507 !important;
+    color: #333 !important;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+/* ==========================================================================
+   Trap status colors
+   ========================================================================== */
+
+.cl-status-ok { color: var(--color-success, #88B922); }
+.cl-status-warning { color: var(--color-warning, #FD9B27); }
+.cl-status-critical { color: var(--color-danger, #FF4A4A); }
+.cl-status-unknown { color: var(--color-aluminium, #818285); }
+.cl-status-pending { color: var(--color-pending, #1EBEB3); }
+
+/* ==========================================================================
+   Infinite scroll wrapper (full-height flex layout)
+   ========================================================================== */
+
+.cl-scroll-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 60px);
+    overflow: hidden;
+}
+.cl-scroll-wrapper .cl-filter-box,
+.cl-scroll-wrapper .cl-actions-bar {
+    flex-shrink: 0;
+}
+.cl-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+}
+.cl-scroll-area table {
+    width: 100%;
+}
+.cl-scroll-area .cl-listing-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--table-header-background, #6b7888);
+}
+
+/* ==========================================================================
+   Expand button (inline detail toggle: +/− in listing rows)
+   ========================================================================== */
+
+.cl-expand-btn {
+    cursor: pointer;
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    background: var(--color-divider, #e8e8e8);
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+}
+.cl-expand-btn:hover {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cl-expand-btn.open {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cl-expand-btn.disabled {
+    cursor: default;
+    opacity: 0.3;
+    pointer-events: none;
+}
+
+/* ==========================================================================
+   Inline detail row (expanded diff inside listing)
+   ========================================================================== */
+
+.cl-detail-row td {
+    padding: 0 !important;
+    background: var(--body-background, #f9f9f9);
+}
+.cl-diff-container {
+    margin: 6px 16px 10px 36px;
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: 12px;
+}
+.cl-diff-header {
+    display: flex;
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.cl-diff-header span {
+    flex: 1;
+    padding: 6px 10px;
+}
+.cl-diff-header span:first-child {
+    flex: 0 0 200px;
+}
+.cl-diff-row {
+    display: flex;
+    border-bottom: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-row:last-child {
+    border-bottom: none;
+}
+.cl-diff-row:hover {
+    background: rgba(0,0,0,0.02);
+}
+.cl-diff-field {
+    flex: 0 0 200px;
+    padding: 5px 10px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+    word-break: break-all;
+    border-right: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-before, .cl-diff-after {
+    flex: 1;
+    padding: 5px 10px;
+    word-break: break-all;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cl-diff-before {
+    background: rgba(255, 74, 74, 0.06);
+    color: #c0392b;
+    border-right: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-after {
+    background: rgba(39, 174, 96, 0.06);
+    color: #27ae60;
+}
+.cl-diff-before:empty, .cl-diff-after:empty {
+    background: transparent;
+}
+.cl-diff-empty {
+    padding: 12px 16px;
+    color: #a7a9ac;
+    font-style: italic;
+    text-align: center;
+}
+.cl-diff-loading {
+    padding: 12px 16px;
+    text-align: center;
+    color: #a7a9ac;
+}
+
+/* ==========================================================================
+   Changelog detail page — Timeline layout (cld- prefix)
+   ========================================================================== */
+
+.cld-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 16px 20px;
+}
+
+/* Header card */
+.cld-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 8px;
+    padding: 16px 24px;
+    margin-bottom: 24px;
+}
+.cld-header-info {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+.cld-header-icon {
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #3a7bbf, #2c5f8f);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 18px;
+    flex-shrink: 0;
+}
+.cld-header-text h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--list-color, #333);
+}
+.cld-header-text .cld-subtitle {
+    margin: 2px 0 0;
+    font-size: 12px;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.cld-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: var(--color-divider, #e8e8e8);
+    color: var(--list-color, #555);
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background 0.15s;
+}
+.cld-back-btn:hover {
+    background: #3a7bbf;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* Timeline */
+.cld-timeline {
+    position: relative;
+    padding-left: 40px;
+}
+.cld-timeline::before {
+    content: '';
+    position: absolute;
+    left: 15px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--color-divider, #ddd);
+    border-radius: 1px;
+}
+.cld-entry {
+    position: relative;
+    margin-bottom: 16px;
+}
+.cld-entry:last-child {
+    margin-bottom: 0;
+}
+
+/* Timeline dot */
+.cld-dot {
+    position: absolute;
+    left: -33px;
+    top: 16px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 2px var(--color-divider, #ddd);
+}
+.cld-dot.dot-create  { background: #27ae60; box-shadow: 0 0 0 2px #27ae60; }
+.cld-dot.dot-change  { background: #e67e22; box-shadow: 0 0 0 2px #e67e22; }
+.cld-dot.dot-delete  { background: #e74c3c; box-shadow: 0 0 0 2px #e74c3c; }
+.cld-dot.dot-enable  { background: #27ae60; box-shadow: 0 0 0 2px #27ae60; }
+.cld-dot.dot-disable { background: #e74c3c; box-shadow: 0 0 0 2px #e74c3c; }
+
+/* Entry card */
+.cld-card {
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 8px;
+    overflow: hidden;
+    transition: box-shadow 0.15s;
+}
+.cld-card:hover {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+.cld-card-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    gap: 12px;
+    cursor: pointer;
+    user-select: none;
+}
+.cld-card-header:hover {
+    background: rgba(0,0,0,0.015);
+}
+.cld-card-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    background: var(--color-divider, #e8e8e8);
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+}
+.cld-card-header:hover .cld-card-toggle {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cld-card-toggle.open {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cld-card-toggle.no-expand {
+    opacity: 0.2;
+    cursor: default;
+    pointer-events: none;
+}
+.cld-card-date {
+    font-size: 13px;
+    color: #888;
+    white-space: nowrap;
+    min-width: 130px;
+}
+.cld-card-badge {
+    flex-shrink: 0;
+}
+.cld-card-author {
+    font-size: 12px;
+    color: #999;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+/* Diff panel (inside timeline cards) */
+.cld-diff-panel {
+    display: none;
+    border-top: 1px solid var(--color-divider, #eee);
+}
+.cld-diff-panel.open {
+    display: block;
+}
+.cld-diff-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.cld-diff-table th {
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 7px 12px;
+    text-align: left;
+}
+.cld-diff-table td {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--color-divider, #eee);
+    vertical-align: top;
+    word-break: break-all;
+}
+.cld-diff-table tr:last-child td {
+    border-bottom: none;
+}
+.cld-diff-table .cld-fname {
+    width: 220px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+}
+.cld-diff-table .cld-fbefore {
+    background: rgba(255, 74, 74, 0.05);
+    color: #c0392b;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cld-diff-table .cld-fafter {
+    background: rgba(39, 174, 96, 0.05);
+    color: #27ae60;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cld-no-changes {
+    padding: 14px 16px;
+    color: #aaa;
+    font-style: italic;
+    text-align: center;
+    font-size: 12px;
+}

--- a/centreon/www/include/common/listing/listing.js
+++ b/centreon/www/include/common/listing/listing.js
@@ -1,0 +1,639 @@
+/*
+ * CentreonListing - Reusable AJAX listing module
+ *
+ * Provides AJAX-driven data tables for Centreon configuration pages,
+ * replacing legacy Smarty server-side rendered listings.
+ *
+ * Usage:
+ *   var listing = new CentreonListing({ ... });
+ *   listing.init();
+ *
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Licensed under the Apache License, Version 2.0
+ */
+
+function CentreonListing(config) {
+
+    // =====================================================================
+    // Configuration (with defaults)
+    // =====================================================================
+
+    var cfg = {
+        // DOM element IDs
+        tableBodyId:        config.tableBodyId        || 'clTableBody',
+        paginationTopId:    config.paginationTopId    || 'clPaginationTop',
+        paginationBottomId: config.paginationBottomId || 'clPaginationBottom',
+        searchInputId:      config.searchInputId      || 'clSearchInput',
+        searchBtnId:        config.searchBtnId        || 'clSearchBtn',
+        limitInputId:       config.limitInputId       || 'limit',
+
+        // AJAX endpoints
+        ajaxListUrl:   config.ajaxListUrl   || '',
+        ajaxToggleUrl: config.ajaxToggleUrl || '',
+
+        // Page identity
+        pageId:      config.pageId      || '',
+        writeAccess: config.writeAccess || false,
+        storageKey:  config.storageKey  || 'cl_listing_limit',
+
+        // Behaviour
+        defaultLimit: config.defaultLimit || 30,
+        autoRefresh:  config.autoRefresh !== undefined ? config.autoRefresh : 30000,
+        emptyMessage: config.emptyMessage || 'No items found',
+
+        // Column definitions
+        // Each column: { id, header, align, render: function(row, listing) }
+        columns: config.columns || [],
+
+        // Row identity field (used for checkboxes, toggle, duplication)
+        rowIdField: config.rowIdField || 'id',
+
+        // Activate field name in row data (for toggle)
+        activateField: config.activateField || 'activate',
+
+        // Edit link builder: function(row) -> URL string
+        editLink: config.editLink || null,
+
+        // Options column renderer (toggle + dup input) — null to hide
+        // function(row, listing) -> HTML string
+        renderOptions: config.renderOptions || null,
+
+        // Extra GET parameters appended to every fetch request
+        extraParams: config.extraParams || {},
+
+        // Show row checkboxes (default true)
+        showCheckboxes: config.showCheckboxes !== undefined ? config.showCheckboxes : true,
+
+        // Field name in row data that indicates a locked/non-selectable row (checkbox disabled)
+        lockedField: config.lockedField || null,
+
+        // Infinite scroll mode (default false) — appends rows on scroll instead of pagination
+        infiniteScroll: config.infiniteScroll || false,
+        infiniteScrollBuffer: config.infiniteScrollBuffer || 600, // px from bottom to trigger load
+        scrollContainerId: config.scrollContainerId || null, // custom scroll container for infinite scroll
+
+        // Callbacks
+        onDataLoaded: config.onDataLoaded || null,
+    };
+
+    // =====================================================================
+    // Internal state
+    // =====================================================================
+
+    var self       = this;
+    var csrfToken  = '';
+    var firstLoad  = true;
+
+    // Restore state from sessionStorage (survives navigation, cleared on browser close)
+    var stateKey   = 'cl_state_' + cfg.storageKey;
+    var savedState = null;
+    try { savedState = JSON.parse(sessionStorage.getItem(stateKey)); } catch(e) {}
+
+    var currentNum    = (savedState && typeof savedState.num === 'number') ? savedState.num : 0;
+    var currentLimit  = parseInt(localStorage.getItem(cfg.storageKey), 10) || (savedState && savedState.limit) || cfg.defaultLimit;
+    var currentSearch = (savedState && savedState.search) || '';
+
+    // Infinite scroll state
+    var isLoadingMore  = false;
+    var allLoaded      = false;
+    var totalLoaded    = 0;
+
+    // =====================================================================
+    // Public: HTML escape utility
+    // =====================================================================
+
+    this.escape = function (str) {
+        if (!str) return '';
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    };
+
+    // =====================================================================
+    // Public: get current CSRF token
+    // =====================================================================
+
+    this.getCsrfToken = function () {
+        return csrfToken;
+    };
+
+    this.setCsrfToken = function (token) {
+        csrfToken = token;
+    };
+
+    // =====================================================================
+    // Public: get current state
+    // =====================================================================
+
+    this.getState = function () {
+        return { num: currentNum, limit: currentLimit, search: currentSearch };
+    };
+
+    // =====================================================================
+    // Internal: save / restore checked row checkboxes
+    // =====================================================================
+
+    function getCheckedIds() {
+        var ids = [];
+        jQuery('#' + cfg.tableBodyId + ' .cl-col-picker input[type=checkbox]:checked').each(function () {
+            var name = jQuery(this).attr('name');
+            if (name) ids.push(name);
+        });
+        return ids;
+    }
+
+    function restoreCheckedIds(ids) {
+        for (var i = 0; i < ids.length; i++) {
+            jQuery('#' + cfg.tableBodyId + ' input[name="' + ids[i] + '"]').prop('checked', true);
+        }
+    }
+
+    // =====================================================================
+    // Public: fetch data from the AJAX listing endpoint
+    //   silent = true  → no loading indicator, no fade (used by auto-refresh)
+    //   silent = false → fade-in animation on success
+    // =====================================================================
+
+    this.fetch = function (num, limit, search, silent) {
+        var isAppend = cfg.infiniteScroll && num > 0 && !firstLoad;
+
+        currentNum    = num;
+        currentLimit  = limit;
+        currentSearch = search;
+
+        // Persist state to sessionStorage (including extra filter params + select2 labels)
+        try {
+            var extra = typeof cfg.extraParams === 'function' ? cfg.extraParams() : cfg.extraParams;
+            var labels = {};
+            if (extra) {
+                jQuery.each(extra, function(key, val) {
+                    if (val) {
+                        var el = jQuery('#' + key);
+                        if (el.length && el.is('select')) {
+                            labels[key] = el.find('option:selected').text() || val;
+                        }
+                    }
+                });
+            }
+            sessionStorage.setItem(stateKey, JSON.stringify({ num: num, limit: limit, search: search, extra: extra || {}, labels: labels }));
+        } catch(e) {}
+
+        var checkedIds = getCheckedIds();
+
+        if (firstLoad) {
+            jQuery('#' + cfg.tableBodyId).html(
+                '<tr><td colspan="99" class="cl-loading">Loading...</td></tr>'
+            );
+        }
+
+        if (isAppend) {
+            isLoadingMore = true;
+            // Show loading indicator at bottom
+            jQuery('#' + cfg.tableBodyId).find('.cl-infinite-loader').remove();
+            jQuery('#' + cfg.tableBodyId).append(
+                '<tr class="cl-infinite-loader"><td colspan="99" style="text-align:center;padding:12px;color:#a7a9ac;">Loading more...</td></tr>'
+            );
+        }
+
+        jQuery.ajax({
+            url: cfg.ajaxListUrl,
+            type: 'GET',
+            dataType: 'json',
+            data: jQuery.extend({ search: search, num: num, limit: limit }, typeof cfg.extraParams === 'function' ? cfg.extraParams() : cfg.extraParams),
+            success: function (data) {
+                csrfToken = data.centreon_token || '';
+                var tbody = jQuery('#' + cfg.tableBodyId);
+
+                if (cfg.infiniteScroll && isAppend) {
+                    // Remove loader row
+                    tbody.find('.cl-infinite-loader').remove();
+                    // Append new rows
+                    self.appendRows(data.rows);
+                    totalLoaded += data.rows.length;
+                    allLoaded = totalLoaded >= data.total;
+                    isLoadingMore = false;
+                    // Update info
+                    self.renderScrollInfo(totalLoaded, data.total);
+                } else {
+                    tbody.removeClass('cl-fade-in');
+                    self.renderRows(data.rows);
+                    if (cfg.infiniteScroll) {
+                        totalLoaded = data.rows.length;
+                        allLoaded = totalLoaded >= data.total;
+                        isLoadingMore = false;
+                        self.renderScrollInfo(totalLoaded, data.total);
+                    } else {
+                        self.renderPagination(data.total, data.num, data.limit);
+                    }
+                    restoreCheckedIds(checkedIds);
+                    jQuery('#' + cfg.limitInputId).val(data.limit);
+                    if (!silent) {
+                        void tbody[0].offsetWidth;
+                        tbody.addClass('cl-fade-in');
+                    }
+                }
+                firstLoad = false;
+                // Reset bulk action dropdowns to default
+                jQuery('select[name="o1"], select[name="o2"]').prop('selectedIndex', 0);
+                if (cfg.onDataLoaded) cfg.onDataLoaded(data);
+            },
+            error: function () {
+                isLoadingMore = false;
+                jQuery('#' + cfg.tableBodyId).find('.cl-infinite-loader').remove();
+                if (firstLoad) {
+                    jQuery('#' + cfg.tableBodyId).html(
+                        '<tr><td colspan="99" style="text-align:center;padding:24px;color:#FF4A4A;">Error loading data</td></tr>'
+                    );
+                }
+            }
+        });
+    };
+
+    // =====================================================================
+    // Public: render table body rows from data
+    // =====================================================================
+
+    this.renderRows = function (rows) {
+        // Allow custom renderRows from config
+        if (typeof cfg.renderRows === 'function') {
+            cfg.renderRows.call(self, rows);
+            return;
+        }
+
+        var tbody = jQuery('#' + cfg.tableBodyId);
+        tbody.empty();
+
+        if (!rows || rows.length === 0) {
+            tbody.html('<tr><td colspan="99" style="text-align:center;padding:24px;color:#a7a9ac;">' +
+                self.escape(cfg.emptyMessage) + '</td></tr>');
+            return;
+        }
+
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var rowId = row[cfg.rowIdField];
+
+            // Checkbox cell (optional)
+            var isLocked = cfg.lockedField && row[cfg.lockedField];
+            var tr = '<tr>';
+            if (cfg.showCheckboxes) {
+                var disabledAttr = isLocked ? ' disabled' : '';
+                tr += '<td class="cl-col-picker">' +
+                    '<div class="md-checkbox md-checkbox-inline">' +
+                        '<input type="checkbox" id="select_' + rowId + '" name="select[' + rowId + ']" value="1"' + disabledAttr + ' />' +
+                        '<label class="empty-label" for="select_' + rowId + '"></label>' +
+                    '</div>' +
+                '</td>';
+            }
+
+            // Data columns
+            for (var c = 0; c < cfg.columns.length; c++) {
+                var col = cfg.columns[c];
+                var align = col.align ? ' class="cl-col-' + col.align + '"' : '';
+                var cellHtml = col.render ? col.render(row, self) : self.escape(row[col.id] || '');
+                tr += '<td' + align + '>' + cellHtml + '</td>';
+            }
+
+            // Options column (always rendered; if read-only, toggle is disabled and dup input hidden)
+            if (cfg.renderOptions) {
+                var optHtml = cfg.renderOptions(row, self, cfg.writeAccess);
+                if (!cfg.writeAccess) {
+                    // Disable toggles and hide dup inputs for read-only users
+                    optHtml = optHtml.replace(/onchange="[^"]*"/g, '').replace(/<input[^>]*cl-dup-input[^>]*>/g, '');
+                    optHtml = optHtml.replace(/<input type="checkbox"/g, '<input type="checkbox" disabled');
+                }
+                tr += '<td class="cl-col-right"><div class="cl-options-cell">' + optHtml + '</div></td>';
+            }
+
+            tr += '</tr>';
+            tbody.append(tr);
+        }
+    };
+
+    // =====================================================================
+    // Public: append rows (infinite scroll mode — adds to existing tbody)
+    // =====================================================================
+
+    this.appendRows = function (rows) {
+        if (!rows || rows.length === 0) return;
+
+        var tbody = jQuery('#' + cfg.tableBodyId);
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var rowId = row[cfg.rowIdField];
+            var isLocked = cfg.lockedField && row[cfg.lockedField];
+
+            var tr = '<tr>';
+            if (cfg.showCheckboxes) {
+                var disabledAttr = isLocked ? ' disabled' : '';
+                tr += '<td class="cl-col-picker">' +
+                    '<div class="md-checkbox md-checkbox-inline">' +
+                        '<input type="checkbox" id="select_' + rowId + '" name="select[' + rowId + ']" value="1"' + disabledAttr + ' />' +
+                        '<label class="empty-label" for="select_' + rowId + '"></label>' +
+                    '</div>' +
+                '</td>';
+            }
+
+            for (var c = 0; c < cfg.columns.length; c++) {
+                var col = cfg.columns[c];
+                var align = col.align ? ' class="cl-col-' + col.align + '"' : '';
+                var cellHtml = col.render ? col.render(row, self) : self.escape(row[col.id] || '');
+                tr += '<td' + align + '>' + cellHtml + '</td>';
+            }
+
+            if (cfg.renderOptions) {
+                var optHtml = cfg.renderOptions(row, self, cfg.writeAccess);
+                if (!cfg.writeAccess) {
+                    optHtml = optHtml.replace(/onchange="[^"]*"/g, '').replace(/<input[^>]*cl-dup-input[^>]*>/g, '');
+                    optHtml = optHtml.replace(/<input type="checkbox"/g, '<input type="checkbox" disabled');
+                }
+                tr += '<td class="cl-col-right"><div class="cl-options-cell">' + optHtml + '</div></td>';
+            }
+
+            tr += '</tr>';
+            tbody.append(tr);
+        }
+    };
+
+    // =====================================================================
+    // Public: render scroll info (infinite scroll mode)
+    // =====================================================================
+
+    this.renderScrollInfo = function (loaded, total) {
+        var html = '<span class="cl-page-info">' + loaded + ' / ' + total + '</span>';
+        if (!allLoaded) {
+            html += '<span style="color:#a7a9ac;margin-left:8px;font-size:11px;">Scroll for more</span>';
+        }
+        jQuery('#' + cfg.paginationTopId).html(html);
+        jQuery('#' + cfg.paginationBottomId).html(html);
+    };
+
+    // =====================================================================
+    // Public: reset infinite scroll (used on filter change)
+    // =====================================================================
+
+    this.resetScroll = function () {
+        totalLoaded = 0;
+        allLoaded = false;
+        isLoadingMore = false;
+        currentNum = 0;
+        self.fetch(0, currentLimit, currentSearch);
+    };
+
+    // =====================================================================
+    // Public: render pagination controls
+    // =====================================================================
+
+    this.renderPagination = function (total, num, limit) {
+        var totalPages = Math.ceil(total / limit);
+        if (totalPages < 1) totalPages = 1;
+
+        var startRow = total > 0 ? num * limit + 1 : 0;
+        var endRow   = Math.min((num + 1) * limit, total);
+        var info     = startRow + '-' + endRow + ' of ' + total;
+
+        var html = '';
+
+        // First / Previous
+        if (num > 0) {
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(0);return false;">'
+                + '<img src="./img/icons/first_rewind.png" title="First page" /></a>';
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (num - 1) + ');return false;">'
+                + '<img src="./img/icons/rewind.png" title="Previous page" /></a>';
+        }
+
+        // Page numbers
+        var startPage = Math.max(0, num - 5);
+        var endPage   = Math.min(totalPages - 1, num + 5);
+        for (var i = startPage; i <= endPage; i++) {
+            if (i === num) {
+                html += '<span class="cl-page-current">' + (i + 1) + '</span>';
+            } else {
+                html += '<a href="#" class="cl-page-num" onclick="' + instanceName() + '.goToPage(' + i + ');return false;">'
+                    + (i + 1) + '</a>';
+            }
+        }
+
+        // Next / Last
+        if (num < totalPages - 1) {
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (num + 1) + ');return false;">'
+                + '<img src="./img/icons/fast_forward.png" title="Next page" /></a>';
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (totalPages - 1) + ');return false;">'
+                + '<img src="./img/icons/end_forward.png" title="Last page" /></a>';
+        }
+
+        // Rows-per-page selector
+        html += ' <select class="cl-limit-select" onchange="' + instanceName() + '.changeLimit(this.value);">';
+        var limits = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        for (var j = 0; j < limits.length; j++) {
+            var sel = limits[j] === limit ? ' selected' : '';
+            html += '<option value="' + limits[j] + '"' + sel + '>' + limits[j] + '</option>';
+        }
+        html += '</select>';
+
+        // Row count info
+        html += '<span class="cl-page-info">' + info + '</span>';
+
+        jQuery('#' + cfg.paginationTopId).html(html);
+        jQuery('#' + cfg.paginationBottomId).html(html);
+    };
+
+    // =====================================================================
+    // Public: navigation helpers
+    // =====================================================================
+
+    this.goToPage = function (num) {
+        self.fetch(num, currentLimit, currentSearch);
+    };
+
+    this.changeLimit = function (limit) {
+        var newLimit = parseInt(limit, 10);
+        localStorage.setItem(cfg.storageKey, newLimit);
+        self.fetch(0, newLimit, currentSearch); // reset to page 0 on limit change
+    };
+
+    // =====================================================================
+    // Public: toggle activation (enable/disable via AJAX)
+    // =====================================================================
+
+    this.toggleActivation = function (toggle) {
+        if (!cfg.ajaxToggleUrl) return;
+
+        var rowId    = jQuery(toggle).data('row-id');
+        var isChecked = toggle.checked;
+        var action   = isChecked ? 's' : 'u';
+
+        toggle.disabled = true;
+
+        jQuery.ajax({
+            url: cfg.ajaxToggleUrl,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                id: rowId,
+                action: action,
+                centreon_token: csrfToken
+            },
+            success: function (response) {
+                if (response.centreon_token) {
+                    csrfToken = response.centreon_token;
+                }
+                toggle.disabled = false;
+            },
+            error: function () {
+                toggle.checked = !isChecked;
+                toggle.disabled = false;
+            }
+        });
+    };
+
+    // =====================================================================
+    // Public: select / deselect all row checkboxes
+    // =====================================================================
+
+    this.checkUncheckAll = function (masterCheckbox) {
+        var table = jQuery(masterCheckbox).closest('table');
+        table.find('tbody .cl-col-picker input[type=checkbox]').each(function () {
+            jQuery(this).prop('checked', masterCheckbox.checked);
+        });
+    };
+
+    // =====================================================================
+    // Public: initialise (first load, bind events, auto-refresh)
+    // =====================================================================
+
+    this.init = function () {
+        // Restore search value from session state (overrides Smarty default if different)
+        if (currentSearch) {
+            jQuery('#' + cfg.searchInputId).val(currentSearch);
+        } else {
+            currentSearch = jQuery('#' + cfg.searchInputId).val() || '';
+        }
+
+        // Restore extra filter params (select2 dropdowns) from session state
+        if (savedState && savedState.extra) {
+            var labels = savedState.labels || {};
+            jQuery.each(savedState.extra, function(key, val) {
+                if (val) {
+                    var el = jQuery('#' + key);
+                    if (el.length && el.is('select')) {
+                        var text = labels[key] || val;
+                        if (!el.find('option[value="' + val + '"]').length) {
+                            el.append(new Option(text, val, true, true));
+                        } else {
+                            el.val(val);
+                        }
+                        el.trigger('change');
+                    }
+                }
+            });
+        }
+
+        // Search button (resets to page 0; in infinite scroll mode, resets scroll state)
+        jQuery('#' + cfg.searchBtnId).on('click', function () {
+            currentSearch = jQuery('#' + cfg.searchInputId).val();
+            if (cfg.infiniteScroll) {
+                self.resetScroll();
+            } else {
+                self.fetch(0, currentLimit, currentSearch);
+            }
+        });
+
+        // Search on Enter key
+        jQuery('#' + cfg.searchInputId).on('keypress', function (e) {
+            if (e.which === 13) {
+                e.preventDefault();
+                jQuery('#' + cfg.searchBtnId).click();
+            }
+        });
+
+        // In infinite scroll mode, always start at page 0 and use a larger batch size
+        if (cfg.infiniteScroll) {
+            currentNum = 0;
+            if (currentLimit < 50) currentLimit = 50;
+        }
+
+        // Initial data load (restore page from session)
+        self.fetch(currentNum, currentLimit, currentSearch);
+
+        // Infinite scroll: listen for scroll on the specified container or window
+        if (cfg.infiniteScroll) {
+            var scrollParent;
+            if (cfg.scrollContainerId) {
+                scrollParent = jQuery('#' + cfg.scrollContainerId);
+            } else {
+                scrollParent = jQuery('#main-content');
+                if (!scrollParent.length) scrollParent = jQuery(window);
+            }
+
+            scrollParent.on('scroll', function () {
+                if (isLoadingMore || allLoaded) return;
+
+                var scrollTop, scrollHeight, clientHeight;
+                if (scrollParent.is(jQuery(window))) {
+                    scrollTop = jQuery(window).scrollTop();
+                    scrollHeight = jQuery(document).height();
+                    clientHeight = jQuery(window).height();
+                } else {
+                    scrollTop = scrollParent.scrollTop();
+                    scrollHeight = scrollParent[0].scrollHeight;
+                    clientHeight = scrollParent[0].clientHeight;
+                }
+
+                if (scrollTop + clientHeight >= scrollHeight - cfg.infiniteScrollBuffer) {
+                    currentNum++;
+                    self.fetch(currentNum, currentLimit, currentSearch, true);
+                }
+            });
+        }
+
+        // Auto-refresh (disabled in infinite scroll mode to avoid resetting the list)
+        if (cfg.autoRefresh > 0 && !cfg.infiniteScroll) {
+            setInterval(function () {
+                self.fetch(currentNum, currentLimit, currentSearch, true);
+            }, cfg.autoRefresh);
+        }
+    };
+
+    // =====================================================================
+    // Internal: resolve the global variable name for onclick handlers
+    // =====================================================================
+
+    var _instanceName = config.instanceName || null;
+
+    function instanceName() {
+        if (_instanceName) return _instanceName;
+        // Fallback: search window properties
+        for (var key in window) {
+            if (window[key] === self) {
+                _instanceName = key;
+                return key;
+            }
+        }
+        return 'this';
+    }
+}
+
+// ==========================================================================
+// Global instant tooltip for [data-cl-tooltip] elements
+// Positioned fixed in body — no overflow clipping, no delay
+// Usage: <span data-cl-tooltip="PID: 123<br>Uptime: 2d">ⓘ</span>
+// ==========================================================================
+(function () {
+    var tip = null;
+    jQuery(document).on('mouseenter', '[data-cl-tooltip]', function () {
+        var content = jQuery(this).attr('data-cl-tooltip');
+        if (!content) return;
+        tip = jQuery('<div class="cl-tooltip-popup">' + content + '</div>');
+        jQuery('body').append(tip);
+        var rect = this.getBoundingClientRect();
+        var top = rect.top - tip.outerHeight() - 6;
+        if (top < 0) top = rect.bottom + 6;
+        tip.css({
+            top: top + 'px',
+            left: (rect.left + rect.width / 2 - tip.outerWidth() / 2) + 'px'
+        });
+    }).on('mouseleave', '[data-cl-tooltip]', function () {
+        if (tip) { tip.remove(); tip = null; }
+    });
+})();

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -110,6 +110,10 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
     <link href="./include/common/javascript/jquery/plugins/colorbox/colorbox.css" rel="stylesheet" type="text/css"/>
     <link href="./include/common/javascript/jquery/plugins/qtip/jquery-qtip.css" rel="stylesheet" type="text/css"/>
 
+    <!-- Modern listing styles and JS module -->
+    <link href="./include/common/listing/listing.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css" />
+    <script type="text/javascript" src="./include/common/listing/listing.js<?php echo $versionParam; ?>"></script>
+
     <!-- graph css -->
     <link href="./include/common/javascript/charts/c3.min.css" type="text/css" rel="stylesheet" />
     <link href="./include/views/graphs/javascript/centreon-status-chart.css" type="text/css" rel="stylesheet" />

--- a/centreon/www/include/options/media/images/ajaxImagesCreateDir.php
+++ b/centreon/www/include/options/media/images/ajaxImagesCreateDir.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb(); // top-level: global for DB-Func helpers (insertDirectory, testDirectoryExistence)
+
+$newToken = $helper->validateCsrfToken();
+$helper->requireWriteAccess(50102);
+
+$respondError = function (string $message, int $code = 400) use ($newToken): void {
+    http_response_code($code);
+    echo json_encode(['success' => false, 'error' => $message, 'centreon_token' => $newToken]);
+    exit;
+};
+
+// Creating a folder is reserved to users allowed to see every folder
+// (same restriction as uploading into a brand new directory)
+$canCreateFolder = $helper->isAdmin() || ! empty($centreon->user->access->hasAccessToAllImageFolders);
+if (! $canCreateFolder) {
+    $respondError('You are not allowed to create a directory.', 403);
+}
+
+$name    = trim((string) ($_POST['name'] ?? ''));
+$comment = (string) ($_POST['comment'] ?? '');
+
+if ($name === '') {
+    $respondError('A directory name is required.');
+}
+
+// Strict allow-list on the directory name (defends against path traversal such
+// as ".." and keeps names display- and filesystem-safe)
+if (! preg_match('/^[A-Za-z0-9_-]+$/', $name)) {
+    $respondError('Invalid directory name (allowed: letters, digits, "-" and "_").');
+}
+
+$oreon = $centreon;
+require_once _CENTREON_PATH_ . '/www/include/options/media/images/DB-Func.php';
+
+// DB-Func helpers work with paths relative to the web root
+chdir(_CENTREON_PATH_ . '/www');
+
+if (testDirectoryExistence($name)) {
+    $respondError('A directory with this name already exists.', 409);
+}
+
+$dirId = insertDirectory($name, $comment);
+if (! $dirId) {
+    $respondError('The directory could not be created.', 409);
+}
+
+echo json_encode(['success' => true, 'dir_id' => (int) $dirId, 'centreon_token' => $newToken]);
+exit;

--- a/centreon/www/include/options/media/images/ajaxImagesDelete.php
+++ b/centreon/www/include/options/media/images/ajaxImagesDelete.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb(); // top-level: exposed as global for DB-Func.php functions
+
+$newToken = $helper->validateCsrfToken();
+$helper->requireWriteAccess(50102);
+
+$selection = $_POST['select'] ?? [];
+if (! is_array($selection) || $selection === []) {
+    AjaxListingHelper::jsonError('No item selected', 400);
+}
+
+// Keep only well-formed selectors: "dirId" (directory) or "dirId-imgId" (image).
+// DB-Func keys deletions on these selectors (1 part = directory, 2 parts = image).
+$clean = [];
+foreach (array_keys($selection) as $selector) {
+    $parts = explode('-', (string) $selector);
+    if (count($parts) < 1 || count($parts) > 2) {
+        continue;
+    }
+    $valid = true;
+    foreach ($parts as $part) {
+        if (filter_var($part, FILTER_VALIDATE_INT) === false) {
+            $valid = false;
+            break;
+        }
+    }
+    if ($valid) {
+        $clean[(string) $selector] = 1;
+    }
+}
+
+if ($clean === []) {
+    AjaxListingHelper::jsonError('No valid selection', 400);
+}
+
+// DB-Func deletes media files using paths relative to the web root
+chdir(_CENTREON_PATH_ . '/www');
+
+// DB-Func guards on $oreon and relies on the global $pearDB
+$oreon = $centreon;
+require_once _CENTREON_PATH_ . '/www/include/options/media/images/DB-Func.php';
+
+deleteMultImg($clean);
+deleteMultDirectory($clean);
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/options/media/images/ajaxImagesListing.php
+++ b/centreon/www/include/options/media/images/ajaxImagesListing.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+$isAdmin       = $helper->isAdmin();
+$hasAllFolders = $isAdmin || ! empty($centreon->user->access->hasAccessToAllImageFolders);
+
+$bindParams = [];
+
+$body = ' FROM view_img_dir AS `directories`'
+    . ' LEFT JOIN view_img_dir_relation AS `vidr` ON vidr.dir_dir_parent_id = directories.dir_id'
+    . ' LEFT JOIN view_img AS `images` ON images.img_id = vidr.img_img_id ';
+
+// Restrict to the folders the user is allowed to see (admins / full-access users skip this)
+if (! $hasAllFolders) {
+    $body .= ' INNER JOIN acl_resources_image_folder_relations armdr ON armdr.dir_id = vidr.dir_dir_parent_id'
+        . ' INNER JOIN acl_resources ar ON ar.acl_res_id = armdr.acl_res_id'
+        . ' INNER JOIN acl_res_group_relations argr ON argr.acl_res_id = ar.acl_res_id'
+        . ' LEFT JOIN acl_group_contacts_relations gcr ON gcr.acl_group_id = argr.acl_group_id'
+        . ' LEFT JOIN acl_group_contactgroups_relations gcgr ON gcgr.acl_group_id = argr.acl_group_id'
+        . ' LEFT JOIN contactgroup_contact_relation cgcr ON cgcr.contactgroup_cg_id = gcgr.cg_cg_id'
+        . ' AND (cgcr.contact_contact_id = :contactId OR gcr.contact_contact_id = :contactId) ';
+    $bindParams[':contactId'] = (int) $centreon->user->user_id;
+}
+
+// Reserved directories are never listed here
+$conditions = " WHERE directories.dir_name NOT IN ('centreon-map', 'dashboards', 'ppm') ";
+if ($search !== '') {
+    $searchEsc = str_replace('_', '\\_', $search);
+    $conditions .= ' AND (images.img_name LIKE :search OR directories.dir_name LIKE :search) ';
+    $bindParams[':search'] = '%' . $searchEsc . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS images.*, directories.*'
+    . $body
+    . $conditions
+    . ' GROUP BY images.img_id, directories.dir_id'
+    . ' ORDER BY dir_alias, img_name LIMIT :offset, :limit'
+);
+foreach ($bindParams as $key => $val) {
+    $statement->bindValue($key, $val, is_int($val) ? PDO::PARAM_INT : PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$result = $statement->fetchAll(PDO::FETCH_ASSOC);
+$total  = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+foreach ($result as $r) {
+    $hasImg = ! empty($r['img_id']);
+
+    // File size and modification date are read from disk (not stored in DB)
+    $size = null;
+    $mtime = null;
+    if ($hasImg) {
+        $fullPath = _CENTREON_PATH_ . '/www/img/media/' . $r['dir_alias'] . '/' . $r['img_path'];
+        if (is_file($fullPath)) {
+            $size = filesize($fullPath) ?: null;
+            $mtime = filemtime($fullPath) ?: null;
+        }
+    }
+
+    $rows[] = [
+        'dir_id'      => (int) $r['dir_id'],
+        'dir_name'    => html_entity_decode($r['dir_name'] ?? '', ENT_QUOTES, 'UTF-8'),
+        'dir_comment' => html_entity_decode($r['dir_comment'] ?? '', ENT_QUOTES, 'UTF-8'),
+        'img_id'      => $hasImg ? (int) $r['img_id'] : null,
+        'img_name'    => $hasImg ? html_entity_decode($r['img_name'], ENT_QUOTES, 'UTF-8') : '',
+        'img_path'    => $hasImg ? html_entity_decode($r['dir_alias'] . '/' . $r['img_path'], ENT_QUOTES, 'UTF-8') : '',
+        'img_comment' => $hasImg ? html_entity_decode($r['img_comment'] ?? '', ENT_QUOTES, 'UTF-8') : '',
+        'size'        => $size,
+        'mtime'       => $mtime,
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/options/media/images/ajaxImagesMove.php
+++ b/centreon/www/include/options/media/images/ajaxImagesMove.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$newToken = $helper->validateCsrfToken();
+$helper->requireWriteAccess(50102);
+
+$respondError = function (string $message, int $code = 400) use ($newToken): void {
+    http_response_code($code);
+    echo json_encode(['success' => false, 'error' => $message, 'centreon_token' => $newToken]);
+    exit;
+};
+
+// Dependency injector (configuration_db) used by CentreonImageManager + getListDirectory ACL helper
+require_once _CENTREON_PATH_ . '/bootstrap.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonImageManager.php';
+$oreon = $centreon;
+require_once _CENTREON_PATH_ . '/www/include/options/media/images/DB-Func.php';
+
+$isCloudPlatform = function_exists('isCloudPlatform') ? isCloudPlatform() : false;
+
+$imgId = filter_var($_POST['img_id'] ?? null, FILTER_VALIDATE_INT);
+$dirId = filter_var($_POST['dir_id'] ?? null, FILTER_VALIDATE_INT);
+if ($imgId === false || $imgId === null || $dirId === false || $dirId === null) {
+    $respondError('Invalid parameters.', 400);
+}
+
+// Current image (name and comment are preserved; only the directory changes).
+// The source directory is fetched too, so we can enforce ACL on it below.
+$imgStmt = $pearDB->prepare(
+    'SELECT i.img_name, i.img_comment, d.dir_name AS current_dir'
+    . ' FROM view_img i'
+    . ' INNER JOIN view_img_dir_relation r ON r.img_img_id = i.img_id'
+    . ' INNER JOIN view_img_dir d ON d.dir_id = r.dir_dir_parent_id'
+    . ' WHERE i.img_id = :imgId LIMIT 1'
+);
+$imgStmt->bindValue(':imgId', $imgId, PDO::PARAM_INT);
+$imgStmt->execute();
+$img = $imgStmt->fetch();
+if ($img === false) {
+    $respondError('Image not found.', 404);
+}
+
+// Target directory
+$dirStmt = $pearDB->prepare('SELECT dir_name FROM view_img_dir WHERE dir_id = :dirId LIMIT 1');
+$dirStmt->bindValue(':dirId', $dirId, PDO::PARAM_INT);
+$dirStmt->execute();
+$dir = $dirStmt->fetch();
+if ($dir === false) {
+    $respondError('Directory not found.', 404);
+}
+$directory = (string) $dir['dir_name'];
+
+// Non-privileged users can only move an image between folders they are allowed
+// to see: both the source (current) and the target directory must be visible.
+$userCanSeeAllFolders = $helper->isAdmin() || ! empty($centreon->user->access->hasAccessToAllImageFolders);
+if (! $userCanSeeAllFolders) {
+    $allowedFolders = getListDirectory();
+    if (! in_array((string) $img['current_dir'], $allowedFolders, true)
+        || ! in_array($directory, $allowedFolders, true)
+    ) {
+        $respondError('You are not allowed to move this image.', 403);
+    }
+}
+
+// CentreonImageManager works with paths relative to the web root
+chdir(_CENTREON_PATH_ . '/www');
+
+// No uploaded file: update() only moves the image to the target directory and
+// keeps its name / comment, so the img_id (and every reference to it) is preserved
+$manager = new CentreonImageManager(
+    $dependencyInjector,
+    [],
+    './img/media/',
+    $directory,
+    (string) $img['img_comment'],
+    $isCloudPlatform
+);
+
+if (! $manager->update($imgId, (string) $img['img_name'])) {
+    $respondError('The image could not be moved.', 409);
+}
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+exit;

--- a/centreon/www/include/options/media/images/ajaxImagesSync.php
+++ b/centreon/www/include/options/media/images/ajaxImagesSync.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+
+$newToken = $helper->validateCsrfToken();
+$helper->requireWriteAccess(50102);
+
+// Synchronizing the media library from disk (create dirs/images, prune dead
+// rows) is reserved to users allowed to see every folder, like folder creation
+$canSync = $helper->isAdmin() || ! empty($centreon->user->access->hasAccessToAllImageFolders);
+if (! $canSync) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'You are not allowed to synchronize the media library.', 'centreon_token' => $newToken]);
+    exit;
+}
+
+require_once __DIR__ . '/mediaSyncWorker.php';
+
+// The worker uses paths relative to the web root
+chdir(_CENTREON_PATH_ . '/www');
+
+$stats = runMediaSync();
+
+echo json_encode(['success' => true, 'stats' => $stats, 'centreon_token' => $newToken]);
+exit;

--- a/centreon/www/include/options/media/images/ajaxImagesUpload.php
+++ b/centreon/www/include/options/media/images/ajaxImagesUpload.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb(); // top-level: global for DB-Func helpers (isCorrectMIMEType, getListDirectory)
+
+$newToken = $helper->validateCsrfToken();
+$helper->requireWriteAccess(50102);
+
+// Error responses still carry a fresh token so the client can keep uploading the queue
+$respondError = function (string $message, int $code = 400) use ($newToken): void {
+    http_response_code($code);
+    echo json_encode(['success' => false, 'error' => $message, 'centreon_token' => $newToken]);
+    exit;
+};
+
+// Dependency injector (configuration_db) used by CentreonImageManager
+require_once _CENTREON_PATH_ . '/bootstrap.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonImageManager.php';
+$oreon = $centreon;
+require_once _CENTREON_PATH_ . '/www/include/options/media/images/DB-Func.php';
+
+$isCloudPlatform = function_exists('isCloudPlatform') ? isCloudPlatform() : false;
+
+$directory = trim((string) ($_POST['directory'] ?? ''));
+$comment   = (string) ($_POST['comment'] ?? '');
+$overwrite = ! empty($_POST['overwrite']);
+
+if ($directory === '') {
+    $respondError('A target directory is required.');
+}
+
+// Strict allow-list on the directory name (defends against path traversal such
+// as ".." which secureName() does not strip, and keeps names display-safe)
+if (! preg_match('/^[A-Za-z0-9_-]+$/', $directory)) {
+    $respondError('Invalid directory name.', 400);
+}
+
+// Non-privileged users can only upload into an existing folder they can access
+$userCanSeeAllFolders = $helper->isAdmin() || ! empty($centreon->user->access->hasAccessToAllImageFolders);
+if (! $userCanSeeAllFolders && ! in_array($directory, getListDirectory(), true)) {
+    $respondError('You are not allowed to use this directory.', 403);
+}
+
+if (! isset($_FILES['filename']) || ($_FILES['filename']['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+    $respondError('Upload failed.');
+}
+
+// Hard cap of 2 MB per file, enforced on every platform (on-premise would
+// otherwise allow up to 5 MB through CentreonImageManager)
+if ((int) ($_FILES['filename']['size'] ?? 0) > 2000000) {
+    $respondError('File too large (maximum 2 MB).', 413);
+}
+
+$fileName  = (string) $_FILES['filename']['name'];
+$extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+if (! in_array($extension, ['jpg', 'jpeg', 'png', 'gif', 'svg'], true)) {
+    $respondError('Unsupported file format.', 415);
+}
+
+// Deep MIME validation (also sanitizes SVG content in place)
+if (! isCorrectMIMEType($_FILES['filename'])) {
+    $respondError('Invalid image file.', 415);
+}
+
+// CentreonImageManager works with paths relative to the web root
+chdir(_CENTREON_PATH_ . '/www');
+
+$uploader = new CentreonImageManager(
+    $dependencyInjector,
+    $_FILES,
+    './img/media/',
+    $directory,
+    $comment,
+    $isCloudPlatform
+);
+
+// Resolve the stored file name the way CentreonImageManager will (mirrors
+// centreonFileManager::secureName(); the directory is already restricted to
+// [A-Za-z0-9_-] above so it needs no further sanitizing)
+$storedName = uploadSecureName(pathinfo($fileName, PATHINFO_FILENAME)) . '.' . $extension;
+$targetPath = './img/media/' . $directory . '/' . $storedName;
+
+// Is there already an image with that name in this directory?
+$lookup = $pearDB->prepare(
+    'SELECT i.img_id FROM view_img i'
+    . ' INNER JOIN view_img_dir_relation r ON r.img_img_id = i.img_id'
+    . ' INNER JOIN view_img_dir d ON d.dir_id = r.dir_dir_parent_id'
+    . ' WHERE d.dir_name = :dir AND i.img_path = :path LIMIT 1'
+);
+$lookup->bindValue(':dir', $directory, PDO::PARAM_STR);
+$lookup->bindValue(':path', $storedName, PDO::PARAM_STR);
+$lookup->execute();
+$existingId = $lookup->fetchColumn();
+$alreadyExists = ($existingId !== false) || file_exists($targetPath);
+
+// Not overwriting: let the client ask the user what to do
+if ($alreadyExists && ! $overwrite) {
+    echo json_encode(['success' => false, 'exists' => true, 'name' => $fileName, 'centreon_token' => $newToken]);
+    exit;
+}
+
+// Overwrite an existing, DB-tracked image in place: keeps the same img_id so
+// every host/service/etc. that references it keeps its icon
+if ($overwrite && $existingId !== false) {
+    if (! $uploader->update((int) $existingId, pathinfo($fileName, PATHINFO_FILENAME))) {
+        $respondError('The image could not be replaced.', 409);
+    }
+    echo json_encode(['success' => true, 'name' => $fileName, 'centreon_token' => $newToken]);
+    exit;
+}
+
+// Overwrite of an orphan file (present on disk but with no DB row)
+if ($overwrite && $existingId === false && file_exists($targetPath)) {
+    @unlink($targetPath);
+}
+
+$result = $uploader->upload();
+if ($result === false || $result === null) {
+    $respondError('The image could not be saved (it may already exist or be too large).', 409);
+}
+
+echo json_encode(['success' => true, 'name' => $fileName, 'centreon_token' => $newToken]);
+exit;
+
+/**
+ * Mirror of centreonFileManager::secureName(): strips accents, spaces, slashes
+ * and quotes so we can predict the on-disk / stored image name.
+ */
+function uploadSecureName(string $text): string
+{
+    $map = [
+        '/[áàâãªä]/u' => 'a', '/[ÁÀÂÃÄ]/u' => 'A',
+        '/[ÍÌÎÏ]/u' => 'I', '/[íìîï]/u' => 'i',
+        '/[éèêë]/u' => 'e', '/[ÉÈÊË]/u' => 'E',
+        '/[óòôõºö]/u' => 'o', '/[ÓÒÔÕÖ]/u' => 'O',
+        '/[úùûü]/u' => 'u', '/[ÚÙÛÜ]/u' => 'U',
+        '/ç/' => 'c', '/Ç/' => 'C', '/ñ/' => 'n', '/Ñ/' => 'N',
+        '/–/' => '-', '/[“”«»„"’‘‹›‚]/u' => '',
+        '/ /' => '', '/\//' => '', '/\'/' => '',
+    ];
+
+    return preg_replace(array_keys($map), array_values($map), $text);
+}

--- a/centreon/www/include/options/media/images/formImg.ihtml
+++ b/centreon/www/include/options/media/images/formImg.ihtml
@@ -1,67 +1,72 @@
 {$form.javascript}
+<link href="./include/common/form/form.css" rel="stylesheet" type="text/css" />
+
 <form {$form.attributes}>
-	<div id='tab1' class='tab'>
-	 <table class="formTable table">
-		{if $o == "w"}
-			{assign var=cols value=3}
-		{else}
-			{assign var=cols value=2}
-		{/if}
-	 	<tr class="list_lvl_1">
-          <td class="ListColLvl1_name" colspan="{$cols}">
-            <h4>{$form.header.title}</h4>
-          </td>
-        </tr>
-		{if $o == "ci" || $o == "w"}
-			<tr class="list_one">
-				{if $o == "w"}
-					<td class="ListColCenter" rowspan="4"><img src='{$form.img_path.label}'></td>
-				{/if}
-				<td class="FormRowField"><img class="helpTooltip" name="img_name"> {$form.img_name.label}</td>
-				<td class="FormRowValue">{$form.img_name.html}</td>
-			</tr>
-		{/if}		
-		<tr class="list_two">
-			<td class="FormRowField"><img class="helpTooltip" name="img_dir"> {$form.directories.label}</td>
-			<td class="FormRowValue">{$form.directories.html}
-			{ if $o == "ci" || $o == "a" }{$form.list_dir.html}{ /if }
-			</td>
-		</tr>
-		<tr class="list_one">
-			<td class="FormRowField"><img class="helpTooltip" name="img_file"> {$form.filename.label}</td>
-			<td class="FormRowValue">
-				{if $o == "a" || $o == "ci"}
-					{$form.filename.html}
-				{else if $o == "w"}
-					{$form.img_path.html}
-				{/if}
-				&nbsp;&nbsp;({$max_uploader_file})
-			</td>
-		</tr>
-		<tr class="list_two">
-			<td class="FormRowField">{$form.img_comment.label}</td>
-			<td class="FormRowValue">{$form.img_comment.html}</td>
-		</tr>
-		
-		{if $o == "a" || $o == "ci"}
-			<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-                {if isset($form.required)}
-                    {$form.required._note}
+<div class="cf-form-wrapper">
+
+    <h1 class="cf-page-title">{$form.header.title}</h1>
+
+    <div class="cf-section" id="cf-sec-info">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.title}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            {if isset($previewSrc)}
+            <div class="cf-row" style="justify-content:center;">
+                <img src="{$previewSrc}" alt="" style="max-width:150px;max-height:150px;background:#fff;border:1px solid var(--c-stroke,#d0d5dd);border-radius:6px;padding:6px;object-fit:contain;" onerror="this.style.display='none';">
+            </div>
+            {/if}
+
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.img_name.html}
+                    <label class="cf-label-float">{$form.img_name.label}</label>
+                    <img class="helpTooltip" name="img_name">
+                </div>
+            </div>
+
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.list_dir.html}
+                    <label class="cf-label-float">{$form.directories.label}</label>
+                    <img class="helpTooltip" name="img_dir">
+                </div>
+                {if $o == "ci"}
+                <div class="cf-field">
+                    {$form.directories.html}
+                    <label class="cf-label-float">{t}Directory name{/t}</label>
+                </div>
                 {/if}
-            </td></tr>
-		{/if}
-	</table>
-	</div>
-	<div id="validForm">
-	{if $o == "a"}
-		<p>{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.cancel.html}</p>
-	{elseif $o == "ci"}
-		<p>{$form.submitC.html}&nbsp;&nbsp;&nbsp;{$form.cancel.html}</p>
-	{elseif $o == "w"}
-		<p>{$form.change.html}&nbsp;&nbsp;&nbsp;{$form.cancel.html}</p>
-	{/if}
-	</div>
-	{$form.hidden}
+            </div>
+
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.img_comment.html}
+                    <label class="cf-label-float">{$form.img_comment.label}</label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="cf-actions">
+        {if $o == "ci"}
+            {$form.cancel.html}
+            {$form.submitC.html}
+        {elseif $o == "w"}
+            {if isset($form.change)}{$form.change.html}{/if}
+        {/if}
+    </div>
+
+</div>
+{$form.hidden}
 </form>
 {$helptext}
 
+{literal}
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    if (window.CentreonForm) { CentreonForm.initFormPage(); }
+});
+</script>
+{/literal}

--- a/centreon/www/include/options/media/images/formImg.php
+++ b/centreon/www/include/options/media/images/formImg.php
@@ -159,7 +159,9 @@ if ($o == IMAGE_ADD) {
     );
 
     $directorySelect->setSelected($img['dir_id']);
-    $form->addElement('file', 'filename', _('Image'));
+    // Editing an image is about renaming / moving it to another directory /
+    // updating its comment. Replacing the file is not offered here (use delete +
+    // upload for that), so no file input.
     $subC = $form->addElement(
         'submit',
         'submitC',
@@ -168,8 +170,6 @@ if ($o == IMAGE_ADD) {
     );
     $form->setDefaults($img);
     $form->addRule('img_name', _('Compulsory image name'), 'required');
-    $form->registerRule('isCorrectMIMEType', 'callback', 'isCorrectMIMEType');
-    $form->addRule('filename', _('Invalid Image Format.'), 'isCorrectMIMEType');
 } elseif ($o == IMAGE_WATCH) {
     $form->addElement('header', 'title', _('View Image'));
     $form->addElement('text', 'img_name', _('Image Name'), $attrsText);
@@ -243,6 +243,11 @@ foreach ($help as $key => $text) {
         . $key . '">' . $text . '</span>' . "\n";
 }
 $tpl->assign('helptext', $helptext);
+
+// Preview source for the edit/view panel
+if (isset($img['dir_alias'], $img['img_path'])) {
+    $tpl->assign('previewSrc', './img/media/' . $img['dir_alias'] . '/' . $img['img_path']);
+}
 
 $valid = false;
 if ($form->validate()) {

--- a/centreon/www/include/options/media/images/formUpload.ihtml
+++ b/centreon/www/include/options/media/images/formUpload.ihtml
@@ -1,0 +1,356 @@
+<style>
+    {literal}
+    .images-title-bar { margin: 0 0 8px 0; max-width: 1400px; }
+    .images-title { margin: 0; padding: 0; font-size: 18px; font-weight: 600; color: var(--body-color, #2d3436); }
+    .images-subtitle { margin: 4px 0 12px; font-size: 12px; line-height: 1.45; color: var(--body-color, #6f7384); opacity: 0.75; }
+
+    .up-wrap { max-width: 760px; }
+    .up-field { margin-bottom: 14px; }
+    .up-field > label { display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; color: var(--body-color, #2d3436); }
+
+    .up-dropzone {
+        border: 2px dashed var(--color-divider, #c8ccd6);
+        border-radius: 8px;
+        padding: 32px;
+        text-align: center;
+        color: var(--body-color, #6f7384);
+        cursor: pointer;
+        transition: border-color .15s, background .15s;
+        background: var(--select-background, #fff);
+    }
+    .up-dropzone.up-over { border-color: var(--color-primary, #009fdf); background: var(--color-listing-hover, #eef5fb); }
+    .up-dropzone .up-hint-sub { font-size: 11px; margin-top: 6px; opacity: .7; }
+
+    .up-list { margin-top: 14px; }
+    .up-item { display: flex; align-items: center; gap: 10px; padding: 8px 4px; border-bottom: 1px solid var(--color-divider, #e3e3e3); }
+    .up-item img { width: 36px; height: 36px; object-fit: contain; border-radius: 4px; background: #f3f3f3; }
+    .up-item .up-name { flex: 1; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .up-item .up-size { font-size: 11px; color: #999; width: 70px; text-align: right; }
+    .up-bar { width: 110px; height: 6px; border-radius: 3px; background: #e3e3e3; overflow: hidden; }
+    .up-bar > span { display: block; height: 100%; width: 0; background: var(--color-primary, #009fdf); transition: width .2s; }
+    .up-status { width: 18px; text-align: center; font-weight: 700; }
+    .up-status.ok { color: #88b917; }
+    .up-status.err { color: #e0202e; cursor: help; }
+    .up-remove { cursor: pointer; color: #999; font-weight: 700; padding: 0 4px; }
+    .up-actions { margin-top: 16px; display: flex; gap: 10px; align-items: center; }
+
+    /* Overwrite confirmation modal */
+    .ov-overlay {
+        display: none;
+        position: fixed; inset: 0;
+        background: rgba(0, 0, 0, 0.35);
+        z-index: 50;
+        align-items: center;
+        justify-content: center;
+    }
+    .ov-dialog {
+        background: var(--body-background, #fff);
+        border-radius: 8px;
+        box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+        padding: 18px 20px;
+        max-width: 440px;
+        width: 90%;
+    }
+    .ov-msg { margin: 0 0 16px; font-size: 14px; line-height: 1.4; color: var(--body-color, #2d3436); }
+    .ov-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+    {/literal}
+</style>
+
+<div class="images-title-bar">
+    <h2 class="images-title">{$pageTitle}</h2>
+    <p class="images-subtitle">{$pageSubtitle}</p>
+</div>
+
+<div class="up-wrap">
+    <div class="up-field">
+        <label>{$wi_directory}</label>
+        <select id="uploadDir">
+            {foreach from=$directories item=d}
+                <option value="{$d}">{$d}</option>
+            {/foreach}
+        </select>
+        {if $canCreateDir == 1}
+            <input type="text" id="uploadNewDir" placeholder="{$wi_newDirectory}" style="margin-left:8px;width:200px;">
+        {/if}
+    </div>
+
+    <div class="up-field">
+        <label>{$wi_comment}</label>
+        <textarea id="uploadComment" rows="2" style="width:100%;box-sizing:border-box;"></textarea>
+    </div>
+
+    <div class="up-field">
+        <div id="dropzone" class="up-dropzone">
+            <div><b>{t}Drop images here{/t}</b> {t}or click to browse{/t}</div>
+            <div class="up-hint-sub">{$wi_maxSize}</div>
+        </div>
+        <input type="file" id="fileInput" multiple accept=".jpg,.jpeg,.png,.gif,.svg" style="display:none;">
+        <div id="uploadList" class="up-list"></div>
+    </div>
+
+    <div class="up-actions">
+        <button type="button" id="uploadBtn" class="btc bt_success">{$wi_upload}</button>
+        <a href="#" onclick="uploadCancel(); return false;" class="btc bt_default">{$wi_cancel}</a>
+    </div>
+</div>
+
+<div class="ov-overlay" id="ovOverlay">
+    <div class="ov-dialog">
+        <p class="ov-msg" id="ovMsg"></p>
+        <div class="ov-actions">
+            <button type="button" class="btc bt_success" data-ov="once">{$wi_overwrite}</button>
+            <button type="button" class="btc bt_success" data-ov="all">{$wi_overwriteAll}</button>
+            <button type="button" class="btc bt_default" data-ov="skip">{$wi_skip}</button>
+            <button type="button" class="btc bt_default" data-ov="skipall">{$wi_skipAll}</button>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    var uploadPageId       = '{$pageId}';
+    var uploadCanCreateDir = {if $canCreateDir == 1}true{else}false{/if};
+    var uploadToken        = {$csrfTokenJs};
+    var uploadSelectDirMsg = {$selectDirJs};
+    var uploadOverwriteMsg = {$overwriteMsgJs};
+</script>
+
+{literal}
+<script type="text/javascript">
+    function uploadInPanel() {
+        return !!(window.frameElement && window.frameElement.id === 'cfSidePanelFrame');
+    }
+    function uploadDone() {
+        if (uploadInPanel()) { try { window.parent.cfClosePanel(); return; } catch (e) {} }
+        window.location.href = './main.php?p=' + uploadPageId;
+    }
+    function uploadCancel() {
+        if (uploadInPanel()) { try { window.parent.cfClosePanel(); return; } catch (e) {} }
+        window.location.href = './main.php?p=' + uploadPageId;
+    }
+    // Overwrite confirmation modal — resolves to 'once' | 'all' | 'skip' | 'skipall'
+    function askOverwrite(filename, cb) {
+        var overlay = document.getElementById('ovOverlay');
+        document.getElementById('ovMsg').textContent = uploadOverwriteMsg.replace('%s', filename);
+        overlay.style.display = 'flex';
+        function handler(e) {
+            var decision = e.target.getAttribute('data-ov');
+            if (!decision) { return; }
+            overlay.style.display = 'none';
+            overlay.removeEventListener('click', handler);
+            cb(decision);
+        }
+        overlay.addEventListener('click', handler);
+    }
+    // Inside the side panel, hide the page chrome (breadcrumb + the form's own title)
+    if (uploadInPanel()) {
+        var _pw = document.querySelector('.pathway');
+        if (_pw) { _pw.style.display = 'none'; }
+        var _tb = document.querySelector('.images-title-bar');
+        if (_tb) { _tb.style.display = 'none'; }
+    }
+
+    (function () {
+        var dz    = document.getElementById('dropzone');
+        var input = document.getElementById('fileInput');
+        var list  = document.getElementById('uploadList');
+        var btn   = document.getElementById('uploadBtn');
+        var queue = [];
+        var allowed = ['jpg', 'jpeg', 'png', 'gif', 'svg'];
+
+        function humanSize(b) {
+            if (b < 1024) return b + ' B';
+            if (b < 1048576) return (b / 1024).toFixed(1) + ' KB';
+            return (b / 1048576).toFixed(1) + ' MB';
+        }
+
+        function ext(name) {
+            var p = name.split('.');
+            return p.length > 1 ? p.pop().toLowerCase() : '';
+        }
+
+        function addFiles(files) {
+            for (var i = 0; i < files.length; i++) {
+                (function (file) {
+                    if (allowed.indexOf(ext(file.name)) < 0) {
+                        return;
+                    }
+                    var item = { file: file, done: false };
+
+                    var row = document.createElement('div');
+                    row.className = 'up-item';
+
+                    var img = document.createElement('img');
+                    var reader = new FileReader();
+                    reader.onload = function (e) { img.src = e.target.result; };
+                    reader.readAsDataURL(file);
+
+                    var name = document.createElement('div');
+                    name.className = 'up-name';
+                    name.textContent = file.name;
+
+                    var size = document.createElement('div');
+                    size.className = 'up-size';
+                    size.textContent = humanSize(file.size);
+
+                    var bar = document.createElement('div');
+                    bar.className = 'up-bar';
+                    var barIn = document.createElement('span');
+                    bar.appendChild(barIn);
+
+                    var status = document.createElement('div');
+                    status.className = 'up-status';
+
+                    var rm = document.createElement('span');
+                    rm.className = 'up-remove';
+                    rm.innerHTML = '&times;';
+                    rm.onclick = function () {
+                        if (item.done) return;
+                        var idx = queue.indexOf(item);
+                        if (idx >= 0) queue.splice(idx, 1);
+                        list.removeChild(row);
+                    };
+
+                    row.appendChild(img);
+                    row.appendChild(name);
+                    row.appendChild(size);
+                    row.appendChild(bar);
+                    row.appendChild(status);
+                    row.appendChild(rm);
+                    list.appendChild(row);
+
+                    item.barIn = barIn;
+                    item.status = status;
+                    item.nameEl = name;
+                    queue.push(item);
+                })(files[i]);
+            }
+        }
+
+        dz.addEventListener('click', function () { input.click(); });
+        input.addEventListener('change', function () { addFiles(input.files); input.value = ''; });
+
+        ['dragenter', 'dragover'].forEach(function (ev) {
+            dz.addEventListener(ev, function (e) { e.preventDefault(); e.stopPropagation(); dz.classList.add('up-over'); });
+        });
+        ['dragleave', 'drop'].forEach(function (ev) {
+            dz.addEventListener(ev, function (e) { e.preventDefault(); e.stopPropagation(); dz.classList.remove('up-over'); });
+        });
+        dz.addEventListener('drop', function (e) {
+            if (e.dataTransfer && e.dataTransfer.files) addFiles(e.dataTransfer.files);
+        });
+
+        function targetDirectory() {
+            if (uploadCanCreateDir) {
+                var nd = document.getElementById('uploadNewDir');
+                if (nd && nd.value.trim() !== '') return nd.value.trim();
+            }
+            var sel = document.getElementById('uploadDir');
+            return sel ? sel.value : '';
+        }
+
+        function showError(it, msg) {
+            it.status.className = 'up-status err';
+            it.status.innerHTML = '&#10007;';
+            it.status.title = msg;
+            if (it.nameEl) {
+                var em = document.createElement('span');
+                em.style.color = '#e0202e';
+                em.style.fontSize = '11px';
+                em.style.marginLeft = '6px';
+                em.textContent = '— ' + msg;
+                it.nameEl.appendChild(em);
+            }
+        }
+
+        function markSkipped(it) {
+            it.status.className = 'up-status';
+            it.status.style.color = '#a7a9ac';
+            it.status.innerHTML = '&#8210;';
+        }
+
+        btn.addEventListener('click', function () {
+            var dir = targetDirectory();
+            if (!dir) { alert(uploadSelectDirMsg); return; }
+
+            var pending = queue.filter(function (it) { return !it.done; });
+            if (pending.length === 0) return;
+
+            btn.disabled = true;
+            var comment = document.getElementById('uploadComment').value;
+            var hadError = false;
+            var batchOverwrite = null; // null = ask, true = overwrite all, false = skip all
+
+            // Upload one file; on a name clash the server replies {exists:true}
+            // and we ask the user whether to overwrite, then retry with overwrite=1
+            function sendFile(it, overwrite, onComplete) {
+                var fd = new FormData();
+                fd.append('filename', it.file);
+                fd.append('directory', dir);
+                fd.append('comment', comment);
+                fd.append('centreon_token', uploadToken);
+                if (overwrite) { fd.append('overwrite', '1'); }
+
+                var xhr = new XMLHttpRequest();
+                xhr.open('POST', './include/options/media/images/ajaxImagesUpload.php');
+                xhr.upload.onprogress = function (e) {
+                    if (e.lengthComputable) it.barIn.style.width = Math.round(e.loaded / e.total * 100) + '%';
+                };
+                xhr.onload = function () {
+                    var resp = {};
+                    try { resp = JSON.parse(xhr.responseText); } catch (err) {}
+                    if (resp.centreon_token) uploadToken = resp.centreon_token;
+
+                    if (resp.success) {
+                        it.done = true;
+                        it.barIn.style.width = '100%';
+                        it.status.className = 'up-status ok';
+                        it.status.innerHTML = '&#10003;';
+                        onComplete();
+                    } else if (resp.exists && !overwrite) {
+                        if (batchOverwrite === true) {
+                            sendFile(it, true, onComplete);
+                        } else if (batchOverwrite === false) {
+                            it.done = true; markSkipped(it); onComplete();
+                        } else {
+                            askOverwrite(it.file.name, function (decision) {
+                                if (decision === 'all') { batchOverwrite = true; sendFile(it, true, onComplete); }
+                                else if (decision === 'once') { sendFile(it, true, onComplete); }
+                                else if (decision === 'skipall') { batchOverwrite = false; it.done = true; markSkipped(it); onComplete(); }
+                                else { it.done = true; markSkipped(it); onComplete(); }
+                            });
+                        }
+                    } else {
+                        it.done = true;
+                        hadError = true;
+                        showError(it, resp.error || 'Upload error');
+                        onComplete();
+                    }
+                };
+                xhr.onerror = function () {
+                    it.done = true;
+                    hadError = true;
+                    showError(it, 'Network error');
+                    onComplete();
+                };
+                xhr.send(fd);
+            }
+
+            function next(i) {
+                if (i >= pending.length) {
+                    if (!hadError) {
+                        uploadDone();
+                    } else {
+                        // Some files failed: keep the panel open to show which, but
+                        // still refresh the list so the successful ones appear.
+                        btn.disabled = false;
+                        if (uploadInPanel()) { try { window.parent.imagesRefresh(); } catch (e) {} }
+                    }
+                    return;
+                }
+                sendFile(pending[i], false, function () { next(i + 1); });
+            }
+            next(0);
+        });
+    })();
+</script>
+{/literal}

--- a/centreon/www/include/options/media/images/formUpload.php
+++ b/centreon/www/include/options/media/images/formUpload.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+if (! isset($centreon)) {
+    exit();
+}
+
+$path = './include/options/media/images/';
+require_once './include/common/common-Func.php';
+
+$tpl = SmartyBC::createSmartyTemplate($path);
+
+$userCanSeeAllFolders = ((int) $centreon->user->admin === 1 || $centreon->user->access->hasAccessToAllImageFolders);
+
+// Directories the user is allowed to upload into
+$dirNames = array_values(getListDirectory());
+sort($dirNames);
+
+// Files are hard-capped at 2 MB by the upload endpoint, regardless of platform
+$maxSize = '2M';
+
+$tpl->assign('pageId', $p);
+$tpl->assign('directories', $dirNames);
+$tpl->assign('canCreateDir', $userCanSeeAllFolders ? 1 : 0);
+
+// Header
+$tpl->assign('pageTitle', _('Add Image(s)'));
+$tpl->assign('pageSubtitle', _('Drag and drop your images, or click to browse.'));
+
+// Labels
+$tpl->assign('wi_directory', _('Directory'));
+$tpl->assign('wi_newDirectory', _('New directory'));
+$tpl->assign('wi_comment', _('Comments'));
+$tpl->assign('wi_upload', _('Upload'));
+$tpl->assign('wi_cancel', _('Cancel'));
+$tpl->assign('wi_overwrite', _('Overwrite'));
+$tpl->assign('wi_overwriteAll', _('Overwrite all'));
+$tpl->assign('wi_skip', _('Skip'));
+$tpl->assign('wi_skipAll', _('Skip all'));
+$tpl->assign('wi_maxSize', sprintf(_('Allowed: JPG, PNG, GIF, SVG — max %s'), $maxSize));
+
+// JS-safe strings
+$jsonFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT;
+$tpl->assign('csrfTokenJs', json_encode(createCSRFToken(), $jsonFlags));
+$tpl->assign('selectDirJs', json_encode(_('Please choose or enter a directory.'), $jsonFlags));
+$tpl->assign('overwriteMsgJs', json_encode(_('"%s" already exists in this directory. Overwrite it?'), $jsonFlags));
+
+$tpl->display('formUpload.ihtml');

--- a/centreon/www/include/options/media/images/images.php
+++ b/centreon/www/include/options/media/images/images.php
@@ -28,7 +28,6 @@ const IMAGE_MODIFY = 'ci';
 const IMAGE_MODIFY_DIRECTORY = 'cd';
 const IMAGE_MOVE = 'm';
 const IMAGE_DELETE = 'd';
-const IMAGE_SYNC_DIR = 'sd';
 
 $imageId = filter_var(
     $_GET['img_id'] ?? $_POST['img_id'] ?? null,
@@ -80,9 +79,6 @@ switch ($o) {
             unvalidFormMessage();
         }
         require_once $path . 'listImg.php';
-        break;
-    case IMAGE_SYNC_DIR:
-        require_once $path . 'syncDir.php';
         break;
     default:
         require_once $path . 'listImg.php';

--- a/centreon/www/include/options/media/images/images.php
+++ b/centreon/www/include/options/media/images/images.php
@@ -48,8 +48,10 @@ require_once $path . 'DB-Func.php';
 require_once './include/common/common-Func.php';
 
 switch ($o) {
-    case IMAGE_MODIFY:
     case IMAGE_ADD:
+        require_once $path . 'formUpload.php';
+        break;
+    case IMAGE_MODIFY:
         require_once $path . 'formImg.php';
         break;
     case IMAGE_WATCH:

--- a/centreon/www/include/options/media/images/listImg.ihtml
+++ b/centreon/www/include/options/media/images/listImg.ihtml
@@ -1,86 +1,394 @@
-<script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<form {$form.attributes}>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Media{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchM" value="{$searchM}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td>
-				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-                {if isset($form.syncDir)}
-                    {$form.syncDir.html}
-                {/if}
-				<label >
-					{$availiableSpace} {$Available}
-				</label>
+<style>
+    {literal}
+    /* Aligned with the reporting charter (.rpt-title) */
+    .images-title-bar {
+        margin: 0 0 8px 0;
+        max-width: 1400px;
+    }
 
-			</td>
-            {pagination}
-		</tr>
-	</table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_img}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_comment}</td>
-        </tr>
+    .images-title {
+        margin: 0;
+        padding: 0;
+        font-size: 18px;
+        font-weight: 600;
+        color: var(--body-color, #2d3436);
+    }
 
-		{foreach from=$elemArr item=dir}
-			<tr class="list_lvl_1">
-			    <td class="ListColCenter">{$dir.head.RowMenu_select}</td>
-			    <td class="ListColLeft" colspan="3"><a href="{$dir.head.RowMenu_DirLink}"><b>{$dir.head.RowMenu_dir}</b></a>{if $dir.head.RowMenu_dir_cmnt}&nbsp;({$dir.head.RowMenu_dir_cmnt}){/if}</td>
-			</tr>
-			{cycle values='list_one,list_two' reset=true print=false advance=false}
-			{if $dir.head.counter > 0 }
-				{foreach item=img from=$dir.elem}
-					    <tr class="{cycle values='list_one,list_two'}">
-						<td class="ListColCenter">{$img.RowMenu_select}</td>
-						<td class="ListColLeft"><img src="./img/media/{$img.RowMenu_img}" alt="{$img.RowMenu_name}" width="16" height="16">&nbsp;<a href="{$img.RowMenu_ImgLink}">{$img.RowMenu_name}</a></td>
-						<td class="ListColLeft"><a href="{$img.RowMenu_ImgLink}">{$img.RowMenu_img}</a></td>
-						<td class="ListColLeft">{$img.RowMenu_comment}</td>
-					    </tr>
-				{/foreach}
-			{else}
-				<tr class="list_one">
-					<td class="ListColLeft" colspan=4>&nbsp;&nbsp;&nbsp;&nbsp;<i>{$dir.head.RowMenu_empty}</i></td>
-				</tr>
-			{/if}
-		{/foreach}
-	</table>
-	<table class="ToolbarTable table">
-		<tr class="ToolbarTR">
-			<td>
-				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-                {if isset($form.syncDir)}
-                    {$form.syncDir.html}
+    .images-subtitle {
+        margin: 4px 0 0;
+        font-size: 12px;
+        line-height: 1.45;
+        color: var(--body-color, #6f7384);
+        opacity: 0.75;
+        max-width: 760px;
+    }
+
+    .cl-listing-table tbody tr.cl-dir-row td {
+        background: var(--list-lvl-1-background-color, #f5f5f0);
+        font-weight: 600;
+    }
+
+    .cl-dir-cmnt {
+        font-weight: 400;
+        opacity: 0.7;
+    }
+
+    .cl-dir-empty {
+        padding-left: 28px !important;
+        color: #a7a9ac;
+    }
+
+    .cl-thumb {
+        width: 20px;
+        height: 20px;
+        vertical-align: middle;
+        margin-right: 6px;
+        object-fit: contain;
+    }
+
+    /* Uniform action-bar buttons (same height/padding for Add, Delete, Sync) */
+    .cl-actions-left .cl-btn-add,
+    .cl-actions-left button.btc {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        height: 34px;
+        padding: 0 16px;
+        font-size: 13px;
+        line-height: 1;
+        box-sizing: border-box;
+        border-radius: 4px;
+        vertical-align: middle;
+    }
+
+    /* Slide-in side panel (same pattern as the pollers configuration page) */
+    .cf-side-overlay {
+        position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+        background: rgba(0, 0, 0, 0.3);
+        z-index: 9998; opacity: 0; visibility: hidden;
+        transition: opacity 0.25s, visibility 0.25s;
+    }
+    .cf-side-overlay.open { opacity: 1; visibility: visible; }
+
+    .cf-side-panel {
+        position: fixed; top: 0; right: 0;
+        width: 55vw; min-width: 400px; max-width: 95vw; height: 100vh;
+        background: var(--body-background, #fff);
+        box-shadow: -4px 0 24px rgba(0, 0, 0, 0.3);
+        z-index: 9999; transform: translateX(100%);
+        transition: transform 0.3s ease;
+        display: flex; flex-direction: column;
+    }
+    .cf-side-panel.open { transform: translateX(0); }
+
+    .cf-side-panel-resize {
+        position: absolute; left: 0; top: 0; bottom: 0; width: 5px;
+        cursor: col-resize; z-index: 10; background: transparent;
+        transition: background 0.15s;
+    }
+    .cf-side-panel-resize:hover, .cf-side-panel-resize.active { background: var(--color-primary, #009fdf); }
+
+    .cf-side-panel-header {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 12px 20px; border-bottom: 1px solid var(--color-divider, #e3e3e3);
+        background: var(--body-background, #fff); flex-shrink: 0;
+    }
+    .cf-side-panel-title { font-size: 16px; font-weight: 600; color: var(--list-color, #333); }
+    .cf-side-panel-close {
+        background: none; border: none; font-size: 22px; color: var(--body-color, #999);
+        cursor: pointer; padding: 4px 8px; border-radius: 4px; line-height: 1;
+        transition: background 0.15s, color 0.15s;
+    }
+    .cf-side-panel-close:hover { background: var(--color-divider, #e8e8e8); color: var(--list-color, #333); }
+    .cf-side-panel-body { flex: 1; overflow: hidden; }
+    .cf-side-panel-body iframe { width: 100%; height: 100%; border: none; }
+    {/literal}
+</style>
+
+<div class="images-title-bar">
+    <h2 class="images-title">{$pageTitle}</h2>
+    <p class="images-subtitle">{$pageSubtitle}</p>
+</div>
+
+<form name="form" id="Form">
+    <div class="cl-filter-box">
+        <div class="cl-filter-bar">
+            <input type="text" id="clSearchInput" name="search" value="" class="cl-search-input" placeholder="{t}Name or directory{/t}" style="width:220px;">
+            <button type="button" id="clSearchBtn" class="btc bt_success">{$wi_search}</button>
+        </div>
+    </div>
+
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('./main.get.php?p={$pageId}&o=a', imagesAddTitle); return false;">{$wi_add}</a>
+                {if $writeAccess == 1}
+                    <button type="button" class="btc bt_danger" onclick="imagesDelete();">{$wi_delete}</button>
                 {/if}
-				<a >
-					{$availiableSpace}  {$Available}
-				</a>
-			</td>
-			
-            {pagination}
-		</tr>
-	</table>
-<input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
-{$form.hidden}
+                {if $isAdmin == 1}
+                    <button type="button" class="btc bt_info" onclick="imagesSyncPopup();">{$wi_sync}</button>
+                {/if}
+                {if $availableSpace != ''}<span class="cl-filter-label">{$availableSpace}&nbsp;{$wi_available}</span>{/if}
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    {if $writeAccess == 1}
+                        <th class="cl-col-picker">
+                            <div class="md-checkbox md-checkbox-inline">
+                                <input type="checkbox" id="checkall" onclick="imagesCheckAll(this);" />
+                                <label class="empty-label" for="checkall"></label>
+                            </div>
+                        </th>
+                    {/if}
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_img}</th>
+                    <th>{$headerMenu_comment}</th>
+                    <th class="cl-col-center">{$headerMenu_size}</th>
+                    <th class="cl-col-center">{$headerMenu_date}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="{if $writeAccess == 1}6{else}5{/if}" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            <div>&nbsp;</div>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
+    <input type="hidden" id="limit" name="limit" value="">
 </form>
+
+<!-- Side panel (hosts the add/upload form, loaded as a chrome-less fragment) -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button type="button" class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
+<script type="text/javascript">
+    var imagesPageId       = '{$pageId}';
+    var imagesIsAdmin      = {if $isAdmin == 1}true{else}false{/if};
+    var imagesWriteAccess  = {if $writeAccess == 1}true{else}false{/if};
+    var imagesDefaultLimit = {$defaultLimit};
+    var imagesEmptyMessage = {$emptyMessageJs};
+    var imagesEmptyDir     = {$emptyDirJs};
+    var imagesDelConfirm   = {$delConfirmJs};
+    var imagesAddTitle     = {$addTitleJs};
+</script>
+
+{literal}
+<script type="text/javascript">
+    // If this listing is rendered inside the side panel (e.g. after an edit form
+    // save redirects to the list), close the panel and let the parent refresh.
+    if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+        try { window.parent.cfClosePanel(); } catch (e) {}
+    }
+
+    (function () {
+        window.imagesListing = new CentreonListing({
+            instanceName:  'imagesListing',
+            ajaxListUrl:   './include/options/media/images/ajaxImagesListing.php',
+            pageId:        imagesPageId,
+            writeAccess:   imagesWriteAccess,
+            storageKey:    'images_listing_limit',
+            defaultLimit:  imagesDefaultLimit,
+            autoRefresh:   0,
+            showCheckboxes: false,
+            emptyMessage:  imagesEmptyMessage,
+            columns:       [{ id: 'name' }, { id: 'image' }, { id: 'comment' }]
+        });
+
+        // Custom grouped rendering: a directory header row followed by its images.
+        // Assigned on the instance (the listing calls self.renderRows internally).
+        imagesListing.renderRows = function (rows) {
+            var self    = this;
+            var picker  = imagesWriteAccess;
+            var nbCols  = picker ? 6 : 5;
+            var tbody   = jQuery('#clTableBody');
+            tbody.empty();
+
+            if (!rows || rows.length === 0) {
+                tbody.html('<tr><td colspan="' + nbCols + '" style="text-align:center;padding:24px;color:#a7a9ac;">'
+                    + self.escape(imagesEmptyMessage) + '</td></tr>');
+                return;
+            }
+
+            function dirCheckbox(dirId) {
+                return '<td class="cl-col-picker"><div class="md-checkbox md-checkbox-inline">'
+                    + '<input type="checkbox" id="seldir_' + dirId + '" class="img-check" data-selector="' + dirId + '"'
+                        + ' data-dir-parent="' + dirId + '" onclick="imagesToggleDir(this);" />'
+                    + '<label class="empty-label" for="seldir_' + dirId + '"></label></div></td>';
+            }
+
+            function imgCheckbox(dirId, imgId) {
+                return '<td class="cl-col-picker"><div class="md-checkbox md-checkbox-inline">'
+                    + '<input type="checkbox" id="selimg_' + imgId + '" class="img-check img-child" data-selector="' + dirId + '-' + imgId + '"'
+                        + ' data-dir="' + dirId + '" />'
+                    + '<label class="empty-label" for="selimg_' + imgId + '"></label></div></td>';
+            }
+
+            var lastDir = null;
+            var html = '';
+            for (var i = 0; i < rows.length; i++) {
+                var row = rows[i];
+
+                if (row.dir_id !== lastDir) {
+                    lastDir = row.dir_id;
+                    html += '<tr class="cl-dir-row">'
+                        + (picker ? dirCheckbox(row.dir_id) : '')
+                        + '<td colspan="5">'
+                            + '<a href="./main.php?p=' + imagesPageId + '&o=cd&dir_id=' + row.dir_id + '"><b>'
+                                + self.escape(row.dir_name) + '</b></a>'
+                            + (row.dir_comment ? ' <span class="cl-dir-cmnt">(' + self.escape(row.dir_comment) + ')</span>' : '')
+                        + '</td></tr>';
+                }
+
+                if (row.img_id) {
+                    var editUrl = './main.php?p=' + imagesPageId + '&o=ci&img_id=' + row.img_id;
+                    html += '<tr>'
+                        + (picker ? imgCheckbox(row.dir_id, row.img_id) : '')
+                        + '<td><img src="./img/media/' + encodeURI(row.img_path) + '" alt="" class="cl-thumb" onerror="this.style.visibility=\'hidden\';" /> '
+                            + '<a href="' + editUrl + '">' + self.escape(row.img_name) + '</a></td>'
+                        + '<td><a href="' + editUrl + '">' + self.escape(row.img_path) + '</a></td>'
+                        + '<td>' + self.escape(row.img_comment) + '</td>'
+                        + '<td class="cl-col-center">' + imagesHumanSize(row.size) + '</td>'
+                        + '<td class="cl-col-center">' + imagesFormatDate(row.mtime) + '</td>'
+                        + '</tr>';
+                } else {
+                    html += '<tr>'
+                        + (picker ? '<td class="cl-col-picker"></td>' : '')
+                        + '<td colspan="5" class="cl-dir-empty"><i>' + self.escape(imagesEmptyDir) + '</i></td>'
+                        + '</tr>';
+                }
+            }
+            tbody.append(html);
+        };
+
+        imagesListing.init();
+    })();
+
+    // Human-readable file size
+    function imagesHumanSize(b) {
+        if (b === null || b === undefined) { return '-'; }
+        if (b < 1024) { return b + ' B'; }
+        if (b < 1048576) { return (b / 1024).toFixed(1) + ' KB'; }
+        return (b / 1048576).toFixed(2) + ' MB';
+    }
+
+    // File modification date (from a unix timestamp)
+    function imagesFormatDate(ts) {
+        if (!ts) { return '-'; }
+        var d = new Date(ts * 1000);
+        return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+
+    // Select / deselect every checkbox
+    function imagesCheckAll(master) {
+        jQuery('#clTableBody input.img-check').prop('checked', master.checked);
+    }
+
+    // A directory checkbox toggles all of its images
+    function imagesToggleDir(cb) {
+        var dirId = cb.getAttribute('data-dir-parent');
+        jQuery('#clTableBody input.img-child[data-dir="' + dirId + '"]').prop('checked', cb.checked);
+    }
+
+    // Delete the selected images and/or directories (AJAX), then refresh the list
+    function imagesDelete() {
+        var selection = {};
+        jQuery('#clTableBody input.img-check:checked').each(function () {
+            selection[jQuery(this).attr('data-selector')] = 1;
+        });
+        if (jQuery.isEmptyObject(selection)) {
+            return;
+        }
+        if (!confirm(imagesDelConfirm)) {
+            return;
+        }
+        jQuery.ajax({
+            url: './include/options/media/images/ajaxImagesDelete.php',
+            type: 'POST',
+            dataType: 'json',
+            data: { select: selection, centreon_token: imagesListing.getCsrfToken() },
+            success: function (resp) {
+                if (resp && resp.centreon_token) {
+                    imagesListing.setCsrfToken(resp.centreon_token);
+                }
+                var checkall = document.getElementById('checkall');
+                if (checkall) {
+                    checkall.checked = false;
+                }
+                var s = imagesListing.getState();
+                imagesListing.fetch(s.num, s.limit, s.search, true);
+            }
+        });
+    }
+
+    // Synchronize media directories from disk (legacy popup, kept for now)
+    function imagesSyncPopup() {
+        window.open(
+            './main.get.php?p=' + imagesPageId + '&o=sd&min=1',
+            '',
+            'toolbar=no,location=no,status=no,scrollbars=yes,resizable=yes,width=350,height=250'
+        );
+    }
+
+    // ----- Side panel (loads the add form as a chrome-less fragment) -----
+    function cfOpenPanel(url, title) {
+        document.getElementById('cfSidePanelTitle').textContent = title || '';
+        document.getElementById('cfSidePanelFrame').src = url;
+        document.getElementById('cfSideOverlay').classList.add('open');
+        document.getElementById('cfSidePanel').classList.add('open');
+    }
+    function cfClosePanel() {
+        document.getElementById('cfSideOverlay').classList.remove('open');
+        document.getElementById('cfSidePanel').classList.remove('open');
+        setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+        imagesRefresh();
+    }
+    // Refresh the listing in place (used after uploads, with or without closing the panel)
+    function imagesRefresh() {
+        var s = imagesListing.getState();
+        imagesListing.fetch(s.num, s.limit, s.search, true);
+    }
+    (function () {
+        var handle = document.getElementById('cfSidePanelResize');
+        var panel = document.getElementById('cfSidePanel');
+        var dragging = false;
+        handle.addEventListener('mousedown', function (e) {
+            e.preventDefault(); dragging = true; handle.classList.add('active');
+            document.body.style.cursor = 'col-resize';
+            var iframe = document.getElementById('cfSidePanelFrame');
+            if (iframe) iframe.style.pointerEvents = 'none';
+        });
+        document.addEventListener('mousemove', function (e) {
+            if (!dragging) return;
+            var w = window.innerWidth - e.clientX;
+            if (w < 400) w = 400;
+            if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+            panel.style.width = w + 'px';
+        });
+        document.addEventListener('mouseup', function () {
+            if (!dragging) return; dragging = false; handle.classList.remove('active');
+            document.body.style.cursor = '';
+            var iframe = document.getElementById('cfSidePanelFrame');
+            if (iframe) iframe.style.pointerEvents = '';
+        });
+    })();
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
+</script>
+{/literal}

--- a/centreon/www/include/options/media/images/listImg.ihtml
+++ b/centreon/www/include/options/media/images/listImg.ihtml
@@ -111,6 +111,52 @@
     .cf-side-panel-close:hover { background: var(--color-divider, #e8e8e8); color: var(--list-color, #333); }
     .cf-side-panel-body { flex: 1; overflow: hidden; }
     .cf-side-panel-body iframe { width: 100%; height: 100%; border: none; }
+
+    /* Lightweight modal (e.g. New folder) */
+    .cl-modal-overlay {
+        position: fixed; inset: 0; z-index: 10000;
+        background: rgba(0, 0, 0, 0.45);
+        display: none; align-items: center; justify-content: center;
+    }
+    .cl-modal-overlay.open { display: flex; }
+    .cl-modal {
+        background: #fff; width: 420px; max-width: calc(100vw - 32px);
+        border-radius: 8px; box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+        overflow: hidden; animation: clModalIn 0.12s ease-out;
+    }
+    @keyframes clModalIn {
+        from { transform: translateY(-8px); opacity: 0; }
+        to   { transform: none; opacity: 1; }
+    }
+    .cl-modal-header {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 14px 18px; border-bottom: 1px solid var(--color-divider, #e8e8e8);
+        font-size: 16px; font-weight: 600; color: var(--list-color, #333);
+    }
+    .cl-modal-close {
+        border: 0; background: none; font-size: 22px; line-height: 1; cursor: pointer;
+        color: #888; border-radius: 4px; width: 28px; height: 28px;
+    }
+    .cl-modal-close:hover { background: var(--color-divider, #e8e8e8); color: #333; }
+    .cl-modal-body { padding: 18px; }
+    .cl-modal-label {
+        display: block; font-size: 12px; font-weight: 600; color: #6c6c6c; margin-bottom: 6px;
+    }
+    .cl-modal-input {
+        width: 100%; box-sizing: border-box; padding: 9px 11px;
+        border: 1px solid var(--c-stroke, #d0d5dd); border-radius: 6px;
+        font-size: 14px; outline: none;
+    }
+    .cl-modal-input:focus {
+        border-color: var(--color-primary, #009fdf);
+        box-shadow: 0 0 0 3px rgba(0, 159, 223, 0.15);
+    }
+    .cl-modal-hint { font-size: 11px; color: #a7a9ac; margin-top: 6px; }
+    .cl-modal-error { font-size: 12px; color: #d9534f; margin-top: 8px; min-height: 14px; }
+    .cl-modal-footer {
+        display: flex; justify-content: flex-end; gap: 8px;
+        padding: 14px 18px; border-top: 1px solid var(--color-divider, #e8e8e8); background: #fafafa;
+    }
     {/literal}
 </style>
 
@@ -130,8 +176,8 @@
                 {if $writeAccess == 1}
                     <button type="button" class="btc bt_danger" onclick="imagesDelete();">{$wi_delete}</button>
                 {/if}
-                {if $isAdmin == 1}
-                    <button type="button" class="btc bt_info" onclick="imagesSyncPopup();">{$wi_sync}</button>
+                {if $canCreateFolder == 1}
+                    <button type="button" id="imagesSyncBtn" class="btc bt_info" onclick="imagesSync();">{$wi_sync}</button>
                 {/if}
                 {if $availableSpace != ''}<span class="cl-filter-label">{$availableSpace}&nbsp;{$wi_available}</span>{/if}
             </div>
@@ -190,6 +236,26 @@
     </div>
 </div>
 
+<div class="cl-modal-overlay" id="imagesDirModal" onclick="if(event.target===this)imagesDirModalClose();">
+    <div class="cl-modal" role="dialog" aria-modal="true" aria-labelledby="imagesDirModalTitle">
+        <div class="cl-modal-header">
+            <span id="imagesDirModalTitle">{t}New folder{/t}</span>
+            <button type="button" class="cl-modal-close" onclick="imagesDirModalClose();" aria-label="{t}Close{/t}">&times;</button>
+        </div>
+        <div class="cl-modal-body">
+            <label class="cl-modal-label" for="imagesDirName">{t}Directory name{/t}</label>
+            <input type="text" id="imagesDirName" class="cl-modal-input" maxlength="255" autocomplete="off"
+                   placeholder="{t}e.g. my-folder{/t}" onkeydown="imagesDirModalKey(event);">
+            <div class="cl-modal-hint">{t}Allowed characters: letters, digits, "-" and "_".{/t}</div>
+            <div class="cl-modal-error" id="imagesDirError"></div>
+        </div>
+        <div class="cl-modal-footer">
+            <button type="button" class="btc bt_default" onclick="imagesDirModalClose();">{t}Cancel{/t}</button>
+            <button type="button" class="btc bt_success" id="imagesDirCreateBtn" onclick="imagesCreateDirSubmit();">{t}Create{/t}</button>
+        </div>
+    </div>
+</div>
+
 <script type="text/javascript">
     var imagesPageId       = '{$pageId}';
     var imagesIsAdmin      = {if $isAdmin == 1}true{else}false{/if};
@@ -201,9 +267,10 @@
     var imagesAddTitle     = {$addTitleJs};
     var imagesMoveOk       = {$moveOkJs};
     var imagesMoveKo       = {$moveKoJs};
-    var imagesNewFolderPrompt = {$newFolderPromptJs};
     var imagesFolderCreated   = {$folderCreatedJs};
     var imagesFolderInvalid   = {$folderInvalidJs};
+    var imagesSyncDone        = {$syncDoneJs};
+    var imagesSyncKo          = {$syncKoJs};
 </script>
 
 {literal}
@@ -390,16 +457,36 @@
         });
     }
 
-    // Create a new (empty) directory, then refresh the list
+    // Open the "New folder" modal
     function imagesCreateDir() {
-        var name = window.prompt(imagesNewFolderPrompt, '');
-        if (name === null) { return; }
-        name = jQuery.trim(name);
-        if (name === '') { return; }
-        if (!/^[A-Za-z0-9_-]+$/.test(name)) {
-            if (window.clToast) { clToast(imagesFolderInvalid, 'error'); }
+        var input = document.getElementById('imagesDirName');
+        var err   = document.getElementById('imagesDirError');
+        if (err) { err.textContent = ''; }
+        if (input) { input.value = ''; }
+        document.getElementById('imagesDirModal').classList.add('open');
+        if (input) { setTimeout(function () { input.focus(); }, 30); }
+    }
+
+    function imagesDirModalClose() {
+        document.getElementById('imagesDirModal').classList.remove('open');
+    }
+
+    function imagesDirModalKey(ev) {
+        if (ev.key === 'Enter') { ev.preventDefault(); imagesCreateDirSubmit(); }
+        else if (ev.key === 'Escape') { imagesDirModalClose(); }
+    }
+
+    // Create a new (empty) directory from the modal, then refresh the list
+    function imagesCreateDirSubmit() {
+        var input = document.getElementById('imagesDirName');
+        var err   = document.getElementById('imagesDirError');
+        var btn   = document.getElementById('imagesDirCreateBtn');
+        var name  = jQuery.trim(input ? input.value : '');
+        if (name === '' || !/^[A-Za-z0-9_-]+$/.test(name)) {
+            if (err) { err.textContent = imagesFolderInvalid; }
             return;
         }
+        if (btn) { btn.disabled = true; }
         jQuery.ajax({
             url: './include/options/media/images/ajaxImagesCreateDir.php',
             type: 'POST',
@@ -410,15 +497,19 @@
                     imagesListing.setCsrfToken(resp.centreon_token);
                 }
                 if (resp && resp.success) {
+                    imagesDirModalClose();
                     if (window.clToast) { clToast(imagesFolderCreated, 'success'); }
                     var s = imagesListing.getState();
                     imagesListing.fetch(s.num, s.limit, s.search, true);
-                } else if (window.clToast) {
-                    clToast((resp && resp.error) ? resp.error : imagesFolderInvalid, 'error');
+                } else if (err) {
+                    err.textContent = (resp && resp.error) ? resp.error : imagesFolderInvalid;
                 }
             },
             error: function () {
-                if (window.clToast) { clToast(imagesFolderInvalid, 'error'); }
+                if (err) { err.textContent = imagesFolderInvalid; }
+            },
+            complete: function () {
+                if (btn) { btn.disabled = false; }
             }
         });
     }
@@ -454,13 +545,40 @@
         });
     }
 
-    // Synchronize media directories from disk (legacy popup, kept for now)
-    function imagesSyncPopup() {
-        window.open(
-            './main.get.php?p=' + imagesPageId + '&o=sd&min=1',
-            '',
-            'toolbar=no,location=no,status=no,scrollbars=yes,resizable=yes,width=350,height=250'
-        );
+    // Synchronize the media library from disk (AJAX), report a summary and refresh
+    function imagesSync() {
+        var btn = document.getElementById('imagesSyncBtn');
+        if (btn) { btn.disabled = true; }
+        jQuery.ajax({
+            url: './include/options/media/images/ajaxImagesSync.php',
+            type: 'POST',
+            dataType: 'json',
+            data: { centreon_token: imagesListing.getCsrfToken() },
+            success: function (resp) {
+                if (resp && resp.centreon_token) {
+                    imagesListing.setCsrfToken(resp.centreon_token);
+                }
+                if (resp && resp.success) {
+                    var s = resp.stats || {};
+                    var summary = imagesSyncDone
+                        .replace('%d1', s.dirCreated || 0)
+                        .replace('%d2', s.regCounter || 0)
+                        .replace('%d3', s.gdCounter || 0)
+                        .replace('%d4', s.fileRemoved || 0);
+                    if (window.clToast) { clToast(summary, 'success'); }
+                    var st = imagesListing.getState();
+                    imagesListing.fetch(st.num, st.limit, st.search, true);
+                } else if (window.clToast) {
+                    clToast((resp && resp.error) ? resp.error : imagesSyncKo, 'error');
+                }
+            },
+            error: function () {
+                if (window.clToast) { clToast(imagesSyncKo, 'error'); }
+            },
+            complete: function () {
+                if (btn) { btn.disabled = false; }
+            }
+        });
     }
 
     // ----- Side panel (loads the add form as a chrome-less fragment) -----

--- a/centreon/www/include/options/media/images/listImg.ihtml
+++ b/centreon/www/include/options/media/images/listImg.ihtml
@@ -46,6 +46,14 @@
         object-fit: contain;
     }
 
+    /* Drag & drop: move an image onto another directory */
+    .cl-listing-table tbody tr.cl-img-row[draggable="true"] { cursor: grab; }
+    .cl-listing-table tbody tr.cl-img-dragging { opacity: 0.45; }
+    .cl-listing-table tbody tr.cl-dir-row.cl-dir-drop td {
+        background: var(--primary-100, #e3f0ff);
+        box-shadow: inset 0 0 0 2px var(--primary, #009fdf);
+    }
+
     /* Uniform action-bar buttons (same height/padding for Add, Delete, Sync) */
     .cl-actions-left .cl-btn-add,
     .cl-actions-left button.btc {
@@ -112,17 +120,13 @@
 </div>
 
 <form name="form" id="Form">
-    <div class="cl-filter-box">
-        <div class="cl-filter-bar">
-            <input type="text" id="clSearchInput" name="search" value="" class="cl-search-input" placeholder="{t}Name or directory{/t}" style="width:220px;">
-            <button type="button" id="clSearchBtn" class="btc bt_success">{$wi_search}</button>
-        </div>
-    </div>
-
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             <div class="cl-actions-left">
                 <a href="#" class="cl-btn-add" onclick="cfOpenPanel('./main.get.php?p={$pageId}&o=a', imagesAddTitle); return false;">{$wi_add}</a>
+                {if $canCreateFolder == 1}
+                    <button type="button" class="btc bt_default" onclick="imagesCreateDir();">{t}New folder{/t}</button>
+                {/if}
                 {if $writeAccess == 1}
                     <button type="button" class="btc bt_danger" onclick="imagesDelete();">{$wi_delete}</button>
                 {/if}
@@ -131,7 +135,14 @@
                 {/if}
                 {if $availableSpace != ''}<span class="cl-filter-label">{$availableSpace}&nbsp;{$wi_available}</span>{/if}
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="search" value="" class="cl-search-simple" placeholder="{t}Search name or directory{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
         </div>
 
         <table class="cl-listing-table">
@@ -188,6 +199,11 @@
     var imagesEmptyDir     = {$emptyDirJs};
     var imagesDelConfirm   = {$delConfirmJs};
     var imagesAddTitle     = {$addTitleJs};
+    var imagesMoveOk       = {$moveOkJs};
+    var imagesMoveKo       = {$moveKoJs};
+    var imagesNewFolderPrompt = {$newFolderPromptJs};
+    var imagesFolderCreated   = {$folderCreatedJs};
+    var imagesFolderInvalid   = {$folderInvalidJs};
 </script>
 
 {literal}
@@ -207,6 +223,7 @@
             storageKey:    'images_listing_limit',
             defaultLimit:  imagesDefaultLimit,
             autoRefresh:   0,
+            liveSearch:    true,
             showCheckboxes: false,
             emptyMessage:  imagesEmptyMessage,
             columns:       [{ id: 'name' }, { id: 'image' }, { id: 'comment' }]
@@ -248,7 +265,9 @@
 
                 if (row.dir_id !== lastDir) {
                     lastDir = row.dir_id;
-                    html += '<tr class="cl-dir-row">'
+                    html += '<tr class="cl-dir-row" data-dir-id="' + row.dir_id + '"'
+                            + (picker ? ' ondragover="imagesDragOver(event)" ondragleave="imagesDragLeave(event)" ondrop="imagesDrop(event,' + row.dir_id + ')"' : '')
+                            + '>'
                         + (picker ? dirCheckbox(row.dir_id) : '')
                         + '<td colspan="5">'
                             + '<a href="./main.php?p=' + imagesPageId + '&o=cd&dir_id=' + row.dir_id + '"><b>'
@@ -258,12 +277,16 @@
                 }
 
                 if (row.img_id) {
-                    var editUrl = './main.php?p=' + imagesPageId + '&o=ci&img_id=' + row.img_id;
-                    html += '<tr>'
+                    var editUrl = './main.get.php?p=' + imagesPageId + '&o=ci&img_id=' + row.img_id;
+                    var openImg = 'cfOpenPanel(\'' + editUrl + '\', \'' + self.escape(row.img_name) + '\'); return false;';
+                    html += '<tr class="cl-img-row"'
+                            + (picker ? ' draggable="true" data-img-id="' + row.img_id + '" data-dir-id="' + row.dir_id + '"'
+                                + ' ondragstart="imagesDragStart(event,' + row.img_id + ',' + row.dir_id + ')" ondragend="imagesDragEnd(event)"' : '')
+                            + '>'
                         + (picker ? imgCheckbox(row.dir_id, row.img_id) : '')
                         + '<td><img src="./img/media/' + encodeURI(row.img_path) + '" alt="" class="cl-thumb" onerror="this.style.visibility=\'hidden\';" /> '
-                            + '<a href="' + editUrl + '">' + self.escape(row.img_name) + '</a></td>'
-                        + '<td><a href="' + editUrl + '">' + self.escape(row.img_path) + '</a></td>'
+                            + '<a href="#" onclick="' + openImg + '">' + self.escape(row.img_name) + '</a></td>'
+                        + '<td><a href="#" onclick="' + openImg + '">' + self.escape(row.img_path) + '</a></td>'
                         + '<td>' + self.escape(row.img_comment) + '</td>'
                         + '<td class="cl-col-center">' + imagesHumanSize(row.size) + '</td>'
                         + '<td class="cl-col-center">' + imagesFormatDate(row.mtime) + '</td>'
@@ -305,6 +328,99 @@
     function imagesToggleDir(cb) {
         var dirId = cb.getAttribute('data-dir-parent');
         jQuery('#clTableBody input.img-child[data-dir="' + dirId + '"]').prop('checked', cb.checked);
+    }
+
+    // --- Drag & drop: move an image to another directory ------------------
+    var imagesDragId = null;
+
+    function imagesDragStart(ev, imgId, fromDirId) {
+        imagesDragId = { imgId: imgId, fromDirId: fromDirId };
+        ev.dataTransfer.effectAllowed = 'move';
+        try { ev.dataTransfer.setData('text/plain', String(imgId)); } catch (e) {}
+        ev.currentTarget.classList.add('cl-img-dragging');
+    }
+
+    function imagesDragEnd(ev) {
+        ev.currentTarget.classList.remove('cl-img-dragging');
+        jQuery('#clTableBody tr.cl-dir-drop').removeClass('cl-dir-drop');
+    }
+
+    function imagesDragOver(ev) {
+        if (!imagesDragId) { return; }
+        ev.preventDefault();
+        ev.dataTransfer.dropEffect = 'move';
+        ev.currentTarget.classList.add('cl-dir-drop');
+    }
+
+    function imagesDragLeave(ev) {
+        ev.currentTarget.classList.remove('cl-dir-drop');
+    }
+
+    function imagesDrop(ev, dirId) {
+        ev.preventDefault();
+        ev.currentTarget.classList.remove('cl-dir-drop');
+        if (!imagesDragId) { return; }
+        var imgId = imagesDragId.imgId;
+        // Dropping onto the directory it already belongs to: nothing to do
+        if (parseInt(imagesDragId.fromDirId, 10) === parseInt(dirId, 10)) {
+            imagesDragId = null;
+            return;
+        }
+        imagesDragId = null;
+        jQuery.ajax({
+            url: './include/options/media/images/ajaxImagesMove.php',
+            type: 'POST',
+            dataType: 'json',
+            data: { img_id: imgId, dir_id: dirId, centreon_token: imagesListing.getCsrfToken() },
+            success: function (resp) {
+                if (resp && resp.centreon_token) {
+                    imagesListing.setCsrfToken(resp.centreon_token);
+                }
+                if (resp && resp.success) {
+                    if (window.clToast) { clToast(imagesMoveOk, 'success'); }
+                    var s = imagesListing.getState();
+                    imagesListing.fetch(s.num, s.limit, s.search, true);
+                } else if (window.clToast) {
+                    clToast((resp && resp.error) ? resp.error : imagesMoveKo, 'error');
+                }
+            },
+            error: function () {
+                if (window.clToast) { clToast(imagesMoveKo, 'error'); }
+            }
+        });
+    }
+
+    // Create a new (empty) directory, then refresh the list
+    function imagesCreateDir() {
+        var name = window.prompt(imagesNewFolderPrompt, '');
+        if (name === null) { return; }
+        name = jQuery.trim(name);
+        if (name === '') { return; }
+        if (!/^[A-Za-z0-9_-]+$/.test(name)) {
+            if (window.clToast) { clToast(imagesFolderInvalid, 'error'); }
+            return;
+        }
+        jQuery.ajax({
+            url: './include/options/media/images/ajaxImagesCreateDir.php',
+            type: 'POST',
+            dataType: 'json',
+            data: { name: name, centreon_token: imagesListing.getCsrfToken() },
+            success: function (resp) {
+                if (resp && resp.centreon_token) {
+                    imagesListing.setCsrfToken(resp.centreon_token);
+                }
+                if (resp && resp.success) {
+                    if (window.clToast) { clToast(imagesFolderCreated, 'success'); }
+                    var s = imagesListing.getState();
+                    imagesListing.fetch(s.num, s.limit, s.search, true);
+                } else if (window.clToast) {
+                    clToast((resp && resp.error) ? resp.error : imagesFolderInvalid, 'error');
+                }
+            },
+            error: function () {
+                if (window.clToast) { clToast(imagesFolderInvalid, 'error'); }
+            }
+        });
     }
 
     // Delete the selected images and/or directories (AJAX), then refresh the list

--- a/centreon/www/include/options/media/images/listImg.php
+++ b/centreon/www/include/options/media/images/listImg.php
@@ -18,271 +18,69 @@
  *
  */
 
-use Adaptation\Database\Connection\Collection\QueryParameters;
-use Adaptation\Database\Connection\Exception\ConnectionException;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
-use Core\Common\Domain\Exception\CollectionException;
-use Core\Common\Domain\Exception\RepositoryException;
-use Core\Common\Domain\Exception\ValueObjectException;
-use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
-
 if (! isset($centreon)) {
     exit();
 }
 
-include './include/common/autoNumLimit.php';
-include_once './class/centreonUtils.class.php';
-
-$search = null;
-if (isset($_POST['searchM'])) {
-    $centreon->historySearch[$url] = CentreonUtils::escapeSecure(
-        $_POST['searchM'],
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    );
-    $search = $centreon->historySearch[$url];
-} elseif (isset($_GET['searchM'])) {
-    $centreon->historySearch[$url] = CentreonUtils::escapeSecure(
-        $_GET['searchM'],
-        CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-    );
-    $search = $centreon->historySearch[$url];
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-try {
-    $queryParameters = [];
-    $selectQuery = <<<'SQL'
-            SELECT
-                images.*,
-                directories.*
-        SQL;
-    if (
-        $centreon->user->admin === '1'
-        || $centreon->user->access->hasAccessToAllImageFolders
-    ) {
-        $bodyQuery = <<<'SQL'
-                FROM view_img_dir AS `directories`
-                LEFT JOIN view_img_dir_relation AS `vidr`
-                    ON vidr.dir_dir_parent_id = directories.dir_id
-                LEFT JOIN view_img AS `images`
-                    ON images.img_id = vidr.img_img_id
-            SQL;
-    } else {
-        $bodyQuery = <<<'SQL'
-                FROM view_img_dir AS `directories`
-                LEFT JOIN view_img_dir_relation AS `vidr`
-                    ON vidr.dir_dir_parent_id = directories.dir_id
-                LEFT JOIN view_img AS `images`
-                    ON images.img_id = vidr.img_img_id
-                INNER JOIN acl_resources_image_folder_relations armdr
-                    ON armdr.dir_id = vidr.dir_dir_parent_id
-                INNER JOIN acl_resources ar
-                    ON ar.acl_res_id = armdr.acl_res_id
-                INNER JOIN acl_res_group_relations argr
-                    ON argr.acl_res_id = ar.acl_res_id
-                LEFT JOIN acl_group_contacts_relations gcr
-                    ON gcr.acl_group_id = argr.acl_group_id
-                LEFT JOIN acl_group_contactgroups_relations gcgr
-                    ON gcgr.acl_group_id = argr.acl_group_id
-                LEFT JOIN contactgroup_contact_relation cgcr
-                    ON cgcr.contactgroup_cg_id = gcgr.cg_cg_id
-                    AND (cgcr.contact_contact_id = :contactId OR gcr.contact_contact_id = :contactId)
-            SQL;
-        $queryParameters[] = QueryParameter::int('contactId', $centreon->user->user_id);
-    }
-
-    if ($search) {
-        $queryParameters[] = QueryParameter::string(
-            'search',
-            '%' . HtmlSanitizer::createFromString($search)->getString() . '%',
-        );
-        $bodyQuery .= <<<'SQL'
-                WHERE (images.img_name LIKE :search OR directories.dir_name LIKE :search) AND directories.dir_name NOT IN ('centreon-map', 'dashboards', 'ppm')
-            SQL;
-    } else {
-        $bodyQuery .= <<<'SQL'
-                WHERE directories.dir_name NOT IN ('centreon-map', 'dashboards', 'ppm')
-            SQL;
-    }
-    $rows = $pearDB->fetchOne(
-        sprintf(
-            <<<'SQL'
-                    SELECT COUNT(DISTINCT images.img_id, directories.dir_id) AS nb
-                    %s
-                SQL,
-            $bodyQuery,
-        ),
-        QueryParameters::create($queryParameters),
-    );
-    $bodyQuery .= ' GROUP BY images.img_id, directories.dir_id';
-    $bodyQuery .= ' ORDER BY dir_alias, img_name LIMIT :offset, :limit';
-    $query = $selectQuery . ' ' . $bodyQuery;
-    $queryParameters[] = QueryParameter::int('offset', $num * $limit);
-    $queryParameters[] = QueryParameter::int('limit', $limit);
-
-    /** @var CentreonDB $pearDB */
-    $res = $pearDB->fetchAllAssociative($query, QueryParameters::create($queryParameters));
-} catch (ValueObjectException|CollectionException|ConnectionException $e) {
-    $exception = new RepositoryException(
-        message: 'Unable to retrieve images and directories',
-        context: ['search' => $search, 'contactId' => $centreon->user->user_id],
-        previous: $e
-    );
-    ExceptionLogger::create()->log($exception);
-
-    throw $exception;
-}
-
-include './include/common/checkPagination.php';
+$path = './include/options/media/images/';
+require_once './include/common/common-Func.php';
 
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// start header menu
+$isAdmin = ($centreon->user->admin === '1');
+
+// Default rows-per-page (shared configuration option)
+$defaultLimit = 30;
+$optResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
+if ($opt = $optResult->fetch()) {
+    $defaultLimit = (int) $opt['value'] ?: 30;
+}
+
+// Available disk space on the media partition (hidden on cloud platforms,
+// where the filesystem is not relevant to the user)
+$availableSpace = '';
+$isCloudPlatform = function_exists('isCloudPlatform') ? isCloudPlatform() : false;
+if (! $isCloudPlatform) {
+    $bytes = @disk_free_space(CentreonMedia::CENTREON_MEDIA_PATH);
+    if ($bytes !== false) {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $class = min((int) log($bytes, 1024), count($units) - 1);
+        $availableSpace = sprintf('%1.2f', $bytes / pow(1024, $class)) . ' ' . $units[$class];
+    }
+}
+
+// Write access: admin, or write level (1) on this page
+$writeAccess = $isAdmin || ($centreon->user->access->page($p) == 1);
+
+// Page identity
+$tpl->assign('pageId', $p);
+$tpl->assign('isAdmin', $isAdmin ? 1 : 0);
+$tpl->assign('writeAccess', $writeAccess ? 1 : 0);
+$tpl->assign('defaultLimit', $defaultLimit);
+$tpl->assign('availableSpace', $availableSpace);
+
+// Page header
+$tpl->assign('pageTitle', _('Images'));
+$tpl->assign('pageSubtitle', _('Browse and manage the images available in Centreon.'));
+
+// Column titles + labels
 $tpl->assign('headerMenu_name', _('Name'));
-$tpl->assign('headerMenu_desc', _('Directory'));
 $tpl->assign('headerMenu_img', _('Image'));
 $tpl->assign('headerMenu_comment', _('Comment'));
+$tpl->assign('headerMenu_size', _('Size'));
+$tpl->assign('headerMenu_date', _('Date'));
+$tpl->assign('wi_available', _('Available'));
+$tpl->assign('wi_add', _('Add'));
+$tpl->assign('wi_delete', _('Delete'));
+$tpl->assign('wi_sync', _('Synchronize Media Directory'));
+$tpl->assign('wi_search', _('Search'));
 
-$form = new HTML_QuickFormCustom('form', 'POST', '?p=' . $p);
+// JS-safe strings
+$jsonFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT;
+$tpl->assign('emptyMessageJs', json_encode(_('No image found'), $jsonFlags));
+$tpl->assign('emptyDirJs', json_encode(_('Empty directory'), $jsonFlags));
+$tpl->assign('delConfirmJs', json_encode(_('Do you confirm the deletion ?'), $jsonFlags));
+$tpl->assign('addTitleJs', json_encode(_('Add Image(s)'), $jsonFlags));
 
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-foreach ($res as $i => $elem) {
-    if (isset($elem['dir_id']) && ! isset($elemArr[$elem['dir_id']])) {
-        $selectedDirElem = $form->addElement('checkbox', 'select[' . $elem['dir_id'] . ']');
-        $selectedDirElem->setAttribute('onclick', "setSubNodes(this, 'select[" . $elem['dir_id'] . "-')");
-        $rowOpt = ['RowMenu_select' => $selectedDirElem->toHtml(), 'RowMenu_DirLink' => 'main.php?p=' . $p . '&o=cd&dir_id=' . $elem['dir_id'], 'RowMenu_dir' => CentreonUtils::escapeSecure(
-            $elem['dir_name'],
-            CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-        ), 'RowMenu_dir_cmnt' => CentreonUtils::escapeSecure(
-            $elem['dir_comment'],
-            CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-        ), 'RowMenu_empty' => _('Empty directory'), 'counter' => 0];
-        $elemArr[$elem['dir_id']] = ['head' => $rowOpt, 'elem' => []];
-    }
-
-    if ($elem['img_id']) {
-        $searchOpt = isset($search) && $search ? '&search=' . $search : '';
-        $selectedImgElem = $form->addElement(
-            'checkbox',
-            'select[' . $elem['dir_id'] . '-' . $elem['img_id'] . ']'
-        );
-        $rowOpt = ['RowMenu_select' => $selectedImgElem->toHtml(), 'RowMenu_ImgLink' => "main.php?p={$p}&o=ci&img_id={$elem['img_id']}", 'RowMenu_DirLink' => "main.php?p={$p}&o=cd&dir_id={$elem['dir_id']}", 'RowMenu_dir' => CentreonUtils::escapeSecure(
-            $elem['dir_name'],
-            CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-        ), 'RowMenu_img' => CentreonUtils::escapeSecure(
-            html_entity_decode($elem['dir_alias'] . '/' . $elem['img_path'], ENT_QUOTES, 'UTF-8'),
-            CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-        ), 'RowMenu_name' => CentreonUtils::escapeSecure(
-            html_entity_decode($elem['img_name'], ENT_QUOTES, 'UTF-8'),
-            CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-        ), 'RowMenu_comment' => CentreonUtils::escapeSecure(
-            html_entity_decode($elem['img_comment'], ENT_QUOTES, 'UTF-8'),
-            CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
-        )];
-        $elemArr[$elem['dir_id']]['elem'][$i] = $rowOpt;
-        $elemArr[$elem['dir_id']]['head']['counter']++;
-    }
-}
-
-$tpl->assign('elemArr', $elemArr);
-
-// Calculate available disk's space
-
-$bytes = disk_free_space(CentreonMedia::CENTREON_MEDIA_PATH);
-$units = ['B', 'KB', 'MB', 'GB', 'TB'];
-$class = min((int) log($bytes, 1024), count($units) - 1);
-$availiableSpace = sprintf('%1.2f', $bytes / pow(1024, $class)) . ' ' . $units[$class];
-$tpl->assign('availiableSpace', $availiableSpace);
-$tpl->assign('Available', _('Available'));
-
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
-
-?>
-    <script type="text/javascript">
-        function openPopup(pageNumber) {
-            window.open(
-              './main.get.php?p=' + pageNumber + '&o=sd&min=1',
-              '',
-              'toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no,' +
-              'width=350,height=250'
-            )
-        }
-
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-
-        function submitO(_i) {
-            if (document.forms['form'].elements[_i].selectedIndex == 1 &&
-                confirm('<?php echo _('Do you confirm the deletion ?'); ?>')
-            ) {
-                setO(document.forms['form'].elements[_i].value);
-                document.forms['form'].submit();
-            } else if (document.forms['form'].elements[_i].selectedIndex == 2) {
-                setO(document.forms['form'].elements[_i].value);
-                document.forms['form'].submit();
-            }
-            document.forms['form'].elements[_i].selectedIndex = 0;
-        }
-
-        function setSubNodes(theElement, like) {
-            var theForm = theElement.form;
-            var z = 0;
-            for (z = 0; z < theForm.length; z++) {
-                if (theForm[z].type == 'checkbox' && theForm[z].disabled == '0' && theForm[z].name.indexOf(like) >= 0) {
-                    if (theElement.checked && !theForm[z].checked) {
-                        theForm[z].checked = true;
-                        if (typeof(_selectedElem) != 'undefined') {
-                            putInSelectedElem(theForm[z].id);
-                        }
-                    } else if (!theElement.checked && theForm[z].checked) {
-                        theForm[z].checked = false;
-                        if (typeof(_selectedElem) != 'undefined') {
-                            removeFromSelectedElem(theForm[z].id);
-                        }
-                    }
-                }
-            }
-        }
-
-
-    </script>
-<?php
-$actions = [null => _('More actions'), IMAGE_DELETE => _('Delete'), IMAGE_MOVE => _('Move images')];
-$form->addElement('select', 'o1', null, $actions, ['onchange' => "javascript:submitO('o1');"]);
-$form->addElement('select', 'o2', null, $actions, ['onchange' => "javascript:submitO('o2');"]);
-if ($centreon->user->admin === '1') {
-    $form->addElement(
-        'button',
-        'syncDir',
-        _('Synchronize Media Directory'),
-        ['onClick' => "openPopup({$p})", 'class' => 'btc bt_info ml-2 mr-1'],
-    );
-}
-$form->setDefaults(['o1' => null]);
-$form->setDefaults(['o2' => null]);
-
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-$o1->setSelected(null);
-
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-$o2->setSelected(null);
-
-$tpl->assign('limit', $limit);
-$tpl->assign('p', $p);
-$tpl->assign('session_id', session_id());
-$tpl->assign('searchM', $search);
-
-$renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
-$form->accept($renderer);
-$tpl->assign('form', $renderer->toArray());
 $tpl->display('listImg.ihtml');

--- a/centreon/www/include/options/media/images/listImg.php
+++ b/centreon/www/include/options/media/images/listImg.php
@@ -90,8 +90,9 @@ $tpl->assign('delConfirmJs', json_encode(_('Do you confirm the deletion ?'), $js
 $tpl->assign('addTitleJs', json_encode(_('Add Image(s)'), $jsonFlags));
 $tpl->assign('moveOkJs', json_encode(_('Image moved.'), $jsonFlags));
 $tpl->assign('moveKoJs', json_encode(_('The image could not be moved.'), $jsonFlags));
-$tpl->assign('newFolderPromptJs', json_encode(_('New directory name:'), $jsonFlags));
 $tpl->assign('folderCreatedJs', json_encode(_('Directory created.'), $jsonFlags));
 $tpl->assign('folderInvalidJs', json_encode(_('Invalid directory name (allowed: letters, digits, "-" and "_").'), $jsonFlags));
+$tpl->assign('syncDoneJs', json_encode(_('Synchronization done: %d1 folder(s), %d2 image(s) added, %d3 converted, %d4 removed.'), $jsonFlags));
+$tpl->assign('syncKoJs', json_encode(_('The media synchronization failed.'), $jsonFlags));
 
 $tpl->display('listImg.ihtml');

--- a/centreon/www/include/options/media/images/listImg.php
+++ b/centreon/www/include/options/media/images/listImg.php
@@ -53,10 +53,16 @@ if (! $isCloudPlatform) {
 // Write access: admin, or write level (1) on this page
 $writeAccess = $isAdmin || ($centreon->user->access->page($p) == 1);
 
+// Folder creation is only offered to users allowed to see every folder
+// (same restriction as uploading into a brand new directory)
+$canCreateFolder = $writeAccess
+    && ($isAdmin || ! empty($centreon->user->access->hasAccessToAllImageFolders));
+
 // Page identity
 $tpl->assign('pageId', $p);
 $tpl->assign('isAdmin', $isAdmin ? 1 : 0);
 $tpl->assign('writeAccess', $writeAccess ? 1 : 0);
+$tpl->assign('canCreateFolder', $canCreateFolder ? 1 : 0);
 $tpl->assign('defaultLimit', $defaultLimit);
 $tpl->assign('availableSpace', $availableSpace);
 
@@ -82,5 +88,10 @@ $tpl->assign('emptyMessageJs', json_encode(_('No image found'), $jsonFlags));
 $tpl->assign('emptyDirJs', json_encode(_('Empty directory'), $jsonFlags));
 $tpl->assign('delConfirmJs', json_encode(_('Do you confirm the deletion ?'), $jsonFlags));
 $tpl->assign('addTitleJs', json_encode(_('Add Image(s)'), $jsonFlags));
+$tpl->assign('moveOkJs', json_encode(_('Image moved.'), $jsonFlags));
+$tpl->assign('moveKoJs', json_encode(_('The image could not be moved.'), $jsonFlags));
+$tpl->assign('newFolderPromptJs', json_encode(_('New directory name:'), $jsonFlags));
+$tpl->assign('folderCreatedJs', json_encode(_('Directory created.'), $jsonFlags));
+$tpl->assign('folderInvalidJs', json_encode(_('Invalid directory name (allowed: letters, digits, "-" and "_").'), $jsonFlags));
 
 $tpl->display('listImg.ihtml');

--- a/centreon/www/include/options/media/images/mediaSyncWorker.php
+++ b/centreon/www/include/options/media/images/mediaSyncWorker.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -20,146 +21,111 @@
 
 use enshrined\svgSanitize\Sanitizer;
 
-require_once realpath(__DIR__ . '/../../../../../config/centreon.config.php');
-
-require_once './class/centreonDB.class.php';
-require_once './class/centreonLog.class.php';
-
-$pearDB = new CentreonDB();
-$mediaLogInstance = CentreonLog::create();
+require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonLog.class.php';
 
 /**
- * Counters
+ * Scans ./img/media, registers new directories and images, converts gd2 -> png,
+ * sanitizes SVG files and prunes DB rows whose file no longer exists on disk.
+ *
+ * Must be called with the working directory set to the Centreon web root.
+ *
+ * @return array{fileRemoved:int,dirCreated:int,regCounter:int,gdCounter:int}
  */
-global $regCounter, $gdCounter, $fileRemoved, $dirCreated;
+function runMediaSync(): array
+{
+    global $regCounter, $gdCounter, $dirCreated;
 
-$sid = session_id();
-if ($sid === false) {
-    exit;
-}
+    $pearDB = new CentreonDB();
+    $mediaLogInstance = CentreonLog::create();
 
-if (isset($sid)) {
-    $DBRESULT = $pearDB->query("SELECT * FROM session WHERE session_id = '" . $pearDB->escape($sid) . "'");
-    if ($DBRESULT->rowCount() === 0) {
-        exit();
-    }
-}
+    $dir = './img/media/';
+    $rejectedDir = ['.' => 1, '..' => 1];
 
-$dir = './img/media/';
+    $dirCreated = 0;
+    $regCounter = 0;
+    $gdCounter = 0;
 
-$rejectedDir = ['.' => 1, '..' => 1];
-
-$dirCreated = 0;
-$regCounter = 0;
-$gdCounter = 0;
-
-if (is_dir($dir)) {
-    if ($dh = opendir($dir)) {
-        while (($subdir = readdir($dh)) !== false) {
-            if (! isset($rejectedDir[$subdir]) && filetype($dir . $subdir) === 'dir') {
-                try {
-                    $dir_id = checkDirectory($subdir, $pearDB);
-                } catch (Exception $ex) {
-                    $mediaLogInstance->error(
-                        CentreonLog::TYPE_BUSINESS_LOG,
-                        $ex->getMessage(),
-                        [],
-                        $ex
-                    );
-                    continue;
-                }
-                if ($dh2 = opendir($dir . $subdir)) {
-                    while (($picture = readdir($dh2)) !== false) {
-                        if (! isset($rejectedDir[$picture])) {
-                            try {
-                                checkPicture($picture, $dir . $subdir, $dir_id, $pearDB);
-                            } catch (Exception $ex) {
-                                $mediaLogInstance->error(
-                                    CentreonLog::TYPE_BUSINESS_LOG,
-                                    $ex->getMessage(),
-                                    [],
-                                    $ex
-                                );
+    if (is_dir($dir)) {
+        if ($dh = opendir($dir)) {
+            while (($subdir = readdir($dh)) !== false) {
+                if (! isset($rejectedDir[$subdir]) && filetype($dir . $subdir) === 'dir') {
+                    try {
+                        $dir_id = checkDirectory($subdir, $pearDB);
+                    } catch (Exception $ex) {
+                        $mediaLogInstance->error(
+                            CentreonLog::TYPE_BUSINESS_LOG,
+                            $ex->getMessage(),
+                            [],
+                            $ex
+                        );
+                        continue;
+                    }
+                    if ($dh2 = opendir($dir . $subdir)) {
+                        while (($picture = readdir($dh2)) !== false) {
+                            if (! isset($rejectedDir[$picture])) {
+                                try {
+                                    checkPicture($picture, $dir . $subdir, $dir_id, $pearDB);
+                                } catch (Exception $ex) {
+                                    $mediaLogInstance->error(
+                                        CentreonLog::TYPE_BUSINESS_LOG,
+                                        $ex->getMessage(),
+                                        [],
+                                        $ex
+                                    );
+                                }
                             }
                         }
+                        closedir($dh2);
                     }
-                    closedir($dh2);
                 }
             }
+            closedir($dh);
         }
-        closedir($dh);
     }
+
+    $fileRemoved = deleteOldPictures($pearDB);
+
+    return [
+        'fileRemoved' => $fileRemoved,
+        'dirCreated'  => $dirCreated,
+        'regCounter'  => $regCounter,
+        'gdCounter'   => $gdCounter,
+    ];
 }
 
-$fileRemoved = deleteOldPictures($pearDB);
-
-// Display Stats
-
-?>
-<script type="text/javascript">
-    jQuery('body').css('overflow-x', 'hidden');
-    function reloadAndClose() {
-        window.opener.location.reload();
-        window.close();
-    }
-</script>
-<br>
-<?php
-echo '<b>&nbsp;&nbsp;' . _('Media Detection') . '</b>';
-?>
-<br><br>
-<div style="width:250px;height:50px;margin-left:5px;padding:20px;background-color:#FFFFFF;border:1px #CDCDCD solid;-moz-border-radius:4px;">
-    <div style='float:left;width:270px;text-align:left;'>
-        <p>
-            <?php
-            echo _('Bad picture alias detected :') . " {$fileRemoved}<br>";
-echo _('New directory added :') . " {$dirCreated}<br>";
-echo _('New images added :') . " {$regCounter}<br>";
-echo _('Convert gd2 -> png :') . " {$gdCounter}<br><br><br>";
-?>
-        </p>
-        <br><br><br>
-        <center><a href='javascript:window.opener.location.reload();javascript:window.close();'>
-                <?php echo _('Close'); ?>
-            </a></center>
-    </div>
-    <br>
-    <?php
-
-    // recreates local centreon directories as defined in DB
-
-    /**
-     * Recreates local centreon directories as defined in DB.
-     *
-     * @param string $directory
-     * @param CentreonDB $db
-     *
-     * @throws CentreonDbException
-     * @return int Id of the directory
-     */
-    function checkDirectory(string $directory, CentreonDB $db): int
-    {
-        global $dirCreated;
+/**
+ * Recreates local centreon directories as defined in DB.
+ *
+ * @param string $directory
+ * @param CentreonDB $db
+ *
+ * @throws CentreonDbException
+ * @return int Id of the directory
+ */
+function checkDirectory(string $directory, CentreonDB $db): int
+{
+    global $dirCreated;
+    $statement = $db->prepareQuery(
+        'SELECT dir_id FROM view_img_dir WHERE dir_alias = :directory'
+    );
+    $db->executePreparedQuery($statement, [':directory' => $directory]);
+    $directoryId = $db->fetchColumn($statement);
+    if ($directoryId === false) {
         $statement = $db->prepareQuery(
-            'SELECT dir_id FROM view_img_dir WHERE dir_alias = :directory'
+            <<<'SQL'
+                INSERT INTO view_img_dir (`dir_name`, `dir_alias`)
+                VALUES (:directory, :directory)
+                SQL
         );
         $db->executePreparedQuery($statement, [':directory' => $directory]);
-        $directoryId = $db->fetchColumn($statement);
-        if ($directoryId === false) {
-            $statement = $db->prepareQuery(
-                <<<'SQL'
-                    INSERT INTO view_img_dir (`dir_name`, `dir_alias`)
-                    VALUES (:directory, :directory)
-                    SQL
-            );
-            $db->executePreparedQuery($statement, [':directory' => $directory]);
-            $directoryId = $db->lastInsertId();
-            @mkdir("./img/media/{$directory}");
-            $dirCreated++;
-        }
-
-        return $directoryId;
+        $directoryId = $db->lastInsertId();
+        @mkdir("./img/media/{$directory}");
+        $dirCreated++;
     }
+
+    return $directoryId;
+}
 
 /**
  * Inserts $dir_id/$picture into DB if not registered yet
@@ -340,6 +306,3 @@ function deleteOldPictures(CentreonDB $pearDB): int
 
     return $fileRemoved;
 }
-
-?>
-</div>


### PR DESCRIPTION
## Modernize Administration > Parameters > Images

Rebuilds the Images media page on top of the shared **CentreonListing** framework; every action is asynchronous (AJAX), no full-page reloads.

> Targets `feature/configuration-legacy-listing-shared-library` (dependency for `listing.css` / `listing.js` / `AjaxListingHelper`).

### Listing
- `ajaxImagesListing.php` — JSON endpoint (`AjaxListingHelper`): per-folder ACL, reserved-directory exclusions (`centreon-map`/`dashboards`/`ppm`), search, pagination.
- Grouped renderer (directory header + nested images), thumbnails, charter title/subtitle, search bar, **file size & date** columns, and a disk-space indicator (hidden on cloud).

### Selection & delete
- `ajaxImagesDelete.php` — admin/write-only, CSRF-validated bulk delete; row checkboxes (a directory toggles its images) + check-all; refreshes the list in place.

### Drag-and-drop upload (slide panel)
- `ajaxImagesUpload.php` — AJAX upload reusing `CentreonImageManager`.
- `formUpload.*` — multi-file drag & drop, thumbnail previews, per-file progress, target directory selector.
- Opens in a **slide-in side panel** (same `cf-side-panel` pattern as the pollers page); the form loads as a chrome-less fragment in an iframe and, on completion, closes the panel and refreshes the list.
- **Duplicate handling**: on a name clash the user is asked whether to overwrite, with batch options (Overwrite / Overwrite all / Skip / Skip all). Overwriting replaces the file in place via `CentreonImageManager::update()`, **preserving the image id** so existing references keep their icon.

### Security (server-side file upload — reviewed end to end)
- **AuthN**: every endpoint validates the session (`AjaxListingHelper::boot()`).
- **AuthZ**: upload & delete require write access (`requireWriteAccess(50102)`); non-privileged users may only upload into ACL-allowed folders.
- **CSRF**: upload & delete consume and rotate a token.
- **File types**: images only — `jpg, jpeg, png, gif, svg` (archives rejected).
- **MIME**: deep validation (`isCorrectMIMEType`); SVG content sanitized before write.
- **Size**: each file hard-capped at **2 MB** on every platform.
- **Path traversal**: target directory validated against `^[A-Za-z0-9_-]+$`.
- **SQLi**: listing and lookup queries fully parameterized.
- **XSS**: listing fields HTML-escaped; image paths `encodeURI()`-d in the `src` attribute.
- **New endpoints** (`ajaxImagesMove.php`, `ajaxImagesCreateDir.php`, `ajaxImagesSync.php`): all validate the session, rotate a CSRF token and require write access (`requireWriteAccess(50102)`). Move enforces folder ACLs on **both** the source and target directory; folder creation and synchronization are restricted to admins / full-folder-access users. Ids are cast to integers and folder names validated against `^[A-Za-z0-9_-]+$`; all queries are prepared.

### Edit an image (side panel)
- Clicking an image opens the edit form in the side panel with a **preview**; it lets you rename / move / edit the comment only. The pointless re-upload of the same file was removed (use delete + upload to replace a file).

### Move an image by drag & drop
- `ajaxImagesMove.php` — drag a thumbnail onto a directory row to move it to another folder. Reuses `CentreonImageManager::update()` (file move + relation update), **preserving the image id** so every host/service keeps its icon. A drop on the current folder is a no-op.

### Create an empty directory
- `ajaxImagesCreateDir.php` — a **New folder** action opens a themed modal (inline validation, Enter to submit, Esc/backdrop to close) and creates an empty directory. Previously a folder could only be created implicitly by uploading a file into it.

### Standard search
- The search moved into the standard toolbar next to the pagination, with live filtering, consistent with the other modernized listings.

### Media synchronization (AJAX)
- The legacy sync popup (`syncDir.php`, `o=sd`) is replaced by `ajaxImagesSync.php`: an AJAX call that reports a **summary toast** (folders/images added, converted, pruned) and refreshes the listing. The scan logic is extracted into a reusable `mediaSyncWorker.php`.

### i18n
- fr/es/de/pt translations for all new strings.

### Screenshot
<img width="1653" height="814" alt="Capture d’écran 2026-06-04 à 16 12 33" src="https://github.com/user-attachments/assets/8bd4675b-d6e2-472d-b4ae-e9e5e3b25607" />

