### PR TITLE
fix(orm): validate identifiers and use prepared statements in data access layer

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -582,6 +582,16 @@ jobs:
         run: composer run test:core
         working-directory: centreon
 
+      - name: Display application logs
+        if: failure()
+        run: |
+          echo "::group::centreon-error.log"
+          cat /var/log/php-fpm/centreon-error.log 2>/dev/null || echo "File not found"
+          echo "::endgroup::"
+          echo "::group::centreon-web.log"
+          cat /var/log/centreon/centreon-web.log 2>/dev/null || echo "File not found"
+          echo "::endgroup::"
+
   backend-lint:
     runs-on: ubuntu-24.04
     needs: [changes, get-environment]

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -585,11 +585,11 @@ jobs:
       - name: Display application logs
         if: failure()
         run: |
-          echo "::group::centreon-error.log"
-          cat /var/log/php-fpm/centreon-error.log 2>/dev/null || echo "File not found"
+          echo "::group::test.web.log"
+          cat /tmp/centreon-test-logs/test.web.log 2>/dev/null || echo "File not found"
           echo "::endgroup::"
-          echo "::group::centreon-web.log"
-          cat /var/log/centreon/centreon-web.log 2>/dev/null || echo "File not found"
+          echo "::group::Symfony logs (var/log/)"
+          find centreon/var/log -type f -name "*.log" -exec echo "--- {} ---" \; -exec cat {} \; 2>/dev/null || echo "No logs found"
           echo "::endgroup::"
 
   backend-lint:

--- a/centreon/lib/Centreon/Object/ObjectRt.php
+++ b/centreon/lib/Centreon/Object/ObjectRt.php
@@ -82,7 +82,7 @@ abstract class Centreon_ObjectRt
         }
         $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = :objectId";
         $stmt = $this->dbMon->prepare($sql);
-        $stmt->bindValue(':objectId', $objectId, \PDO::PARAM_INT);
+        $stmt->bindValue(':objectId', $objectId, PDO::PARAM_INT);
         $stmt->execute();
 
         return $stmt->fetch();

--- a/centreon/lib/Centreon/Object/ObjectRt.php
+++ b/centreon/lib/Centreon/Object/ObjectRt.php
@@ -75,10 +75,17 @@ abstract class Centreon_ObjectRt
      */
     public function getParameters($objectId, $parameterNames)
     {
-        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
-        $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = ?";
+        if (is_array($parameterNames)) {
+            $params = implode(',', array_map([$this, 'sanitizeIdentifier'], $parameterNames));
+        } else {
+            $params = $parameterNames !== '*' ? $this->sanitizeIdentifier($parameterNames) : $parameterNames;
+        }
+        $sql = "SELECT {$params} FROM {$this->table} WHERE {$this->primaryKey} = :objectId";
+        $stmt = $this->dbMon->prepare($sql);
+        $stmt->bindValue(':objectId', $objectId, \PDO::PARAM_INT);
+        $stmt->execute();
 
-        return $this->getResult($sql, [$objectId], 'fetch');
+        return $stmt->fetch();
     }
 
     /**
@@ -108,31 +115,43 @@ abstract class Centreon_ObjectRt
         if ($filterType != 'OR' && $filterType != 'AND') {
             throw new Exception('Unknown filter type');
         }
-        $params = is_array($parameterNames) ? implode(',', $parameterNames) : $parameterNames;
-        $sql = "SELECT {$params} FROM {$this->table} ";
-        $filterTab = [];
-        if (count($filters)) {
-            foreach ($filters as $key => $rawvalue) {
-                if ($filterTab === []) {
-                    $sql .= " WHERE {$key} LIKE ? ";
-                } else {
-                    $sql .= " {$filterType} {$key} LIKE ? ";
-                }
-                $value = trim($rawvalue);
-                $value = str_replace('\\', '\\\\', $value);
-                $value = str_replace('_', "\_", $value);
-                $value = str_replace(' ', "\ ", $value);
-                $filterTab[] = $value;
-            }
+        if (is_array($parameterNames)) {
+            $params = implode(',', array_map([$this, 'sanitizeIdentifier'], $parameterNames));
+        } else {
+            $params = $parameterNames !== '*' ? $this->sanitizeIdentifier($parameterNames) : $parameterNames;
         }
-        if (isset($order, $sort)   && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+        $sql = "SELECT {$params} FROM {$this->table} ";
+        $bindParams = [];
+        $filterIndex = 0;
+        $whereClauses = [];
+        foreach ($filters as $key => $rawvalue) {
+            $key = $this->sanitizeIdentifier($key);
+            $paramName = ':filter_' . $filterIndex++;
+            $value = trim($rawvalue);
+            $value = str_replace('\\', '\\\\', $value);
+            $value = str_replace('_', "\_", $value);
+            $value = str_replace(' ', "\ ", $value);
+            $whereClauses[] = "{$key} LIKE {$paramName}";
+            $bindParams[$paramName] = $value;
+        }
+        if ($whereClauses !== []) {
+            $sql .= ' WHERE ' . implode(" {$filterType} ", $whereClauses);
+        }
+        if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            $order = $this->sanitizeIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
             $sql = $this->dbMon->limit($sql, $count, $offset);
         }
 
-        return $this->getResult($sql, $filterTab, 'fetchAll');
+        $stmt = $this->dbMon->prepare($sql);
+        foreach ($bindParams as $paramName => $paramValue) {
+            $stmt->bindValue($paramName, $paramValue);
+        }
+        $stmt->execute();
+
+        return $stmt->fetchAll();
     }
 
     /**
@@ -145,29 +164,35 @@ abstract class Centreon_ObjectRt
      */
     public function getIdByParameter($paramName, $paramValues = [])
     {
-        $sql = "SELECT {$this->primaryKey} FROM {$this->table} WHERE ";
-        $condition = '';
+        $paramName = $this->sanitizeIdentifier($paramName);
         if (! is_array($paramValues)) {
             $paramValues = [$paramValues];
         }
-        foreach ($paramValues as $val) {
-            if ($condition != '') {
-                $condition .= ' OR ';
-            }
-            $condition .= $paramName . ' = ? ';
-        }
-        if ($condition) {
-            $sql .= $condition;
-            $rows = $this->getResult($sql, $paramValues, 'fetchAll');
-            $tab = [];
-            foreach ($rows as $val) {
-                $tab[] = $val[$this->primaryKey];
-            }
-
-            return $tab;
+        if ($paramValues === []) {
+            return [];
         }
 
-        return [];
+        $conditions = [];
+        $bindParams = [];
+        foreach ($paramValues as $index => $val) {
+            $paramKey = ':val_' . $index;
+            $conditions[] = $paramName . ' = ' . $paramKey;
+            $bindParams[$paramKey] = $val;
+        }
+
+        $sql = "SELECT {$this->primaryKey} FROM {$this->table} WHERE " . implode(' OR ', $conditions);
+        $stmt = $this->dbMon->prepare($sql);
+        foreach ($bindParams as $paramKey => $paramValue) {
+            $stmt->bindValue($paramKey, $paramValue);
+        }
+        $stmt->execute();
+
+        $tab = [];
+        foreach ($stmt->fetchAll() as $row) {
+            $tab[] = $row[$this->primaryKey];
+        }
+
+        return $tab;
     }
 
     /**
@@ -198,6 +223,19 @@ abstract class Centreon_ObjectRt
     public function getTableName()
     {
         return $this->table;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
     }
 
     /**

--- a/centreon/lib/Centreon/Object/Relation/Relation.php
+++ b/centreon/lib/Centreon/Object/Relation/Relation.php
@@ -178,13 +178,13 @@ abstract class Centreon_Object_Relation
             if ($fString != '') {
                 $fString .= ',';
             }
-            $fString .= $this->firstObject->getTableName() . '.' . $fparams;
+            $fString .= $this->firstObject->getTableName() . '.' . $this->sanitizeIdentifier($fparams);
         }
         foreach ($secondTableParams as $sparams) {
             if ($fString != '' || $sString != '') {
                 $sString .= ',';
             }
-            $sString .= $this->secondObject->getTableName() . '.' . $sparams;
+            $sString .= $this->secondObject->getTableName() . '.' . $this->sanitizeIdentifier($sparams);
         }
         $sql = 'SELECT ' . $fString . $sString . ' FROM ' . $this->firstObject->getTableName() . ','
             . $this->secondObject->getTableName() . ',' . $this->relationTable
@@ -192,30 +192,45 @@ abstract class Centreon_Object_Relation
             . $this->firstObject->getPrimaryKey() . ' = ' . $this->relationTable . '.' . $this->firstKey
             . ' AND ' . $this->relationTable . '.' . $this->secondKey . ' = ' . $this->secondObject->getTableName()
             . '.' . $this->secondObject->getPrimaryKey();
-        $filterTab = [];
+        $bindParams = [];
+        $filterIndex = 0;
         if (count($filters)) {
             foreach ($filters as $key => $rawvalue) {
+                $key = $this->sanitizeIdentifier($key);
                 if (is_array($rawvalue)) {
-                    $sql .= " {$filterType} {$key} IN (" . str_repeat('?,', count($rawvalue) - 1) . '?) ';
-                    $filterTab = array_merge($filterTab, $rawvalue);
+                    $inPlaceholders = [];
+                    foreach ($rawvalue as $inValue) {
+                        $paramName = ':filter_' . $filterIndex++;
+                        $inPlaceholders[] = $paramName;
+                        $bindParams[$paramName] = $inValue;
+                    }
+                    $sql .= " {$filterType} {$key} IN (" . implode(',', $inPlaceholders) . ') ';
                 } else {
-                    $sql .= " {$filterType} {$key} LIKE ? ";
+                    $paramName = ':filter_' . $filterIndex++;
                     $value = trim($rawvalue);
                     $value = str_replace('\\', '\\\\', $value);
                     $value = str_replace('_', "\_", $value);
                     $value = str_replace(' ', "\ ", $value);
-                    $filterTab[] = $value;
+                    $sql .= " {$filterType} {$key} LIKE {$paramName} ";
+                    $bindParams[$paramName] = $value;
                 }
             }
         }
-        if (isset($order, $sort)   && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+        if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            $order = $this->sanitizeIdentifier($order);
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {
             $sql = $this->db->limit($sql, $count, $offset);
         }
 
-        return $this->getResult($sql, $filterTab);
+        $stmt = $this->db->prepare($sql);
+        foreach ($bindParams as $paramName => $paramValue) {
+            $stmt->bindValue($paramName, $paramValue);
+        }
+        $stmt->execute();
+
+        return $stmt->fetchAll();
     }
 
     /**
@@ -228,11 +243,16 @@ abstract class Centreon_Object_Relation
      */
     public function getTargetIdFromSourceId($targetKey, $sourceKey, $sourceId)
     {
+        $targetKey = $this->sanitizeIdentifier($targetKey);
+        $sourceKey = $this->sanitizeIdentifier($sourceKey);
         if (! is_array($sourceId)) {
             $sourceId = [$sourceId];
         }
-        $sql = "SELECT {$targetKey} FROM {$this->relationTable} WHERE {$sourceKey} = ?";
-        $result = $this->getResult($sql, $sourceId);
+        $sql = "SELECT {$targetKey} FROM {$this->relationTable} WHERE {$sourceKey} = :sourceId";
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':sourceId', $sourceId[0]);
+        $stmt->execute();
+        $result = $stmt->fetchAll();
         $tab = [];
         foreach ($result as $rez) {
             $tab[] = $rez[$targetKey];
@@ -259,6 +279,19 @@ abstract class Centreon_Object_Relation
     public function getSecondKey()
     {
         return $this->secondKey;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
     }
 
     /**

--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -158,14 +158,16 @@ trait ConnectionTrait
             if (empty($tableName)) {
                 throw ConnectionException::batchInsertQueryBadUsage('Table name must not be empty');
             }
-            if (preg_match('/^[a-zA-Z_]\w*$/', $tableName) !== 1) {
+            $bareTableName = str_replace('`', '', $tableName);
+            if (preg_match('/^[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)?$/', $bareTableName) !== 1) {
                 throw ConnectionException::batchInsertQueryBadUsage("Invalid table name: {$tableName}");
             }
             if ($columns === []) {
                 throw ConnectionException::batchInsertQueryBadUsage('Columns must not be empty');
             }
             foreach ($columns as $column) {
-                if (preg_match('/^[a-zA-Z_]\w*$/', $column) !== 1) {
+                $bareColumn = str_replace('`', '', $column);
+                if (preg_match('/^[a-zA-Z_]\w*$/', $bareColumn) !== 1) {
                     throw ConnectionException::batchInsertQueryBadUsage("Invalid column name: {$column}");
                 }
             }

--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -158,14 +158,14 @@ trait ConnectionTrait
             if (empty($tableName)) {
                 throw ConnectionException::batchInsertQueryBadUsage('Table name must not be empty');
             }
-            if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName) !== 1) {
+            if (preg_match('/^[a-zA-Z_]\w*$/', $tableName) !== 1) {
                 throw ConnectionException::batchInsertQueryBadUsage("Invalid table name: {$tableName}");
             }
             if ($columns === []) {
                 throw ConnectionException::batchInsertQueryBadUsage('Columns must not be empty');
             }
             foreach ($columns as $column) {
-                if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $column) !== 1) {
+                if (preg_match('/^[a-zA-Z_]\w*$/', $column) !== 1) {
                     throw ConnectionException::batchInsertQueryBadUsage("Invalid column name: {$column}");
                 }
             }

--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -158,8 +158,16 @@ trait ConnectionTrait
             if (empty($tableName)) {
                 throw ConnectionException::batchInsertQueryBadUsage('Table name must not be empty');
             }
+            if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName) !== 1) {
+                throw ConnectionException::batchInsertQueryBadUsage("Invalid table name: {$tableName}");
+            }
             if ($columns === []) {
                 throw ConnectionException::batchInsertQueryBadUsage('Columns must not be empty');
+            }
+            foreach ($columns as $column) {
+                if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $column) !== 1) {
+                    throw ConnectionException::batchInsertQueryBadUsage("Invalid column name: {$column}");
+                }
             }
             if ($batchInsertParameters->isEmpty()) {
                 throw ConnectionException::batchInsertQueryBadUsage('Batch insert parameters must not be empty');

--- a/centreon/src/Centreon/Domain/Repository/Traits/CheckListOfIdsTrait.php
+++ b/centreon/src/Centreon/Domain/Repository/Traits/CheckListOfIdsTrait.php
@@ -38,6 +38,13 @@ trait CheckListOfIdsTrait
         string $tableName,
         string $columnNameOfIdentificator,
     ): bool {
+        if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName) !== 1) {
+            throw new \InvalidArgumentException("Invalid table name: {$tableName}");
+        }
+        if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $columnNameOfIdentificator) !== 1) {
+            throw new \InvalidArgumentException("Invalid column name: {$columnNameOfIdentificator}");
+        }
+
         $count = count($ids);
 
         $collector = new StatementCollector();

--- a/centreon/src/Centreon/Infrastructure/CentreonLegacyDB/CentreonDBAdapter.php
+++ b/centreon/src/Centreon/Infrastructure/CentreonLegacyDB/CentreonDBAdapter.php
@@ -266,16 +266,6 @@ class CentreonDBAdapter
         return $this->errorInfo;
     }
 
-    private function sanitizeIdentifier(string $name): string
-    {
-        $name = trim(trim($name), '`');
-        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
-            throw new \InvalidArgumentException("Invalid identifier: {$name}");
-        }
-
-        return $name;
-    }
-
     public function beginTransaction(): void
     {
         $this->db->beginTransaction();
@@ -289,5 +279,15 @@ class CentreonDBAdapter
     public function rollBack(): void
     {
         $this->db->rollBack();
+    }
+
+    private function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new \InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
     }
 }

--- a/centreon/src/Centreon/Infrastructure/CentreonLegacyDB/CentreonDBAdapter.php
+++ b/centreon/src/Centreon/Infrastructure/CentreonLegacyDB/CentreonDBAdapter.php
@@ -135,10 +135,12 @@ class CentreonDBAdapter
             throw new \Exception("The argument `fields` can't be empty");
         }
 
+        $table = $this->sanitizeIdentifier($table);
         $keys = [];
         $keyVars = [];
 
         foreach ($fields as $key => $value) {
+            $key = $this->sanitizeIdentifier($key);
             $keys[] = "`{$key}`";
             $keyVars[] = ":{$key}";
         }
@@ -151,6 +153,7 @@ class CentreonDBAdapter
         $stmt = $this->db->prepare($sql);
 
         foreach ($fields as $key => $value) {
+            $key = $this->sanitizeIdentifier($key);
             $stmt->bindValue(':' . $key, $value);
         }
 
@@ -177,15 +180,12 @@ class CentreonDBAdapter
      */
     public function loadDataInfile(string $file, string $table, array $fieldsClause, array $linesClause, array $columns): void
     {
-        // SQL statement format:
-        // LOAD DATA
-        // INFILE 'file_name'
-        // INTO TABLE tbl_name
-        // FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\'
-        // LINES TERMINATED BY '\n' STARTING BY ''
-        // (`col_name`, `col_name`,...)
+        if (str_contains($file, "'") || str_contains($file, '..')) {
+            throw new \InvalidArgumentException("Invalid file path: {$file}");
+        }
+        $table = $this->sanitizeIdentifier($table);
+        $columns = array_map([$this, 'sanitizeIdentifier'], $columns);
 
-        // Construct SQL statement
         $sql = "LOAD DATA LOCAL INFILE '{$file}'";
         $sql .= " INTO TABLE {$table}";
         $sql .= " FIELDS TERMINATED BY '" . $fieldsClause['terminated_by'] . "' ENCLOSED BY '"
@@ -194,10 +194,8 @@ class CentreonDBAdapter
             . $linesClause['starting_by'] . "'";
         $sql .= ' (`' . implode('`, `', $columns) . '`)';
 
-        // Prepare PDO statement.
         $stmt = $this->db->prepare($sql);
 
-        // Execute
         try {
             $stmt->execute();
         } catch (\Exception $e) {
@@ -215,11 +213,12 @@ class CentreonDBAdapter
      */
     public function update($table, array $fields, int $id)
     {
-
+        $table = $this->sanitizeIdentifier($table);
         $keys = [];
         $keyValues = [];
 
         foreach ($fields as $key => $value) {
+            $key = $this->sanitizeIdentifier($key);
             array_push($keys, $key . '= :' . $key);
             array_push($keyValues, [$key, $value]);
         }
@@ -265,6 +264,16 @@ class CentreonDBAdapter
     public function errorInfo()
     {
         return $this->errorInfo;
+    }
+
+    private function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new \InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
     }
 
     public function beginTransaction(): void

--- a/centreon/www/class/centreon-partition/partEngine.class.php
+++ b/centreon/www/class/centreon-partition/partEngine.class.php
@@ -326,7 +326,7 @@ class PartEngine
         }
         $filename .= '_' . date('Ymd-hi') . '.dump';
 
-        if (str_contains($filename, "'") || str_contains($filename, '..')) {
+        if (str_contains($filename, "'") || str_contains($filename, '..') || preg_match('/[\x00-\x1f;\\\\]/', $filename) === 1) {
             throw new InvalidArgumentException("Invalid backup filename: {$filename}");
         }
 

--- a/centreon/www/class/centreon-partition/partEngine.class.php
+++ b/centreon/www/class/centreon-partition/partEngine.class.php
@@ -27,6 +27,21 @@
  */
 class PartEngine
 {
+    private function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
+    }
+
+    private function buildTableName($table): string
+    {
+        return '`' . $this->sanitizeIdentifier($table->getSchema()) . '`.`' . $this->sanitizeIdentifier($table->getName()) . '`';
+    }
+
     /**
      * Create a new table with partitions
      *
@@ -38,7 +53,7 @@ class PartEngine
      */
     public function createParts($table, $db, $createPastPartitions): void
     {
-        $tableName = '`' . $table->getSchema() . '`.' . $table->getName();
+        $tableName = $this->buildTableName($table);
         if ($table->exists()) {
             throw new Exception('Warning: Table ' . $tableName . " already exists\n");
         }
@@ -55,7 +70,7 @@ class PartEngine
         }
 
         try {
-            $dbResult = $db->query('use `' . $table->getSchema() . '`');
+            $dbResult = $db->query('use `' . $this->sanitizeIdentifier($table->getSchema()) . '`');
         } catch (PDOException $e) {
             throw new Exception(
                 'SQL Error: Cannot use database '
@@ -97,30 +112,34 @@ class PartEngine
             $condition = $this->purgeDailyPartitionCondition($table);
         }
 
-        $tableName = '`' . $table->getSchema() . '`.' . $table->getName();
+        $tableName = $this->buildTableName($table);
         if (! $table->exists()) {
             throw new Exception('Error: Table ' . $tableName . " does not exists\n");
         }
 
         $request = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS
-            WHERE TABLE_NAME='" . $table->getName() . "'
-            AND TABLE_SCHEMA='" . $table->getSchema() . "'
+            WHERE TABLE_NAME = :tableName
+            AND TABLE_SCHEMA = :tableSchema
             AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) IS NOT NULL ";
         $request .= $condition;
 
         try {
-            $dbResult = $db->query($request);
+            $stmt = $db->prepare($request);
+            $stmt->bindValue(':tableName', $table->getName(), PDO::PARAM_STR);
+            $stmt->bindValue(':tableSchema', $table->getSchema(), PDO::PARAM_STR);
+            $stmt->execute();
         } catch (PDOException $e) {
             throw new Exception('Error : Cannot get partitions to purge for table '
                 . $tableName . ', ' . $e->getMessage() . "\n");
         }
 
-        while ($row = $dbResult->fetch()) {
-            $request = 'ALTER TABLE ' . $tableName . ' DROP PARTITION `' . $row['PARTITION_NAME'] . '`;';
+        while ($row = $stmt->fetch()) {
+            $partitionName = $this->sanitizeIdentifier($row['PARTITION_NAME']);
+            $request = 'ALTER TABLE ' . $tableName . ' DROP PARTITION `' . $partitionName . '`;';
             try {
-                $dbResult2 = & $db->query($request);
+                $db->query($request);
             } catch (PDOException $e) {
-                throw new Exception('Error : Cannot drop partition ' . $row['PARTITION_NAME'] . ' of table '
+                throw new Exception('Error : Cannot drop partition ' . $partitionName . ' of table '
                     . $tableName . ', ' . $e->getMessage() . "\n");
             }
         }
@@ -142,7 +161,7 @@ class PartEngine
      */
     public function migrate($table, $db): void
     {
-        $tableName = '`' . $table->getSchema() . '`.' . $table->getName();
+        $tableName = $this->buildTableName($table);
 
         $db->query('SET bulk_insert_buffer_size= 1024 * 1024 * 256');
 
@@ -191,7 +210,7 @@ class PartEngine
      */
     public function updateParts($table, $db): void
     {
-        $tableName = '`' . $table->getSchema() . '`.' . $table->getName();
+        $tableName = $this->buildTableName($table);
 
         // verifying if table is partitioned
         if ($this->isPartitioned($table, $db) === false) {
@@ -218,7 +237,7 @@ class PartEngine
      */
     public function listParts($table, $db, $throwException = true)
     {
-        $tableName = '`' . $table->getSchema() . '`.' . $table->getName();
+        $tableName = $this->buildTableName($table);
         if (! $table->exists()) {
             throw new Exception('Parts list error: Table ' . $tableName . " does not exists\n");
         }
@@ -231,11 +250,14 @@ class PartEngine
         $request .= 'PARTITION_NAME, PARTITION_ORDINAL_POSITION, '
             . 'INDEX_LENGTH, DATA_LENGTH, CREATE_TIME, TABLE_ROWS ';
         $request .= 'FROM information_schema.`PARTITIONS` ';
-        $request .= "WHERE `TABLE_NAME`='" . $table->getName() . "' ";
-        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
+        $request .= 'WHERE `TABLE_NAME` = :tableName ';
+        $request .= 'AND TABLE_SCHEMA = :tableSchema ';
         $request .= 'ORDER BY PARTITION_NAME DESC ';
         try {
-            $dbResult = $db->query($request);
+            $stmt = $db->prepare($request);
+            $stmt->bindValue(':tableName', $table->getName(), PDO::PARAM_STR);
+            $stmt->bindValue(':tableSchema', $table->getSchema(), PDO::PARAM_STR);
+            $stmt->execute();
         } catch (PDOException $e) {
             throw new Exception(
                 'Error : Cannot get table schema information  for '
@@ -244,7 +266,7 @@ class PartEngine
         }
 
         $partitions = [];
-        while ($row = $dbResult->fetch()) {
+        while ($row = $stmt->fetch()) {
             if (! is_null($row['PARTITION_NAME'])) {
                 $row['INDEX_LENGTH'] = round($row['INDEX_LENGTH'] / (1024 * 1024), 2);
                 $row['DATA_LENGTH'] = round($row['DATA_LENGTH'] / (1024 * 1024), 2);
@@ -270,23 +292,30 @@ class PartEngine
      */
     public function backupParts($table, $db): void
     {
-        $tableName = '`' . $table->getSchema() . '`.' . $table->getName();
+        $tableName = $this->buildTableName($table);
         if (! $table->exists()) {
             throw new Exception('Error: Table ' . $tableName . " does not exists\n");
         }
         $format = 'PARTITION_DESCRIPTION';
         if (! is_null($table->getBackupFormat()) && $table->getType() == 'date' && $table->getDuration() == 'daily') {
-            $format = "date_format(FROM_UNIXTIME(PARTITION_DESCRIPTION), '" . $table->getBackupFormat() . "')";
+            $backupFormat = $table->getBackupFormat();
+            if (preg_match('/^[%a-zA-Z\-_\/]+$/', $backupFormat) !== 1) {
+                throw new InvalidArgumentException("Invalid backup format: {$backupFormat}");
+            }
+            $format = "date_format(FROM_UNIXTIME(PARTITION_DESCRIPTION), '" . $backupFormat . "')";
         }
 
         $request = 'SELECT PARTITION_NAME, PARTITION_DESCRIPTION, '
             . $format . ' as filename FROM information_schema.`PARTITIONS` ';
-        $request .= "WHERE `TABLE_NAME`='" . $table->getName() . "' ";
-        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
-        $request .= 'ORDER BY  PARTITION_ORDINAL_POSITION desc ';
+        $request .= 'WHERE `TABLE_NAME` = :tableName ';
+        $request .= 'AND TABLE_SCHEMA = :tableSchema ';
+        $request .= 'ORDER BY PARTITION_ORDINAL_POSITION desc ';
         $request .= 'LIMIT 2';
         try {
-            $dbResult = $db->query($request);
+            $stmt = $db->prepare($request);
+            $stmt->bindValue(':tableName', $table->getName(), PDO::PARAM_STR);
+            $stmt->bindValue(':tableSchema', $table->getSchema(), PDO::PARAM_STR);
+            $stmt->execute();
         } catch (PDOException $e) {
             throw new Exception(
                 'Error : Cannot get table schema information  for '
@@ -297,9 +326,10 @@ class PartEngine
         $filename = $table->getBackupFolder() . '/' . $tableName;
         $start = '';
         $end = '';
-        while ($row = $dbResult->fetch()) {
+        while ($row = $stmt->fetch()) {
             if (! $count) {
-                $filename .= '_' . $row['PARTITION_NAME'] . '_' . $row['filename'];
+                $partName = $this->sanitizeIdentifier($row['PARTITION_NAME']);
+                $filename .= '_' . $partName . '_' . $row['filename'];
                 $end = $row['PARTITION_DESCRIPTION'];
                 $count++;
             } else {
@@ -311,15 +341,23 @@ class PartEngine
         }
         $filename .= '_' . date('Ymd-hi') . '.dump';
 
-        $dbResult->closeCursor();
+        if (str_contains($filename, "'") || str_contains($filename, '..')) {
+            throw new InvalidArgumentException("Invalid backup filename: {$filename}");
+        }
 
+        $stmt->closeCursor();
+
+        $columnName = $this->sanitizeIdentifier($table->getColumn());
         $request = 'SELECT * FROM ' . $tableName;
-        $request .= ' WHERE ' . $table->getColumn() . ' >= ' . $start;
-        $request .= ' AND ' . $table->getColumn() . ' < ' . $end;
+        $request .= ' WHERE ' . $columnName . ' >= :rangeStart';
+        $request .= ' AND ' . $columnName . ' < :rangeEnd';
         $request .= " INTO OUTFILE '" . $filename . "'";
 
         try {
-            $dbResult = $db->query($request);
+            $stmt = $db->prepare($request);
+            $stmt->bindValue(':rangeStart', $start);
+            $stmt->bindValue(':rangeEnd', $end);
+            $stmt->execute();
         } catch (PDOException $e) {
             throw new Exception(
                 'FATAL : Cannot dump table ' . $tableName
@@ -389,7 +427,7 @@ class PartEngine
     {
         try {
             $dbResult = $db->query(
-                'SHOW CREATE TABLE `' . $table->getSchema() . '`.`' . $table->getName() . '`'
+                'SHOW CREATE TABLE ' . $this->buildTableName($table)
             );
         } catch (PDOException $e) {
             throw new Exception('Cannot get partition information');
@@ -562,7 +600,7 @@ class PartEngine
         date_default_timezone_set($table->getTimezone());
         $ltime = localtime();
 
-        $createPart = ' PARTITION BY RANGE(' . $table->getColumn() . ') (';
+        $createPart = ' PARTITION BY RANGE(' . $this->sanitizeIdentifier($table->getColumn()) . ') (';
 
         // Create past partitions if needed (not needed in fresh install)
         $num_days = ($createPastPartitions === true) ? $table->getRetention() : 0;
@@ -624,7 +662,7 @@ class PartEngine
         $error = false;
         try {
             $dbResult = $db->query(
-                'SHOW CREATE TABLE `' . $table->getSchema() . '`.`' . $table->getName() . '`'
+                'SHOW CREATE TABLE ' . $this->buildTableName($table)
             );
         } catch (PDOException $e) {
             $error = true;
@@ -663,7 +701,7 @@ class PartEngine
     {
         // Check if we need to create it
         try {
-            $dbResult = $db->query('SHOW CREATE TABLE `' . $table->getSchema() . '`.`' . $table->getName() . '`');
+            $dbResult = $db->query('SHOW CREATE TABLE ' . $this->buildTableName($table));
         } catch (PDOException $e) {
             throw new Exception(
                 'Error : Cannot get partition maxvalue information for table '

--- a/centreon/www/class/centreon-partition/partEngine.class.php
+++ b/centreon/www/class/centreon-partition/partEngine.class.php
@@ -27,21 +27,6 @@
  */
 class PartEngine
 {
-    private function sanitizeIdentifier(string $name): string
-    {
-        $name = trim(trim($name), '`');
-        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
-            throw new InvalidArgumentException("Invalid identifier: {$name}");
-        }
-
-        return $name;
-    }
-
-    private function buildTableName($table): string
-    {
-        return '`' . $this->sanitizeIdentifier($table->getSchema()) . '`.`' . $this->sanitizeIdentifier($table->getName()) . '`';
-    }
-
     /**
      * Create a new table with partitions
      *
@@ -117,10 +102,10 @@ class PartEngine
             throw new Exception('Error: Table ' . $tableName . " does not exists\n");
         }
 
-        $request = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS
+        $request = 'SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS
             WHERE TABLE_NAME = :tableName
             AND TABLE_SCHEMA = :tableSchema
-            AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) IS NOT NULL ";
+            AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) IS NOT NULL ';
         $request .= $condition;
 
         try {
@@ -440,6 +425,21 @@ class PartEngine
         }
 
         return false;
+    }
+
+    private function sanitizeIdentifier(string $name): string
+    {
+        $name = trim(trim($name), '`');
+        if ($name === '' || preg_match('/[;\'"\\\\#]|--|\/\*/', $name) === 1) {
+            throw new InvalidArgumentException("Invalid identifier: {$name}");
+        }
+
+        return $name;
+    }
+
+    private function buildTableName($table): string
+    {
+        return '`' . $this->sanitizeIdentifier($table->getSchema()) . '`.`' . $this->sanitizeIdentifier($table->getName()) . '`';
     }
 
     /**


### PR DESCRIPTION
## Description

Add identifier validation and prepared statements across the generic ORM/DB data access layer. This includes:

- `ObjectRt.php` and `Relation.php`: add `sanitizeIdentifier()` method and switch to named bind parameters
- `ConnectionTrait.php`: add regex validation for identifiers in `batchInsert`
- `CentreonDBAdapter.php`: add `sanitizeIdentifier()` for insert, update and loadDataInfile operations
- `CheckListOfIdsTrait.php`: add regex validation for table and column names
- `partEngine.class.php`: add `sanitizeIdentifier()`, use prepare/bind for INFORMATION_SCHEMA queries, and validate backup format/path

**Fixes** MON-200900

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Verify that all existing unit and integration tests pass
2. Confirm host/service/contact configuration CRUD operations still work correctly
3. Verify partition management operations (listing, creation, backup) function as expected
4. Run the monitoring stack and confirm real-time data flows through without issues

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).