### PR TITLE
fix(api): restore service select2 list for non-admin users

### DIFF
--- a/centreon/www/api/class/centreon_configuration_service.class.php
+++ b/centreon/www/api/class/centreon_configuration_service.class.php
@@ -65,7 +65,7 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
         // Get ACL if user is not admin
         if (! $isAdmin) {
             $acl = new CentreonACL($userId, false);
-            $allowedServiceIds = array_map('intval', array_filter(explode(',', $acl->getServicesString('ID', $this->pearDBMonitoring)), 'is_numeric'));
+            $allowedServiceIds = array_map('intval', array_filter(explode(',', $acl->getServicesString('ID', $this->pearDBMonitoring, false)), 'is_numeric'));
             if ($allowedServiceIds !== []) {
                 $placeholders = array_map(fn ($k) => ':aclSvc' . $k, array_keys($allowedServiceIds));
                 $aclServiceBindParams = array_combine($placeholders, $allowedServiceIds);


### PR DESCRIPTION
## Summary

- Non-admin (ACL) users got an empty service list from the legacy
  `centreon_configuration_service&action=list` webservice, breaking the
  service select2 on ~20 legacy pages (Service Groups "Linked Host
  Services", Escalations, Dependencies, Downtimes, Comments, Event Logs…)
- Root cause: `getServicesString('ID', …)` returns IDs wrapped in single
  quotes by default, so the `explode`/`is_numeric` filtering introduced in
  #9946 rejected every ID and forced the `AND 1 = 0` no-access fallback
- Pass `$escape = false` to get a plain ID list; the prepared-statement
  placeholder binding from #9946 is kept intact

## Jira

MON-200316

## Test plan

- [ ] As a non-admin (ACL) user, Configuration > Services > Service Groups > Add — the **Linked Host Services** selector lists the ACL-allowed services
- [ ] As a non-admin user with a restricted ACL, verify only allowed services are returned
- [ ] Regression check (MON-196465): Monitoring > Event Logs — selecting a host filters the Service dropdown to that host's services; no host selected lists all visible services
- [ ] As admin, both pages behave unchanged