### PR TITLE
fix(packaging): add missing symfony cache rebuild commands

### DIFF
--- a/centreon/packaging/scripts/centreon-web-postinstall.sh
+++ b/centreon/packaging/scripts/centreon-web-postinstall.sh
@@ -135,6 +135,8 @@ rebuildSymfonyCache() {
     echo "Rebuilding Centreon application cache ..."
     rm -rf /var/cache/centreon/symfony
     su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear -q" || :
+    rm -rf /var/cache/centreon/symfony.new
+    su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console.new cache:clear -q" || :    
   fi
 }
 

--- a/centreon/packaging/scripts/centreon-web-posttrans.sh
+++ b/centreon/packaging/scripts/centreon-web-posttrans.sh
@@ -5,6 +5,8 @@ rebuildSymfonyCache() {
     echo "Rebuilding Centreon application cache ..."
     rm -rf /var/cache/centreon/symfony
     su - apache -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear -q" || :
+    rm -rf /var/cache/centreon/symfony.new
+    su - apache -s /bin/bash -c "/usr/share/centreon/bin/console.new cache:clear -q" || :    
   fi
 }
 


### PR DESCRIPTION
## Description

* add missing symfony cache rebuild commands (with console.new)

**Fixes** #MON-200876

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

* perform a fresh install
* perform an update from 25.10.14
* perform an upgrade from 24.10 latest version

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
