### PR TITLE
fix(docker): pin collect sub-packages on bookworm dependencies image

### DIFF
--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -135,9 +135,14 @@ if [[ "$STABILITY" == "stable" ]]; then
   apt-get install -y \
     centreon-common=${MAJOR_VERSION}.${COMMON_MINOR_VERSION}-*+deb12u1 \
     centreon-gorgone=${MAJOR_VERSION}.${GORGONE_MINOR_VERSION}-*+deb12u1 \
+    centreon-clib=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-engine=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-engine-daemon=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbmod=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-connector-perl=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-connector-ssh=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-connector=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1
 else
   apt-get install -y \


### PR DESCRIPTION
## Description

Backport of the Debian collect-pinning fix. The stable `Dockerfile.dependencies` only pinned the collect metapackages; their transitive deps (`centreon-clib`, `centreon-broker-core`, `centreon-engine-daemon`, `centreon-connector-perl/ssh`) were unpinned, so `apt` pulled the newest version and conflicted with the strict `(= version)` dependency of the pinned metapackages when building an older collect minor.

Pin the whole collect closure to `COLLECT_MINOR_VERSION`.

Refs: MON-198218