### PR TITLE
fix(docker): complete collect & dsm pinning on trixie images

### DIFF
--- a/.github/docker/centreon-web/trixie/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/trixie/Dockerfile.dependencies
@@ -158,6 +158,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-clib=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-engine=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-engine-daemon=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-engine-opentelemetry=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-broker=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-connector-perl=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \

--- a/.github/docker/centreon-web/trixie/Dockerfile.oss
+++ b/.github/docker/centreon-web/trixie/Dockerfile.oss
@@ -14,6 +14,8 @@ RUN bash -e <<EOF
 if [[ "$STABILITY" == "stable" ]]; then
   apt-get install -y \
     centreon-awie=${MAJOR_VERSION}.${AWIE_MINOR_VERSION}-*+deb13u1 \
+    centreon-dsm-client=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb13u1 \
+    centreon-dsm-server=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb13u1 \
     centreon-dsm=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb13u1 \
     centreon-open-tickets=${MAJOR_VERSION}.${OPEN_TICKETS_MINOR_VERSION}-*+deb13u1
 else


### PR DESCRIPTION
Follow-up to the collect-pinning fix. Pin the full transitive closure (centreon-broker, centreon-engine-opentelemetry via circular collect deps; centreon-dsm-client/server via strict = dependency of centreon-dsm) so apt builds an older minor without version conflicts on Debian. Validated end-to-end on dev-25.10.x (bookworm equivalent). Refs: MON-198218