### PR TITLE
feat(ui): compact top counter layout with descriptive tooltips

### DIFF
--- a/centreon/packages/ui/src/TopCounterElements/TopCounterLayout.tsx
+++ b/centreon/packages/ui/src/TopCounterElements/TopCounterLayout.tsx
@@ -1,7 +1,7 @@
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { SvgIcon } from '@mui/material';
-import { Badge, ClickAwayListener } from '@mui/material';
+import { Badge, ClickAwayListener, Tooltip } from '@mui/material';
 
 import { useEffect, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
@@ -11,61 +11,28 @@ import useCloseOnLegacyPage from './useCloseOnLegacyPage';
 const useStyles = makeStyles()((theme) => ({
   button: {
     '& > svg': {
-      height: '0.9em',
-      margin: `-${theme.spacing(0.5)}`,
-      [theme.breakpoints.down(1025)]: {
-        margin: `-${theme.spacing(0.5)}`
-      }
+      height: '1.15em'
     },
+    alignItems: 'center',
     appearance: 'none',
     background: 'none',
     border: 0,
     color: theme.palette.common.white,
     cursor: 'pointer',
-    display: 'flex',
-
-    [theme.breakpoints.up(1025)]: {
-      alignItems: 'center',
-      flexFlow: 'row no-wrap',
-      marginTop: theme.spacing(0.5)
-    },
-
-    [theme.breakpoints.down(1025)]: {
-      alignItems: 'center',
-      flexFlow: 'column wrap',
-      order: 1
-    },
-
-    padding: '0'
+    display: 'inline-flex',
+    flexFlow: 'row nowrap',
+    gap: theme.spacing(1),
+    padding: 0
   },
   container: {
     position: 'relative'
   },
-  header: {
-    [theme.breakpoints.down(1025)]: {
-      display: 'flex',
-      flexFlow: 'row no-wrap'
-    }
-  },
-  iconWrapper: {
-    [theme.breakpoints.up(1025)]: {
-      position: 'absolute',
-      top: '0'
-    }
-  },
   indicators: {
+    alignItems: 'center',
+    display: 'inline-flex',
     lineHeight: 1,
     [theme.breakpoints.down(600)]: {
       display: 'none'
-    },
-    [theme.breakpoints.down(1025)]: {
-      flex: 'initial',
-      marginLeft: theme.spacing(0.5),
-      order: 2
-    },
-    [theme.breakpoints.up(1025)]: {
-      height: theme.spacing(2.5),
-      marginLeft: theme.spacing(3.75)
     }
   },
   subMenu: {
@@ -82,18 +49,6 @@ const useStyles = makeStyles()((theme) => ({
   },
   subMenuOpen: {
     visibility: 'visible'
-  },
-  textWrapper: {
-    alignItems: 'center',
-    display: 'inline-flex',
-    flex: '100%',
-    fontSize: theme.typography.body1.fontSize,
-    fontWeight: theme.typography.fontWeightBold,
-    lineHeight: '1',
-    whiteSpace: 'nowrap',
-    [theme.breakpoints.down(1025)]: {
-      display: 'none'
-    }
   }
 }));
 
@@ -103,6 +58,7 @@ interface TopCounterLayoutProps {
   renderSubMenu: (params: { closeSubMenu: () => void }) => JSX.Element;
   showPendingBadge?: boolean;
   title: string;
+  tooltipDescription?: string;
 }
 
 const TopCounterLayout = ({
@@ -110,7 +66,8 @@ const TopCounterLayout = ({
   title,
   renderIndicators,
   renderSubMenu,
-  showPendingBadge
+  showPendingBadge,
+  tooltipDescription
 }: TopCounterLayoutProps): JSX.Element => {
   const { classes, cx } = useStyles();
   const [toggled, setToggled] = useState(false);
@@ -147,33 +104,36 @@ const TopCounterLayout = ({
       }}
     >
       <div className={classes.container}>
-        <div className={classes.header}>
-          <div className={classes.indicators}>{renderIndicators()}</div>
-          <button
-            aria-controls={`${subMenuId}-menu`}
-            aria-expanded={toggled}
-            aria-haspopup="true"
-            aria-label={title}
-            className={classes.button}
-            id={`${subMenuId}-button`}
-            onClick={(): void => setToggled(!toggled)}
-            type="button"
+        <button
+          aria-controls={`${subMenuId}-menu`}
+          aria-expanded={toggled}
+          aria-haspopup="true"
+          aria-label={title}
+          className={classes.button}
+          id={`${subMenuId}-button`}
+          onClick={(): void => setToggled(!toggled)}
+          type="button"
+        >
+          <Tooltip
+            disableInteractive
+            enterDelay={500}
+            enterNextDelay={500}
+            placement="bottom"
+            title={tooltipDescription ?? title}
           >
-            <span className={classes.iconWrapper}>
-              <Badge
-                anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
-                color="pending"
-                invisible={!showPendingBadge}
-                overlap="circular"
-                variant="dot"
-              >
-                <Icon />
-              </Badge>
-            </span>
-            <span className={classes.textWrapper}>{title}</span>
-            {toggled ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-          </button>
-        </div>
+            <Badge
+              anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+              color="pending"
+              invisible={!showPendingBadge}
+              overlap="circular"
+              variant="dot"
+            >
+              <Icon />
+            </Badge>
+          </Tooltip>
+          <span className={classes.indicators}>{renderIndicators()}</span>
+          {toggled ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </button>
         <div
           aria-labelledby={`${subMenuId}-button`}
           className={cx(classes.subMenu, { [classes.subMenuOpen]: toggled })}

--- a/centreon/www/front_src/src/Header/Poller/index.tsx
+++ b/centreon/www/front_src/src/Header/Poller/index.tsx
@@ -3,15 +3,18 @@ import PollerIcon from '@mui/icons-material/DeviceHub';
 import { MenuSkeleton, TopCounterLayout } from '@centreon/ui';
 
 import { flatten, includes } from 'ramda';
+import { useTranslation } from 'react-i18next';
 
 import useNavigation from '../../Navigation/useNavigation';
 import PollerStatusIcon from './PollerStatusIcon';
 import { PollerSubMenu } from './PollerSubMenu/PollerSubMenu';
+import { labelPollersOverview } from './translatedLabels';
 import { usePollerData } from './usePollerData';
 
 export const pollerConfigurationPageNumber = '60901';
 
 const ServiceStatusCounter = (): JSX.Element | null => {
+  const { t } = useTranslation();
   const { isLoading, data, isAllowed } = usePollerData();
   const { allowedPages } = useNavigation();
 
@@ -41,6 +44,7 @@ const ServiceStatusCounter = (): JSX.Element | null => {
         />
       )}
       title={data.buttonLabel}
+      tooltipDescription={t(labelPollersOverview)}
     />
   );
 };

--- a/centreon/www/front_src/src/Header/Poller/translatedLabels.ts
+++ b/centreon/www/front_src/src/Header/Poller/translatedLabels.ts
@@ -28,3 +28,5 @@ export const labelPollerRunning = 'Everything is OK';
 export const labelConfigurePollers = 'Configure pollers';
 export const labelAllPollers = 'All pollers:';
 export const labelPollers = 'Pollers';
+export const labelPollersOverview =
+  'Current status of the pollers and monitoring engines';

--- a/centreon/www/front_src/src/Header/Resources/Host/index.tsx
+++ b/centreon/www/front_src/src/Header/Resources/Host/index.tsx
@@ -7,14 +7,18 @@ import {
   TopCounterResourceSubMenu
 } from '@centreon/ui';
 
+import { useTranslation } from 'react-i18next';
+
 import type { HostStatusResponse } from '../../api/decoders';
 import { hostStatusDecoder } from '../../api/decoders';
 import { hostStatusEndpoint } from '../../api/endpoints';
 import useResourceCounters from '../useResourceCounters';
 import type { HostPropsAdapterOutput } from './getHostPropsAdapter';
 import getHostPropsAdapter from './getHostPropsAdapter';
+import { labelHostsOverview } from './translatedLabels';
 
 const HostStatusCounter = (): JSX.Element | null => {
+  const { t } = useTranslation();
   const { isLoading, data, isAllowed } = useResourceCounters<
     HostStatusResponse,
     HostPropsAdapterOutput
@@ -44,6 +48,7 @@ const HostStatusCounter = (): JSX.Element | null => {
       )}
       showPendingBadge={data.hasPending}
       title={data.buttonLabel}
+      tooltipDescription={t(labelHostsOverview)}
     />
   );
 };

--- a/centreon/www/front_src/src/Header/Resources/Host/translatedLabels.ts
+++ b/centreon/www/front_src/src/Header/Resources/Host/translatedLabels.ts
@@ -1,4 +1,5 @@
 export const labelHosts = 'Hosts';
+export const labelHostsOverview = 'Current status of the hosts being monitored';
 export const labelDownStatusHosts = 'Down status hosts';
 export const labelUnreachableStatusHosts = 'Unreachable status hosts';
 export const labelUpStatusHosts = 'Up status hosts';

--- a/centreon/www/front_src/src/Header/Resources/Service/index.tsx
+++ b/centreon/www/front_src/src/Header/Resources/Service/index.tsx
@@ -7,14 +7,18 @@ import {
   TopCounterResourceSubMenu
 } from '@centreon/ui';
 
+import { useTranslation } from 'react-i18next';
+
 import type { ServiceStatusResponse } from '../../api/decoders';
 import { serviceStatusDecoder } from '../../api/decoders';
 import { serviceStatusEndpoint } from '../../api/endpoints';
 import useResourceCounters from '../useResourceCounters';
 import type { ServicesPropsAdapterOutput } from './getServicePropsAdapter';
 import getServicePropsAdapter from './getServicePropsAdapter';
+import { labelServicesOverview } from './translatedLabels';
 
 const ServiceStatusCounter = (): JSX.Element | null => {
+  const { t } = useTranslation();
   const { isLoading, data, isAllowed } = useResourceCounters<
     ServiceStatusResponse,
     ServicesPropsAdapterOutput
@@ -44,6 +48,7 @@ const ServiceStatusCounter = (): JSX.Element | null => {
       )}
       showPendingBadge={data.hasPending}
       title={data.buttonLabel}
+      tooltipDescription={t(labelServicesOverview)}
     />
   );
 };

--- a/centreon/www/front_src/src/Header/Resources/Service/translatedLabels.ts
+++ b/centreon/www/front_src/src/Header/Resources/Service/translatedLabels.ts
@@ -1,4 +1,6 @@
 export const labelServices = 'Services';
+export const labelServicesOverview =
+  'Current status of the services being monitored';
 
 export const labelCriticalStatusServices = 'Critical status services';
 export const labelWarningStatusServices = 'Warning status services';


### PR DESCRIPTION
## Description

Reworks the top counter elements for a cleaner, more informative header.

## Changes
- **TopCounterLayout**: compact layout — icon on the left, badges in the middle, chevron on the right.
- Add a **500ms-delayed tooltip** over each top counter icon, with an explanatory description of what the counter represents.
- Wire the descriptions and labels for the **Poller**, **Host** and **Service** counters (`index` + `translatedLabels`).

## Scope
UI layout and tooltips — no change to the underlying counter data.