### PR TITLE
fix(ci): resolve web FROM image tag on on-prem feature branches

### DIFF
--- a/.github/actions/get-docker-from-image-version/action.yml
+++ b/.github/actions/get-docker-from-image-version/action.yml
@@ -2,9 +2,9 @@ name: get-docker-from-image-version
 description: |
   Resolves the Docker image tag to use as FROM in a dockerize job.
   Resolution order:
-    1. current_tag (e.g. develop-26.10 or branch name) if it exists in the registry
-    2. major_version if the current branch is dev-XX.YY.x
-    3. (cloud only) develop-<major_version> if it exists in the registry (feature branches)
+    1. current_tag if it exists in the registry
+    2. major_version on a maintenance branch (dev-XX.YY.x)
+    3. otherwise probe the base branch tag (develop-<major> cloud, dev-<major>.x on-prem)
     4. fallback: develop (cloud) or major_version (on-prem)
   Each resolved tag has tag_suffix appended (e.g. -alma9) when provided.
 
@@ -62,11 +62,17 @@ runs:
           FROM_IMAGE_VERSION="${CURRENT_TAG}${TAG_SUFFIX}"
         elif [[ "$BRANCH_NAME" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
           FROM_IMAGE_VERSION="${MAJOR_VERSION}${TAG_SUFFIX}"
-        elif [[ "$IS_CLOUD" == "true" && "$BRANCH_NAME" != "develop" ]]; then
-          DEVELOP_VERSION_TAG="develop-${MAJOR_VERSION}${TAG_SUFFIX}"
-          IMAGE_TAG_EXISTS=$(docker manifest inspect ${REGISTRY}/${FROM_IMAGE}:${DEVELOP_VERSION_TAG} >/dev/null 2>&1 && echo yes || echo no)
+        elif [[ "$BRANCH_NAME" != "develop" ]]; then
+          # Probe the base maintenance branch tag (dev-<major>.x on-prem,
+          # develop-<major> cloud) and use it only if it exists.
+          if [[ "$IS_CLOUD" == "true" ]]; then
+            CANDIDATE_TAG="develop-${MAJOR_VERSION}${TAG_SUFFIX}"
+          else
+            CANDIDATE_TAG="dev-${MAJOR_VERSION}.x${TAG_SUFFIX}"
+          fi
+          IMAGE_TAG_EXISTS=$(docker manifest inspect ${REGISTRY}/${FROM_IMAGE}:${CANDIDATE_TAG} >/dev/null 2>&1 && echo yes || echo no)
           if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
-            FROM_IMAGE_VERSION="${DEVELOP_VERSION_TAG}"
+            FROM_IMAGE_VERSION="${CANDIDATE_TAG}"
           fi
         fi
 


### PR DESCRIPTION
## Description

The `get-docker-from-image-version` composite action resolves the Docker tag used as `FROM` in the dockerize jobs:
- `web.yml` resolves the **dependencies** image (`centreon-web-dependencies-collect`), tagged `major_version` (e.g. `25.10`) on dev branches.
- `open-tickets.yml` resolves the **web** image (`centreon-web-<os>`), tagged `dev-XX.YY.x` on dev branches.

On **on-prem feature branches**, the action had no base-branch probe (unlike the cloud path which probes `develop-<major>`). It fell straight through to the `major_version` fallback (e.g. `25.10`) — the *dependencies* image convention. For the *web* image that tag does not exist, so the open-tickets dockerize job failed pulling `centreon-web-<os>:25.10` instead of `centreon-web-<os>:dev-XX.YY.x`.

## Fix

Add a symmetric on-prem feature-branch probe for `dev-<major>.x`. The probe is existence-checked, so the dependencies image (which has no `dev-<major>.x` tag) still falls back to `major_version` — no regression for `web.yml`.

## Refs

Refs: MON-200368