### PR TITLE
chore(php): add PHP 8.2-compatible cs-fixer rules and lock rector to php82 set

### DIFF
--- a/php-tools/composer.json
+++ b/php-tools/composer.json
@@ -6,7 +6,7 @@
     "php": "8.4.*",
     "ext-mbstring": "*",
     "deptrac/deptrac": "3.0.*",
-    "friendsofphp/php-cs-fixer": "3.80.*",
+    "friendsofphp/php-cs-fixer": "3.76.*",
     "maglnet/composer-require-checker": "4.16.*",
     "phpstan/phpstan": "2.1.*",
     "phpstan/phpstan-beberlei-assert": "2.0.*",

--- a/php-tools/composer.lock
+++ b/php-tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abb12175a261bb8f6ad66c6a7d42dac8",
+    "content-hash": "730dc14b1d0815950d82b24bd02b6a63",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -450,16 +450,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.80.0",
+            "version": "v3.76.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "e49ed46b8f7adcc451d4cd2ed34eaae33372bc60"
+                "reference": "0e3c484cef0ae9314b0f85986a36296087432c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/e49ed46b8f7adcc451d4cd2ed34eaae33372bc60",
-                "reference": "e49ed46b8f7adcc451d4cd2ed34eaae33372bc60",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/0e3c484cef0ae9314b0f85986a36296087432c40",
+                "reference": "0e3c484cef0ae9314b0f85986a36296087432c40",
                 "shasum": ""
             },
             "require": {
@@ -543,7 +543,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.80.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.76.0"
             },
             "funding": [
                 {
@@ -551,7 +551,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-06T21:00:51+00:00"
+            "time": "2025-06-30T14:15:06+00:00"
         },
         {
             "name": "maglnet/composer-require-checker",

--- a/php-tools/php-cs-fixer/config/base.strict.php
+++ b/php-tools/php-cs-fixer/config/base.strict.php
@@ -25,14 +25,18 @@ use PhpCsFixer\Config;
 use Tools\PhpCsFixer\Php82MbStrFunctionsFixer;
 use Tools\PhpCsFixer\PhpCsFixerRuleSet;
 
-return new Config()
+// CS Fixer 3.76 does not declare PHP 8.4 support. This flag suppresses the version-check abort.
+// Pinned at 3.76 to avoid cosmetic side effects introduced in 3.77+ (phpdoc_order phpstan/psalm
+// annotation reordering) and to stay backport-compatible with dev-25.10.x.
+// setUnsupportedPhpVersionAllowed() exists only on Config (not ConfigInterface), so it must be
+// called before any fluent method that narrows the return type to ConfigInterface.
+$config = new Config();
+$config->setUnsupportedPhpVersionAllowed(true);
+
+return $config
     // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     // custom rule for backward compatibility with php 8.2
     ->registerCustomFixers([new Php82MbStrFunctionsFixer()])
     ->setRiskyAllowed(true)
-    // CS Fixer 3.76 does not declare PHP 8.4 support. This flag suppresses the version-check abort.
-    // Pinned at 3.76 to avoid cosmetic side effects introduced in 3.77+ (phpdoc_order phpstan/psalm
-    // annotation reordering) and to stay backport-compatible with dev-25.10.x.
-    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules(PhpCsFixerRuleSet::getRules());

--- a/php-tools/php-cs-fixer/config/base.strict.php
+++ b/php-tools/php-cs-fixer/config/base.strict.php
@@ -22,10 +22,17 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Config;
+use Tools\PhpCsFixer\Php82MbStrFunctionsFixer;
 use Tools\PhpCsFixer\PhpCsFixerRuleSet;
 
 return new Config()
     // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    // custom rule for backward compatibility with php 8.2
+    ->registerCustomFixers([new Php82MbStrFunctionsFixer()])
     ->setRiskyAllowed(true)
+    // CS Fixer 3.76 does not declare PHP 8.4 support. This flag suppresses the version-check abort.
+    // Pinned at 3.76 to avoid cosmetic side effects introduced in 3.77+ (phpdoc_order phpstan/psalm
+    // annotation reordering) and to stay backport-compatible with dev-25.10.x.
+    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules(PhpCsFixerRuleSet::getRules());

--- a/php-tools/php-cs-fixer/config/base.unstrict.php
+++ b/php-tools/php-cs-fixer/config/base.unstrict.php
@@ -24,12 +24,16 @@ declare(strict_types=1);
 use PhpCsFixer\Config;
 use Tools\PhpCsFixer\PhpCsFixerRuleSet;
 
-return new Config()
+// CS Fixer 3.76 does not declare PHP 8.4 support. This flag suppresses the version-check abort.
+// Pinned at 3.76 to avoid cosmetic side effects introduced in 3.77+ (phpdoc_order phpstan/psalm
+// annotation reordering) and to stay backport-compatible with dev-25.10.x.
+// setUnsupportedPhpVersionAllowed() exists only on Config (not ConfigInterface), so it must be
+// called before any fluent method that narrows the return type to ConfigInterface.
+$config = new Config();
+$config->setUnsupportedPhpVersionAllowed(true);
+
+return $config
     // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(false)
-    // CS Fixer 3.76 does not declare PHP 8.4 support. This flag suppresses the version-check abort.
-    // Pinned at 3.76 to avoid cosmetic side effects introduced in 3.77+ (phpdoc_order phpstan/psalm
-    // annotation reordering) and to stay backport-compatible with dev-25.10.x.
-    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules(PhpCsFixerRuleSet::getRulesSafe());

--- a/php-tools/php-cs-fixer/config/base.unstrict.php
+++ b/php-tools/php-cs-fixer/config/base.unstrict.php
@@ -28,4 +28,8 @@ return new Config()
     // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7777
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(false)
+    // CS Fixer 3.76 does not declare PHP 8.4 support. This flag suppresses the version-check abort.
+    // Pinned at 3.76 to avoid cosmetic side effects introduced in 3.77+ (phpdoc_order phpstan/psalm
+    // annotation reordering) and to stay backport-compatible with dev-25.10.x.
+    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules(PhpCsFixerRuleSet::getRulesSafe());

--- a/php-tools/php-cs-fixer/src/Php82MbStrFunctionsFixer.php
+++ b/php-tools/php-cs-fixer/src/Php82MbStrFunctionsFixer.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tools\PhpCsFixer;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Replacement for MbStrFunctionsFixer capped at the PHP 8.2 function set.
+ *
+ * The upstream fixer expands its replacement map at runtime based on PHP_VERSION_ID,
+ * adding str_pad (8.3+) and trim/ltrim/rtrim (8.4+). Running it on PHP 8.4 would
+ * rewrite those functions in code that targets PHP 8.2, breaking backport branches.
+ * This fixer keeps exactly the functions available since PHP 8.2.
+ */
+final class Php82MbStrFunctionsFixer extends AbstractFixer
+{
+    /** @var array<string, array{alternativeName: string, argumentCount: list<int>}> */
+    private const FUNCTIONS_MAP = [
+        'str_split' => ['alternativeName' => 'mb_str_split', 'argumentCount' => [1, 2, 3]],
+        'stripos' => ['alternativeName' => 'mb_stripos', 'argumentCount' => [2, 3]],
+        'stristr' => ['alternativeName' => 'mb_stristr', 'argumentCount' => [2, 3]],
+        'strlen' => ['alternativeName' => 'mb_strlen', 'argumentCount' => [1]],
+        'strpos' => ['alternativeName' => 'mb_strpos', 'argumentCount' => [2, 3]],
+        'strrchr' => ['alternativeName' => 'mb_strrchr', 'argumentCount' => [2]],
+        'strripos' => ['alternativeName' => 'mb_strripos', 'argumentCount' => [2, 3]],
+        'strrpos' => ['alternativeName' => 'mb_strrpos', 'argumentCount' => [2, 3]],
+        'strstr' => ['alternativeName' => 'mb_strstr', 'argumentCount' => [2, 3]],
+        'strtolower' => ['alternativeName' => 'mb_strtolower', 'argumentCount' => [1]],
+        'strtoupper' => ['alternativeName' => 'mb_strtoupper', 'argumentCount' => [1]],
+        'substr' => ['alternativeName' => 'mb_substr', 'argumentCount' => [2, 3]],
+        'substr_count' => ['alternativeName' => 'mb_substr_count', 'argumentCount' => [2, 3, 4]],
+    ];
+
+    public function getName(): string
+    {
+        return 'Centreon/mb_str_functions_php82';
+    }
+
+    /**
+     * @param Tokens<Token> $tokens
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_STRING);
+    }
+
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Must run before NativeFunctionInvocationFixer.
+     */
+    public function getPriority(): int
+    {
+        return 2;
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Replace non multibyte-safe functions with corresponding mb function (PHP 8.2 baseline only).',
+            [
+                new CodeSample(
+                    '<?php
+$a = strlen($a);
+$a = strpos($a, $b);
+$a = strtolower($a);
+'
+                ),
+            ],
+            null,
+            'Risky when any of the functions are overridden, or when relying on the string byte size rather than its length in characters.'
+        );
+    }
+
+    /**
+     * @param Tokens<Token> $tokens
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
+        $functionsAnalyzer = new FunctionsAnalyzer();
+
+        for ($index = $tokens->count() - 1; $index > 0; --$index) {
+            if (! $tokens[$index]->isGivenKind(T_STRING)) {
+                continue;
+            }
+
+            $lowercasedContent = mb_strtolower($tokens[$index]->getContent());
+            if (! isset(self::FUNCTIONS_MAP[$lowercasedContent])) {
+                continue;
+            }
+
+            if ($functionsAnalyzer->isGlobalFunctionCall($tokens, $index)) {
+                $openParenthesis = $tokens->getNextMeaningfulToken($index);
+                $closeParenthesis = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
+                $numberOfArguments = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis);
+                if (! \in_array($numberOfArguments, self::FUNCTIONS_MAP[$lowercasedContent]['argumentCount'], true)) {
+                    continue;
+                }
+                $tokens[$index] = new Token([T_STRING, self::FUNCTIONS_MAP[$lowercasedContent]['alternativeName']]);
+
+                continue;
+            }
+
+            // global function import (use function strlen;)
+            $functionIndex = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$functionIndex]->isGivenKind(T_NS_SEPARATOR)) {
+                $functionIndex = $tokens->getPrevMeaningfulToken($functionIndex);
+            }
+            if (! $tokens[$functionIndex]->isGivenKind(CT::T_FUNCTION_IMPORT)) {
+                continue;
+            }
+            $useIndex = $tokens->getPrevMeaningfulToken($functionIndex);
+            if (! $tokens[$useIndex]->isGivenKind(T_USE)) {
+                continue;
+            }
+            $tokens[$index] = new Token([T_STRING, self::FUNCTIONS_MAP[$lowercasedContent]['alternativeName']]);
+        }
+    }
+}

--- a/php-tools/php-cs-fixer/src/Php82MbStrFunctionsFixer.php
+++ b/php-tools/php-cs-fixer/src/Php82MbStrFunctionsFixer.php
@@ -124,6 +124,9 @@ $a = strtolower($a);
 
             if ($functionsAnalyzer->isGlobalFunctionCall($tokens, $index)) {
                 $openParenthesis = $tokens->getNextMeaningfulToken($index);
+                if ($openParenthesis === null) {
+                    continue;
+                }
                 $closeParenthesis = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
                 $numberOfArguments = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis);
                 if (! \in_array($numberOfArguments, self::FUNCTIONS_MAP[$lowercasedContent]['argumentCount'], true)) {
@@ -136,13 +139,22 @@ $a = strtolower($a);
 
             // global function import (use function strlen;)
             $functionIndex = $tokens->getPrevMeaningfulToken($index);
+            if ($functionIndex === null) {
+                continue;
+            }
             if ($tokens[$functionIndex]->isGivenKind(T_NS_SEPARATOR)) {
                 $functionIndex = $tokens->getPrevMeaningfulToken($functionIndex);
+                if ($functionIndex === null) {
+                    continue;
+                }
             }
             if (! $tokens[$functionIndex]->isGivenKind(CT::T_FUNCTION_IMPORT)) {
                 continue;
             }
             $useIndex = $tokens->getPrevMeaningfulToken($functionIndex);
+            if ($useIndex === null) {
+                continue;
+            }
             if (! $tokens[$useIndex]->isGivenKind(T_USE)) {
                 continue;
             }

--- a/php-tools/php-cs-fixer/src/PhpCsFixerRuleSet.php
+++ b/php-tools/php-cs-fixer/src/PhpCsFixerRuleSet.php
@@ -195,7 +195,9 @@ class PhpCsFixerRuleSet
             'get_class_to_class_keyword' => true,
             'implode_call' => true,
             'logical_operators' => true,
-            'mb_str_functions' => true,
+            // Custom replace original mb_str_function rule for backward compatibility with php 8.2
+            'Centreon/mb_str_functions_php82' => true,
+            'mb_str_functions' => false,
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'no_alias_functions' => true,

--- a/php-tools/rector.php
+++ b/php-tools/rector.php
@@ -33,4 +33,7 @@ return $rectorConfig
         // files
         __DIR__ . '/.php-cs-fixer.php',
         __DIR__ . '/rector.php',
+    ])
+    ->withSkip([
+        __DIR__ . '/php-cs-fixer/src/Php82MbStrFunctionsFixer.php', // conflicts with fully_qualified_strict_types cs-fixer rule on phpdoc generics
     ]);

--- a/php-tools/rector/config/base.strict.php
+++ b/php-tools/rector/config/base.strict.php
@@ -33,7 +33,7 @@ return RectorConfig::configure()
     ->withBootstrapFiles([
         __DIR__ . '/centreon.bootstrap.php',
     ])
-    ->withPhpSets()
+    ->withPhpSets(php82: true) // limit rules set to <=php8.2 for backport compatibility
     ->withComposerBased(doctrine: true, phpunit: true, symfony: true)
     ->withPreparedSets(
         deadCode: true,


### PR DESCRIPTION
## Description

Pin PHP CS Fixer to `3.76.*` and configure the toolchain to run safely on PHP 8.4
while keeping results backport-compatible with `dev-25.10.x` (which uses CS Fixer 3.76).
Cap Rector rules to PHP 8.2 for the same reason.

**Changes:**
- Downgrade `friendsofphp/php-cs-fixer` constraint from `3.80.*` to `3.76.*` in `php-tools/composer.json`
- Add `->setUnsupportedPhpVersionAllowed(true)` to `base.strict.php` and `base.unstrict.php`
  to suppress the version-check abort when running CS Fixer 3.76 under PHP 8.4
- Add custom `Php82MbStrFunctionsFixer` that replaces the upstream `mb_str_functions` rule:
  the upstream fixer uses the runtime PHP version to decide which functions to rewrite —
  on PHP 8.4 it would add `mb_trim()`/`mb_ltrim()`/`mb_rtrim()` and `mb_str_pad()`, breaking
  code that targets PHP 8.2. The custom fixer caps the replacement map at the PHP 8.2 baseline.
- Lock Rector to the PHP 8.2 rule set: change `->withPhpSets()` to `->withPhpSets(php82: true)` in
  `rector/config/base.strict.php` so Rector never applies rules targeting PHP 8.3+ (backport compatibility)
- Skip `Php82MbStrFunctionsFixer.php` in `rector.php`: the custom fixer conflicts with Rector's
  `fully_qualified_strict_types` rule on phpdoc generics

**Why 3.76 and not 3.80:** CS Fixer 3.77 introduced cosmetic changes (ex: `PhpdocOrderFixer` support for
`@phpstan-param`/`@psalm-param` annotation reordering). This produces thousands of cosmetic
diffs across the codebase with no functional value, and the resulting files cannot be
cherry-picked to `dev-25.10.x` without conflicts.
Those cosmetic changes will be handled later on and cs-fixer will be updated accordingly.

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

Run PHP CS Fixer on any Core file and confirm:
1. The tool starts without aborting (only a warning about unsupported PHP version)
2. No `@phpstan-param`/`@param` reordering diffs are produced
3. No `mb_trim()` rewrites appear in the output

```bash
cd centreon/
../php-tools/vendor/bin/php-cs-fixer fix src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardRepository.php --dry-run --diff --config .php-cs-fixer.core.php
```
___
Relates to MON-198134