### PR TITLE
fix(docker): complete collect & dsm pinning on bookworm images

### DIFF
--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -155,6 +155,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-clib=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-engine=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-engine-daemon=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-engine-opentelemetry=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-broker=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-connector-perl=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \

--- a/.github/docker/centreon-web/bookworm/Dockerfile.oss
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.oss
@@ -14,6 +14,8 @@ RUN bash -e <<EOF
 if [[ "$STABILITY" == "stable" ]]; then
   apt-get install -y \
     centreon-awie=${MAJOR_VERSION}.${AWIE_MINOR_VERSION}-*+deb12u1 \
+    centreon-dsm-client=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb12u1 \
+    centreon-dsm-server=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb12u1 \
     centreon-dsm=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb12u1 \
     centreon-open-tickets=${MAJOR_VERSION}.${OPEN_TICKETS_MINOR_VERSION}-*+deb12u1
 else


### PR DESCRIPTION
## Description

Follow-up to the collect-pinning fix. Building a stable image for an **older** minor on Debian still broke because more packages were pulled transitively and left unpinned:

- **`Dockerfile.dependencies`** (collect): `centreon-broker` and `centreon-engine-opentelemetry` are pulled through circular dependencies (`broker-core ↔ broker`, `engine-daemon ↔ engine-opentelemetry`).
- **`Dockerfile.oss`** (DSM): `centreon-dsm` depends on `centreon-dsm-client` / `centreon-dsm-server` with a strict `(= version)`.

apt selected the newest version for these unpinned packages, conflicting with the strict equality constraints.

## Fix

Pin the full closure to the relevant minor version (`COLLECT_MINOR_VERSION` / `DSM_MINOR_VERSION`).

## Validation

`docker-stable` run on bundle `release-onprem-20251000-25.10` (centreon-web 25.10.0) is now **green on all 3 distribs** (alma8, alma9, bookworm).

Refs: MON-198218