### PR TITLE
fix(install): allow upgrade when broker not linked to cbd

### DIFF
--- a/centreon/www/install/php/Update-25.10.10.php
+++ b/centreon/www/install/php/Update-25.10.10.php
@@ -639,8 +639,7 @@ $insertEventScriptOutputForCMA = function () use ($pearDB, &$errorMessage, $vers
         <<<'SQL'
             SELECT cb.config_id
             FROM cfg_centreonbroker cb
-            WHERE daemon = 1
-                AND config_activate = '1'
+            WHERE config_activate = '1'
                 AND ns_nagios_server = (
                     SELECT id FROM nagios_server WHERE localhost = '1'
                 )


### PR DESCRIPTION
Backport of #10646 to `release-25.10-next`.

Refs: MON-201240

## Summary

- The 25.10.10 upgrade script failed with "Unable to find the Central's broker configuration" when the central broker config has the "linked to cbd service" option disabled, which is the standard setup on HA platforms.
- Remove the `daemon = 1` condition from the query locating the central broker configuration — the remaining conditions (active config, central server, unified_sql output) are sufficient to identify it.

## Test plan

- [ ] On a 25.10.x platform older than 25.10.10, set "linked to cbd service" to **no** on the central-broker-master configuration
- [ ] Run the upgrade: it completes and the `central-broker-master-event-script` output is created
- [ ] Upgrade with the option set to **yes** still works (no regression)