### PR TITLE
style(ui): introduce #131D5A as the primary brand color

### DIFF
--- a/centreon/packages/ui/src/ThemeProvider/palettes.ts
+++ b/centreon/packages/ui/src/ThemeProvider/palettes.ts
@@ -267,9 +267,9 @@ export const lightPalette: PaletteOptions = {
   },
   primary: {
     contrastText: '#fff',
-    dark: '#255891',
-    light: '#cde7fc',
-    main: '#2E68AA'
+    dark: '#2A3575',
+    light: '#D8DCE9',
+    main: '#131D5A'
   },
   secondary: {
     contrastText: '#fff',

--- a/centreon/packages/ui/src/ThemeProvider/tailwindcss.css
+++ b/centreon/packages/ui/src/ThemeProvider/tailwindcss.css
@@ -95,9 +95,9 @@
   --color-pending-main: #1ebeb3;
 
   /* Primary & Secondary colors */
-  --color-primary-main: #2e68aa;
-  --color-primary-light: #cde7fc;
-  --color-primary-dark: #255891;
+  --color-primary-main: #131d5a;
+  --color-primary-light: #d8dce9;
+  --color-primary-dark: #2a3575;
   --color-primary-contrastText: #fff;
   --color-secondary-main: #c772d6;
   --color-secondary-light: #e5a5f0;

--- a/centreon/www/Themes/Generic-theme/Variables-css/color-variables.css
+++ b/centreon/www/Themes/Generic-theme/Variables-css/color-variables.css
@@ -1,12 +1,12 @@
 :root {
     /** Main colors **/
-    --color-primary-light: #2E68AA;
+    --color-primary-light: #131D5A;
     --color-primary-dark: #6EAFF8;
     --color-primary-body-dark : #b2aca2;
     --color-primary-body-background-dark:#212121;
     --color-primary-body-background-light:#fff;
     --color-primary-success-dark : #84bd00;
-    --color-primary-hover: #255891;
+    --color-primary-hover: #2A3575;
     --color-primary-hover-dark: #4974A5;
     --color-secondary : #666666 ;
     --color-secondary-dark : #b5b5b5 ;

--- a/centreon/www/front_src/src/Header/index.tsx
+++ b/centreon/www/front_src/src/Header/index.tsx
@@ -73,7 +73,7 @@ const Header = (): JSX.Element => {
       className={cx(
         classes.header,
         isFullscreenActivated && classes.fullscreenActivated,
-        'bg-[#131D5A] dark:bg-black'
+        'bg-primary-main dark:bg-black'
       )}
       ref={headerRef}
     >

--- a/centreon/www/front_src/src/Header/index.tsx
+++ b/centreon/www/front_src/src/Header/index.tsx
@@ -73,7 +73,7 @@ const Header = (): JSX.Element => {
       className={cx(
         classes.header,
         isFullscreenActivated && classes.fullscreenActivated,
-        'bg-primary-dark dark:bg-black'
+        'bg-[#131D5A] dark:bg-black'
       )}
       ref={headerRef}
     >

--- a/centreon/www/front_src/src/Navigation/Sidebar/Menu/MenuItems.tsx
+++ b/centreon/www/front_src/src/Navigation/Sidebar/Menu/MenuItems.tsx
@@ -55,22 +55,26 @@ const useStyles = makeStyles<{ isRoot?: boolean }>()((theme, { isRoot }) => ({
       }
     },
     '& .MuiSvgIcon-root': {
-      color: isDarkMode(theme)
-        ? theme.palette.common.white
-        : theme.palette.primary.main
+      color:
+        isRoot || isDarkMode(theme)
+          ? theme.palette.common.white
+          : theme.palette.primary.main
     },
     '&:hover': {
       backgroundColor: isDarkMode(theme)
         ? theme.palette.primary.dark
-        : theme.palette.primary.light
+        : isRoot
+          ? 'rgba(255, 255, 255, 0.12)'
+          : theme.palette.primary.light
     },
     backgroundColor: isDarkMode(theme)
       ? theme.palette.primary.dark
-      : theme.palette.primary.light,
-    color:
-      isDarkMode(theme) && isRoot
-        ? theme.palette.common.white
-        : theme.palette.primary.main
+      : isRoot
+        ? 'rgba(255, 255, 255, 0.20)'
+        : theme.palette.primary.light,
+    color: isRoot
+      ? theme.palette.common.white
+      : theme.palette.primary.main
   },
   arrowIcon: {
     color: 'inherit'

--- a/centreon/www/front_src/src/Navigation/Sidebar/index.tsx
+++ b/centreon/www/front_src/src/Navigation/Sidebar/index.tsx
@@ -53,7 +53,7 @@ const Drawer = styled(MuiDrawer, {
   '& .MuiPaper-root': {
     backgroundColor: isDarkMode(theme)
       ? theme.palette.common.black
-      : theme.palette.primary.dark,
+      : theme.palette.primary.main,
     border: 'none'
   },
   boxSizing: 'border-box',


### PR DESCRIPTION
## Description

Refreshes the product look by introducing a new dark-navy primary color (`#131D5A`) and propagating it across both the React theme and the legacy CSS theme.

## Changes
- **React theme** (`ThemeProvider/palettes.ts`, `tailwindcss.css`): set `#131D5A` as the primary color.
- **Legacy theme** (`color-variables.css`): align the primary variable to the same value.
- **Header & left sidebar**: use `#131D5A` as the background in light mode.
- **Sidebar menu items**: adapt the selected/hover states to read well on the new dark-navy background.

## Scope
Visual styling only — no behavioral change.