### PR TITLE
fix(ci): expand specs_path glob in cypress component spec-list

### DIFF
--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -53,7 +53,9 @@ jobs:
           SPEC_EXTENSION: ${{ inputs.spec_extension }}
         run: |
           cd "$MODULE_NAME"
-          echo "specs=$(find "$SPECS_PATH" -type f -name "*$SPEC_EXTENSION" -exec basename {} \; | sed -e "s/$SPEC_EXTENSION//" | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          # SPECS_PATH is a glob pattern (e.g. "src/**", "www/**") that must be expanded by the
+          # shell before being passed to find, so it is intentionally left unquoted here.
+          echo "specs=$(find $SPECS_PATH -type f -name "*$SPEC_EXTENSION" -exec basename {} \; | sed -e "s/$SPEC_EXTENSION//" | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   cypress-component-test-run:
     needs: [cypress-component-test-list]


### PR DESCRIPTION
## Context

The GHA hardening commit [1e66250](https://github.com/centreon/centreon/commit/1e662503218240784afe522d3b2c931f05473c3c) (PR #10546) moved all `${{ ... }}` interpolations out of `run:` blocks into `env:` variables to prevent script injection.

## Problem

In `.github/workflows/cypress-component-parallelization.yml`, the `List of specs` step (job `cypress-component-test-list`) stopped returning any spec, so the downstream test matrix had nothing to run.

`specs_path` is a **glob pattern**, not a literal path:
- `centreon-ui.yml` → `specs_path: src/**`
- `web.yml` → `specs_path: www/**`

Before the hardening the pattern was passed **unquoted** to `find`, so the shell expanded the glob into real paths first:
```bash
find ${{ inputs.specs_path }} -type f ...
```

After the hardening it is passed through a **quoted** env variable:
```bash
env:
  SPECS_PATH: ${{ inputs.specs_path }}
run: |
  find "$SPECS_PATH" -type f ...
```
`"$SPECS_PATH"` is no longer glob-expanded, so `find` looks for a literal path named `src/**`, which does not exist → `find` errors → empty output → empty spec list.

## Fix

Keep the env-var indirection (the value is no longer interpolated into the script text, so the injection hardening is preserved) but leave the variable unquoted so the shell still performs glob expansion:
```bash
find $SPECS_PATH -type f ...
```
A comment documents why this single occurrence is intentionally unquoted.

## Scope

- Affected: `.github/workflows/cypress-component-parallelization.yml` (component spec list).
- Not affected: the e2e equivalent (`e2e-test-list` action / `cypress-e2e-parallelization.yml`) — its `features_path` inputs are literal directories (`tests/e2e/features`, `features`), so quoting is correct there.

Refs: MON-200388
