### PR TITLE
fix(acl): update query builder in centreonACL and centreonAclGroup

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -1856,7 +1856,7 @@ class CentreonACL
                 prefix: 'acl_group_',
                 paramType: QueryParameterTypeEnum::INTEGER
             );
-            $query = 'SELECT ' . $request['fields'] . ' '
+            $query = $request['select'] . $request['fields'] . ' '
                 . "FROM host_service_relation hsr, host h, service s, `{$db_name_acl}`.centreon_acl "
                 . 'WHERE h.host_id = :host_id '
                 . "AND h.host_activate = '1' "
@@ -1899,7 +1899,7 @@ class CentreonACL
             }
 
             if (isset($options['total']) && $options['total'] == true) {
-                return ['items' => $result, 'total' => count($result)];
+                return ['items' => $result, 'total' => CentreonDBInstance::getDbCentreonInstance()->numberRows()];
             }
 
             return $result;
@@ -1914,7 +1914,7 @@ class CentreonACL
         }
 
         if (isset($options['total']) && $options['total'] == true) {
-            return ['items' => $result, 'total' => count($result)];
+            return ['items' => $result, 'total' => CentreonDBInstance::getDbCentreonInstance()->numberRows()];
         }
 
         return $result;

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -1848,9 +1848,13 @@ class CentreonACL
 
                 return [];
             }
-            [$bindValues, $bindQuery] = createMultipleBindQuery(
-                list: array_keys($this->accessGroups),
-                prefix: ':acl_group_'
+            [
+                'parameters' => $bindParams,
+                'placeholderList' => $placeholders,
+            ] = createMultipleBindParameters(
+                values: array_keys($this->accessGroups),
+                prefix: 'acl_group_',
+                paramType: QueryParameterTypeEnum::INTEGER
             );
             $query = 'SELECT ' . $request['fields'] . ' '
                 . "FROM host_service_relation hsr, host h, service s, `{$db_name_acl}`.centreon_acl "
@@ -1863,7 +1867,7 @@ class CentreonACL
                 . "AND `{$db_name_acl}`.centreon_acl.host_id = h.host_id "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id IS NOT NULL "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id = s.service_id "
-                . "AND `{$db_name_acl}`.centreon_acl.group_id IN ({$bindQuery}) "
+                . "AND `{$db_name_acl}`.centreon_acl.group_id IN ({$placeholders}) "
                 . 'UNION '
                 . 'SELECT ' . $request['fields'] . ' '
                 . 'FROM host h, hostgroup_relation hgr, '
@@ -1877,14 +1881,28 @@ class CentreonACL
                 . "AND `{$db_name_acl}`.centreon_acl.host_id = h.host_id "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id IS NOT NULL "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id = s.service_id "
-                . "AND `{$db_name_acl}`.centreon_acl.group_id IN ({$bindQuery}) ";
+                . "AND `{$db_name_acl}`.centreon_acl.group_id IN ({$placeholders}) ";
             $query .= $request['order'] . $request['pages'];
-            $stmt = CentreonDBInstance::getDbCentreonInstance()->prepare($query);
-            $stmt->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
-            foreach ($bindValues as $key => $value) {
-                $stmt->bindValue($key, $value, PDO::PARAM_INT);
+            $rows = CentreonDBInstance::getDbCentreonInstance()->fetchAllAssociative(
+                $query,
+                QueryParameters::create([
+                    QueryParameter::int('host_id', (int) $host_id),
+                    ...$bindParams,
+                ])
+            );
+            $result = [];
+            foreach ($rows as $elem) {
+                $key = $this->constructKey($elem, $options);
+                if ($key !== '' && ! isset($result[$key])) {
+                    $result[$key] = isset($options['get_row']) ? $elem[$options['get_row']] : $elem;
+                }
             }
-            $stmt->execute();
+
+            if (isset($options['total']) && $options['total'] == true) {
+                return ['items' => $result, 'total' => count($result)];
+            }
+
+            return $result;
         }
 
         $result = [];

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -21,8 +21,8 @@
 
 use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Core\Common\Domain\Exception\CollectionException;
 use Core\Common\Domain\Exception\RepositoryException;
 
@@ -1885,6 +1885,7 @@ class CentreonACL
                 $result[$key] = isset($options['get_row']) ? $elem[$options['get_row']] : $elem;
             }
         }
+
         return $result;
     }
 

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -1246,6 +1246,9 @@ class CentreonACL
             }
             $stmt->closeCursor();
         } else {
+            if ($this->accessGroups === []) {
+                return $tab;
+            }
             [
                 'parameters' => $bindParams,
                 'placeholderList' => $placeholders,
@@ -1395,6 +1398,7 @@ class CentreonACL
                     $host_name = getMyHostName($data['id']);
 
                     if ($data['action'] == 'ADD') {
+                        $svc = getMyHostServices($data['id']);
                         // Put new entries in the table with group_id
                         foreach ($groupIds as $group_id) {
                             CentreonDBInstance::getDbCentreonStorageInstance()->executeStatement(
@@ -1404,20 +1408,18 @@ class CentreonACL
                                     QueryParameter::int('group_id', (int) $group_id),
                                 ])
                             );
-                        }
-
-                        // Insert services
-                        $svc = getMyHostServices($data['id']);
-                        foreach ($svc as $svc_id => $svc_name) {
-                            CentreonDBInstance::getDbCentreonStorageInstance()->executeStatement(
-                                'INSERT INTO centreon_acl (host_id, service_id, group_id) VALUES (:host_id, :service_id, :group_id) '
-                                . 'ON DUPLICATE KEY UPDATE group_id = VALUES(group_id)',
-                                QueryParameters::create([
-                                    QueryParameter::int('host_id', (int) $data['id']),
-                                    QueryParameter::int('service_id', (int) $svc_id),
-                                    QueryParameter::int('group_id', (int) $group_id),
-                                ])
-                            );
+                            // Insert services for this group
+                            foreach ($svc as $svc_id => $svc_name) {
+                                CentreonDBInstance::getDbCentreonStorageInstance()->executeStatement(
+                                    'INSERT INTO centreon_acl (host_id, service_id, group_id) VALUES (:host_id, :service_id, :group_id) '
+                                    . 'ON DUPLICATE KEY UPDATE group_id = VALUES(group_id)',
+                                    QueryParameters::create([
+                                        QueryParameter::int('host_id', (int) $data['id']),
+                                        QueryParameter::int('service_id', (int) $svc_id),
+                                        QueryParameter::int('group_id', (int) $group_id),
+                                    ])
+                                );
+                            }
                         }
                     } elseif ($data['action'] == 'DUP' && isset($data['duplicate_host'])) {
                         // Get current ACL configuration from centreon_storage.centreon_acl table
@@ -1839,6 +1841,13 @@ class CentreonACL
             $stmt->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
             $stmt->execute();
         } else {
+            if ($this->accessGroups === []) {
+                if (isset($options['total']) && $options['total'] == true) {
+                    return ['items' => [], 'total' => 0];
+                }
+
+                return [];
+            }
             [$bindValues, $bindQuery] = createMultipleBindQuery(
                 list: array_keys($this->accessGroups),
                 prefix: ':acl_group_'
@@ -1884,6 +1893,10 @@ class CentreonACL
             if ($key !== '' && ! isset($result[$key])) {
                 $result[$key] = isset($options['get_row']) ? $elem[$options['get_row']] : $elem;
             }
+        }
+
+        if (isset($options['total']) && $options['total'] == true) {
+            return ['items' => $result, 'total' => count($result)];
         }
 
         return $result;

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -21,6 +21,7 @@
 
 use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Adaptation\Database\Connection\Exception\ConnectionException;
 use Core\Common\Domain\Exception\CollectionException;
 use Core\Common\Domain\Exception\RepositoryException;
@@ -1220,38 +1221,54 @@ class CentreonACL
                 . 'FROM host_service_relation hsr, host h, service s '
                 . "WHERE h.host_activate = '1' "
                 . 'AND hsr.host_host_id = h.host_id '
-                . "AND h.host_id = '" . CentreonDB::escape($host_id) . "'"
+                . 'AND h.host_id = :host_id '
                 . 'AND hsr.service_service_id = s.service_id '
                 . "AND s.service_activate = '1' ";
-            $DBRESULT = CentreonDBInstance::getDbCentreonInstance()->query($query);
-            while ($row = $DBRESULT->fetchRow()) {
+            $stmt = CentreonDBInstance::getDbCentreonInstance()->prepare($query);
+            $stmt->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+            $stmt->execute();
+            while ($row = $stmt->fetchRow()) {
                 $tab[$row['service_id']] = $row['service_description'];
             }
-            $DBRESULT->closeCursor();
+            $stmt->closeCursor();
 
             // Get Services attached to hostgroups
             $query = 'SELECT DISTINCT service_id, service_description '
                 . 'FROM hostgroup_relation hgr, service, host_service_relation hsr '
-                . "WHERE hgr.host_host_id = '" . CentreonDB::escape($host_id) . "' "
+                . 'WHERE hgr.host_host_id = :host_id '
                 . 'AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id '
                 . 'AND service_id = hsr.service_service_id ';
-            $DBRESULT = CentreonDBInstance::getDbCentreonInstance()->query($query);
-            while ($elem = $DBRESULT->fetchRow()) {
+            $stmt = CentreonDBInstance::getDbCentreonInstance()->prepare($query);
+            $stmt->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+            $stmt->execute();
+            while ($elem = $stmt->fetchRow()) {
                 $tab[$elem['service_id']] = html_entity_decode($elem['service_description'], ENT_QUOTES, 'UTF-8');
             }
-            $DBRESULT->closeCursor();
+            $stmt->closeCursor();
         } else {
-            $query = 'SELECT DISTINCT s.service_id, s.description '
+            [
+                'parameters' => $bindParams,
+                'placeholderList' => $placeholders,
+            ] = createMultipleBindParameters(
+                values: array_keys($this->accessGroups),
+                prefix: 'group_',
+                paramType: QueryParameterTypeEnum::INTEGER
+            );
+            $rows = $pearDBMonitoring->fetchAllAssociative(
+                'SELECT DISTINCT s.service_id, s.description '
                 . 'FROM services s '
                 . 'JOIN centreon_acl ca '
                 . 'ON s.service_id = ca.service_id '
-                . "AND ca.host_id = '" . CentreonDB::escape($host_id) . "' "
-                . 'AND ca.group_id IN (' . $this->getAccessGroupsString() . ') ';
-            $DBRESULT = $pearDBMonitoring->query($query);
-            while ($row = $DBRESULT->fetchRow()) {
+                . 'AND ca.host_id = :host_id '
+                . "AND ca.group_id IN ({$placeholders}) ",
+                QueryParameters::create([
+                    QueryParameter::int('host_id', (int) $host_id),
+                    ...$bindParams,
+                ])
+            );
+            foreach ($rows as $row) {
                 $tab[$row['service_id']] = $row['description'];
             }
-            $DBRESULT->closeCursor();
         }
 
         return $tab;
@@ -1380,18 +1397,27 @@ class CentreonACL
                     if ($data['action'] == 'ADD') {
                         // Put new entries in the table with group_id
                         foreach ($groupIds as $group_id) {
-                            $request2 = 'INSERT INTO centreon_acl (host_id, service_id, group_id) '
-                                . "VALUES ('" . $data['id'] . "', NULL, " . $group_id . ')';
-                            CentreonDBInstance::getDbCentreonStorageInstance()->query($request2);
+                            CentreonDBInstance::getDbCentreonStorageInstance()->executeStatement(
+                                'INSERT INTO centreon_acl (host_id, service_id, group_id) VALUES (:host_id, NULL, :group_id)',
+                                QueryParameters::create([
+                                    QueryParameter::int('host_id', (int) $data['id']),
+                                    QueryParameter::int('group_id', (int) $group_id),
+                                ])
+                            );
                         }
 
                         // Insert services
                         $svc = getMyHostServices($data['id']);
                         foreach ($svc as $svc_id => $svc_name) {
-                            $request2 = 'INSERT INTO centreon_acl (host_id, service_id, group_id) '
-                                . "VALUES ('" . $data['id'] . "', '" . $svc_id . "', " . $group_id . ') '
-                                . 'ON DUPLICATE KEY UPDATE group_id = ' . $group_id;
-                            CentreonDBInstance::getDbCentreonStorageInstance()->query($request2);
+                            CentreonDBInstance::getDbCentreonStorageInstance()->executeStatement(
+                                'INSERT INTO centreon_acl (host_id, service_id, group_id) VALUES (:host_id, :service_id, :group_id) '
+                                . 'ON DUPLICATE KEY UPDATE group_id = VALUES(group_id)',
+                                QueryParameters::create([
+                                    QueryParameter::int('host_id', (int) $data['id']),
+                                    QueryParameter::int('service_id', (int) $svc_id),
+                                    QueryParameter::int('group_id', (int) $group_id),
+                                ])
+                            );
                         }
                     } elseif ($data['action'] == 'DUP' && isset($data['duplicate_host'])) {
                         // Get current ACL configuration from centreon_storage.centreon_acl table
@@ -1473,21 +1499,29 @@ class CentreonACL
                         if ($data['action'] == 'ADD') {
                             // Put new entries in the table with group_id
                             foreach ($groupIds as $group_id) {
-                                $request2 = 'INSERT INTO centreon_acl (host_id, service_id, group_id) '
-                                    . "VALUES ('" . $host_id . "', '" . $data['id'] . "', " . $group_id . ')';
-                                CentreonDBInstance::getDbCentreonStorageInstance()->query($request2);
+                                CentreonDBInstance::getDbCentreonStorageInstance()->executeStatement(
+                                    'INSERT INTO centreon_acl (host_id, service_id, group_id) VALUES (:host_id, :service_id, :group_id)',
+                                    QueryParameters::create([
+                                        QueryParameter::int('host_id', (int) $host_id),
+                                        QueryParameter::int('service_id', (int) $data['id']),
+                                        QueryParameter::int('group_id', (int) $group_id),
+                                    ])
+                                );
                             }
                         } elseif ($data['action'] == 'DUP' && isset($data['duplicate_service'])) {
                             // Get current configuration into Centreon_acl table
-                            $request = 'SELECT group_id FROM centreon_acl '
-                                . "WHERE host_id = {$host_id} AND service_id = " . $data['duplicate_service'];
-                            $DBRESULT = CentreonDBInstance::getDbCentreonStorageInstance()->query($request);
+                            $selectAcl = CentreonDBInstance::getDbCentreonStorageInstance()->prepare(
+                                'SELECT group_id FROM centreon_acl WHERE host_id = :host_id AND service_id = :service_id'
+                            );
+                            $selectAcl->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+                            $selectAcl->bindValue(':service_id', (int) $data['duplicate_service'], PDO::PARAM_INT);
+                            $selectAcl->execute();
                             $statement = CentreonDBInstance::getDbCentreonStorageInstance()
                                 ->prepare(
                                     'INSERT INTO centreon_acl (host_id, service_id, group_id) '
                                     . 'VALUES (:host_id, :data_id, :group_id)'
                                 );
-                            while ($record = $DBRESULT->fetchRow()) {
+                            while ($record = $selectAcl->fetchRow()) {
                                 $statement->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
                                 $statement->bindValue(':data_id', (int) $data['id'], PDO::PARAM_INT);
                                 $statement->bindValue(':group_id', (int) $record['group_id'], PDO::PARAM_INT);
@@ -1784,7 +1818,7 @@ class CentreonACL
                 . 'FROM ( '
                 . 'SELECT ' . $request['fields'] . ' '
                 . 'FROM host_service_relation hsr, host h, service s '
-                . "WHERE h.host_id = '" . CentreonDB::escape($host_id) . "' "
+                . 'WHERE h.host_id = :host_id '
                 . "AND h.host_activate = '1' "
                 . "AND h.host_register = '1' "
                 . 'AND h.host_id = hsr.host_host_id '
@@ -1793,17 +1827,25 @@ class CentreonACL
                 . 'UNION '
                 . 'SELECT ' . $request['fields'] . ' '
                 . 'FROM host h, hostgroup_relation hgr, service s, host_service_relation hsr '
-                . "WHERE h.host_id = '" . CentreonDB::escape($host_id) . "' "
+                . 'WHERE h.host_id = :host_id '
                 . "AND h.host_activate = '1' "
                 . "AND h.host_register = '1' "
                 . 'AND h.host_id = hgr.host_host_id '
                 . 'AND hgr.hostgroup_hg_id = hsr.hostgroup_hg_id '
                 . 'AND hsr.service_service_id = s.service_id '
                 . ') as t ';
+            $query .= $request['order'] . $request['pages'];
+            $stmt = CentreonDBInstance::getDbCentreonInstance()->prepare($query);
+            $stmt->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+            $stmt->execute();
         } else {
+            [$bindValues, $bindQuery] = createMultipleBindQuery(
+                list: array_keys($this->accessGroups),
+                prefix: ':acl_group_'
+            );
             $query = 'SELECT ' . $request['fields'] . ' '
                 . "FROM host_service_relation hsr, host h, service s, `{$db_name_acl}`.centreon_acl "
-                . "WHERE h.host_id = '" . CentreonDB::escape($host_id) . "' "
+                . 'WHERE h.host_id = :host_id '
                 . "AND h.host_activate = '1' "
                 . "AND h.host_register = '1' "
                 . 'AND h.host_id = hsr.host_host_id '
@@ -1812,12 +1854,12 @@ class CentreonACL
                 . "AND `{$db_name_acl}`.centreon_acl.host_id = h.host_id "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id IS NOT NULL "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id = s.service_id "
-                . "AND `{$db_name_acl}`.centreon_acl.group_id IN (" . $this->getAccessGroupsString() . ') '
+                . "AND `{$db_name_acl}`.centreon_acl.group_id IN ({$bindQuery}) "
                 . 'UNION '
                 . 'SELECT ' . $request['fields'] . ' '
                 . 'FROM host h, hostgroup_relation hgr, '
                 . "service s, host_service_relation hsr, `{$db_name_acl}`.centreon_acl "
-                . "WHERE h.host_id = '" . CentreonDB::escape($host_id) . "' "
+                . 'WHERE h.host_id = :host_id '
                 . "AND h.host_activate = '1' "
                 . "AND h.host_register = '1' "
                 . 'AND h.host_id = hgr.host_host_id '
@@ -1826,12 +1868,24 @@ class CentreonACL
                 . "AND `{$db_name_acl}`.centreon_acl.host_id = h.host_id "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id IS NOT NULL "
                 . "AND `{$db_name_acl}`.centreon_acl.service_id = s.service_id "
-                . "AND `{$db_name_acl}`.centreon_acl.group_id IN (" . $this->getAccessGroupsString() . ') ';
+                . "AND `{$db_name_acl}`.centreon_acl.group_id IN ({$bindQuery}) ";
+            $query .= $request['order'] . $request['pages'];
+            $stmt = CentreonDBInstance::getDbCentreonInstance()->prepare($query);
+            $stmt->bindValue(':host_id', (int) $host_id, PDO::PARAM_INT);
+            foreach ($bindValues as $key => $value) {
+                $stmt->bindValue($key, $value, PDO::PARAM_INT);
+            }
+            $stmt->execute();
         }
 
-        $query .= $request['order'] . $request['pages'];
-
-        return $this->constructResult($query, $options);
+        $result = [];
+        while ($elem = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $key = $this->constructKey($elem, $options);
+            if ($key !== '' && ! isset($result[$key])) {
+                $result[$key] = isset($options['get_row']) ? $elem[$options['get_row']] : $elem;
+            }
+        }
+        return $result;
     }
 
     /**

--- a/centreon/www/class/centreonAclGroup.class.php
+++ b/centreon/www/class/centreonAclGroup.class.php
@@ -53,9 +53,9 @@ class CentreonAclGroup
         $listValues = '';
         $queryValues = [];
         if (! empty($values)) {
-            foreach ($values as $k => $v) {
-                $listValues .= ':group' . $v . ',';
-                $queryValues['group' . $v] = (int) $v;
+            foreach (array_values($values) as $k => $v) {
+                $listValues .= ':group' . $k . ',';
+                $queryValues['group' . $k] = (int) $v;
             }
             $listValues = rtrim($listValues, ',');
         } else {


### PR DESCRIPTION
## Description

Replace unprepared SQL statements in the ACL legacy classes with parameterized queries.

- `centreonACL.class.php`: migrate `getHostServices()` (admin and non-admin branches),
  host/service ADD and DUP insert flows, and `getHostServiceAclConf()` UNION query
  from string concatenation / `CentreonDB::escape()` to `prepare()`/`bindValue()`,
  `executeStatement()` + `QueryParameters`, and `createMultipleBindQuery()` /
  `createMultipleBindParameters()` for IN clauses.
- `centreonAclGroup.class.php`: fix `getObjectForSelect2()` placeholder names built
  from array values instead of sequential indices, which allowed non-numeric input
  to appear in the SQL string before `prepare()`.

**Fixes** MON-199674

## Type of change
- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Log in as a **non-admin user** with ACL groups assigned.
2. Navigate to a monitored host — verify services are listed correctly in the monitoring view.
3. In **Administration > ACL > Access Groups**, add a host to an ACL group — verify the `centreon_acl` row is inserted in centstorage.
4. Add a service to an ACL group — verify the INSERT and the ON DUPLICATE KEY UPDATE path both succeed.
5. Duplicate a service in the configuration — verify the ACL group_id is copied correctly to the new service.
6. Call the ACL group select2 endpoint (`/api/internal.php?object=centreon_aclgroup&action=getObjectForSelect2`) with group IDs that include special characters and verify the query executes safely.