### PR TITLE
enh(session): modernize the Administration > Sessions page with an AJAX listing

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4718,6 +4718,15 @@ msgid "Discard"
 msgstr ""
 
 #: centreon/www/include/options/session/connected_user.php
+msgid "Active Sessions"
+msgstr "Aktive Sitzungen"
+
+msgid "Users currently connected to the platform."
+msgstr "Aktuell mit der Plattform verbundene Benutzer."
+
+msgid "You cannot disconnect your own session."
+msgstr "Sie können Ihre eigene Sitzung nicht trennen."
+
 msgid "Disconnect user"
 msgstr ""
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4978,6 +4978,15 @@ msgid "Discard"
 msgstr ""
 
 #: centreon/www/include/options/session/connected_user.php
+msgid "Active Sessions"
+msgstr "Sesiones activas"
+
+msgid "Users currently connected to the platform."
+msgstr "Usuarios conectados actualmente a la plataforma."
+
+msgid "You cannot disconnect your own session."
+msgstr "No puede desconectar su propia sesión."
+
 msgid "Disconnect user"
 msgstr ""
 

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4796,6 +4796,15 @@ msgid "Discard"
 msgstr "Annuler"
 
 #: centreon/www/include/options/session/connected_user.php
+msgid "Active Sessions"
+msgstr "Sessions actives"
+
+msgid "Users currently connected to the platform."
+msgstr "Utilisateurs actuellement connectés à la plateforme."
+
+msgid "You cannot disconnect your own session."
+msgstr "Vous ne pouvez pas déconnecter votre propre session."
+
 msgid "Disconnect user"
 msgstr "Déconnecter l'utilisateur"
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4963,6 +4963,15 @@ msgid "Discard"
 msgstr ""
 
 #: centreon/www/include/options/session/connected_user.php
+msgid "Active Sessions"
+msgstr "Sessões ativas"
+
+msgid "Users currently connected to the platform."
+msgstr "Usuários atualmente conectados à plataforma."
+
+msgid "You cannot disconnect your own session."
+msgstr "Você não pode desconectar sua própria sessão."
+
 msgid "Disconnect user"
 msgstr ""
 

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -4952,6 +4952,15 @@ msgid "Discard"
 msgstr ""
 
 #: centreon/www/include/options/session/connected_user.php
+msgid "Active Sessions"
+msgstr "Sessões ativas"
+
+msgid "Users currently connected to the platform."
+msgstr "Utilizadores atualmente ligados à plataforma."
+
+msgid "You cannot disconnect your own session."
+msgstr "Não pode desligar a sua própria sessão."
+
 msgid "Disconnect user"
 msgstr ""
 

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
@@ -1,0 +1,82 @@
+Feature: Modern AJAX listing common features
+    As a Centreon admin
+    I want the modernized listing pages to work correctly
+    So that I can manage configuration objects efficiently
+
+  Background:
+    Given a user is logged in Centreon
+    And some service templates exist
+
+  @TEST_LISTING-001
+  Scenario: AJAX listing loads data without page reload
+    When the user navigates to the service templates listing
+    Then the listing table is rendered via AJAX
+    And the table contains service template rows
+
+  @TEST_LISTING-002
+  Scenario: Search filters listing results
+    When the user navigates to the service templates listing
+    And the user types a search term in the search field
+    And the user clicks the search button
+    Then only matching service templates are displayed
+    And the pagination reflects the filtered count
+
+  @TEST_LISTING-003
+  Scenario: Pagination navigates between pages
+    When the user navigates to the service templates listing
+    Then the pagination shows the total number of items
+    When the user clicks page 2
+    Then the listing shows the second page of results
+    And the current page indicator shows page 2
+
+  @TEST_LISTING-004
+  Scenario: Rows per page selector changes limit
+    When the user navigates to the service templates listing
+    And the user changes the rows per page to 10
+    Then the listing shows at most 10 rows
+    And the pagination is recalculated
+
+  @TEST_LISTING-005
+  Scenario: Locked elements checkbox toggles locked templates visibility
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked service templates are visible in the listing
+    When the user unchecks the locked checkbox and searches
+    Then locked service templates are hidden from the listing
+
+  @TEST_LISTING-006
+  Scenario: Locked templates have disabled checkboxes and dup inputs
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked rows have disabled selection checkboxes
+    And locked rows have disabled duplication inputs
+
+  @TEST_LISTING-007
+  Scenario: Bulk duplication works via the More actions dropdown
+    When the user navigates to the service templates listing
+    And the user selects a service template checkbox
+    And the user selects Duplicate from the More actions dropdown
+    Then a duplicated service template appears in the listing
+
+  @TEST_LISTING-008
+  Scenario: Bulk deletion works via the More actions dropdown
+    When the user navigates to the service templates listing
+    And the user selects a service template checkbox
+    And the user selects Delete from the More actions dropdown
+    Then the service template is removed from the listing
+
+  @TEST_LISTING-009
+  Scenario: Clicking a service template name navigates to the edit form
+    When the user navigates to the service templates listing
+    And the user clicks on a service template name
+    Then the service template edit form is displayed
+
+  @TEST_LISTING-010
+  Scenario: Session state persists search and pagination across navigation
+    When the user navigates to the service templates listing
+    And the user types a search term in the search field
+    And the user clicks the search button
+    And the user clicks on a service template name
+    And the user navigates back to the service templates listing
+    Then the search field still contains the search term
+    And the listing shows the same filtered results

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
@@ -1,0 +1,344 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const serviceTemplatesPage = PAGES.configuration.servicesTemplatesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('a user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('some service templates exist', () => {
+  // The default Centreon install includes many service templates (generic-active-service, etc.)
+  // Add a custom one for targeted testing
+  cy.addServiceTemplate({
+    name: 'test_listing_template',
+    template: 'generic-active-service'
+  });
+  cy.addServiceTemplate({
+    name: 'test_listing_other',
+    template: 'generic-active-service'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitListingAndWait(): void {
+  cy.visit(serviceTemplatesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  // Wait for AJAX data to load (tbody should have real rows, not just loading)
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  // Wait for table body to be populated after an AJAX call
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: AJAX listing loads data without page reload
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service templates listing', () => {
+  visitListingAndWait();
+});
+
+Then('the listing table is rendered via AJAX', () => {
+  // The modern listing uses cl-listing-table class and #clTableBody
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .should('exist');
+});
+
+Then('the table contains service template rows', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+  // Verify our test template is visible
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search filters listing results
+// ---------------------------------------------------------------------------
+
+When('the user types a search term in the search field', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('test_listing_template');
+});
+
+When('the user clicks the search button', () => {
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only matching service templates are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_other')
+    .should('not.exist');
+});
+
+Then('the pagination reflects the filtered count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .should('contain', '1-');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination navigates between pages
+// ---------------------------------------------------------------------------
+
+Then('the pagination shows the total number of items', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user clicks page 2', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop a.cl-page-num')
+    .contains('2')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('the listing shows the second page of results', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('the current page indicator shows page 2', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop span.cl-page-current')
+    .should('contain', '2');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Rows per page selector changes limit
+// ---------------------------------------------------------------------------
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('the listing shows at most 10 rows', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+Then('the pagination is recalculated', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /1-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked elements checkbox
+// ---------------------------------------------------------------------------
+
+When('the locked checkbox is checked', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .then($cb => {
+      if (!$cb.is(':checked')) {
+        cy.wrap($cb).click();
+        cy.getIframeBody().find('#clSearchBtn').click();
+        waitForAjaxRefresh();
+      }
+    });
+});
+
+Then('locked service templates are visible in the listing', () => {
+  // With locked checked, count the total rows
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .as('countWithLocked');
+});
+
+When('the user unchecks the locked checkbox and searches', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .uncheck();
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('locked service templates are hidden from the listing', () => {
+  // Without locked, the count should be less or equal
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .then(countWithoutLocked => {
+      cy.get('@countWithLocked').then(countWithLocked => {
+        expect(countWithoutLocked).to.be.at.most(countWithLocked as unknown as number);
+      });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked templates have disabled checkboxes and dup inputs
+// ---------------------------------------------------------------------------
+
+Then('locked rows have disabled selection checkboxes', () => {
+  // Find a row with a disabled checkbox (locked row)
+  cy.getIframeBody()
+    .find('#clTableBody .cl-col-picker input[type="checkbox"][disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('locked rows have disabled duplication inputs', () => {
+  cy.getIframeBody()
+    .find('#clTableBody input.cl-dup-input[disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a service template checkbox', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+});
+
+When('the user selects Duplicate from the More actions dropdown', () => {
+  // Override onchange to avoid confirm dialog
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated service template appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects Delete from the More actions dropdown', () => {
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the service template is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a service template name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'test_listing_template')
+    .click();
+});
+
+Then('the service template edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="service_description"]');
+  cy.getIframeBody()
+    .find('input[name="service_description"]')
+    .should('have.value', 'test_listing_template');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the service templates listing', () => {
+  cy.visit(serviceTemplatesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'test_listing_template');
+});
+
+Then('the listing shows the same filtered results', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+});

--- a/centreon/www/img/icons/logout.svg
+++ b/centreon/www/img/icons/logout.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' height='18px' viewBox='0 0 24 24' width='18px'><path d='M0 0h24v24H0z' fill='none'/><path d='M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z'/></svg>

--- a/centreon/www/include/common/listing/AjaxListingHelper.php
+++ b/centreon/www/include/common/listing/AjaxListingHelper.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * Helper class for AJAX listing endpoints.
+ *
+ * Provides boilerplate: session validation, parameter parsing,
+ * Centreon autoloader registration, and JSON response helpers.
+ *
+ * Usage in an AJAX endpoint:
+ *
+ *   $helper = AjaxListingHelper::boot();
+ *   $params = $helper->getParams();
+ *   $centreon = $helper->getCentreon();  // may be null
+ *   $db = $helper->getDb();
+ *   // ... run your query ...
+ *   $helper->jsonResponse($rows, $total, $params['num'], $params['limit']);
+ */
+class AjaxListingHelper
+{
+    private CentreonDB $db;
+    private mixed $centreon;
+
+    private function __construct(CentreonDB $db, mixed $centreon)
+    {
+        $this->db = $db;
+        $this->centreon = $centreon;
+    }
+
+    /**
+     * Bootstrap the AJAX endpoint: config, session, autoloader, JSON header.
+     * Exits with appropriate HTTP error on failure.
+     */
+    public static function boot(): self
+    {
+        require_once realpath(__DIR__ . '/../../../../config/centreon.config.php');
+        require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+        require_once _CENTREON_PATH_ . '/www/class/centreonSession.class.php';
+        require_once _CENTREON_PATH_ . '/www/include/common/common-Func.php';
+        require_once _CENTREON_PATH_ . '/www/class/HtmlAnalyzer.php';
+
+        header('Content-Type: application/json');
+
+        session_start();
+
+        $db = new CentreonDB();
+
+        try {
+            if (! CentreonSession::checkSession(session_id(), $db)) {
+                self::jsonError('Unauthorized', 401);
+            }
+        } catch (\Exception $e) {
+            self::jsonError('Internal error', 500);
+        }
+
+        // Register Centreon class autoloader for session deserialization
+        require_once _CENTREON_PATH_ . '/www/class/centreon.class.php';
+        require_once _CENTREON_PATH_ . '/www/class/centreonACL.class.php';
+
+        spl_autoload_register(function ($sClass): void {
+            $fileName = lcfirst($sClass);
+            $fileNameType1 = _CENTREON_PATH_ . '/www/class/' . $fileName . '.class.php';
+            $fileNameType2 = _CENTREON_PATH_ . '/www/class/' . $fileName . '.php';
+            if (file_exists($fileNameType1)) {
+                require_once $fileNameType1;
+            } elseif (file_exists($fileNameType2)) {
+                require_once $fileNameType2;
+            }
+        });
+
+        $centreon = $_SESSION['centreon'] ?? null;
+
+        return new self($db, $centreon);
+    }
+
+    /**
+     * Get sanitized listing parameters from the request.
+     *
+     * @return array{search: string, num: int, limit: int}
+     */
+    public function getParams(): array
+    {
+        return [
+            'search' => HtmlAnalyzer::sanitizeAndRemoveTags($_GET['search'] ?? ''),
+            'num'    => filter_var($_GET['num'] ?? 0, FILTER_VALIDATE_INT) ?: 0,
+            'limit'  => filter_var($_GET['limit'] ?? 30, FILTER_VALIDATE_INT) ?: 30,
+        ];
+    }
+
+    /**
+     * Get the Centreon session object (or null if deserialization failed).
+     */
+    public function getCentreon(): mixed
+    {
+        return $this->centreon;
+    }
+
+    /**
+     * Get the Centreon session object, or exit 403 if unavailable.
+     */
+    public function requireCentreon(): mixed
+    {
+        if (! $this->centreon) {
+            self::jsonError('Forbidden', 403);
+        }
+        return $this->centreon;
+    }
+
+    /**
+     * Get the database connection.
+     */
+    public function getDb(): CentreonDB
+    {
+        return $this->db;
+    }
+
+    /**
+     * Check if the current user is admin.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->centreon ? (bool) $this->centreon->user->admin : false;
+    }
+
+    /**
+     * Get the ACL object for the current user.
+     */
+    public function getAcl(): ?CentreonACL
+    {
+        return $this->centreon ? $this->centreon->user->access : null;
+    }
+
+    /**
+     * Require write access on a given topology page. Exits 403 if read-only or no access.
+     * Admins always pass.
+     *
+     * @param int $pageId The topology page number (e.g. 60101 for hosts, 60201 for servicegroups)
+     */
+    public function requireWriteAccess(int $pageId): void
+    {
+        if ($this->isAdmin()) {
+            return;
+        }
+        $acl = $this->getAcl();
+        if (! $acl || $acl->page($pageId) !== 1) {
+            self::jsonError('Write access denied', 403);
+        }
+    }
+
+    /**
+     * Validate and consume a CSRF token from POST. Exits 403 on failure.
+     * Returns a fresh token for the next request.
+     */
+    public function validateCsrfToken(): string
+    {
+        $token = $_POST['centreon_token'] ?? null;
+
+        if ($token === null || ! in_array($token, $_SESSION['x-centreon-token'] ?? [], true)) {
+            self::jsonError('Invalid CSRF token', 403);
+        }
+
+        $key = array_search($token, $_SESSION['x-centreon-token'], true);
+        unset($_SESSION['x-centreon-token'][$key], $_SESSION['x-centreon-token-generated-at'][$token]);
+
+        return createCSRFToken();
+    }
+
+    /**
+     * Log a toggle action (enable/disable) to the audit log.
+     * Uses direct SQL to avoid dependencies on CentreonLogAction.
+     *
+     * @param string $objectType Object type (e.g. 'servicegroup', 'host', 'contact')
+     * @param int $objectId Object ID
+     * @param string $objectName Object name for display
+     * @param string $actionType Action type ('enable' or 'disable')
+     */
+    public function logToggleAction(string $objectType, int $objectId, string $objectName, string $actionType): void
+    {
+        try {
+            $pearDBO = new CentreonDB('centstorage');
+
+            // Check if audit log is enabled
+            $optResult = $pearDBO->query("SELECT audit_log_option FROM `config` LIMIT 1");
+            $auditOpt = $optResult->fetchColumn();
+            if ($auditOpt != '1') {
+                return;
+            }
+
+            $userId = $this->centreon ? $this->centreon->user->get_id() : 0;
+
+            $stmt = $pearDBO->prepare(
+                "INSERT INTO `log_action` (action_log_date, object_type, object_id, object_name, action_type, log_contact_id)"
+                . " VALUES (:ts, :obj_type, :obj_id, :obj_name, :action, :uid)"
+            );
+            $stmt->bindValue(':ts', time(), PDO::PARAM_INT);
+            $stmt->bindValue(':obj_type', $objectType, PDO::PARAM_STR);
+            $stmt->bindValue(':obj_id', $objectId, PDO::PARAM_INT);
+            $stmt->bindValue(':obj_name', $objectName, PDO::PARAM_STR);
+            $stmt->bindValue(':action', $actionType, PDO::PARAM_STR);
+            $stmt->bindValue(':uid', $userId, PDO::PARAM_INT);
+            $stmt->execute();
+        } catch (\Throwable $e) {
+            // Silently fail logging — don't break the toggle
+        }
+    }
+
+    /**
+     * Send a successful JSON listing response and exit.
+     */
+    public function jsonResponse(array $rows, int $total, int $num, int $limit): void
+    {
+        echo json_encode([
+            'rows'           => $rows,
+            'total'          => $total,
+            'num'            => $num,
+            'limit'          => $limit,
+            'centreon_token' => createCSRFToken(),
+        ]);
+        exit;
+    }
+
+    /**
+     * Send a JSON error response and exit.
+     */
+    public static function jsonError(string $message, int $httpCode = 400): void
+    {
+        http_response_code($httpCode);
+        echo json_encode(['error' => $message]);
+        exit;
+    }
+}

--- a/centreon/www/include/common/listing/listing.css
+++ b/centreon/www/include/common/listing/listing.css
@@ -1,0 +1,1018 @@
+/*
+ * Centreon Modern Listing Styles
+ *
+ * Shared CSS for AJAX-based configuration listing pages.
+ * Prefix: cl- (centreon-listing)
+ *
+ * Usage: Include this file in any Smarty listing template, then use
+ * the CentreonListing JS module for AJAX data loading and rendering.
+ */
+
+/* ==========================================================================
+   Layout container
+   ========================================================================== */
+
+.cl-listing-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+/* ==========================================================================
+   Actions bar (top toolbar: add button, bulk actions, search, pagination)
+   ========================================================================== */
+
+.cl-actions-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    gap: 12px;
+}
+
+.cl-actions-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+/* "More actions" dropdown in actions bar */
+.cl-actions-left select {
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    background: var(--select-background, #fff);
+    cursor: pointer;
+    line-height: 1.4;
+    height: auto;
+}
+
+/* ==========================================================================
+   Add button (blue with "+" prefix)
+   ========================================================================== */
+
+.cl-btn-add {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #fff;
+    background-color: var(--color-primary-light, #2E68AA);
+    border: none;
+    border-radius: 4px;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+    line-height: 1.4;
+    transition: background-color 0.15s ease;
+}
+
+.cl-btn-add:hover {
+    background-color: var(--color-primary-hover, #255891);
+    color: #fff;
+    text-decoration: none;
+}
+
+.cl-btn-add::before {
+    content: '+';
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 1;
+}
+
+/* ==========================================================================
+   Search bar (centered between actions and pagination)
+   ========================================================================== */
+
+.cl-search-center {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 24px;
+}
+
+.cl-search-input {
+    width: 100%;
+    max-width: 400px;
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.cl-search-input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+.cl-search-input::placeholder {
+    color: var(--color-grey-chateau, #a7a9ac);
+}
+
+/* ==========================================================================
+   Pagination (page numbers, nav arrows, limit selector, row count)
+   ========================================================================== */
+
+.cl-pagination {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.cl-pagination a,
+.cl-pagination span.cl-page-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    font-size: 13px;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.cl-pagination a {
+    color: var(--color-primary-light, #2E68AA);
+}
+
+.cl-pagination a:hover {
+    background-color: var(--color-listing-hover, #E6EDF5);
+    text-decoration: none;
+}
+
+/* Navigation arrows (first, prev, next, last) */
+.cl-pagination a.cl-page-nav img {
+    width: 14px;
+    height: 14px;
+    opacity: 0.6;
+}
+
+.cl-pagination a.cl-page-nav:hover img {
+    opacity: 1;
+}
+
+/* Current page indicator */
+.cl-pagination span.cl-page-current {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    background-color: var(--color-primary-light, #2E68AA);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+/* "X-Y of Z" label */
+.cl-pagination .cl-page-info {
+    font-size: 13px;
+    color: var(--body-color, #555);
+    padding: 0 4px;
+}
+
+/* Rows-per-page selector */
+.cl-pagination .cl-limit-select {
+    padding: 4px 8px;
+    font-size: 13px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    background: var(--select-background, #fff);
+    cursor: pointer;
+    min-width: 50px;
+}
+
+/* ==========================================================================
+   Data table
+   ========================================================================== */
+
+.cl-listing-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    background: var(--select-background, #fff);
+    border: none;
+}
+
+/* -- Table header --------------------------------------------------------- */
+
+.cl-listing-table thead th {
+    padding: 6px 16px;
+    font-weight: 600;
+    font-size: 13px;
+    color: #fff;
+    text-align: left;
+    border-bottom: none;
+    background: #8C8C8C;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.cl-listing-table thead th.cl-col-center {
+    text-align: center;
+}
+
+.cl-listing-table thead th.cl-col-right {
+    text-align: right;
+}
+
+.cl-listing-table thead th.cl-col-picker {
+    width: 40px;
+    text-align: center;
+    padding: 6px 8px;
+    vertical-align: middle;
+}
+
+/* -- Table body rows ------------------------------------------------------ */
+
+.cl-listing-table tbody tr {
+    background: var(--select-background, #fff);
+    transition: background-color 0.15s ease;
+    cursor: pointer;
+}
+
+.cl-listing-table tbody tr:hover {
+    background-color: var(--color-listing-hover, #E6EDF5);
+}
+
+.cl-listing-table tbody td {
+    padding: 4px 16px;
+    font-size: 13px;
+    color: var(--body-color, #555);
+    border-bottom: 1px solid var(--color-divider, #E3E3E3);
+    vertical-align: middle;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 300px;
+}
+
+.cl-listing-table tbody td.cl-col-center {
+    text-align: center;
+}
+
+.cl-listing-table tbody td.cl-col-right {
+    text-align: right;
+}
+
+.cl-listing-table tbody td.cl-col-picker {
+    width: 40px;
+    text-align: center;
+    padding: 4px 8px;
+}
+
+/* -- Links inside rows ---------------------------------------------------- */
+
+.cl-listing-table tbody td a {
+    color: var(--color-primary-light, #2E68AA);
+    text-decoration: none;
+}
+
+.cl-listing-table tbody td a:hover {
+    text-decoration: underline;
+}
+
+.cl-listing-table tbody tr:hover td {
+    color: var(--color-charcoal, #444);
+}
+
+.cl-listing-table tbody tr:hover td a {
+    color: var(--color-primary-hover, #255891);
+}
+
+/* ==========================================================================
+   Options cell (actions column: toggle + duplication input)
+   ========================================================================== */
+
+.cl-options-cell {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.cl-dup-input {
+    width: 36px;
+    height: 22px;
+    text-align: center;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    font-size: 11px;
+    margin: 0;
+    padding: 0 2px;
+    line-height: 20px;
+}
+
+.cl-dup-input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+    outline: none;
+}
+
+/* ==========================================================================
+   Toggle switch (iPhone style enable/disable)
+   ========================================================================== */
+
+.cl-toggle {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.cl-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.cl-toggle-slider {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    border-radius: 20px;
+    transition: background-color 0.25s ease;
+}
+
+.cl-toggle-slider::before {
+    content: '';
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: #fff;
+    border-radius: 50%;
+    transition: transform 0.25s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.cl-toggle input:checked + .cl-toggle-slider {
+    background-color: var(--color-success, #88B922);
+}
+
+.cl-toggle input:checked + .cl-toggle-slider::before {
+    transform: translateX(16px);
+}
+
+.cl-toggle input:disabled + .cl-toggle-slider {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ==========================================================================
+   Bottom bar (bulk actions + pagination)
+   ========================================================================== */
+
+.cl-bottom-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+}
+
+/* ==========================================================================
+   Checkbox alignment (header and body rows)
+   ========================================================================== */
+
+.cl-listing-table .cl-col-picker .md-checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    height: 100%;
+}
+
+.cl-listing-table .cl-col-picker .md-checkbox input[type="checkbox"] {
+    margin: 0;
+}
+
+.cl-listing-table .cl-col-picker .md-checkbox label {
+    margin: 0;
+    padding: 0;
+    min-height: auto;
+    line-height: 1;
+}
+
+/* White checkbox border on dark header */
+.cl-listing-table thead th .md-checkbox label::before {
+    border-color: #fff;
+}
+
+/* ==========================================================================
+   States: loading, empty, fade-in animation
+   ========================================================================== */
+
+.cl-loading {
+    text-align: center;
+    padding: 24px;
+    color: var(--color-grey-chateau, #a7a9ac);
+    font-size: 14px;
+}
+
+.cl-listing-table tbody {
+    transition: opacity 0.2s ease;
+}
+
+.cl-listing-table tbody.cl-fade-in {
+    animation: clFadeIn 0.25s ease;
+}
+
+@keyframes clFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* ==========================================================================
+   Sub-listing header (e.g. meta service metric listing)
+   ========================================================================== */
+
+.cl-meta-header {
+    padding: 10px 16px;
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--body-color, #555);
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 4px;
+    margin-bottom: 8px;
+}
+
+/* ==========================================================================
+   Tooltip (instant, no-delay, fixed position in body)
+   ========================================================================== */
+
+.cl-tooltip-popup {
+    position: fixed;
+    z-index: 99999;
+    background: var(--body-background, #222);
+    color: var(--body-color, #eee);
+    border: 1px solid var(--listing-border-botom-color, #555);
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+.cl-tooltip-popup b {
+    margin-right: 4px;
+}
+
+/* ==========================================================================
+   Add button dropdown (two-level: Wizard / Advanced)
+   ========================================================================== */
+
+.cl-add-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.cl-add-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    min-width: 160px;
+    margin-top: 4px;
+    overflow: hidden;
+}
+
+.cl-add-dropdown.cl-open .cl-add-dropdown-menu {
+    display: block;
+}
+
+.cl-add-dropdown-menu a {
+    display: block;
+    padding: 8px 16px;
+    color: var(--body-color, #444);
+    text-decoration: none;
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.cl-add-dropdown-menu a:hover {
+    background: var(--list-hover-background-color, #E6EDF5);
+    text-decoration: none;
+}
+
+/* ==========================================================================
+   Filter box (advanced search with multiple fields)
+   ========================================================================== */
+
+.cl-filter-box {
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 6px;
+    padding: 10px 16px;
+    margin-bottom: 8px;
+}
+
+.cl-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.cl-filter-bar .cl-search-input {
+    max-width: none;
+    width: 200px;
+    height: 28px;
+    padding: 4px 8px;
+    font-size: 13px;
+}
+
+.cl-filter-bar .select2-container {
+    width: 180px !important;
+}
+
+.cl-filter-bar .select2-container .select2-selection {
+    height: 30px;
+    min-height: 30px;
+}
+
+.cl-filter-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--body-color, #555);
+    margin-right: 4px;
+}
+
+/* ==========================================================================
+   Clear button for individual select2 dropdowns
+   ========================================================================== */
+
+.cl-clear-select {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--color-danger, #FF4A4A);
+    padding: 0 2px;
+    margin-left: -2px;
+    margin-right: 4px;
+    opacity: 0.6;
+}
+
+.cl-clear-select:hover {
+    opacity: 1;
+}
+
+/* ==========================================================================
+   Monitoring status badges (real-time host/poller status)
+   ========================================================================== */
+
+.cl-mon-badge {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.cl-mon-up {
+    background: var(--color-success, #88B922);
+    box-shadow: 0 0 4px var(--color-success, #88B922);
+}
+
+.cl-mon-down {
+    background: var(--color-danger, #FF4A4A);
+    box-shadow: 0 0 4px var(--color-danger, #FF4A4A);
+}
+
+.cl-mon-unreach {
+    background: var(--color-aluminium, #818285);
+    box-shadow: 0 0 4px var(--color-aluminium, #818285);
+}
+
+.cl-mon-warning {
+    background: var(--color-warning, #FD9B27);
+    box-shadow: 0 0 4px var(--color-warning, #FD9B27);
+}
+
+.cl-mon-unknown {
+    background: var(--color-aluminium, #818285);
+    box-shadow: 0 0 4px var(--color-aluminium, #818285);
+}
+
+.cl-mon-pending {
+    background: var(--color-pending, #1EBEB3);
+    box-shadow: 0 0 4px var(--color-pending, #1EBEB3);
+}
+
+/* ==========================================================================
+   Stale last-update highlight (pollers)
+   ========================================================================== */
+
+.cl-stale {
+    background-color: #F7D507 !important;
+    color: #333 !important;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+/* ==========================================================================
+   Trap status colors
+   ========================================================================== */
+
+.cl-status-ok { color: var(--color-success, #88B922); }
+.cl-status-warning { color: var(--color-warning, #FD9B27); }
+.cl-status-critical { color: var(--color-danger, #FF4A4A); }
+.cl-status-unknown { color: var(--color-aluminium, #818285); }
+.cl-status-pending { color: var(--color-pending, #1EBEB3); }
+
+/* ==========================================================================
+   Infinite scroll wrapper (full-height flex layout)
+   ========================================================================== */
+
+.cl-scroll-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 60px);
+    overflow: hidden;
+}
+.cl-scroll-wrapper .cl-filter-box,
+.cl-scroll-wrapper .cl-actions-bar {
+    flex-shrink: 0;
+}
+.cl-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+}
+.cl-scroll-area table {
+    width: 100%;
+}
+.cl-scroll-area .cl-listing-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--table-header-background, #6b7888);
+}
+
+/* ==========================================================================
+   Expand button (inline detail toggle: +/− in listing rows)
+   ========================================================================== */
+
+.cl-expand-btn {
+    cursor: pointer;
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    background: var(--color-divider, #e8e8e8);
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+}
+.cl-expand-btn:hover {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cl-expand-btn.open {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cl-expand-btn.disabled {
+    cursor: default;
+    opacity: 0.3;
+    pointer-events: none;
+}
+
+/* ==========================================================================
+   Inline detail row (expanded diff inside listing)
+   ========================================================================== */
+
+.cl-detail-row td {
+    padding: 0 !important;
+    background: var(--body-background, #f9f9f9);
+}
+.cl-diff-container {
+    margin: 6px 16px 10px 36px;
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: 12px;
+}
+.cl-diff-header {
+    display: flex;
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.cl-diff-header span {
+    flex: 1;
+    padding: 6px 10px;
+}
+.cl-diff-header span:first-child {
+    flex: 0 0 200px;
+}
+.cl-diff-row {
+    display: flex;
+    border-bottom: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-row:last-child {
+    border-bottom: none;
+}
+.cl-diff-row:hover {
+    background: rgba(0,0,0,0.02);
+}
+.cl-diff-field {
+    flex: 0 0 200px;
+    padding: 5px 10px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+    word-break: break-all;
+    border-right: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-before, .cl-diff-after {
+    flex: 1;
+    padding: 5px 10px;
+    word-break: break-all;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cl-diff-before {
+    background: rgba(255, 74, 74, 0.06);
+    color: #c0392b;
+    border-right: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-after {
+    background: rgba(39, 174, 96, 0.06);
+    color: #27ae60;
+}
+.cl-diff-before:empty, .cl-diff-after:empty {
+    background: transparent;
+}
+.cl-diff-empty {
+    padding: 12px 16px;
+    color: #a7a9ac;
+    font-style: italic;
+    text-align: center;
+}
+.cl-diff-loading {
+    padding: 12px 16px;
+    text-align: center;
+    color: #a7a9ac;
+}
+
+/* ==========================================================================
+   Changelog detail page — Timeline layout (cld- prefix)
+   ========================================================================== */
+
+.cld-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 16px 20px;
+}
+
+/* Header card */
+.cld-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 8px;
+    padding: 16px 24px;
+    margin-bottom: 24px;
+}
+.cld-header-info {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+.cld-header-icon {
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #3a7bbf, #2c5f8f);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 18px;
+    flex-shrink: 0;
+}
+.cld-header-text h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--list-color, #333);
+}
+.cld-header-text .cld-subtitle {
+    margin: 2px 0 0;
+    font-size: 12px;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.cld-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: var(--color-divider, #e8e8e8);
+    color: var(--list-color, #555);
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background 0.15s;
+}
+.cld-back-btn:hover {
+    background: #3a7bbf;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* Timeline */
+.cld-timeline {
+    position: relative;
+    padding-left: 40px;
+}
+.cld-timeline::before {
+    content: '';
+    position: absolute;
+    left: 15px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--color-divider, #ddd);
+    border-radius: 1px;
+}
+.cld-entry {
+    position: relative;
+    margin-bottom: 16px;
+}
+.cld-entry:last-child {
+    margin-bottom: 0;
+}
+
+/* Timeline dot */
+.cld-dot {
+    position: absolute;
+    left: -33px;
+    top: 16px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 2px var(--color-divider, #ddd);
+}
+.cld-dot.dot-create  { background: #27ae60; box-shadow: 0 0 0 2px #27ae60; }
+.cld-dot.dot-change  { background: #e67e22; box-shadow: 0 0 0 2px #e67e22; }
+.cld-dot.dot-delete  { background: #e74c3c; box-shadow: 0 0 0 2px #e74c3c; }
+.cld-dot.dot-enable  { background: #27ae60; box-shadow: 0 0 0 2px #27ae60; }
+.cld-dot.dot-disable { background: #e74c3c; box-shadow: 0 0 0 2px #e74c3c; }
+
+/* Entry card */
+.cld-card {
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 8px;
+    overflow: hidden;
+    transition: box-shadow 0.15s;
+}
+.cld-card:hover {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+.cld-card-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    gap: 12px;
+    cursor: pointer;
+    user-select: none;
+}
+.cld-card-header:hover {
+    background: rgba(0,0,0,0.015);
+}
+.cld-card-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    background: var(--color-divider, #e8e8e8);
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+}
+.cld-card-header:hover .cld-card-toggle {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cld-card-toggle.open {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cld-card-toggle.no-expand {
+    opacity: 0.2;
+    cursor: default;
+    pointer-events: none;
+}
+.cld-card-date {
+    font-size: 13px;
+    color: #888;
+    white-space: nowrap;
+    min-width: 130px;
+}
+.cld-card-badge {
+    flex-shrink: 0;
+}
+.cld-card-author {
+    font-size: 12px;
+    color: #999;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+/* Diff panel (inside timeline cards) */
+.cld-diff-panel {
+    display: none;
+    border-top: 1px solid var(--color-divider, #eee);
+}
+.cld-diff-panel.open {
+    display: block;
+}
+.cld-diff-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.cld-diff-table th {
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 7px 12px;
+    text-align: left;
+}
+.cld-diff-table td {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--color-divider, #eee);
+    vertical-align: top;
+    word-break: break-all;
+}
+.cld-diff-table tr:last-child td {
+    border-bottom: none;
+}
+.cld-diff-table .cld-fname {
+    width: 220px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+}
+.cld-diff-table .cld-fbefore {
+    background: rgba(255, 74, 74, 0.05);
+    color: #c0392b;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cld-diff-table .cld-fafter {
+    background: rgba(39, 174, 96, 0.05);
+    color: #27ae60;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cld-no-changes {
+    padding: 14px 16px;
+    color: #aaa;
+    font-style: italic;
+    text-align: center;
+    font-size: 12px;
+}

--- a/centreon/www/include/common/listing/listing.js
+++ b/centreon/www/include/common/listing/listing.js
@@ -1,0 +1,639 @@
+/*
+ * CentreonListing - Reusable AJAX listing module
+ *
+ * Provides AJAX-driven data tables for Centreon configuration pages,
+ * replacing legacy Smarty server-side rendered listings.
+ *
+ * Usage:
+ *   var listing = new CentreonListing({ ... });
+ *   listing.init();
+ *
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Licensed under the Apache License, Version 2.0
+ */
+
+function CentreonListing(config) {
+
+    // =====================================================================
+    // Configuration (with defaults)
+    // =====================================================================
+
+    var cfg = {
+        // DOM element IDs
+        tableBodyId:        config.tableBodyId        || 'clTableBody',
+        paginationTopId:    config.paginationTopId    || 'clPaginationTop',
+        paginationBottomId: config.paginationBottomId || 'clPaginationBottom',
+        searchInputId:      config.searchInputId      || 'clSearchInput',
+        searchBtnId:        config.searchBtnId        || 'clSearchBtn',
+        limitInputId:       config.limitInputId       || 'limit',
+
+        // AJAX endpoints
+        ajaxListUrl:   config.ajaxListUrl   || '',
+        ajaxToggleUrl: config.ajaxToggleUrl || '',
+
+        // Page identity
+        pageId:      config.pageId      || '',
+        writeAccess: config.writeAccess || false,
+        storageKey:  config.storageKey  || 'cl_listing_limit',
+
+        // Behaviour
+        defaultLimit: config.defaultLimit || 30,
+        autoRefresh:  config.autoRefresh !== undefined ? config.autoRefresh : 30000,
+        emptyMessage: config.emptyMessage || 'No items found',
+
+        // Column definitions
+        // Each column: { id, header, align, render: function(row, listing) }
+        columns: config.columns || [],
+
+        // Row identity field (used for checkboxes, toggle, duplication)
+        rowIdField: config.rowIdField || 'id',
+
+        // Activate field name in row data (for toggle)
+        activateField: config.activateField || 'activate',
+
+        // Edit link builder: function(row) -> URL string
+        editLink: config.editLink || null,
+
+        // Options column renderer (toggle + dup input) — null to hide
+        // function(row, listing) -> HTML string
+        renderOptions: config.renderOptions || null,
+
+        // Extra GET parameters appended to every fetch request
+        extraParams: config.extraParams || {},
+
+        // Show row checkboxes (default true)
+        showCheckboxes: config.showCheckboxes !== undefined ? config.showCheckboxes : true,
+
+        // Field name in row data that indicates a locked/non-selectable row (checkbox disabled)
+        lockedField: config.lockedField || null,
+
+        // Infinite scroll mode (default false) — appends rows on scroll instead of pagination
+        infiniteScroll: config.infiniteScroll || false,
+        infiniteScrollBuffer: config.infiniteScrollBuffer || 600, // px from bottom to trigger load
+        scrollContainerId: config.scrollContainerId || null, // custom scroll container for infinite scroll
+
+        // Callbacks
+        onDataLoaded: config.onDataLoaded || null,
+    };
+
+    // =====================================================================
+    // Internal state
+    // =====================================================================
+
+    var self       = this;
+    var csrfToken  = '';
+    var firstLoad  = true;
+
+    // Restore state from sessionStorage (survives navigation, cleared on browser close)
+    var stateKey   = 'cl_state_' + cfg.storageKey;
+    var savedState = null;
+    try { savedState = JSON.parse(sessionStorage.getItem(stateKey)); } catch(e) {}
+
+    var currentNum    = (savedState && typeof savedState.num === 'number') ? savedState.num : 0;
+    var currentLimit  = parseInt(localStorage.getItem(cfg.storageKey), 10) || (savedState && savedState.limit) || cfg.defaultLimit;
+    var currentSearch = (savedState && savedState.search) || '';
+
+    // Infinite scroll state
+    var isLoadingMore  = false;
+    var allLoaded      = false;
+    var totalLoaded    = 0;
+
+    // =====================================================================
+    // Public: HTML escape utility
+    // =====================================================================
+
+    this.escape = function (str) {
+        if (!str) return '';
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    };
+
+    // =====================================================================
+    // Public: get current CSRF token
+    // =====================================================================
+
+    this.getCsrfToken = function () {
+        return csrfToken;
+    };
+
+    this.setCsrfToken = function (token) {
+        csrfToken = token;
+    };
+
+    // =====================================================================
+    // Public: get current state
+    // =====================================================================
+
+    this.getState = function () {
+        return { num: currentNum, limit: currentLimit, search: currentSearch };
+    };
+
+    // =====================================================================
+    // Internal: save / restore checked row checkboxes
+    // =====================================================================
+
+    function getCheckedIds() {
+        var ids = [];
+        jQuery('#' + cfg.tableBodyId + ' .cl-col-picker input[type=checkbox]:checked').each(function () {
+            var name = jQuery(this).attr('name');
+            if (name) ids.push(name);
+        });
+        return ids;
+    }
+
+    function restoreCheckedIds(ids) {
+        for (var i = 0; i < ids.length; i++) {
+            jQuery('#' + cfg.tableBodyId + ' input[name="' + ids[i] + '"]').prop('checked', true);
+        }
+    }
+
+    // =====================================================================
+    // Public: fetch data from the AJAX listing endpoint
+    //   silent = true  → no loading indicator, no fade (used by auto-refresh)
+    //   silent = false → fade-in animation on success
+    // =====================================================================
+
+    this.fetch = function (num, limit, search, silent) {
+        var isAppend = cfg.infiniteScroll && num > 0 && !firstLoad;
+
+        currentNum    = num;
+        currentLimit  = limit;
+        currentSearch = search;
+
+        // Persist state to sessionStorage (including extra filter params + select2 labels)
+        try {
+            var extra = typeof cfg.extraParams === 'function' ? cfg.extraParams() : cfg.extraParams;
+            var labels = {};
+            if (extra) {
+                jQuery.each(extra, function(key, val) {
+                    if (val) {
+                        var el = jQuery('#' + key);
+                        if (el.length && el.is('select')) {
+                            labels[key] = el.find('option:selected').text() || val;
+                        }
+                    }
+                });
+            }
+            sessionStorage.setItem(stateKey, JSON.stringify({ num: num, limit: limit, search: search, extra: extra || {}, labels: labels }));
+        } catch(e) {}
+
+        var checkedIds = getCheckedIds();
+
+        if (firstLoad) {
+            jQuery('#' + cfg.tableBodyId).html(
+                '<tr><td colspan="99" class="cl-loading">Loading...</td></tr>'
+            );
+        }
+
+        if (isAppend) {
+            isLoadingMore = true;
+            // Show loading indicator at bottom
+            jQuery('#' + cfg.tableBodyId).find('.cl-infinite-loader').remove();
+            jQuery('#' + cfg.tableBodyId).append(
+                '<tr class="cl-infinite-loader"><td colspan="99" style="text-align:center;padding:12px;color:#a7a9ac;">Loading more...</td></tr>'
+            );
+        }
+
+        jQuery.ajax({
+            url: cfg.ajaxListUrl,
+            type: 'GET',
+            dataType: 'json',
+            data: jQuery.extend({ search: search, num: num, limit: limit }, typeof cfg.extraParams === 'function' ? cfg.extraParams() : cfg.extraParams),
+            success: function (data) {
+                csrfToken = data.centreon_token || '';
+                var tbody = jQuery('#' + cfg.tableBodyId);
+
+                if (cfg.infiniteScroll && isAppend) {
+                    // Remove loader row
+                    tbody.find('.cl-infinite-loader').remove();
+                    // Append new rows
+                    self.appendRows(data.rows);
+                    totalLoaded += data.rows.length;
+                    allLoaded = totalLoaded >= data.total;
+                    isLoadingMore = false;
+                    // Update info
+                    self.renderScrollInfo(totalLoaded, data.total);
+                } else {
+                    tbody.removeClass('cl-fade-in');
+                    self.renderRows(data.rows);
+                    if (cfg.infiniteScroll) {
+                        totalLoaded = data.rows.length;
+                        allLoaded = totalLoaded >= data.total;
+                        isLoadingMore = false;
+                        self.renderScrollInfo(totalLoaded, data.total);
+                    } else {
+                        self.renderPagination(data.total, data.num, data.limit);
+                    }
+                    restoreCheckedIds(checkedIds);
+                    jQuery('#' + cfg.limitInputId).val(data.limit);
+                    if (!silent) {
+                        void tbody[0].offsetWidth;
+                        tbody.addClass('cl-fade-in');
+                    }
+                }
+                firstLoad = false;
+                // Reset bulk action dropdowns to default
+                jQuery('select[name="o1"], select[name="o2"]').prop('selectedIndex', 0);
+                if (cfg.onDataLoaded) cfg.onDataLoaded(data);
+            },
+            error: function () {
+                isLoadingMore = false;
+                jQuery('#' + cfg.tableBodyId).find('.cl-infinite-loader').remove();
+                if (firstLoad) {
+                    jQuery('#' + cfg.tableBodyId).html(
+                        '<tr><td colspan="99" style="text-align:center;padding:24px;color:#FF4A4A;">Error loading data</td></tr>'
+                    );
+                }
+            }
+        });
+    };
+
+    // =====================================================================
+    // Public: render table body rows from data
+    // =====================================================================
+
+    this.renderRows = function (rows) {
+        // Allow custom renderRows from config
+        if (typeof cfg.renderRows === 'function') {
+            cfg.renderRows.call(self, rows);
+            return;
+        }
+
+        var tbody = jQuery('#' + cfg.tableBodyId);
+        tbody.empty();
+
+        if (!rows || rows.length === 0) {
+            tbody.html('<tr><td colspan="99" style="text-align:center;padding:24px;color:#a7a9ac;">' +
+                self.escape(cfg.emptyMessage) + '</td></tr>');
+            return;
+        }
+
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var rowId = row[cfg.rowIdField];
+
+            // Checkbox cell (optional)
+            var isLocked = cfg.lockedField && row[cfg.lockedField];
+            var tr = '<tr>';
+            if (cfg.showCheckboxes) {
+                var disabledAttr = isLocked ? ' disabled' : '';
+                tr += '<td class="cl-col-picker">' +
+                    '<div class="md-checkbox md-checkbox-inline">' +
+                        '<input type="checkbox" id="select_' + rowId + '" name="select[' + rowId + ']" value="1"' + disabledAttr + ' />' +
+                        '<label class="empty-label" for="select_' + rowId + '"></label>' +
+                    '</div>' +
+                '</td>';
+            }
+
+            // Data columns
+            for (var c = 0; c < cfg.columns.length; c++) {
+                var col = cfg.columns[c];
+                var align = col.align ? ' class="cl-col-' + col.align + '"' : '';
+                var cellHtml = col.render ? col.render(row, self) : self.escape(row[col.id] || '');
+                tr += '<td' + align + '>' + cellHtml + '</td>';
+            }
+
+            // Options column (always rendered; if read-only, toggle is disabled and dup input hidden)
+            if (cfg.renderOptions) {
+                var optHtml = cfg.renderOptions(row, self, cfg.writeAccess);
+                if (!cfg.writeAccess) {
+                    // Disable toggles and hide dup inputs for read-only users
+                    optHtml = optHtml.replace(/onchange="[^"]*"/g, '').replace(/<input[^>]*cl-dup-input[^>]*>/g, '');
+                    optHtml = optHtml.replace(/<input type="checkbox"/g, '<input type="checkbox" disabled');
+                }
+                tr += '<td class="cl-col-right"><div class="cl-options-cell">' + optHtml + '</div></td>';
+            }
+
+            tr += '</tr>';
+            tbody.append(tr);
+        }
+    };
+
+    // =====================================================================
+    // Public: append rows (infinite scroll mode — adds to existing tbody)
+    // =====================================================================
+
+    this.appendRows = function (rows) {
+        if (!rows || rows.length === 0) return;
+
+        var tbody = jQuery('#' + cfg.tableBodyId);
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var rowId = row[cfg.rowIdField];
+            var isLocked = cfg.lockedField && row[cfg.lockedField];
+
+            var tr = '<tr>';
+            if (cfg.showCheckboxes) {
+                var disabledAttr = isLocked ? ' disabled' : '';
+                tr += '<td class="cl-col-picker">' +
+                    '<div class="md-checkbox md-checkbox-inline">' +
+                        '<input type="checkbox" id="select_' + rowId + '" name="select[' + rowId + ']" value="1"' + disabledAttr + ' />' +
+                        '<label class="empty-label" for="select_' + rowId + '"></label>' +
+                    '</div>' +
+                '</td>';
+            }
+
+            for (var c = 0; c < cfg.columns.length; c++) {
+                var col = cfg.columns[c];
+                var align = col.align ? ' class="cl-col-' + col.align + '"' : '';
+                var cellHtml = col.render ? col.render(row, self) : self.escape(row[col.id] || '');
+                tr += '<td' + align + '>' + cellHtml + '</td>';
+            }
+
+            if (cfg.renderOptions) {
+                var optHtml = cfg.renderOptions(row, self, cfg.writeAccess);
+                if (!cfg.writeAccess) {
+                    optHtml = optHtml.replace(/onchange="[^"]*"/g, '').replace(/<input[^>]*cl-dup-input[^>]*>/g, '');
+                    optHtml = optHtml.replace(/<input type="checkbox"/g, '<input type="checkbox" disabled');
+                }
+                tr += '<td class="cl-col-right"><div class="cl-options-cell">' + optHtml + '</div></td>';
+            }
+
+            tr += '</tr>';
+            tbody.append(tr);
+        }
+    };
+
+    // =====================================================================
+    // Public: render scroll info (infinite scroll mode)
+    // =====================================================================
+
+    this.renderScrollInfo = function (loaded, total) {
+        var html = '<span class="cl-page-info">' + loaded + ' / ' + total + '</span>';
+        if (!allLoaded) {
+            html += '<span style="color:#a7a9ac;margin-left:8px;font-size:11px;">Scroll for more</span>';
+        }
+        jQuery('#' + cfg.paginationTopId).html(html);
+        jQuery('#' + cfg.paginationBottomId).html(html);
+    };
+
+    // =====================================================================
+    // Public: reset infinite scroll (used on filter change)
+    // =====================================================================
+
+    this.resetScroll = function () {
+        totalLoaded = 0;
+        allLoaded = false;
+        isLoadingMore = false;
+        currentNum = 0;
+        self.fetch(0, currentLimit, currentSearch);
+    };
+
+    // =====================================================================
+    // Public: render pagination controls
+    // =====================================================================
+
+    this.renderPagination = function (total, num, limit) {
+        var totalPages = Math.ceil(total / limit);
+        if (totalPages < 1) totalPages = 1;
+
+        var startRow = total > 0 ? num * limit + 1 : 0;
+        var endRow   = Math.min((num + 1) * limit, total);
+        var info     = startRow + '-' + endRow + ' of ' + total;
+
+        var html = '';
+
+        // First / Previous
+        if (num > 0) {
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(0);return false;">'
+                + '<img src="./img/icons/first_rewind.png" title="First page" /></a>';
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (num - 1) + ');return false;">'
+                + '<img src="./img/icons/rewind.png" title="Previous page" /></a>';
+        }
+
+        // Page numbers
+        var startPage = Math.max(0, num - 5);
+        var endPage   = Math.min(totalPages - 1, num + 5);
+        for (var i = startPage; i <= endPage; i++) {
+            if (i === num) {
+                html += '<span class="cl-page-current">' + (i + 1) + '</span>';
+            } else {
+                html += '<a href="#" class="cl-page-num" onclick="' + instanceName() + '.goToPage(' + i + ');return false;">'
+                    + (i + 1) + '</a>';
+            }
+        }
+
+        // Next / Last
+        if (num < totalPages - 1) {
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (num + 1) + ');return false;">'
+                + '<img src="./img/icons/fast_forward.png" title="Next page" /></a>';
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (totalPages - 1) + ');return false;">'
+                + '<img src="./img/icons/end_forward.png" title="Last page" /></a>';
+        }
+
+        // Rows-per-page selector
+        html += ' <select class="cl-limit-select" onchange="' + instanceName() + '.changeLimit(this.value);">';
+        var limits = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        for (var j = 0; j < limits.length; j++) {
+            var sel = limits[j] === limit ? ' selected' : '';
+            html += '<option value="' + limits[j] + '"' + sel + '>' + limits[j] + '</option>';
+        }
+        html += '</select>';
+
+        // Row count info
+        html += '<span class="cl-page-info">' + info + '</span>';
+
+        jQuery('#' + cfg.paginationTopId).html(html);
+        jQuery('#' + cfg.paginationBottomId).html(html);
+    };
+
+    // =====================================================================
+    // Public: navigation helpers
+    // =====================================================================
+
+    this.goToPage = function (num) {
+        self.fetch(num, currentLimit, currentSearch);
+    };
+
+    this.changeLimit = function (limit) {
+        var newLimit = parseInt(limit, 10);
+        localStorage.setItem(cfg.storageKey, newLimit);
+        self.fetch(0, newLimit, currentSearch); // reset to page 0 on limit change
+    };
+
+    // =====================================================================
+    // Public: toggle activation (enable/disable via AJAX)
+    // =====================================================================
+
+    this.toggleActivation = function (toggle) {
+        if (!cfg.ajaxToggleUrl) return;
+
+        var rowId    = jQuery(toggle).data('row-id');
+        var isChecked = toggle.checked;
+        var action   = isChecked ? 's' : 'u';
+
+        toggle.disabled = true;
+
+        jQuery.ajax({
+            url: cfg.ajaxToggleUrl,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                id: rowId,
+                action: action,
+                centreon_token: csrfToken
+            },
+            success: function (response) {
+                if (response.centreon_token) {
+                    csrfToken = response.centreon_token;
+                }
+                toggle.disabled = false;
+            },
+            error: function () {
+                toggle.checked = !isChecked;
+                toggle.disabled = false;
+            }
+        });
+    };
+
+    // =====================================================================
+    // Public: select / deselect all row checkboxes
+    // =====================================================================
+
+    this.checkUncheckAll = function (masterCheckbox) {
+        var table = jQuery(masterCheckbox).closest('table');
+        table.find('tbody .cl-col-picker input[type=checkbox]').each(function () {
+            jQuery(this).prop('checked', masterCheckbox.checked);
+        });
+    };
+
+    // =====================================================================
+    // Public: initialise (first load, bind events, auto-refresh)
+    // =====================================================================
+
+    this.init = function () {
+        // Restore search value from session state (overrides Smarty default if different)
+        if (currentSearch) {
+            jQuery('#' + cfg.searchInputId).val(currentSearch);
+        } else {
+            currentSearch = jQuery('#' + cfg.searchInputId).val() || '';
+        }
+
+        // Restore extra filter params (select2 dropdowns) from session state
+        if (savedState && savedState.extra) {
+            var labels = savedState.labels || {};
+            jQuery.each(savedState.extra, function(key, val) {
+                if (val) {
+                    var el = jQuery('#' + key);
+                    if (el.length && el.is('select')) {
+                        var text = labels[key] || val;
+                        if (!el.find('option[value="' + val + '"]').length) {
+                            el.append(new Option(text, val, true, true));
+                        } else {
+                            el.val(val);
+                        }
+                        el.trigger('change');
+                    }
+                }
+            });
+        }
+
+        // Search button (resets to page 0; in infinite scroll mode, resets scroll state)
+        jQuery('#' + cfg.searchBtnId).on('click', function () {
+            currentSearch = jQuery('#' + cfg.searchInputId).val();
+            if (cfg.infiniteScroll) {
+                self.resetScroll();
+            } else {
+                self.fetch(0, currentLimit, currentSearch);
+            }
+        });
+
+        // Search on Enter key
+        jQuery('#' + cfg.searchInputId).on('keypress', function (e) {
+            if (e.which === 13) {
+                e.preventDefault();
+                jQuery('#' + cfg.searchBtnId).click();
+            }
+        });
+
+        // In infinite scroll mode, always start at page 0 and use a larger batch size
+        if (cfg.infiniteScroll) {
+            currentNum = 0;
+            if (currentLimit < 50) currentLimit = 50;
+        }
+
+        // Initial data load (restore page from session)
+        self.fetch(currentNum, currentLimit, currentSearch);
+
+        // Infinite scroll: listen for scroll on the specified container or window
+        if (cfg.infiniteScroll) {
+            var scrollParent;
+            if (cfg.scrollContainerId) {
+                scrollParent = jQuery('#' + cfg.scrollContainerId);
+            } else {
+                scrollParent = jQuery('#main-content');
+                if (!scrollParent.length) scrollParent = jQuery(window);
+            }
+
+            scrollParent.on('scroll', function () {
+                if (isLoadingMore || allLoaded) return;
+
+                var scrollTop, scrollHeight, clientHeight;
+                if (scrollParent.is(jQuery(window))) {
+                    scrollTop = jQuery(window).scrollTop();
+                    scrollHeight = jQuery(document).height();
+                    clientHeight = jQuery(window).height();
+                } else {
+                    scrollTop = scrollParent.scrollTop();
+                    scrollHeight = scrollParent[0].scrollHeight;
+                    clientHeight = scrollParent[0].clientHeight;
+                }
+
+                if (scrollTop + clientHeight >= scrollHeight - cfg.infiniteScrollBuffer) {
+                    currentNum++;
+                    self.fetch(currentNum, currentLimit, currentSearch, true);
+                }
+            });
+        }
+
+        // Auto-refresh (disabled in infinite scroll mode to avoid resetting the list)
+        if (cfg.autoRefresh > 0 && !cfg.infiniteScroll) {
+            setInterval(function () {
+                self.fetch(currentNum, currentLimit, currentSearch, true);
+            }, cfg.autoRefresh);
+        }
+    };
+
+    // =====================================================================
+    // Internal: resolve the global variable name for onclick handlers
+    // =====================================================================
+
+    var _instanceName = config.instanceName || null;
+
+    function instanceName() {
+        if (_instanceName) return _instanceName;
+        // Fallback: search window properties
+        for (var key in window) {
+            if (window[key] === self) {
+                _instanceName = key;
+                return key;
+            }
+        }
+        return 'this';
+    }
+}
+
+// ==========================================================================
+// Global instant tooltip for [data-cl-tooltip] elements
+// Positioned fixed in body — no overflow clipping, no delay
+// Usage: <span data-cl-tooltip="PID: 123<br>Uptime: 2d">ⓘ</span>
+// ==========================================================================
+(function () {
+    var tip = null;
+    jQuery(document).on('mouseenter', '[data-cl-tooltip]', function () {
+        var content = jQuery(this).attr('data-cl-tooltip');
+        if (!content) return;
+        tip = jQuery('<div class="cl-tooltip-popup">' + content + '</div>');
+        jQuery('body').append(tip);
+        var rect = this.getBoundingClientRect();
+        var top = rect.top - tip.outerHeight() - 6;
+        if (top < 0) top = rect.bottom + 6;
+        tip.css({
+            top: top + 'px',
+            left: (rect.left + rect.width / 2 - tip.outerWidth() / 2) + 'px'
+        });
+    }).on('mouseleave', '[data-cl-tooltip]', function () {
+        if (tip) { tip.remove(); tip = null; }
+    });
+})();

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -110,6 +110,10 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
     <link href="./include/common/javascript/jquery/plugins/colorbox/colorbox.css" rel="stylesheet" type="text/css"/>
     <link href="./include/common/javascript/jquery/plugins/qtip/jquery-qtip.css" rel="stylesheet" type="text/css"/>
 
+    <!-- Modern listing styles and JS module -->
+    <link href="./include/common/listing/listing.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css" />
+    <script type="text/javascript" src="./include/common/listing/listing.js<?php echo $versionParam; ?>"></script>
+
     <!-- graph css -->
     <link href="./include/common/javascript/charts/c3.min.css" type="text/css" rel="stylesheet" />
     <link href="./include/views/graphs/javascript/centreon-status-chart.css" type="text/css" rel="stylesheet" />

--- a/centreon/www/include/options/session/ajaxSessionKick.php
+++ b/centreon/www/include/options/session/ajaxSessionKick.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../common/listing/AjaxListingHelper.php');
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$userId = filter_var($_POST['user'] ?? null, FILTER_VALIDATE_INT);
+if (! $userId) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+// Disconnecting a user is an administrator-only action
+if (! $helper->isAdmin()) {
+    AjaxListingHelper::jsonError('Forbidden', 403);
+}
+
+// A user cannot disconnect their own session
+if ($userId === (int) $centreon->user->get_id()) {
+    AjaxListingHelper::jsonError('You cannot disconnect your own session', 400);
+}
+
+$stmt = $pearDB->prepare('DELETE FROM session WHERE user_id = :userId');
+$stmt->bindValue(':userId', $userId, PDO::PARAM_INT);
+$stmt->execute();
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/options/session/ajaxSessionListing.php
+++ b/centreon/www/include/options/session/ajaxSessionListing.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../../common/listing/AjaxListingHelper.php');
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// Search filter (user name or IP address)
+$conditions = 'WHERE 1=1 ';
+$bindParams = [];
+if ($search !== '') {
+    $searchEsc = str_replace('_', '\\_', $search);
+    $conditions .= 'AND (contact_name LIKE :search OR ip_address LIKE :search) ';
+    $bindParams[':search'] = '%' . $searchEsc . '%';
+}
+
+// Single query: sessions joined to their contact and current topology page
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS session.*, contact_name, contact_admin, contact_auth_type,'
+    . ' contact_ldap_last_sync, topology_name, topology_url_opt'
+    . ' FROM session'
+    . ' INNER JOIN contact ON contact_id = user_id'
+    . ' LEFT JOIN topology ON topology_page = current_page '
+    . $conditions
+    . ' ORDER BY contact_name, contact_admin LIMIT :offset, :limit'
+);
+foreach ($bindParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$isAdmin = $helper->isAdmin();
+
+$rows = [];
+while ($r = $statement->fetch(PDO::FETCH_ASSOC)) {
+    // LDAP-linked accounts expose their last synchronization time (admins only)
+    $lastSync = '';
+    if ($isAdmin && $r['contact_auth_type'] === 'ldap') {
+        $lastSync = $r['contact_ldap_last_sync'] > 0 ? (int) $r['contact_ldap_last_sync'] : '-';
+    }
+
+    $rows[] = [
+        'user_id'       => (int) $r['user_id'],
+        'user_alias'    => $r['contact_name'],
+        'admin'         => (int) $r['contact_admin'],
+        'ip_address'    => $r['ip_address'],
+        'last_reload'   => (int) $r['last_reload'],
+        'ldapContact'   => $r['contact_auth_type'],
+        'current_page'  => $r['current_page'] . ($r['topology_url_opt'] ?? ''),
+        'topology_name' => $r['topology_name'] != '' ? _($r['topology_name']) : '',
+        'last_sync'     => $lastSync,
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/options/session/connected_user.ihtml
+++ b/centreon/www/include/options/session/connected_user.ihtml
@@ -1,53 +1,184 @@
-<div align="center">
-<form id="Form">
-	<table class="ListTableMedium">
-		<tr class="ListHeader">
-			<td class="ListColHeaderLeft">{ $wi_user }</td>
-			<td class="ListColHeaderCenter">{ $distant_location }</td>
-			<td class="ListColHeaderCenter">{ $wi_where }</td>
-			<td class="ListColHeaderCenter">{ $wi_last_req }</td>
-			{if $isAdmin == 1}
-				<td class="ListColHeaderCenter">
-					{if isset($wi_last_sync)}
-						{ $wi_last_sync }
-					{/if}
-				</td>
-				<td class="ListColHeaderCenter">
-					{if isset($wi_syncLdap)}
-						{ $wi_syncLdap }
-					{/if}
-				</td>
-				<td class="ListColHeaderCenter">
-					{if isset($wi_logoutUser)}
-						{ $wi_logoutUser }
-					{/if}
-				</td>
-			{/if}
-		</tr>
-		{foreach name=outer item=sd from=$session_data }
-			<tr class="{$sd.class}">
-				<td class="ListColLeft">
-					{if $sd.admin == 1}
-                    <span class="ico-18">
-                        {$adminIcon}
-                    </span>
-					{else}
-                    <span class="ico-18">
-                        {$userIcon}
-                    </span>
-					{/if}&nbsp;
-						<a href='./main.php?p=60301&o=w&contact_id={$sd.user_id}'>{$sd.user_alias}</a>
-				</td>
-				<td class="ListColCenter">{$sd.ip_address}</td>
-				<td class="ListColCenter"><a href='./main.php?p={$sd.current_page}'>{$sd.topology_name}</a></td>
-				<td class="ListColCenter isTimestamp isShortTime" align=right>{$sd.last_reload}</td>
-				{if $isAdmin == 1}
-					<td class="ListColCenter isTimestamp isShortDate" width="150" align=right>{$sd.last_sync}</td>
-					<td class="ListColCenter" align=right>{$sd.synchronize}</td>
-					<td class="ListColCenter" align=right>{$sd.actions}</td>
-				{/if}
-			</tr>
-		{/foreach}
-	</table>
-</form>
+<style>
+    {literal}
+    /* Aligned with the reporting charter (.rpt-title / .rpt-title-bar) */
+    .session-title-bar {
+        margin: 0 0 8px 0;
+        max-width: 1400px;
+    }
+
+    .session-title {
+        margin: 0;
+        padding: 0;
+        font-size: 18px;
+        font-weight: 600;
+        color: var(--body-color, #2d3436);
+    }
+
+    .session-subtitle {
+        margin: 4px 0 0;
+        font-size: 12px;
+        line-height: 1.45;
+        color: var(--body-color, #6f7384);
+        opacity: 0.75;
+        max-width: 760px;
+    }
+    {/literal}
+</style>
+
+<div class="session-title-bar">
+    <h2 class="session-title">{$pageTitle}</h2>
+    <p class="session-subtitle">{$pageSubtitle}</p>
 </div>
+
+<form name="form" id="Form">
+    <div class="cl-filter-box">
+        <div class="cl-filter-bar">
+            <span class="cl-filter-label">{$wi_user}</span>
+            <input type="text" id="clSearchInput" name="search" value="" class="cl-search-input" placeholder="{t}Name or IP address{/t}" style="width:200px;">
+            <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+        </div>
+    </div>
+
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            <div class="cl-actions-left">&nbsp;</div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th>{$wi_user}</th>
+                    <th class="cl-col-center">{$distant_location}</th>
+                    <th class="cl-col-center">{$wi_where}</th>
+                    <th class="cl-col-center">{$wi_last_req}</th>
+                    {if $isAdmin == 1}
+                        <th class="cl-col-center">{$wi_last_sync}</th>
+                        <th class="cl-col-center">{$wi_syncLdap}</th>
+                        <th class="cl-col-right">{$wi_logoutUser}</th>
+                    {/if}
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="99" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            <div>&nbsp;</div>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
+    <input type="hidden" id="limit" name="limit" value="">
+</form>
+
+<script type="text/javascript">
+    var sessionPageId      = '{$pageId}';
+    var sessionIsAdmin     = {if $isAdmin == 1}true{else}false{/if};
+    var sessionDefaultLimit = {$defaultLimit};
+    var sessionEmptyMessage = {$emptyMessageJs};
+    var sessionAdminIcon   = {$adminIconJs};
+    var sessionUserIcon    = {$userIconJs};
+    var sessionRefreshIcon = {$refreshIconJs};
+    var sessionLogoutIcon  = {$logoutIconJs};
+    var sessionSyncTitle    = {$wi_syncTitleJs};
+    var sessionKickTitle    = {$wi_kickTitleJs};
+    var sessionSyncConfirm  = {$wi_syncConfirmJs};
+    var sessionCurrentUserId = {$currentUserId};
+    var sessionSelfKickTitle = {$wi_selfKickTitleJs};
+</script>
+
+{literal}
+<script type="text/javascript">
+    (function () {
+        var columns = [
+            { id: 'user_alias', render: function (row, l) {
+                var icon = row.admin == 1 ? sessionAdminIcon : sessionUserIcon;
+                return '<span class="ico-18">' + icon + '</span>&nbsp;'
+                    + '<a href="./main.php?p=60301&o=w&contact_id=' + row.user_id + '">' + l.escape(row.user_alias) + '</a>';
+            }},
+            { id: 'ip_address', align: 'center' },
+            { id: 'topology_name', align: 'center', render: function (row, l) {
+                if (!row.topology_name) return '';
+                return '<a href="./main.php?p=' + l.escape(row.current_page) + '">' + l.escape(row.topology_name) + '</a>';
+            }},
+            { id: 'last_reload', align: 'center', render: function (row) {
+                return '<span class="isTimestamp isShortTime">' + row.last_reload + '</span>';
+            }}
+        ];
+
+        if (sessionIsAdmin) {
+            columns.push({ id: 'last_sync', align: 'center', render: function (row) {
+                return row.last_sync ? '<span class="isTimestamp isShortDate">' + row.last_sync + '</span>' : '';
+            }});
+            columns.push({ id: 'sync', align: 'center', render: function (row) {
+                if (row.ldapContact !== 'ldap') return '';
+                return '<a href="#" onclick="sessionSyncLdap(' + row.user_id + ');return false;" title="' + sessionSyncTitle + '">' + sessionRefreshIcon + '</a>';
+            }});
+            columns.push({ id: 'logout', align: 'right', render: function (row) {
+                // A user cannot disconnect their own session: show a greyed-out, non-clickable icon
+                if (row.user_id == sessionCurrentUserId) {
+                    return '<span title="' + sessionSelfKickTitle + '" style="opacity:.3;cursor:not-allowed;">' + sessionLogoutIcon + '</span>';
+                }
+                return '<a href="#" onclick="sessionKickUser(' + row.user_id + ');return false;" title="' + sessionKickTitle + '">' + sessionLogoutIcon + '</a>';
+            }});
+        }
+
+        window.sessionListing = new CentreonListing({
+            instanceName:  'sessionListing',
+            ajaxListUrl:   './include/options/session/ajaxSessionListing.php',
+            pageId:        sessionPageId,
+            writeAccess:   sessionIsAdmin,
+            storageKey:    'session_listing_limit',
+            defaultLimit:  sessionDefaultLimit,
+            autoRefresh:   30000,
+            emptyMessage:  sessionEmptyMessage,
+            showCheckboxes: false,
+            rowIdField:    'user_id',
+            columns:       columns,
+            onDataLoaded:  function () {
+                if (typeof formatDateMoment === 'function') {
+                    formatDateMoment();
+                }
+            }
+        });
+        sessionListing.init();
+    })();
+
+    // Disconnect a user (admin only) — AJAX, then refresh the listing in place
+    function sessionKickUser(userId) {
+        jQuery.ajax({
+            url: './include/options/session/ajaxSessionKick.php',
+            type: 'POST',
+            dataType: 'json',
+            data: { user: userId, centreon_token: sessionListing.getCsrfToken() },
+            success: function (resp) {
+                if (resp && resp.centreon_token) {
+                    sessionListing.setCsrfToken(resp.centreon_token);
+                }
+                var s = sessionListing.getState();
+                sessionListing.fetch(s.num, s.limit, s.search, true);
+            }
+        });
+    }
+
+    // Request an LDAP re-synchronization for a contact — AJAX, then refresh the listing
+    function sessionSyncLdap(userId) {
+        if (!confirm(sessionSyncConfirm)) {
+            return;
+        }
+        jQuery.ajax({
+            url: './api/internal.php?object=centreon_ldap_synchro&action=requestLdapSynchro',
+            type: 'POST',
+            data: { contactId: userId },
+            success: function (data) {
+                if (data === true) {
+                    var s = sessionListing.getState();
+                    sessionListing.fetch(s.num, s.limit, s.search, true);
+                }
+            }
+        });
+    }
+</script>
+{/literal}

--- a/centreon/www/include/options/session/connected_user.php
+++ b/centreon/www/include/options/session/connected_user.php
@@ -22,156 +22,59 @@ if (! isset($centreon)) {
     exit();
 }
 
-/**
- * Kick a logged user
- */
-const KICK_USER = 'k';
-
 $path = './include/options/session/';
 require_once './include/common/common-Func.php';
-require_once './class/centreonMsg.class.php';
-
-$action = HtmlSanitizer::createFromString($_GET['o'] ?? '')
-    ->removeTags()
-    ->sanitize()
-    ->getString();
-
-$selectedUserId = filter_var(
-    $_GET['user'] ?? null,
-    FILTER_VALIDATE_INT
-);
-
-$currentPage = filter_var(
-    $_GET['p'] ?? $_POST['p'] ?? 0,
-    FILTER_VALIDATE_INT
-);
-
-if ($selectedUserId) {
-    $msg = new CentreonMsg();
-    $msg->setTextStyle('bold');
-    $msg->setTimeOut('3');
-
-    switch ($action) {
-        // logout action
-        case KICK_USER:
-            // check if the user is allowed to kick this user
-            if ($centreon->user->admin == 0) {
-                $msg->setText(_('You are not allowed to disconnect this user'));
-                break;
-            }
-            $stmt = $pearDB->prepare('DELETE FROM session WHERE user_id = :userId');
-            $stmt->bindValue(':userId', $selectedUserId, PDO::PARAM_INT);
-            $stmt->execute();
-            $msg->setText(_('User disconnected'));
-            break;
-    }
-}
 
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-$session_data = [];
-$res = $pearDB->query(
-    'SELECT session.*, contact_name, contact_admin, contact_auth_type, `contact_ldap_last_sync`
-    FROM session, contact
-    WHERE contact_id = user_id ORDER BY contact_name, contact_admin'
-);
-for ($cpt = 0; $r = $res->fetch(); $cpt++) {
-    $session_data[$cpt] = [];
-    $session_data[$cpt]['class'] = $cpt % 2 ? 'list_one' : 'list_two';
-    $session_data[$cpt]['user_id'] = $r['user_id'];
-    $session_data[$cpt]['user_alias'] = $r['contact_name'];
-    $session_data[$cpt]['admin'] = $r['contact_admin'];
-    $session_data[$cpt]['ip_address'] = $r['ip_address'];
-    $session_data[$cpt]['last_reload'] = $r['last_reload'];
-    $session_data[$cpt]['ldapContact'] = $r['contact_auth_type'];
+// $centreon->user->admin is a string '1' or '0'
+$isAdmin = ($centreon->user->admin == 1);
 
-    $resCP = $pearDB->prepare(
-        'SELECT topology_name, topology_page, topology_url_opt FROM topology '
-        . 'WHERE topology_page = :topologyPage'
-    );
-    $resCP->bindValue(':topologyPage', $r['current_page'], PDO::PARAM_INT);
-    $resCP->execute();
-    $rCP = $resCP->fetch();
-
-    // getting the current users' position in the IHM
-    $session_data[$cpt]['current_page'] = $r['current_page'] . $rCP['topology_url_opt'];
-    $session_data[$cpt]['topology_name'] = $rCP['topology_name'] != '' ? _($rCP['topology_name']) : $rCP['topology_name'];
-
-    // $centreon->user->admin is a string '1' or '0'
-    if ($centreon->user->admin == 1) {
-        // adding the link to be able to kick the user
-        $session_data[$cpt]['actions']
-            = "<a href='./main.php?p=" . $p . '&o=k&user=' . $r['user_id'] . "'>"
-                . "<span title='" . _('Disconnect user') . "'>"
-                    . returnSvg('www/img/icons/delete.svg', 'var(--icons-fill-color)', 22, 22)
-                . '</span>'
-            . '</a>';
-
-        // checking if the user account is linked to an LDAP
-        if ($r['contact_auth_type'] === 'ldap') {
-            // adding the last synchronization time
-            if ($r['contact_ldap_last_sync'] > 0) {
-                $session_data[$cpt]['last_sync'] = (int) $r['contact_ldap_last_sync'];
-            } elseif ($r['contact_ldap_last_sync'] === 0 || $r['contact_ldap_last_sync'] === null) {
-                $session_data[$cpt]['last_sync'] = '-';
-            }
-            $session_data[$cpt]['synchronize']
-                = "<a href='#'>"
-                    . "<span onclick='submitSync(" . $currentPage . ', "' . $r['user_id'] . "\")' 
-                    title='" . _('Synchronize LDAP') . "'>"
-                        . returnSvg('www/img/icons/refresh.svg', 'var(--icons-fill-color)', 18, 18)
-                    . '</span>'
-                . '</a>';
-        } else {
-            // hiding the synchronization option and details
-            $session_data[$cpt]['last_sync'] = '';
-            $session_data[$cpt]['synchronize'] = '';
-        }
-        // adding the column titles
-        $tpl->assign('wi_last_sync', _('Last LDAP sync'));
-        $tpl->assign('wi_syncLdap', _('Refresh LDAP'));
-        $tpl->assign('wi_logoutUser', _('Logout user'));
-    }
+// Default rows-per-page (shared configuration option)
+$defaultLimit = 30;
+$optResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
+if ($opt = $optResult->fetch()) {
+    $defaultLimit = (int) $opt['value'] ?: 30;
 }
 
-if (isset($msg)) {
-    $tpl->assign('msg', $msg);
-}
-
-$tpl->assign('session_data', $session_data);
+// Page identity
+$tpl->assign('pageId', $p);
 $tpl->assign('isAdmin', $centreon->user->admin);
+$tpl->assign('currentUserId', (int) $centreon->user->get_id());
+$tpl->assign('defaultLimit', $defaultLimit);
+
+// Page header
+$tpl->assign('pageTitle', _('Active Sessions'));
+$tpl->assign('pageSubtitle', _('Users currently connected to the platform.'));
+
+// Column titles (rendered in the table header)
 $tpl->assign('wi_user', _('Users'));
 $tpl->assign('wi_where', _('Position'));
 $tpl->assign('wi_last_req', _('Last request'));
 $tpl->assign('distant_location', _('IP Address'));
-$tpl->assign('adminIcon', returnSvg('www/img/icons/admin.svg', 'var(--icons-fill-color)', 17, 17));
-$tpl->assign('userIcon', returnSvg('www/img/icons/user.svg', 'var(--icons-fill-color)', 17, 17));
+if ($isAdmin) {
+    $tpl->assign('wi_last_sync', _('Last LDAP sync'));
+    $tpl->assign('wi_syncLdap', _('Refresh LDAP'));
+    $tpl->assign('wi_logoutUser', _('Logout user'));
+}
+
+// JS-safe strings (json_encode produces valid, escaped JS string literals)
+$jsonFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT;
+$tpl->assign('emptyMessageJs', json_encode(_('No active session'), $jsonFlags));
+$tpl->assign('wi_kickTitleJs', json_encode(_('Disconnect user'), $jsonFlags));
+$tpl->assign('wi_syncTitleJs', json_encode(_('Synchronize LDAP'), $jsonFlags));
+$tpl->assign('wi_syncConfirmJs', json_encode(
+    _('All this contact sessions will be closed. Are you sure you want to request a '
+        . 'synchronization at the next login of this Contact ?'),
+    $jsonFlags
+));
+$tpl->assign('wi_selfKickTitleJs', json_encode(_('You cannot disconnect your own session.'), $jsonFlags));
+
+// Icons (json-encoded for safe embedding in the JS column renderers)
+$tpl->assign('adminIconJs', json_encode(returnSvg('www/img/icons/admin.svg', 'var(--icons-fill-color)', 17, 17), $jsonFlags));
+$tpl->assign('userIconJs', json_encode(returnSvg('www/img/icons/user.svg', 'var(--icons-fill-color)', 17, 17), $jsonFlags));
+$tpl->assign('refreshIconJs', json_encode(returnSvg('www/img/icons/refresh.svg', 'var(--icons-fill-color)', 18, 18), $jsonFlags));
+$tpl->assign('logoutIconJs', json_encode(returnSvg('www/img/icons/logout.svg', 'var(--icons-fill-color)', 18, 18), $jsonFlags));
+
 $tpl->display('connected_user.ihtml');
-?>
-
-<script>
-    //formatting the tags containing a class isTimestamp
-    formatDateMoment();
-
-    // ask for confirmation when requesting to resynchronize contact data from the LDAP
-    function submitSync(p, contactId) {
-        // msg = localized message to be displayed in the confirmation popup
-        let msg = "<?= _('All this contact sessions will be closed. Are you sure you want to request a '
-            . 'synchronization at the next login of this Contact ?'); ?>";
-        // then executing the request and refreshing the page
-        if (confirm(msg)) {
-            $.ajax({
-                url: './api/internal.php?object=centreon_ldap_synchro&action=requestLdapSynchro',
-                type: 'POST',
-                async: false,
-                data: {contactId: contactId},
-                success: function(data) {
-                    if (data === true) {
-                        window.location.href = "?p=" + p;
-                    }
-                }
-            });
-        }
-    }
-</script>


### PR DESCRIPTION
## Modernize Administration > Sessions

Rebuilds the legacy "Administration > Sessions" page on top of the shared **CentreonListing** framework; every action is asynchronous (AJAX), no full-page reloads.

> ⚠️ **Merge order** — this PR depends on **`feature/configuration-legacy-listing-shared-library`** (shared `listing.css` / `listing.js` / `AjaxListingHelper`). **Merge that branch first.** This PR targets it so the diff stays limited to the Sessions page.

### Listing
- `ajaxSessionListing.php` — JSON data endpoint (`AjaxListingHelper`): connected sessions fetched in a single query (explicit INNER/LEFT JOINs to `contact` and `topology`), with server-side search (user name or IP) and pagination.
- `connected_user.ihtml` rebuilt on `CentreonListing`: paginated AJAX table using the shared `cl-listing-*` styles, a search box and a 30s auto-refresh.
- `connected_user.php` slimmed to a bootstrap controller; the per-row topology lookup (N+1) and the old kick GET handler are gone.

### Actions (AJAX — refresh the list in place)
- **Disconnect a user** — `ajaxSessionKick.php`, admin-only and CSRF-validated. A user cannot disconnect their own session (enforced server-side, shown as a greyed-out icon on their own row).
- **LDAP re-synchronization** — keeps the internal API but refreshes the listing instead of reloading the whole page.

### UI / i18n
- Page header: an "Active Sessions" title aligned with the reporting charter + a short subtitle.
- Dedicated modern logout icon for the disconnect action (instead of the shared delete/cross icon).
- fr/es/de/pt translations for all new strings.

### Screenshot
<!-- drag & drop a screenshot of the modernized Sessions page here -->
