### PR TITLE
fix(open-tickets): validate widgetId in toolbar

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/toolbar.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/toolbar.php
@@ -50,7 +50,7 @@ $template = SmartyBC::createSmartyTemplate($path . 'templates/', './');
 
 /** @var Centreon $centreon */
 $centreon = $_SESSION['centreon'];
-$widgetId = $_POST['widgetId'];
+$widgetId = filter_input(INPUT_POST, 'widgetId', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
 $db = new CentreonDB();
 $widgetObj = new CentreonWidget($centreon, $db);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);


### PR DESCRIPTION
## Description

Cast the POST widgetId parameter through FILTER_VALIDATE_INT with a default of 0 in the open-tickets widget toolbar.

[MON-191975](https://centreon.atlassian.net/browse/MON-191975)
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-191975]: https://centreon.atlassian.net/browse/MON-191975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ