### PR TITLE
fix(test): resolve DST e2e fixtures imports on 24.10 (backport 24.10)

### DIFF
--- a/centreon/tests/e2e/features/Downtime/01-realtime-dst-transitions/index.ts
+++ b/centreon/tests/e2e/features/Downtime/01-realtime-dst-transitions/index.ts
@@ -1,6 +1,6 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { INTERCEPTORS } from 'fixtures/shared/constants/interceptors';
-import { PAGES } from 'fixtures/shared/constants/pages';
+import { INTERCEPTORS } from 'e2e/fixtures/shared/constants/interceptors';
+import { PAGES } from 'e2e/fixtures/shared/constants/pages';
 
 import {
   cases,


### PR DESCRIPTION
Follow-up fix for the DST realtime e2e backport (#10644, MON-200996).

The backported `01-realtime-dst-transitions/index.ts` imported the shared constants with develop's module root:

```
import { INTERCEPTORS } from 'fixtures/shared/constants/interceptors';
import { PAGES } from 'fixtures/shared/constants/pages';
```

On `dev-24.10.x` the Cypress preprocessor resolves modules from `tests/`, not `tests/e2e/`, so those bare `fixtures/...` specifiers do not resolve and the spec fails to **compile** (esbuild: `Could not resolve "fixtures/shared/constants/..."`, 0 ms, 1 of 1 failed). The files exist at the same path on every branch — only the import root differs between release lines.

This aligns the two imports with the 24.10 convention (`e2e/fixtures/...`), matching every other e2e test on this branch. No other change.

Ref: MON-200996