### PR TITLE
fix(meta services): csv download

### DIFF
--- a/centreon/src/Core/Infrastructure/Common/Presenter/DownloadPresenter.php
+++ b/centreon/src/Core/Infrastructure/Common/Presenter/DownloadPresenter.php
@@ -43,7 +43,7 @@ class DownloadPresenter implements PresenterFormatterInterface
         $headers['Content-Type'] = 'application/force-download';
         $headers['Content-Disposition'] = 'attachment; filename="' . $filename . '"';
 
-        return $this->formatter->format($data->performanceMetrics, $headers);
+        return $this->formatter->format($data->performanceMetrics ?? [], $headers);
     }
 
     /**

--- a/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -56,6 +56,10 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
         DateTimeInterface $startDate,
         DateTimeInterface $endDate,
     ): iterable {
+        if ($metrics === []) {
+            return;
+        }
+
         $this->db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
         $this->db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 

--- a/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetrics.php
+++ b/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetrics.php
@@ -100,7 +100,8 @@ final class DownloadPerformanceMetrics
                 $this->debug('Filtering by access groups', ['access_groups' => $accessGroups]);
                 $isServiceExists = $this->readServiceRepository->existsByAccessGroups(
                     $request->serviceId,
-                    $accessGroups
+                    $accessGroups,
+                    $request->hostId,
                 );
                 if (! $isServiceExists) {
                     $this->error(

--- a/centreon/src/Core/Service/Application/Repository/ReadServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/ReadServiceRepositoryInterface.php
@@ -61,12 +61,13 @@ interface ReadServiceRepositoryInterface
      *
      * @param int $serviceId
      * @param AccessGroup[] $accessGroups
+     * @param int|null $hostId
      *
      * @throws \Throwable
      *
      * @return bool
      */
-    public function existsByAccessGroups(int $serviceId, array $accessGroups): bool;
+    public function existsByAccessGroups(int $serviceId, array $accessGroups, ?int $hostId = null): bool;
 
     /**
      * Retrieve the monitoring server id related to the service.

--- a/centreon/src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
@@ -59,7 +59,7 @@ class ApiReadServiceRepository implements ReadServiceRepositoryInterface
     /**
      * @inheritDoc
      */
-    public function existsByAccessGroups(int $serviceId, array $accessGroups): bool
+    public function existsByAccessGroups(int $serviceId, array $accessGroups, ?int $hostId = null): bool
     {
         throw RepositoryException::notYetImplemented();
     }

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -174,7 +174,7 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
     /**
      * @inheritDoc
      */
-    public function existsByAccessGroups(int $serviceId, array $accessGroups): bool
+    public function existsByAccessGroups(int $serviceId, array $accessGroups, ?int $hostId = null): bool
     {
         if ($accessGroups === []) {
             $this->debug('Access groups array empty');
@@ -200,6 +200,8 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
                 AND scr.sc_id IN ({$subRequest})
                 SQL;
 
+        $hostFilter = $hostId === null ? '' : 'AND acl.`host_id` = :host_id';
+
         $statement = $this->db->prepare($this->translateDbName(
             <<<SQL
                 SELECT 1
@@ -207,13 +209,17 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
                 LEFT JOIN `:db`.`service_categories_relation` scr
                     ON scr.`service_service_id` = s.`service_id`
                 JOIN `:dbstg`.`centreon_acl` acl
+                    ON s.`service_id` = acl.`service_id`
                 WHERE acl.`group_id` IN ({$bindParamsAsString})
+                    {$hostFilter}
                     AND s.`service_id` = :service_id
-                    AND s.`service_register` = '1'
                     {$categoryAcls}
                 SQL
         ));
         $statement->bindValue(':service_id', $serviceId, \PDO::PARAM_INT);
+        if ($hostId !== null) {
+            $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+        }
         foreach ($bindValuesArray as $bindParam => $bindValue) {
             $statement->bindValue($bindParam, $bindValue, \PDO::PARAM_INT);
         }

--- a/centreon/tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
+++ b/centreon/tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
@@ -25,6 +25,7 @@ namespace Tests\Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\RealTime\Repository\ReadIndexDataRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadPerformanceDataRepositoryInterface;
 use Core\Domain\RealTime\Model\IndexData;
@@ -228,3 +229,101 @@ it(
         ),
     ],
 ]);
+
+it('passes hostId to the ACL check so meta services resolve through centreon_acl', function (): void {
+    $indexDataRepository = $this->createMock(ReadIndexDataRepositoryInterface::class);
+    $indexDataRepository
+        ->expects($this->once())
+        ->method('findIndexByHostIdAndServiceId')
+        ->with($this->equalTo($this->hostId), $this->equalTo($this->serviceId))
+        ->willReturn($this->indexId);
+    $indexDataRepository
+        ->expects($this->once())
+        ->method('findHostNameAndServiceDescriptionByIndex')
+        ->willReturn(null);
+
+    $metricRepository = $this->createMock(ReadMetricRepositoryInterface::class);
+    $performanceDataRepository = $this->createMock(ReadPerformanceDataRepositoryInterface::class);
+    $performanceDataRepository
+        ->expects($this->once())
+        ->method('findDataByMetricsAndDates')
+        ->willReturn([]);
+
+    $readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+
+    $readServiceRepository = $this->createMock(ReadServiceRepositoryInterface::class);
+    $readServiceRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->with($this->equalTo($this->serviceId), $this->equalTo([]), $this->equalTo($this->hostId))
+        ->willReturn(true);
+
+    $contact = $this->createMock(ContactInterface::class);
+    $contact->method('hasTopologyRole')->willReturn(true);
+    $contact->method('isAdmin')->willReturn(false);
+
+    $useCase = new DownloadPerformanceMetrics(
+        $indexDataRepository,
+        $metricRepository,
+        $performanceDataRepository,
+        $readAccessGroupRepository,
+        $readServiceRepository,
+        $contact,
+    );
+
+    $useCase(
+        new DownloadPerformanceMetricRequest(
+            $this->hostId,
+            $this->serviceId,
+            new DateTimeImmutable('2022-01-01'),
+            new DateTimeImmutable('2023-01-01')
+        ),
+        $this->createMock(DownloadPerformanceMetricPresenterInterface::class)
+    );
+});
+
+it('returns NotFoundResponse when the (host, service) pair is not in the user ACL', function (): void {
+    $indexDataRepository = $this->createMock(ReadIndexDataRepositoryInterface::class);
+    $indexDataRepository->expects($this->never())->method('findIndexByHostIdAndServiceId');
+
+    $readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $readAccessGroupRepository->method('findByContact')->willReturn([]);
+
+    $readServiceRepository = $this->createMock(ReadServiceRepositoryInterface::class);
+    $readServiceRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->with($this->equalTo($this->serviceId), $this->equalTo([]), $this->equalTo($this->hostId))
+        ->willReturn(false);
+
+    $contact = $this->createMock(ContactInterface::class);
+    $contact->method('hasTopologyRole')->willReturn(true);
+    $contact->method('isAdmin')->willReturn(false);
+
+    $presenter = new DownloadPerformanceMetricsPresenterStub($this->createMock(PresenterFormatterInterface::class));
+
+    $useCase = new DownloadPerformanceMetrics(
+        $indexDataRepository,
+        $this->createMock(ReadMetricRepositoryInterface::class),
+        $this->createMock(ReadPerformanceDataRepositoryInterface::class),
+        $readAccessGroupRepository,
+        $readServiceRepository,
+        $contact,
+    );
+
+    $useCase(
+        new DownloadPerformanceMetricRequest(
+            $this->hostId,
+            $this->serviceId,
+            new DateTimeImmutable('2022-01-01'),
+            new DateTimeImmutable('2023-01-01')
+        ),
+        $presenter
+    );
+
+    expect($presenter->getPresentedData())->toBeInstanceOf(NotFoundResponse::class);
+});


### PR DESCRIPTION
## Description

Non-admin users get an empty CSV when downloading the performance graph of a Meta Service.

Root cause is in `DbReadServiceRepository::existsByAccessGroups`, the SQL filtered on `service_register = '1'` (regular services only) and the join to `centreon_acl` was missing its `ON` clause.

[MON-200142](https://centreon.atlassian.net/browse/MON-200142)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-200142]: https://centreon.atlassian.net/browse/MON-200142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ