### PR TITLE
fix(gorgone): use snowflake UID instead of hardcoded id in gorgone config

### DIFF
--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/15-installation.sh
@@ -89,13 +89,6 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
 fi
 
 sed -i 's#severity=error#severity=debug#' /etc/sysconfig/gorgoned
-if [[ -f /etc/centreon-gorgone/config.d/40-gorgoned.yaml ]]; then
-  if grep -Pzo '(?s)gorgonecore:.*?(?=\n\S|\Z)' /etc/centreon-gorgone/config.d/40-gorgoned.yaml | grep -q 'id:'; then
-    sed -Ei '/^gorgonecore:/,/^[^[:space:]]/ s/^([[:space:]]*id:).*/\1 1/' /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-  else
-    sed -Ei '/^gorgonecore:/a\    id: 1' /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-  fi
-fi
 sed -i 's#enable: true#enable: false#' /etc/centreon-gorgone/config.d/50-centreon-audit.yaml
 
 

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/15-installation.sh
@@ -89,13 +89,6 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
 fi
 
 sed -i 's#severity=error#severity=debug#' /etc/sysconfig/gorgoned
-if [[ -f /etc/centreon-gorgone/config.d/40-gorgoned.yaml ]]; then
-  if grep -Pzo '(?s)gorgonecore:.*?(?=\n\S|\Z)' /etc/centreon-gorgone/config.d/40-gorgoned.yaml | grep -q 'id:'; then
-    sed -Ei '/^gorgonecore:/,/^[^[:space:]]/ s/^([[:space:]]*id:).*/\1 1/' /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-  else
-    sed -Ei '/^gorgonecore:/a\    id: 1' /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-  fi
-fi
 sed -i 's#enable: true#enable: false#' /etc/centreon-gorgone/config.d/50-centreon-audit.yaml
 
 

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/15-installation.sh
@@ -89,13 +89,6 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
 fi
 
 sed -i 's#severity=error#severity=debug#' /etc/sysconfig/gorgoned
-if [[ -f /etc/centreon-gorgone/config.d/40-gorgoned.yaml ]]; then
-  if grep -Pzo '(?s)gorgonecore:.*?(?=\n\S|\Z)' /etc/centreon-gorgone/config.d/40-gorgoned.yaml | grep -q 'id:'; then
-    sed -Ei '/^gorgonecore:/,/^[^[:space:]]/ s/^([[:space:]]*id:).*/\1 1/' /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-  else
-    sed -Ei '/^gorgonecore:/a\    id: 1' /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-  fi
-fi
 sed -i 's#enable: true#enable: false#' /etc/centreon-gorgone/config.d/50-centreon-audit.yaml
 
 

--- a/centreon/src/Centreon/Infrastructure/Service/VmwareConfigurationService.php
+++ b/centreon/src/Centreon/Infrastructure/Service/VmwareConfigurationService.php
@@ -44,10 +44,11 @@ final class VmwareConfigurationService
      *
      * @param int $pollerId
      * @param bool $isLocalhost true → systemctl restart locally, false → write VMWARERESTART to centcore pipe
+     * @param string|int|null $pollerUid Gorgone routing UID (falls back to $pollerId if null)
      *
      * @throws Exception when writing to the centcore pipe fails
      */
-    public function restartIfConfigurationChanged(int $pollerId, bool $isLocalhost): void
+    public function restartIfConfigurationChanged(int $pollerId, bool $isLocalhost, string|int|null $pollerUid = null): void
     {
         if (! $this->writeMonitoringServerRepository->resetVmwareConfigurationChange($pollerId)) {
             return;
@@ -55,7 +56,7 @@ final class VmwareConfigurationService
 
         $succeeded = $isLocalhost
             ? $this->restartLocally()
-            : $this->writeRestartCommandToCentcorePipe($pollerId);
+            : $this->writeRestartCommandToCentcorePipe($pollerUid ?? $pollerId);
 
         if ($succeeded) {
             return;
@@ -76,7 +77,7 @@ final class VmwareConfigurationService
         return $process->isSuccessful();
     }
 
-    private function writeRestartCommandToCentcorePipe(int $pollerId): bool
+    private function writeRestartCommandToCentcorePipe(string|int $pollerId): bool
     {
         $pipePath = $this->getCentcorePipePath();
         $written = file_put_contents(

--- a/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -130,7 +130,7 @@ class PollerInteractionService
 
         $tabServer = [];
         $tabs = $this->centreon->user->access->getPollerAclConf([
-            'fields' => ['name', 'id', 'localhost'],
+            'fields' => ['name', 'id', 'uid', 'localhost'],
             'order' => ['name'],
             'conditions' => ['ns_activate' => '1'],
             'keys' => ['id'],
@@ -140,6 +140,7 @@ class PollerInteractionService
             if (in_array($tab['id'], $pollerIDs)) {
                 $tabServer[$tab['id']] = [
                     'id' => $tab['id'],
+                    'uid' => $tab['uid'],
                     'name' => $tab['name'],
                     'localhost' => $tab['localhost'],
                 ];
@@ -150,7 +151,7 @@ class PollerInteractionService
             if (in_array($host['id'], $pollerIDs)) {
                 $written = file_put_contents(
                     $centCorePipe,
-                    'SENDCFGFILE:' . (int) $host['id'] . "\n",
+                    'SENDCFGFILE:' . $host['uid'] . "\n",
                     FILE_APPEND | LOCK_EX
                 );
 
@@ -160,7 +161,8 @@ class PollerInteractionService
 
                 $vmwareConfigurationService->restartIfConfigurationChanged(
                     (int) $host['id'],
-                    isset($host['localhost']) && $host['localhost'] == 1
+                    isset($host['localhost']) && $host['localhost'] == 1,
+                    $host['uid']
                 );
             }
         }
@@ -180,7 +182,7 @@ class PollerInteractionService
             : '/var/lib/centreon/centcore.cmd';
 
         $tabs = $this->centreon->user->access->getPollerAclConf([
-            'fields' => ['name', 'id', 'localhost', 'engine_restart_command'],
+            'fields' => ['name', 'id', 'uid', 'localhost', 'engine_restart_command'],
             'order' => ['name'],
             'conditions' => ['ns_activate' => '1'],
             'keys' => ['id'],
@@ -193,6 +195,7 @@ class PollerInteractionService
             if (in_array($tab['id'], $pollerIDs)) {
                 $tabServers[$tab['id']] = [
                     'id' => $tab['id'],
+                    'uid' => $tab['uid'],
                     'name' => $tab['name'],
                     'localhost' => $tab['localhost'],
                     'engine_restart_command' => $tab['engine_restart_command'],
@@ -206,7 +209,7 @@ class PollerInteractionService
             } else {
                 $written = file_put_contents(
                     $centCorePipe,
-                    'RESTART:' . (int) $poller['id'] . "\n",
+                    'RESTART:' . $poller['uid'] . "\n",
                     FILE_APPEND | LOCK_EX
                 );
 

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -153,13 +153,13 @@ class CentreonConfigPoller
 
         $this->commandGenerator = $this->container->get(EngineCommandGenerator::class);
         $reloadCommand = $this->commandGenerator->getEngineCommand('RELOAD');
-        $return_code = $this->writeToCentcorePipe($reloadCommand, $host['id']);
+        $return_code = $this->writeToCentcorePipe($reloadCommand, $host['uid']);
         if ($return_code === 1) {
             echo "Error while writing the command {$reloadCommand} in centcore pipe file for host id {$host['id']}" . PHP_EOL;
 
             return $return_code;
         }
-        $return_code = $this->writeToCentcorePipe('RELOADBROKER', $host['id']);
+        $return_code = $this->writeToCentcorePipe('RELOADBROKER', $host['uid']);
         if ($return_code === 1) {
             echo "Error while writing the command RELOADBROKER in centcore pipe file for host id {$host['id']}" . PHP_EOL;
 
@@ -244,13 +244,13 @@ class CentreonConfigPoller
 
         $this->commandGenerator = $this->container->get(EngineCommandGenerator::class);
         $restartCommand = $this->commandGenerator->getEngineCommand('RESTART');
-        $return_code = $this->writeToCentcorePipe($restartCommand, $host['id']);
+        $return_code = $this->writeToCentcorePipe($restartCommand, $host['uid']);
         if ($return_code === 1) {
             echo "Error while writing the command {$restartCommand} in centcore pipe file for host id {$host['id']}" . PHP_EOL;
 
             return $return_code;
         }
-        $return_code = $this->writeToCentcorePipe('RELOADBROKER', $host['id']);
+        $return_code = $this->writeToCentcorePipe('RELOADBROKER', $host['uid']);
         if ($return_code === 1) {
             echo "Error while writing the command RELOADBROKER in centcore pipe file for host id {$host['id']}" . PHP_EOL;
 
@@ -640,10 +640,10 @@ class CentreonConfigPoller
                     ['params' => $exportParams]
                 );
             }
-            $return = $this->writeToCentcorePipe('SENDCFGFILE', $host['id']);
+            $return = $this->writeToCentcorePipe('SENDCFGFILE', $host['uid']);
 
             $this->container->get(VmwareConfigurationService::class)
-                ->restartIfConfigurationChanged((int) $host['id'], false);
+                ->restartIfConfigurationChanged((int) $host['id'], false, $host['uid']);
 
             $msg_copy .= _(
                 "OK: All configuration will be send to '"
@@ -700,7 +700,7 @@ class CentreonConfigPoller
 
         $centreonDir = $this->centreon_path;
         $pearDB = $this->dependencyInjector['configuration_db'];
-        $statement = $pearDB->prepare('SELECT snmp_trapd_path_conf FROM nagios_server WHERE id = :pollerId');
+        $statement = $pearDB->prepare('SELECT snmp_trapd_path_conf, uid FROM nagios_server WHERE id = :pollerId');
         $statement->bindValue(':pollerId', $pollerId, PDO::PARAM_INT);
         $statement->execute();
         $row = $statement->fetchRow();
@@ -721,7 +721,7 @@ class CentreonConfigPoller
         );
         passthru($cmd);
 
-        return $this->writeToCentcorePipe('SYNCTRAP', $pollerId);
+        return $this->writeToCentcorePipe('SYNCTRAP', $row['uid']);
     }
 
     /**
@@ -745,17 +745,17 @@ class CentreonConfigPoller
      * when possible
      *
      * @param string $cmd
-     * @param int $id
+     * @param string|int $uid
      * @return int
      */
-    private function writeToCentcorePipe($cmd, $id): int
+    private function writeToCentcorePipe($cmd, $uid): int
     {
         if (is_dir(_CENTREON_VARLIB_ . '/centcore')) {
             $pipe = _CENTREON_VARLIB_ . '/centcore/' . hrtime(true) . '-externalcommand.cmd';
         } else {
             $pipe = _CENTREON_VARLIB_ . '/centcore.cmd';
         }
-        $fullCommand = sprintf('%s:%d' . PHP_EOL, $cmd, $id);
+        $fullCommand = sprintf('%s:%s' . PHP_EOL, $cmd, $uid);
         $result = file_put_contents($pipe, $fullCommand, FILE_APPEND);
 
         return ($result !== false) ? 0 : 1;

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -229,11 +229,11 @@ try {
         ->get(VmwareConfigurationService::class);
 
     $tab_server = [];
-    $tabs = $centreon->user->access->getPollerAclConf(['fields' => ['name', 'id', 'localhost'], 'order' => ['name'], 'conditions' => ['ns_activate' => '1'], 'keys' => ['id']]);
+    $tabs = $centreon->user->access->getPollerAclConf(['fields' => ['name', 'id', 'uid', 'localhost'], 'order' => ['name'], 'conditions' => ['ns_activate' => '1'], 'keys' => ['id']]);
 
     foreach ($tabs as $tab) {
         if (isset($ret['host']) && ($ret['host'] == 0 || in_array($tab['id'], $ret['host']))) {
-            $tab_server[$tab['id']] = ['id' => $tab['id'], 'name' => $tab['name'], 'localhost' => $tab['localhost']];
+            $tab_server[$tab['id']] = ['id' => $tab['id'], 'uid' => $tab['uid'], 'name' => $tab['name'], 'localhost' => $tab['localhost']];
         }
     }
 
@@ -351,13 +351,13 @@ try {
             } else {
                 $written = file_put_contents(
                     $centcore_pipe,
-                    'SENDCFGFILE:' . (int) $host['id'] . "\n",
+                    'SENDCFGFILE:' . $host['uid'] . "\n",
                     FILE_APPEND | LOCK_EX
                 );
                 if ($written === false) {
                     throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
                 }
-                $vmwareConfigurationService->restartIfConfigurationChanged((int) $host['id'], false);
+                $vmwareConfigurationService->restartIfConfigurationChanged((int) $host['id'], false, $host['uid']);
                 if (! isset($msg_restart[$host['id']])) {
                     $msg_restart[$host['id']] = '';
                 }

--- a/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -172,6 +172,7 @@ try {
         'fields' => [
             'name',
             'id',
+            'uid',
             'engine_restart_command',
             'engine_reload_command',
             'broker_reload_command',
@@ -182,7 +183,7 @@ try {
     ]);
     foreach ($tabs as $tab) {
         if (isset($ret['host']) && ($ret['host'] == 0 || in_array($tab['id'], $ret['host']))) {
-            $poller[$tab['id']] = ['id' => $tab['id'], 'name' => $tab['name'], 'engine_restart_command' => $tab['engine_restart_command'], 'engine_reload_command' => $tab['engine_reload_command'], 'broker_reload_command' => $tab['broker_reload_command']];
+            $poller[$tab['id']] = ['id' => $tab['id'], 'uid' => $tab['uid'], 'name' => $tab['name'], 'engine_restart_command' => $tab['engine_restart_command'], 'engine_reload_command' => $tab['engine_reload_command'], 'broker_reload_command' => $tab['broker_reload_command']];
         }
     }
 
@@ -199,7 +200,7 @@ try {
                 $reloadCommand = ($commandGenerator !== null)
                     ? $commandGenerator->getEngineCommand('RELOAD')
                     : 'RELOAD';
-                fwrite($fh, $reloadCommand . ':' . $host['id'] . "\n");
+                fwrite($fh, $reloadCommand . ':' . $host['uid'] . "\n");
                 fclose($fh);
             } else {
                 throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));
@@ -218,7 +219,7 @@ try {
                 $restartCommand = ($commandGenerator !== null)
                     ? $commandGenerator->getEngineCommand('RESTART')
                     : 'RESTART';
-                fwrite($fh, $restartCommand . ':' . $host['id'] . "\n");
+                fwrite($fh, $restartCommand . ':' . $host['uid'] . "\n");
                 fclose($fh);
             } else {
                 throw new Exception(_('Could not write into centcore.cmd. Please check file permissions.'));

--- a/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -99,12 +99,12 @@ if ($form->validate()) {
     if ($ret['host'] == 0 || $ret['host'] != -1) {
         // Create Server List to snmptt generation file
         $tab_server = [];
-        $query = 'SELECT `name`, `id`, `snmp_trapd_path_conf`, `localhost` FROM `nagios_server` '
+        $query = 'SELECT `name`, `id`, `uid`, `snmp_trapd_path_conf`, `localhost` FROM `nagios_server` '
             . "WHERE `ns_activate` = '1' ORDER BY `localhost` DESC";
         $DBRESULT_Servers = $pearDB->query($query);
         while ($tab = $DBRESULT_Servers->fetchRow()) {
             if (isset($ret['host']) && ($ret['host'] == 0 || $ret['host'] == $tab['id'])) {
-                $tab_server[$tab['id']] = ['id' => $tab['id'], 'name' => $tab['name'], 'localhost' => $tab['localhost']];
+                $tab_server[$tab['id']] = ['id' => $tab['id'], 'uid' => $tab['uid'], 'name' => $tab['name'], 'localhost' => $tab['localhost']];
             }
             if ($tab['localhost'] && $tab['snmp_trapd_path_conf']) {
                 $trapdPath = $tab['snmp_trapd_path_conf'];
@@ -143,7 +143,7 @@ if ($form->validate()) {
             foreach ($tab_server as $host) {
                 $return = file_put_contents(
                     $centcore_pipe,
-                    'SYNCTRAP:' . (int) $host['id'] . "\n",
+                    'SYNCTRAP:' . $host['uid'] . "\n",
                     FILE_APPEND | LOCK_EX
                 );
                 if ($return === false) {

--- a/centreon/www/include/configuration/configServers/popup/popup.php
+++ b/centreon/www/include/configuration/configServers/popup/popup.php
@@ -65,7 +65,7 @@ $dbResult->closeCursor();
 
 // get poller informations
 $statement = $pearDB->prepare(
-    "SELECT ns.`id`, ns.`name`, ns.`gorgone_port`, ns.`ns_ip_address`, ns.`localhost`, ns.remote_id,
+    "SELECT ns.`id`, ns.`uid`, ns.`name`, ns.`gorgone_port`, ns.`ns_ip_address`, ns.`localhost`, ns.remote_id,
       remote_server_use_as_proxy, cn.`command_file`, GROUP_CONCAT( pr.`remote_server_id` ) AS list_remote_server_id
     FROM nagios_server AS ns
     LEFT JOIN remote_servers AS rs ON rs.server_id = ns.id
@@ -123,7 +123,7 @@ if ($server['localhost'] === '1') {
         ],
         [
             $server['name'],
-            $server['id'],
+            $server['uid'],
             $server['command_file'],
             _CENTREON_VARLIB_,
             _CENTREON_CACHEDIR_,
@@ -193,7 +193,7 @@ if ($server['localhost'] === '1') {
             ],
             [
                 $server['name'],
-                $server['id'],
+                $server['uid'],
                 $server['gorgone_port'],
                 $thumbprints,
                 $server['command_file'],
@@ -215,7 +215,7 @@ if ($server['localhost'] === '1') {
             ],
             [
                 $server['name'],
-                $server['id'],
+                $server['uid'],
                 $server['gorgone_port'],
                 $thumbprints,
                 $server['command_file'],

--- a/centreon/www/install/step_upgrade/process/process_step5.php
+++ b/centreon/www/install/step_upgrade/process/process_step5.php
@@ -23,6 +23,8 @@ session_start();
 require_once __DIR__ . '/../../../../bootstrap.php';
 require_once '../../steps/functions.php';
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Core\Platform\Application\Repository\WriteUpdateRepositoryInterface;
 
 $kernel = App\Kernel::createForWeb();
@@ -42,6 +44,24 @@ if ($parameters) {
     $db = $dependencyInjector['configuration_db'];
     $db->query("DELETE FROM options WHERE `key` = 'send_statistics'");
     $db->query($query);
+}
+
+/**
+ * Gorgone core id must match the central's snowflake UID for correct message routing.
+ * Old configs have id hardcoded to 1 or a template placeholder.
+ * Already-resolved UIDs are left untouched so the operation is idempotent.
+ */
+$gorgoneConfigFile = _CENTREON_ETC_ . '/../centreon-gorgone/config.d/40-gorgoned.yaml';
+if (file_exists($gorgoneConfigFile) && is_writable($gorgoneConfigFile)) {
+    $centralUid = $db->fetchOne(
+        'SELECT `uid` FROM `nagios_server` WHERE `localhost` = :localhost',
+        QueryParameters::create([QueryParameter::string(':localhost', '1')])
+    );
+    if ($centralUid !== false) {
+        $contents = file_get_contents($gorgoneConfigFile);
+        $contents = preg_replace('/^( {4}id:\s+)(1|--GORGONE_ID--)\s*$/m', '${1}' . $centralUid, $contents);
+        file_put_contents($gorgoneConfigFile, $contents);
+    }
 }
 
 try {

--- a/centreon/www/install/steps/process/insertBaseConf.php
+++ b/centreon/www/install/steps/process/insertBaseConf.php
@@ -75,9 +75,17 @@ try {
 
     $snowflake = new Snowflake(0, 0);
     $snowflake->setStartTimeStamp(SnowflakePollerUidGenerator::CUSTOM_EPOCH_MS);
+    $uid = (int) $snowflake->id();
     $stmt = $link->prepare('UPDATE `nagios_server` SET `uid` = :uid WHERE `id` = 1');
-    $stmt->bindValue(':uid', (int) $snowflake->id(), PDO::PARAM_INT);
+    $stmt->bindValue(':uid', $uid, PDO::PARAM_INT);
     $stmt->execute();
+
+    $gorgoneConfigFile = _CENTREON_ETC_ . '/../centreon-gorgone/config.d/40-gorgoned.yaml';
+    if (file_exists($gorgoneConfigFile) && is_writable($gorgoneConfigFile)) {
+        $contents = file_get_contents($gorgoneConfigFile);
+        $contents = str_replace('--GORGONE_ID--', (string) $uid, $contents);
+        file_put_contents($gorgoneConfigFile, $contents);
+    }
 
     $utils->executeSqlFile(__DIR__ . '/../../var/baseconf/centreon-broker.sql', $macros);
     $utils->executeSqlFile(__DIR__ . '/../../insertTopology.sql', $macros);

--- a/centreon/www/install/steps/process/process_step9.php
+++ b/centreon/www/install/steps/process/process_step9.php
@@ -23,6 +23,8 @@ session_start();
 require_once __DIR__ . '/../../../../bootstrap.php';
 require_once __DIR__ . '/../../../include/common/vault-functions.php';
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use App\Kernel;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Infrastructure\FeatureFlags;
@@ -67,6 +69,24 @@ try {
             if ($gorgoneVaultPaths !== []) {
                 updateGorgoneApiFile($gorgoneVaultPaths);
             }
+        }
+    }
+
+    /**
+     * Gorgone core id must match the central's snowflake UID for correct message routing.
+     * Old configs have id hardcoded to 1 or a template placeholder.
+     * Already-resolved UIDs are left untouched so the operation is idempotent.
+     */
+    $gorgoneConfigFile = _CENTREON_ETC_ . '/../centreon-gorgone/config.d/40-gorgoned.yaml';
+    if (file_exists($gorgoneConfigFile) && is_writable($gorgoneConfigFile)) {
+        $centralUid = $db->fetchOne(
+            'SELECT `uid` FROM `nagios_server` WHERE `localhost` = :localhost',
+            QueryParameters::create([QueryParameter::string(':localhost', '1')])
+        );
+        if ($centralUid !== false) {
+            $contents = file_get_contents($gorgoneConfigFile);
+            $contents = preg_replace('/^( {4}id:\s+)(1|--GORGONE_ID--)\s*$/m', '${1}' . $centralUid, $contents);
+            file_put_contents($gorgoneConfigFile, $contents);
         }
     }
 

--- a/centreon/www/install/steps/process/process_step9.php
+++ b/centreon/www/install/steps/process/process_step9.php
@@ -23,8 +23,6 @@ session_start();
 require_once __DIR__ . '/../../../../bootstrap.php';
 require_once __DIR__ . '/../../../include/common/vault-functions.php';
 
-use Adaptation\Database\Connection\Collection\QueryParameters;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use App\Kernel;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Infrastructure\FeatureFlags;
@@ -69,24 +67,6 @@ try {
             if ($gorgoneVaultPaths !== []) {
                 updateGorgoneApiFile($gorgoneVaultPaths);
             }
-        }
-    }
-
-    /**
-     * Gorgone core id must match the central's snowflake UID for correct message routing.
-     * Old configs have id hardcoded to 1 or a template placeholder.
-     * Already-resolved UIDs are left untouched so the operation is idempotent.
-     */
-    $gorgoneConfigFile = _CENTREON_ETC_ . '/../centreon-gorgone/config.d/40-gorgoned.yaml';
-    if (file_exists($gorgoneConfigFile) && is_writable($gorgoneConfigFile)) {
-        $centralUid = $db->fetchOne(
-            'SELECT `uid` FROM `nagios_server` WHERE `localhost` = :localhost',
-            QueryParameters::create([QueryParameter::string(':localhost', '1')])
-        );
-        if ($centralUid !== false) {
-            $contents = file_get_contents($gorgoneConfigFile);
-            $contents = preg_replace('/^( {4}id:\s+)(1|--GORGONE_ID--)\s*$/m', '${1}' . $centralUid, $contents);
-            file_put_contents($gorgoneConfigFile, $contents);
         }
     }
 

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -2,7 +2,7 @@ gorgone:
   gorgonecore:
     privkey: "--GORGONE_VARLIB--/.keys/rsakey.priv.pem"
     pubkey: "--GORGONE_VARLIB--/.keys/rsakey.pub.pem"
-    id: 1
+    id: --GORGONE_ID--
 
   modules:
     - name: httpserver


### PR DESCRIPTION
## Description

Replace hardcoded `id: 1` in gorgone central configuration with the snowflake UID from `nagios_server.uid`. This ensures gorgone correctly identifies messages targeting the central server.

- Template uses `--GORGONE_ID--` placeholder resolved at install time
- Upgrade path replaces `id: 1` or unresolved placeholder with the actual UID
- Poller config popup now uses UID for all server types (central, remote, poller)

**Fixes** MON-200737

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Fresh install: verify `/etc/centreon-gorgone/config.d/40-gorgoned.yaml` has `id: <snowflake_uid>` (not `1`)
2. Upgrade: verify the gorgone config is updated from `id: 1` to the central's UID
3. Poller config popup: navigate to Configuration > Pollers, click the gorgone config icon — verify the `id:` field shows the UID

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).