### PR TITLE
fix(web): use nagios_server.uid to match instances in poller list

### DIFF
--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -114,7 +114,7 @@ $tpl->assign('headerMenu_options', _('Options'));
 $ACLString = $centreon->user->access->queryBuilder('WHERE', 'id', $pollerstring);
 
 $query = 'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, updated '
-    . ', gorgone_communication_type FROM `nagios_server` ' . $ACLString . ' '
+    . ', gorgone_communication_type, uid FROM `nagios_server` ' . $ACLString . ' '
     . ($LCASearch != '' ? ($ACLString != '' ? 'AND ' : 'WHERE ') . $LCASearch : '')
     . ' ORDER BY name LIMIT ' . $num * $limit . ', ' . $limit;
 $dbResult = $pearDB->query($query);
@@ -163,8 +163,8 @@ foreach ($servers as $config) {
         . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
         . "name='dupNbr[" . $config['id'] . "]' />";
 
-    if (! isset($nagiosInfo[$config['id']]['is_currently_running'])) {
-        $nagiosInfo[$config['id']]['is_currently_running'] = 0;
+    if (! isset($nagiosInfo[$config['uid']]['is_currently_running'])) {
+        $nagiosInfo[$config['uid']]['is_currently_running'] = 0;
     }
 
     // Manage flag for changes
@@ -175,9 +175,9 @@ foreach ($servers as $config) {
 
     // Manage flag for update time
     $lastUpdateTimeFlag = 0;
-    if (! isset($nagiosInfo[$config['id']]['last_alive'])) {
+    if (! isset($nagiosInfo[$config['uid']]['last_alive'])) {
         $lastUpdateTimeFlag = 0;
-    } elseif (time() - $nagiosInfo[$config['id']]['last_alive'] > 10 * 60) {
+    } elseif (time() - $nagiosInfo[$config['uid']]['last_alive'] > 10 * 60) {
         $lastUpdateTimeFlag = 1;
     }
 
@@ -189,14 +189,14 @@ foreach ($servers as $config) {
     $cfg_id = $dbResult2->rowCount() ? $dbResult2->fetch() : -1;
 
     $uptime = '-';
-    $isRunning = (isset($nagiosInfo[$config['id']]['is_currently_running'])
-        && $nagiosInfo[$config['id']]['is_currently_running'] == 1)
+    $isRunning = (isset($nagiosInfo[$config['uid']]['is_currently_running'])
+        && $nagiosInfo[$config['uid']]['is_currently_running'] == 1)
         ? true
         : false;
-    $version = $nagiosInfo[$config['id']]['version'] ?? _('N/A');
-    $updateTime = (isset($nagiosInfo[$config['id']]['last_alive'])
-        && $nagiosInfo[$config['id']]['last_alive'])
-        ? $nagiosInfo[$config['id']]['last_alive']
+    $version = $nagiosInfo[$config['uid']]['version'] ?? _('N/A');
+    $updateTime = (isset($nagiosInfo[$config['uid']]['last_alive'])
+        && $nagiosInfo[$config['uid']]['last_alive'])
+        ? $nagiosInfo[$config['uid']]['last_alive']
         : '-';
     $serverType = $config['localhost'] ? _('Central') : _('Poller');
     $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
@@ -204,11 +204,11 @@ foreach ($servers as $config) {
         : $serverType;
 
     if (
-        isset($nagiosInfo[$config['id']]['is_currently_running'])
-        && $nagiosInfo[$config['id']]['is_currently_running'] == 1
+        isset($nagiosInfo[$config['uid']]['is_currently_running'])
+        && $nagiosInfo[$config['uid']]['is_currently_running'] == 1
     ) {
         $now = new DateTime();
-        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$config['id']]['program_start_time']);
+        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$config['uid']]['program_start_time']);
         $interval = date_diff($now, $startDate);
         if (intval($interval->format('%a')) >= 2) {
             $uptime = $interval->format('%a days');
@@ -224,7 +224,7 @@ foreach ($servers as $config) {
     }
 
     $pollerProcessId = $isRunning
-        ? $nagiosInfo[$config['id']]['process_id']
+        ? $nagiosInfo[$config['uid']]['process_id']
         : '-';
 
     // Manage different styles between each line
@@ -244,7 +244,7 @@ foreach ($servers as $config) {
         'RowMenu_link' => $serverLink,
         'RowMenu_type' => $serverType,
         'RowMenu_is_running' => $isRunning ? _('Yes') : _('No'),
-        'RowMenu_is_runningFlag' => $nagiosInfo[$config['id']]['is_currently_running'],
+        'RowMenu_is_runningFlag' => $nagiosInfo[$config['uid']]['is_currently_running'],
         'RowMenu_is_default' => $config['is_default'] ? _('Yes') : _('No'),
         'RowMenu_hasChanged' => $confChangedMessage,
         'RowMenu_pid' => $pollerProcessId,


### PR DESCRIPTION
The poller list was always showing "No" for the "Is running" column, along with stale/missing version, PID, uptime and last update data.

The root cause: $nagiosInfo was indexed by instances.instance_id (a large generated integer, e.g. 323161637651481690), but lookups were done using nagios_server.id (a small auto-increment integer, e.g. 1). The two keys never match, so every lookup fell through to the default "not running" state.

nagios_server.uid holds the value that matches instances.instance_id and is the intended join key between the two tables. Adding uid to the SELECT and using it for all $nagiosInfo lookups fixes the mismatch.

Refs: MON-200819