### PR TITLE
fix(docker): complete collect & dsm pinning on bookworm images

### DIFF
--- a/.github/docker/centreon-web/bookworm/Dockerfile
+++ b/.github/docker/centreon-web/bookworm/Dockerfile
@@ -29,6 +29,7 @@ apt-get update
 
 if [[ "$STABILITY" == "stable" ]]; then
   apt-get install -y \
+    centreon-perl-libs=${MAJOR_VERSION}.${WEB_MINOR_VERSION}-*+deb12u1 \
     centreon-poller=${MAJOR_VERSION}.${WEB_MINOR_VERSION}-*+deb12u1 \
     centreon-trap=${MAJOR_VERSION}.${WEB_MINOR_VERSION}-*+deb12u1 \
     centreon-web=${MAJOR_VERSION}.${WEB_MINOR_VERSION}-*+deb12u1

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -138,6 +138,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-clib=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-engine=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-engine-daemon=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-engine-opentelemetry=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-broker=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbmod=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -42,8 +42,9 @@ if [[ "${IS_CLOUD}" == "true" ]]; then
   echo "deb https://packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
 else
   echo "deb https://packages.centreon.com/apt-standard-${MAJOR_VERSION}-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-  echo "deb https://packages.centreon.com/apt-standard-${MAJOR_VERSION}-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-  echo "deb https://packages.centreon.com/apt-standard-${MAJOR_VERSION}-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
 fi
 echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
 echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -41,10 +41,9 @@ wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/tr
 if [[ "${IS_CLOUD}" == "true" ]]; then
   echo "deb https://packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
 else
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-stable main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+  echo "deb https://packages.centreon.com/apt-standard-${MAJOR_VERSION}-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
+  echo "deb https://packages.centreon.com/apt-standard-${MAJOR_VERSION}-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+  echo "deb https://packages.centreon.com/apt-standard-${MAJOR_VERSION}-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
 fi
 echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
 echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list

--- a/.github/docker/centreon-web/bookworm/Dockerfile.oss
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.oss
@@ -14,6 +14,8 @@ RUN bash -e <<EOF
 if [[ "$STABILITY" == "stable" ]]; then
   apt-get install -y \
     centreon-awie=${MAJOR_VERSION}.${AWIE_MINOR_VERSION}-*+deb12u1 \
+    centreon-dsm-client=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb12u1 \
+    centreon-dsm-server=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb12u1 \
     centreon-dsm=${MAJOR_VERSION}.${DSM_MINOR_VERSION}-*+deb12u1 \
     centreon-open-tickets=${MAJOR_VERSION}.${OPEN_TICKETS_MINOR_VERSION}-*+deb12u1
 else


### PR DESCRIPTION
Follow-up to the collect-pinning fix. Pin the full transitive closure (centreon-broker, centreon-engine-opentelemetry via circular collect deps; centreon-dsm-client/server via strict = dependency of centreon-dsm) so apt builds an older minor without version conflicts on Debian. Verified the 24.10 collect/dsm dependency graph matches. Refs: MON-198218