### PR TITLE
fix(address): centralize IP/hostname validation and allow underscores

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/AgentConfiguration/CmaConfigurationParameters.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/AgentConfiguration/CmaConfigurationParameters.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\AgentConfiguration;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Webmozart\Assert\Assert;
 
 class CmaConfigurationParameters extends AbstractConfigurationParameters
@@ -152,7 +152,7 @@ class CmaConfigurationParameters extends AbstractConfigurationParameters
 
         /** @var string $hostAddress */
         $hostAddress = $host[self::HOST_ADDRESS];
-        AppAssert::ipOrHostname($hostAddress, 'configuration.hosts[].address');
+        CentreonAssert::ipOrHostname($hostAddress, 'configuration.hosts[].address');
 
         Assert::range($host[self::HOST_PORT], 1, 65535, '[configuration.hosts[].port] Port must be between 1 and 65535. Got: %s');
 

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/AgentConfiguration/CmaConfigurationParameters.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/AgentConfiguration/CmaConfigurationParameters.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\AgentConfiguration;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Webmozart\Assert\Assert;
 
 class CmaConfigurationParameters extends AbstractConfigurationParameters
@@ -151,11 +152,7 @@ class CmaConfigurationParameters extends AbstractConfigurationParameters
 
         /** @var string $hostAddress */
         $hostAddress = $host[self::HOST_ADDRESS];
-        Assert::true(
-            filter_var($hostAddress, FILTER_VALIDATE_IP) !== false
-            || filter_var($hostAddress, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false,
-            sprintf('[configuration.hosts[].address] "%s" is not a valid IP or domain.', $hostAddress)
-        );
+        AppAssert::ipOrHostname($hostAddress, 'configuration.hosts[].address');
 
         Assert::range($host[self::HOST_PORT], 1, 65535, '[configuration.hosts[].port] Port must be between 1 and 65535. Got: %s');
 

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/PollerAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/PollerAddress.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\Poller;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Webmozart\Assert\Assert;
 
 final readonly class PollerAddress
@@ -34,6 +34,6 @@ final readonly class PollerAddress
     public function __construct(public string $value)
     {
         Assert::lengthBetween($value, self::MIN_LENGTH, self::MAX_LENGTH);
-        AppAssert::ipOrHostname($value, 'PollerAddress::value');
+        CentreonAssert::ipOrHostname($value, 'PollerAddress::value');
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/PollerAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/PollerAddress.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\Poller;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Webmozart\Assert\Assert;
 
 final readonly class PollerAddress
@@ -33,10 +34,6 @@ final readonly class PollerAddress
     public function __construct(public string $value)
     {
         Assert::lengthBetween($value, self::MIN_LENGTH, self::MAX_LENGTH);
-        Assert::true(
-            filter_var($value, FILTER_VALIDATE_IP) !== false
-            || filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false,
-            'The value "%s" is not a valid IPv4, IPv6 address or FQDN.'
-        );
+        AppAssert::ipOrHostname($value, 'PollerAddress::value');
     }
 }

--- a/centreon/src/App/Shared/Domain/Assert/Assert.php
+++ b/centreon/src/App/Shared/Domain/Assert/Assert.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Assert;
+
+use Webmozart\Assert\Assert as WebmozartAssert;
+
+final class Assert
+{
+    /**
+     * RFC 1123 hostname + underscore (allowed for NetBIOS / Active Directory names).
+     * Labels: 1-63 chars, may start/end with alphanumeric or '_', '-' allowed in the middle.
+     * Whole hostname: max 253 chars.
+     */
+    private const HOSTNAME_PATTERN
+        = '/^(?=.{1,253}$)\w([\w-]{0,61}\w)?(\.\w([\w-]{0,61}\w)?)*$/';
+
+    public static function ipOrHostname(string $value, ?string $propertyPath = null): void
+    {
+        WebmozartAssert::true(
+            filter_var($value, FILTER_VALIDATE_IP) !== false
+            || preg_match(self::HOSTNAME_PATTERN, $value) === 1,
+            sprintf(
+                '[%s] The value "%s" was expected to be a valid IP address or hostname',
+                $propertyPath ?? '',
+                $value
+            )
+        );
+    }
+}

--- a/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -285,24 +285,6 @@ class Assertion
     }
 
     /**
-     * Assert that value is a valid IP or Domain name.
-     *
-     * @param string $value
-     * @param string|null $propertyPath
-     *
-     * @throws \Assert\AssertionFailedException
-     */
-    public static function ipOrDomain(string $value, ?string $propertyPath = null): void
-    {
-        if (
-            filter_var($value, FILTER_VALIDATE_IP) === false
-            && filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
-        ) {
-            throw AssertionException::ipOrDomain($value, $propertyPath);
-        }
-    }
-
-    /**
      * Assert that value is a valid IP.
      *
      * @param mixed $value

--- a/centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
@@ -48,7 +48,6 @@ class AssertionException extends \Assert\InvalidArgumentException
     // Error codes of Centreon assertion start from 1000
 
     public const INVALID_MAX_DATE = 1001;
-    public const INVALID_IP_OR_DOMAIN = 1002;
     public const INVALID_CHARACTERS = 1003;
     public const INVALID_ARRAY_JSON_ENCODABLE = 1004;
     public const INVALID_MIN_DATE = 1005;
@@ -440,28 +439,6 @@ class AssertionException extends \Assert\InvalidArgumentException
                 $maxValue
             ),
             self::INVALID_RANGE,
-            $propertyPath,
-            $value
-        );
-    }
-
-    /**
-     * Exception when the value does not respect ip format.
-     *
-     * @param string $value Tested value
-     * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
-     *
-     * @return self
-     */
-    public static function ipOrDomain(string $value, ?string $propertyPath = null): self
-    {
-        return new self(
-            sprintf(
-                _('[%s] The value "%s" was expected to be a valid ip address or domain name'),
-                $propertyPath,
-                $value
-            ),
-            self::INVALID_IP_OR_DOMAIN,
             $propertyPath,
             $value
         );

--- a/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
+++ b/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformTopology\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformInterface;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -322,7 +322,7 @@ class PlatformPending implements PlatformInterface
         }
 
         try {
-            AppAssert::ipOrHostname($address);
+            CentreonAssert::ipOrHostname($address);
         } catch (InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
                 sprintf(

--- a/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
+++ b/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
@@ -23,7 +23,9 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformTopology\Model;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformInterface;
+use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * Class designed to retrieve servers to be added using the wizard
@@ -314,19 +316,22 @@ class PlatformPending implements PlatformInterface
      */
     private function checkIpAddress(?string $address): ?string
     {
-        // Check for valid IPv4 or IPv6 IP
-        // or not sent address (in the case of Central's "parent_address")
-        if (
-            $address !== null
-            && ! filter_var($address, FILTER_VALIDATE_IP)
-            && ! filter_var($address, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
-        ) {
+        // Skip when no address is sent (e.g. Central's "parent_address")
+        if ($address === null) {
+            return null;
+        }
+
+        try {
+            AppAssert::ipOrHostname($address);
+        } catch (InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
                 sprintf(
                     _("The address '%s' of '%s' is not valid or not resolvable"),
                     $address,
                     $this->getName()
-                )
+                ),
+                0,
+                $e
             );
         }
 

--- a/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
+++ b/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
@@ -23,7 +23,9 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformTopology\Model;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformInterface;
+use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * Class designed to retrieve servers to be added using the wizard
@@ -314,17 +316,21 @@ class PlatformRegistered implements PlatformInterface
      */
     private function checkIpAddress(?string $address): ?string
     {
-        if (
-            $address !== null
-            && ! filter_var($address, FILTER_VALIDATE_IP)
-            && ! filter_var($address, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
-        ) {
+        if ($address === null) {
+            return null;
+        }
+
+        try {
+            AppAssert::ipOrHostname($address);
+        } catch (InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
                 sprintf(
                     _("The address '%s' of '%s' is not valid or not resolvable"),
                     $address,
                     $this->getName()
-                )
+                ),
+                0,
+                $e
             );
         }
 

--- a/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
+++ b/centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformTopology\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformInterface;
 use Webmozart\Assert\InvalidArgumentException;
 
@@ -321,7 +321,7 @@ class PlatformRegistered implements PlatformInterface
         }
 
         try {
-            AppAssert::ipOrHostname($address);
+            CentreonAssert::ipOrHostname($address);
         } catch (InvalidArgumentException $e) {
             throw new \InvalidArgumentException(
                 sprintf(

--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -21,6 +21,7 @@
 
 namespace CentreonRemote\Application\Webservice;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Centreon\Domain\Entity\Task;
 use Centreon\Domain\PlatformTopology\Model\PlatformPending;
 use CentreonRemote\Application\Validator\WizardConfigurationRequestValidator;
@@ -29,6 +30,7 @@ use CentreonRemote\Domain\Service\ConfigurationWizard\{
     RemoteConnectionConfigurationService
 };
 use CentreonRemote\Domain\Value\ServerWizardIdentity;
+use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * @OA\Tag(name="centreon_configuration_remote", description="")
@@ -410,11 +412,9 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $serverIP = parse_url($this->arguments['server_ip'], PHP_URL_HOST) ?: $this->arguments['server_ip'];
         $serverName = substr($this->arguments['server_name'], 0, 40);
 
-        // Check IPv6, IPv4 and FQDN format
-        if (
-            ! filter_var($serverIP, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
-            && ! filter_var($serverIP, FILTER_VALIDATE_IP)
-        ) {
+        try {
+            AppAssert::ipOrHostname($serverIP);
+        } catch (InvalidArgumentException) {
             return ['error' => true, 'message' => 'Invalid IP address'];
         }
         $dbAdapter = $this->getDi()['centreon.db-manager']->getAdapter('configuration_db');

--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -21,7 +21,7 @@
 
 namespace CentreonRemote\Application\Webservice;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Centreon\Domain\Entity\Task;
 use Centreon\Domain\PlatformTopology\Model\PlatformPending;
 use CentreonRemote\Application\Validator\WizardConfigurationRequestValidator;
@@ -413,7 +413,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $serverName = substr($this->arguments['server_name'], 0, 40);
 
         try {
-            AppAssert::ipOrHostname($serverIP);
+            CentreonAssert::ipOrHostname($serverIP);
         } catch (InvalidArgumentException) {
             return ['error' => true, 'message' => 'Invalid IP address'];
         }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Domain\Model\ConfigurationParameters;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
@@ -107,7 +108,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         } else {
             foreach ($this->parameters['hosts'] as $key => $host) {
                 Assertion::positiveInt($host['id'], 'configuration.hosts[].id');
-                Assertion::ipOrDomain($host['address'], 'configuration.hosts[].address');
+                AppAssert::ipOrHostname($host['address'], 'configuration.hosts[].address');
                 Assertion::range($host['port'], 0, 65535, 'configuration.hosts[].port');
                 $this->parameters['hosts'][$key]['poller_ca_certificate'] = $this->validateCertificatePath(
                     $host['poller_ca_certificate'],

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Domain\Model\ConfigurationParameters;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
@@ -108,7 +108,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         } else {
             foreach ($this->parameters['hosts'] as $key => $host) {
                 Assertion::positiveInt($host['id'], 'configuration.hosts[].id');
-                AppAssert::ipOrHostname($host['address'], 'configuration.hosts[].address');
+                CentreonAssert::ipOrHostname($host['address'], 'configuration.hosts[].address');
                 Assertion::range($host['port'], 0, 65535, 'configuration.hosts[].port');
                 $this->parameters['hosts'][$key]['poller_ca_certificate'] = $this->validateCertificatePath(
                     $host['poller_ca_certificate'],

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -63,6 +63,7 @@ use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepository
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\WriteAccessGroupRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Webmozart\Assert\InvalidArgumentException;
 
 final class AddHost
 {
@@ -151,7 +152,7 @@ final class AddHost
             $presenter->presentResponse(
                 $this->createResponse($hostId, $request->templates)
             );
-        } catch (AssertionFailedException|\ValueError $ex) {
+        } catch (AssertionFailedException|InvalidArgumentException|\ValueError $ex) {
             $presenter->presentResponse(new InvalidArgumentResponse($ex));
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
         } catch (HostException $ex) {

--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -76,6 +76,7 @@ use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Utility\Difference\BasicDifference;
+use Webmozart\Assert\InvalidArgumentException;
 
 final class PartialUpdateHost
 {
@@ -169,7 +170,7 @@ final class PartialUpdateHost
                 }
             );
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
-        } catch (AssertionFailedException $ex) {
+        } catch (AssertionFailedException|InvalidArgumentException $ex) {
             $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
         } catch (\Throwable $ex) {

--- a/centreon/src/Core/Host/Domain/Model/Host.php
+++ b/centreon/src/Core/Host/Domain/Model/Host.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Host\Domain\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Common\Domain\YesNoDefault;
@@ -553,7 +553,7 @@ class Host extends NewHost
     {
         $this->address = mb_trim($address);
         Assertion::maxLength($this->address, self::MAX_ADDRESS_LENGTH, "{$this->shortName}::address");
-        AppAssert::ipOrHostname($this->address, "{$this->shortName}::address");
+        CentreonAssert::ipOrHostname($this->address, "{$this->shortName}::address");
     }
 
     public function setMonitoringServerId(int $monitoringServerId): void

--- a/centreon/src/Core/Host/Domain/Model/Host.php
+++ b/centreon/src/Core/Host/Domain/Model/Host.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Host\Domain\Model;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Common\Domain\YesNoDefault;
@@ -552,7 +553,7 @@ class Host extends NewHost
     {
         $this->address = mb_trim($address);
         Assertion::maxLength($this->address, self::MAX_ADDRESS_LENGTH, "{$this->shortName}::address");
-        Assertion::ipOrDomain($this->address, "{$this->shortName}::address");
+        AppAssert::ipOrHostname($this->address, "{$this->shortName}::address");
     }
 
     public function setMonitoringServerId(int $monitoringServerId): void

--- a/centreon/src/Core/Host/Domain/Model/NewHost.php
+++ b/centreon/src/Core/Host/Domain/Model/NewHost.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Host\Domain\Model;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Common\Domain\YesNoDefault;
@@ -185,7 +186,7 @@ class NewHost
         Assertion::min($highFlapThreshold ?? 0, 0, "{$shortName}::highFlapThreshold");
 
         // Other assert
-        Assertion::ipOrDomain($address, "{$shortName}::address");
+        AppAssert::ipOrHostname($address, "{$shortName}::address");
     }
 
     /**

--- a/centreon/src/Core/Host/Domain/Model/NewHost.php
+++ b/centreon/src/Core/Host/Domain/Model/NewHost.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Host\Domain\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Common\Domain\YesNoDefault;
@@ -186,7 +186,7 @@ class NewHost
         Assertion::min($highFlapThreshold ?? 0, 0, "{$shortName}::highFlapThreshold");
 
         // Other assert
-        AppAssert::ipOrHostname($address, "{$shortName}::address");
+        CentreonAssert::ipOrHostname($address, "{$shortName}::address");
     }
 
     /**

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfiguration.php
@@ -54,6 +54,7 @@ use Core\Security\ProviderConfiguration\Domain\OpenId\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * @phpstan-import-type _RoleMapping from PartialUpdateOpenIdConfigurationRequest
@@ -120,7 +121,7 @@ final class PartialUpdateOpenIdConfiguration
             $configuration->setCustomConfiguration($customConfiguration);
 
             $this->repository->updateConfiguration($configuration);
-        } catch (AssertionException|AssertionFailedException|ConfigurationException $ex) {
+        } catch (AssertionException|AssertionFailedException|ConfigurationException|InvalidArgumentException $ex) {
             $this->error(
                 'Unable to perform partial update on OpenID Provider because one or several parameters are invalid',
                 [

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
@@ -52,6 +52,7 @@ use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * @phpstan-import-type _RoleMapping from UpdateOpenIdConfigurationRequest
@@ -130,7 +131,7 @@ class UpdateOpenIdConfiguration
 
             $this->info('Updating OpenID Provider');
             $this->repository->updateConfiguration($configuration);
-        } catch (AssertionException|AssertionFailedException|ConfigurationException $ex) {
+        } catch (AssertionException|AssertionFailedException|ConfigurationException|InvalidArgumentException $ex) {
             $this->error(
                 'Unable to create OpenID Provider because one or several parameters are invalid',
                 [

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/Model/AuthenticationConditions.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/Model/AuthenticationConditions.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Domain\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Core\Security\ProviderConfiguration\Domain\Exception\ConfigurationException;
 
 /**
@@ -192,7 +192,7 @@ class AuthenticationConditions
      */
     private function validateClientAddressOrFail(string $clientAddress, string $fieldName): void
     {
-        AppAssert::ipOrHostname($clientAddress, 'AuthenticationConditions::' . $fieldName);
+        CentreonAssert::ipOrHostname($clientAddress, 'AuthenticationConditions::' . $fieldName);
     }
 
     /**

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/Model/AuthenticationConditions.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/Model/AuthenticationConditions.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Domain\Model;
 
-use Centreon\Domain\Common\Assertion\Assertion;
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Core\Security\ProviderConfiguration\Domain\Exception\ConfigurationException;
 
 /**
@@ -192,7 +192,7 @@ class AuthenticationConditions
      */
     private function validateClientAddressOrFail(string $clientAddress, string $fieldName): void
     {
-        Assertion::ipOrDomain($clientAddress, 'AuthenticationConditions::' . $fieldName);
+        AppAssert::ipOrHostname($clientAddress, 'AuthenticationConditions::' . $fieldName);
     }
 
     /**

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/DbReadConfigurationRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/DbReadConfigurationRepository.php
@@ -54,6 +54,7 @@ use Core\Security\ProviderConfiguration\Domain\SAML\Exception\MissingLogoutUrlEx
 use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration as SAMLCustomConfiguration;
 use Core\Security\ProviderConfiguration\Domain\WebSSO\Model\CustomConfiguration as WebSSOCustomConfiguration;
 use JsonSchema\Exception\InvalidArgumentException;
+use Webmozart\Assert\InvalidArgumentException as WebmozartAssertException;
 
 /**
  * @phpstan-import-type _EndpointArray from Endpoint
@@ -639,7 +640,7 @@ final class DbReadConfigurationRepository extends AbstractRepositoryDRB implemen
                 $authenticationConditions->setTrustedClientAddresses(
                     $authenticationConditionsRecord['trusted_client_addresses']
                 );
-            } catch (AssertionFailedException $e) {
+            } catch (AssertionFailedException|WebmozartAssertException $e) {
                 throw new RepositoryException(
                     message: 'Could not set trusted client addresses for authentication conditions: ' . $e->getMessage(),
                     context: ['trusted_client_addresses' => $authenticationConditionsRecord['trusted_client_addresses']],
@@ -653,7 +654,7 @@ final class DbReadConfigurationRepository extends AbstractRepositoryDRB implemen
                 $authenticationConditions->setBlacklistClientAddresses(
                     $authenticationConditionsRecord['blacklist_client_addresses']
                 );
-            } catch (AssertionFailedException $e) {
+            } catch (AssertionFailedException|WebmozartAssertException $e) {
                 throw new RepositoryException(
                     message: 'Could not set blacklist client addresses for authentication conditions: ' . $e->getMessage(),
                     context: ['blacklist_client_addresses' => $authenticationConditionsRecord['blacklist_client_addresses']],

--- a/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Core\Security\Vault\Application\UseCase\UpdateVaultConfiguration;
 
-use Assert\InvalidArgumentException;
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
@@ -42,6 +41,7 @@ use Core\Security\Vault\Application\Repository\{
     WriteVaultConfigurationRepositoryInterface
 };
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Webmozart\Assert\InvalidArgumentException;
 
 final class UpdateVaultConfiguration
 {

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Vault\Domain\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Security\Interfaces\EncryptionInterface;
@@ -73,7 +73,7 @@ class NewVaultConfiguration
         Assertion::maxLength($name, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::name');
         Assertion::regex($name, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         Assertion::minLength($address, self::MIN_LENGTH, 'NewVaultConfiguration::address');
-        AppAssert::ipOrHostname($address, 'NewVaultConfiguration::address');
+        CentreonAssert::ipOrHostname($address, 'NewVaultConfiguration::address');
         Assertion::max($port, self::MAX_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::min($port, self::MIN_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::minLength($rootPath, self::MIN_LENGTH, 'NewVaultConfiguration::rootPath');

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Vault\Domain\Model;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Security\Interfaces\EncryptionInterface;
@@ -72,7 +73,7 @@ class NewVaultConfiguration
         Assertion::maxLength($name, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::name');
         Assertion::regex($name, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         Assertion::minLength($address, self::MIN_LENGTH, 'NewVaultConfiguration::address');
-        Assertion::ipOrDomain($address, 'NewVaultConfiguration::address');
+        AppAssert::ipOrHostname($address, 'NewVaultConfiguration::address');
         Assertion::max($port, self::MAX_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::min($port, self::MIN_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::minLength($rootPath, self::MIN_LENGTH, 'NewVaultConfiguration::rootPath');

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Vault\Domain\Model;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Security\Interfaces\EncryptionInterface;
@@ -177,7 +177,7 @@ class VaultConfiguration
     public function setAddress(string $address): void
     {
         Assertion::minLength($address, self::MIN_LENGTH, 'VaultConfiguration::address');
-        AppAssert::ipOrHostname($address, 'VaultConfiguration::address');
+        CentreonAssert::ipOrHostname($address, 'VaultConfiguration::address');
         $this->address = $address;
     }
 

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Vault\Domain\Model;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Security\Interfaces\EncryptionInterface;
@@ -176,7 +177,7 @@ class VaultConfiguration
     public function setAddress(string $address): void
     {
         Assertion::minLength($address, self::MIN_LENGTH, 'VaultConfiguration::address');
-        Assertion::ipOrDomain($address, 'VaultConfiguration::address');
+        AppAssert::ipOrHostname($address, 'VaultConfiguration::address');
         $this->address = $address;
     }
 

--- a/centreon/tests/php/App/Shared/Domain/Assert/AssertTest.php
+++ b/centreon/tests/php/App/Shared/Domain/Assert/AssertTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Domain\Assert;
+
+use App\Shared\Domain\Assert\Assert;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AssertTest extends TestCase
+{
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validIpOrHostnameProvider(): array
+    {
+        return [
+            'IPv4' => ['192.168.1.1'],
+            'IPv6' => ['2001:db8::1'],
+            'simple hostname' => ['host01'],
+            'FQDN' => ['host.example.com'],
+            'underscore hostname (NetBIOS)' => ['host_01'],
+            'underscore in FQDN (AD)' => ['netbios_name.local'],
+            'hyphenated label' => ['foo-bar.example.com'],
+            'single label' => ['localhost'],
+            'max-length label (63 chars)' => [str_repeat('a', 63)],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidIpOrHostnameProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'has space' => ['hello world'],
+            'has colon' => ['not:valid'],
+            'has at sign' => ['foo@bar'],
+            'consecutive dots' => ['a..b'],
+            'leading dot' => ['.invalid'],
+            'leading hyphen' => ['-bad'],
+            'trailing hyphen' => ['bad-'],
+            'label too long (64 chars)' => [str_repeat('a', 64)],
+            'hostname too long (254 chars)' => [str_repeat('a', 254)],
+        ];
+    }
+
+    #[DataProvider('validIpOrHostnameProvider')]
+    public function testIpOrHostnameAcceptsValidValues(string $value): void
+    {
+        Assert::ipOrHostname($value);
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[DataProvider('invalidIpOrHostnameProvider')]
+    public function testIpOrHostnameRejectsInvalidValues(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Assert::ipOrHostname($value);
+    }
+}

--- a/centreon/tests/php/Centreon/Domain/Common/AssertionTest.php
+++ b/centreon/tests/php/Centreon/Domain/Common/AssertionTest.php
@@ -151,16 +151,6 @@ $failDataProvider = [
         AssertionException::matchRegex('1234', '/^\d+$/', $propertyPath)->getMessage(),
         AssertionException::INVALID_REGEX,
     ],
-    'ipOrDomain("")' => [
-        fn () => Assertion::ipOrDomain('', $propertyPath),
-        AssertionException::ipOrDomain('', $propertyPath)->getMessage(),
-        AssertionException::INVALID_IP_OR_DOMAIN,
-    ],
-    'ipOrDomain("not:valid")' => [
-        fn () => Assertion::ipOrDomain('not:valid', $propertyPath),
-        AssertionException::ipOrDomain('not:valid', $propertyPath)->getMessage(),
-        AssertionException::INVALID_IP_OR_DOMAIN,
-    ],
     'ipAddress("any-hostname")' => [
         fn () => Assertion::ipAddress('any-hostname', $propertyPath),
         AssertionException::ipAddressNotValid('any-hostname', $propertyPath)->getMessage(),
@@ -315,12 +305,6 @@ $successDataProvider = [
     ],
     'regex("1234", "/^\d+$/")' => [
         fn () => Assertion::regex('1234', '/^\d+$/', $propertyPath),
-    ],
-    'ipOrDomain("1.2.3.4")' => [
-        fn () => Assertion::ipOrDomain('1.2.3.4', $propertyPath),
-    ],
-    'ipOrDomain("any-hostname")' => [
-        fn () => Assertion::ipOrDomain('any-hostname', $propertyPath),
     ],
     'ipAddress("2.3.4.5")' => [
         fn () => Assertion::ipAddress('2.3.4.5', $propertyPath),

--- a/centreon/tests/php/Core/Host/Domain/Model/HostTest.php
+++ b/centreon/tests/php/Core/Host/Domain/Model/HostTest.php
@@ -203,8 +203,8 @@ it(
     'should throw an exception when host address does not respect format',
     fn () => ($this->createHost)(['address' => 'hello world'])
 )->throws(
-    InvalidArgumentException::class,
-    AssertionException::ipOrDomain('hello world', 'Host::address')->getMessage()
+    \InvalidArgumentException::class,
+    '[Host::address] The value "hello world" was expected to be a valid IP address or hostname'
 );
 it(
     'should throw an exception when host address does not respect format in setter',
@@ -213,9 +213,14 @@ it(
         $host->setAddress('hello world');
     }
 )->throws(
-    InvalidArgumentException::class,
-    AssertionException::ipOrDomain('hello world', 'Host::address')->getMessage()
+    \InvalidArgumentException::class,
+    '[Host::address] The value "hello world" was expected to be a valid IP address or hostname'
 );
+
+it('should accept an address containing underscores (NETBIOS / Active Directory)', function (): void {
+    $host = ($this->createHost)(['address' => 'netbios_name.local']);
+    expect($host->getAddress())->toBe('netbios_name.local');
+});
 
 // name and conmmands args should be formated
 it('should return trimmed and formatted field name after construct', function (): void {

--- a/centreon/tests/php/Core/Host/Domain/Model/NewHostTest.php
+++ b/centreon/tests/php/Core/Host/Domain/Model/NewHostTest.php
@@ -189,9 +189,14 @@ it(
     'should throw an exception when host address does not respect format',
     fn () => ($this->createHost)(['address' => 'hello world'])
 )->throws(
-    InvalidArgumentException::class,
-    AssertionException::ipOrDomain('hello world', 'NewHost::address')->getMessage()
+    \InvalidArgumentException::class,
+    '[NewHost::address] The value "hello world" was expected to be a valid IP address or hostname'
 );
+
+it('should accept an address containing underscores (NETBIOS / Active Directory)', function (): void {
+    $host = ($this->createHost)(['address' => 'netbios_name.local']);
+    expect($host->getAddress())->toBe('netbios_name.local');
+});
 
 // name and conmmands args should be formated
 it('should return trimmed and formatted name field after construct', function (): void {

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfigurationTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Tests\Core\Security\ProviderConfiguration\Application\OpenId\UseCase\PartialUpdateOpenIdConfiguration;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -254,7 +253,7 @@ it('should present an ErrorResponse when an error occured during the use case ex
         ->expects($this->once())
         ->method('setResponseStatus')
         ->with(new ErrorResponse(
-            AssertionException::ipOrDomain('abcd_.@', 'AuthenticationConditions::trustedClientAddresses')->getMessage()
+            '[AuthenticationConditions::trustedClientAddresses] The value "abcd_.@" was expected to be a valid IP address or hostname'
         ));
 
     $useCase = new PartialUpdateOpenIdConfiguration(

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Tests\Core\Security\ProviderConfiguration\Application\OpenId\UseCase\UpdateOpenIdConfiguration;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -177,7 +176,7 @@ it('should present an ErrorResponse when an error occured during the use case ex
         ->expects($this->once())
         ->method('setResponseStatus')
         ->with(new ErrorResponse(
-            AssertionException::ipOrDomain('abcd_.@', 'AuthenticationConditions::trustedClientAddresses')->getMessage()
+            '[AuthenticationConditions::trustedClientAddresses] The value "abcd_.@" was expected to be a valid IP address or hostname'
         ));
 
     $useCase = new UpdateOpenIdConfiguration(

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Tests\Core\Security\Vault\Application\UseCase\UpdateVaultConfiguration;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Application\Common\UseCase\{
     ErrorResponse,
@@ -126,10 +125,10 @@ it('should present InvalidArgumentResponse when one parameter is not valid', fun
 
     expect($presenter->getResponseStatus())->toBeInstanceOf(InvalidArgumentResponse::class);
     expect($presenter->getResponseStatus()?->getMessage())->toBe(
-        AssertionException::ipOrDomain(
-            $invalidAddress,
-            'VaultConfiguration::address'
-        )->getMessage()
+        sprintf(
+            '[VaultConfiguration::address] The value "%s" was expected to be a valid IP address or hostname',
+            $invalidAddress
+        )
     );
 });
 

--- a/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
@@ -108,7 +108,7 @@ it(
     )->getMessage()
 );
 
-it('should throw AssertionException when vault configuration address is \'._@\'', function (): void {
+it('should throw an exception when vault configuration address is \'._@\'', function (): void {
     new NewVaultConfiguration(
         $this->encryption,
         '._@',
@@ -119,9 +119,22 @@ it('should throw AssertionException when vault configuration address is \'._@\''
         'myVault',
     );
 })->throws(
-    AssertionException::class,
-    AssertionException::ipOrDomain('._@', 'NewVaultConfiguration::address')->getMessage()
+    \InvalidArgumentException::class,
+    '[NewVaultConfiguration::address] The value "._@" was expected to be a valid IP address or hostname'
 );
+
+it('should accept a vault address containing underscores (NETBIOS / Active Directory)', function (): void {
+    $vaultConfiguration = new NewVaultConfiguration(
+        $this->encryption,
+        'netbios_name.local',
+        8200,
+        'myStorage',
+        'myRoleId',
+        'mySecretId',
+        'myVault',
+    );
+    expect($vaultConfiguration->getAddress())->toBe('netbios_name.local');
+});
 
 it(
     'should throw InvalidArgumentException when vault configuration port value is lower than allowed range',

--- a/centreon/www/class/centreon-clapi/centreonInstance.class.php
+++ b/centreon/www/class/centreon-clapi/centreonInstance.class.php
@@ -21,7 +21,7 @@
 
 namespace CentreonClapi;
 
-use App\Shared\Domain\Assert\Assert as AppAssert;
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Centreon_Object_Instance;
 use Centreon_Object_Relation_Instance_Host;
 use Exception;
@@ -128,7 +128,7 @@ class CentreonInstance extends CentreonObject
         $addParams['gorgone_port'] = $params[self::ORDER_GORGONE_PORT];
 
         try {
-            AppAssert::ipOrHostname($addParams['ns_ip_address']);
+            CentreonAssert::ipOrHostname($addParams['ns_ip_address']);
         } catch (InvalidArgumentException) {
             throw new CentreonClapiException(self::INCORRECTIPADDRESS);
         }
@@ -154,7 +154,7 @@ class CentreonInstance extends CentreonObject
 
         if ($params[1] == 'ns_ip_address') {
             try {
-                AppAssert::ipOrHostname($params[2]);
+                CentreonAssert::ipOrHostname($params[2]);
             } catch (InvalidArgumentException) {
                 throw new CentreonClapiException(self::INCORRECTIPADDRESS);
             }

--- a/centreon/www/class/centreon-clapi/centreonInstance.class.php
+++ b/centreon/www/class/centreon-clapi/centreonInstance.class.php
@@ -21,12 +21,14 @@
 
 namespace CentreonClapi;
 
+use App\Shared\Domain\Assert\Assert as AppAssert;
 use Centreon_Object_Instance;
 use Centreon_Object_Relation_Instance_Host;
 use Exception;
 use LogicException;
 use PDOException;
 use Pimple\Container;
+use Webmozart\Assert\InvalidArgumentException;
 
 require_once 'centreonObject.class.php';
 require_once 'centreon.Config.Poller.class.php';
@@ -125,11 +127,9 @@ class CentreonInstance extends CentreonObject
         $addParams['ssh_port'] = $params[self::ORDER_SSH_PORT];
         $addParams['gorgone_port'] = $params[self::ORDER_GORGONE_PORT];
 
-        // Check IPv6, IPv4 and FQDN format
-        if (
-            ! filter_var($addParams['ns_ip_address'], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
-            && ! filter_var($addParams['ns_ip_address'], FILTER_VALIDATE_IP)
-        ) {
+        try {
+            AppAssert::ipOrHostname($addParams['ns_ip_address']);
+        } catch (InvalidArgumentException) {
             throw new CentreonClapiException(self::INCORRECTIPADDRESS);
         }
 
@@ -152,13 +152,12 @@ class CentreonInstance extends CentreonObject
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
 
-        // Check IPv6, IPv4 and FQDN format
-        if (
-            $params[1] == 'ns_ip_address'
-            && ! filter_var($params[2], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
-            && ! filter_var($params[2], FILTER_VALIDATE_IP)
-        ) {
-            throw new CentreonClapiException(self::INCORRECTIPADDRESS);
+        if ($params[1] == 'ns_ip_address') {
+            try {
+                AppAssert::ipOrHostname($params[2]);
+            } catch (InvalidArgumentException) {
+                throw new CentreonClapiException(self::INCORRECTIPADDRESS);
+            }
         }
 
         $objectId = $this->getObjectId($params[self::ORDER_UNIQUENAME]);

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -21,11 +21,13 @@
 
 use App\Kernel;
 use App\MonitoringConfiguration\Infrastructure\Service\SnowflakePollerUidGenerator;
+use App\Shared\Domain\Assert\Assert;
 use Centreon\Domain\PlatformTopology\Model\PlatformRegistered;
 use Core\AgentConfiguration\Application\UseCase\DeployDefaultAgentConfigurationForPoller\DeployDefaultAgentConfigurationForPoller;
 use Core\AgentConfiguration\Application\UseCase\DeployDefaultAgentConfigurationForPoller\DeployDefaultAgentConfigurationForPollerRequest;
 use Core\MonitoringServer\Model\MonitoringServer;
 use Godruoyi\Snowflake\Snowflake;
+use Webmozart\Assert\InvalidArgumentException;
 
 if (! isset($centreon)) {
     exit();
@@ -157,12 +159,13 @@ function testExistence($name = null): bool
  */
 function isValidIpAddress(string $ipAddress): bool
 {
-    // Check IPv6, IPv4 and FQDN format
-    return ! (
-        ! filter_var($ipAddress, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
-        && ! filter_var($ipAddress, FILTER_VALIDATE_IP)
-    );
+    try {
+        Assert::ipOrHostname($ipAddress);
 
+        return true;
+    } catch (InvalidArgumentException) {
+        return false;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **New centralized assertion**: introduce `App\Shared\Domain\Assert\Assert::ipOrHostname` in the App layer — a single source of truth for "value is a valid IP or hostname" checks across the codebase.
- **Replaces duplicated logic**: previously, 13 callsites duplicated the same `filter_var($v, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) || filter_var($v, FILTER_VALIDATE_IP)` dance (or its `Assertion::ipOrDomain` wrapper). They are all now migrated to the new assertion:
    - Host configuration: `Host`, `NewHost`
    - Vault: `VaultConfiguration`, `NewVaultConfiguration`
    - OpenID trusted client addresses: `AuthenticationConditions`
    - Centreon Monitoring Agent: `CmaConfigurationParameters` (Core + App)
    - Poller: `PollerAddress`
    - Platform topology: `PlatformPending`, `PlatformRegistered`
    - Remote server webservice: `CentreonConfigurationRemote`
    - Legacy/CLAPI: `DB-Func.php`, `centreonInstance.class.php`
- **Behaviour change**: the new assertion mirrors RFC 1123 hostname rules but additionally accepts the underscore (`_`) character. This unblocks NETBIOS / Active Directory hostnames (e.g. `host_01.local`), which are legitimately used in real customer networks but were rejected by PHP's strict `FILTER_FLAG_HOSTNAME` since 24.10.

## Jira

Fixes: [MON-199503](https://centreon.atlassian.net/browse/MON-199503)

## Test plan

- [ ] Create / edit a host with an address containing `_` (e.g. `netbios_name.local`) — should be accepted.
- [ ] Same for: poller / monitoring server address, vault configuration address, OpenID trusted client addresses, platform topology address.
- [ ] Regular IPv4 / IPv6 / FQDN addresses still work.
- [ ] Clearly invalid values (`hello world`, `not:valid`, `foo@bar`, empty string, leading/trailing `-`) are still rejected.

[MON-199503]: https://centreon.atlassian.net/browse/MON-199503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ