### PR TITLE
style(ui): give top counter badges a tonal treatment

### DIFF
--- a/centreon/packages/ui/src/TopCounterElements/StatusCounter.tsx
+++ b/centreon/packages/ui/src/TopCounterElements/StatusCounter.tsx
@@ -1,4 +1,4 @@
-import { Badge, Tooltip } from '@mui/material';
+import { Badge, Tooltip, alpha } from '@mui/material';
 
 import { getStatusColors, type SeverityCode } from '@centreon/ui';
 
@@ -9,25 +9,30 @@ export interface StyleProps {
   severityCode?: SeverityCode | null;
 }
 
-const useStyles = makeStyles<StyleProps>()((theme, { severityCode }) => ({
-  badge: {
-    background: severityCode
-      ? getStatusColors({ severityCode, theme })?.backgroundColor
-      : 'transparent',
-    borderRadius: theme.spacing(1.25),
-    color: theme.palette.common.black,
-    cursor: 'pointer',
-    fontSize: theme.typography.body2.fontSize,
-    fontWeight: theme.typography.fontWeightBold,
-    height: theme.spacing(2.125),
-    lineHeight: theme.spacing(2.125),
-    minWidth: theme.spacing(2.125),
-    position: 'relative',
-    right: 0,
-    top: 0,
-    transform: 'none'
-  }
-}));
+const useStyles = makeStyles<StyleProps>()((theme, { severityCode }) => {
+  const statusColor = severityCode
+    ? getStatusColors({ severityCode, theme })?.backgroundColor
+    : null;
+
+  return {
+    badge: {
+      background: statusColor ? alpha(statusColor, 0.8) : 'transparent',
+      borderRadius: theme.spacing(1.5),
+      color: theme.palette.common.white,
+      cursor: 'pointer',
+      fontSize: theme.typography.body1.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      height: theme.spacing(2.5),
+      lineHeight: theme.spacing(2.5),
+      minWidth: theme.spacing(2.5),
+      padding: theme.spacing(0, 0.75),
+      position: 'relative',
+      right: 0,
+      top: 0,
+      transform: 'none'
+    }
+  };
+});
 
 export interface Props {
   className?: string;

--- a/centreon/www/front_src/src/Header/Poller/PollerStatusIcon/index.tsx
+++ b/centreon/www/front_src/src/Header/Poller/PollerStatusIcon/index.tsx
@@ -1,6 +1,6 @@
 import LatencyIcon from '@mui/icons-material/Speed';
 import StorageIcon from '@mui/icons-material/Storage';
-import { Avatar } from '@mui/material';
+import { Avatar, alpha } from '@mui/material';
 
 import { getStatusColors, SeverityCode } from '@centreon/ui';
 
@@ -28,21 +28,18 @@ interface StyleProps {
 const useStatusStyles = makeStyles<StyleProps>()(
   (theme, { databaseSeverity, latencySeverity }) => {
     const getSeverityColor = (severityCode): CSSObject => ({
-      background: getStatusColors({
-        severityCode,
-        theme
-      }).backgroundColor,
-      color: getStatusColors({
-        severityCode,
-        theme
-      }).color
+      background: alpha(
+        getStatusColors({ severityCode, theme }).backgroundColor,
+        0.8
+      ),
+      color: theme.palette.common.white
     });
 
     return {
       avatar: {
         fontSize: theme.typography.body1.fontSize,
-        height: theme.spacing(2.125),
-        width: theme.spacing(2.125)
+        height: theme.spacing(2.5),
+        width: theme.spacing(2.5)
       },
       container: {
         display: 'flex',
@@ -60,8 +57,8 @@ const useStatusStyles = makeStyles<StyleProps>()(
       },
       database: getSeverityColor(databaseSeverity),
       icon: {
-        height: theme.spacing(1.75),
-        width: theme.spacing(1.75)
+        height: theme.spacing(2),
+        width: theme.spacing(2)
       },
       latency: getSeverityColor(latencySeverity),
       visuallyHiddenText: {


### PR DESCRIPTION
## Description

Modernizes the top counter badges and Poller status icons with a tonal look that reads better on the header.

## Changes
- **StatusCounter**: turn the badges into tonal chips (translucent background + white text, slightly larger) and raise the background alpha to 0.8 for stronger contrast.
- **PollerStatusIcon**: apply the same tonal treatment and bump the Poller status avatars to 20px to match the Host/Service badge sizing.

## Scope
Visual styling only — no behavioral change.