### PR TITLE
fix(install): allow upgrade when broker not linked to cbd

### DIFF
--- a/centreon/www/install/php/Update-26.05.0.php
+++ b/centreon/www/install/php/Update-26.05.0.php
@@ -458,8 +458,7 @@ $insertEventScriptOutputForCMA = function () use ($pearDB, &$errorMessage, $vers
         <<<'SQL'
             SELECT cb.config_id
             FROM cfg_centreonbroker cb
-            WHERE daemon = 1
-                AND config_activate = '1'
+            WHERE config_activate = '1'
                 AND ns_nagios_server = (
                     SELECT id FROM nagios_server WHERE localhost = '1'
                 )


### PR DESCRIPTION
## Summary

- The 26.05.0 upgrade script (25.10.10 on the 25.10 serie) failed with "Unable to find the Central's broker configuration" when the central broker config has the "linked to cbd service" option disabled, which is the standard setup on HA platforms.
- Remove the `daemon = 1` condition from the query locating the central broker configuration — the remaining conditions (active config, central server, unified_sql output) are sufficient to identify it.

## Jira

Fixes: [MON-197253](https://centreon.atlassian.net/browse/MON-197253)

## Test plan

- [ ] On a platform older than the fixed version, set "linked to cbd service" to **no** on the central-broker-master configuration
- [ ] Run the upgrade: it completes and the `central-broker-master-event-script` output is created
- [ ] Upgrade with the option set to **yes** still works (no regression)

[MON-197253]: https://centreon.atlassian.net/browse/MON-197253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ