### PR TITLE
fix(docker): pin collect sub-packages on trixie dependencies image

### DIFF
--- a/.github/docker/centreon-web/trixie/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/trixie/Dockerfile.dependencies
@@ -155,8 +155,13 @@ if [[ "$STABILITY" == "stable" ]]; then
   apt-get install -y \
     centreon-common=${MAJOR_VERSION}.${COMMON_MINOR_VERSION}-*+deb13u1 \
     centreon-gorgone=${MAJOR_VERSION}.${GORGONE_MINOR_VERSION}-*+deb13u1 \
+    centreon-clib=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-engine=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-engine-daemon=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-connector-perl=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-connector-ssh=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-connector=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1
 else
   apt-get install -y \


### PR DESCRIPTION
## Description

When building a **stable** dependency image for an older collect minor, the Debian build (`Dockerfile.dependencies`) only pinned the collect **metapackages** (`centreon-engine`, `centreon-broker-cbd`, `centreon-connector`). Their transitive dependencies (`centreon-clib`, `centreon-broker-core`, `centreon-engine-daemon`, `centreon-connector-perl`, `centreon-connector-ssh`) were left unpinned, so `apt` resolved them to the **newest** available version, conflicting with the strict `(= version)` dependency of the pinned metapackages:

```
centreon-broker-cbd : Depends: centreon-broker-core (= 25.10.0-...) but 25.10.8-... is to be installed
E: Unable to correct problems, you have held broken packages.
```

RPM/`dnf` (alma) resolves this correctly, so only Debian was affected.

## Fix

Pin the whole collect dependency closure to `COLLECT_MINOR_VERSION` so `apt` selects a consistent set.

## Scope

Found while validating the `docker-stable` workflow (MON-198218). Same fix backported to `dev-25.10.x` and `dev-24.10.x` (bookworm).

Refs: MON-198218