### PR TITLE
fix(auth): evaluate the OpenID trusted-client filter correctly

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -763,11 +763,19 @@ class OpenIdProvider implements OpenIdProviderInterface
             }
         }
 
-        foreach ($authenticationConditions->getTrustedClientAddresses() as $trustedClientAddress) {
-            if (
-                $trustedClientAddress !== ''
-                && preg_match('/' . $trustedClientAddress . '/', $clientIp)
-            ) {
+        $trustedClientAddresses = array_filter(
+            $authenticationConditions->getTrustedClientAddresses(),
+            static fn (string $trustedClientAddress): bool => $trustedClientAddress !== ''
+        );
+        if ($trustedClientAddresses !== []) {
+            $isTrusted = false;
+            foreach ($trustedClientAddresses as $trustedClientAddress) {
+                if (preg_match('/' . $trustedClientAddress . '/', $clientIp)) {
+                    $isTrusted = true;
+                    break;
+                }
+            }
+            if (! $isTrusted) {
                 LoggerAuthentication::create()->loginFailure(
                     'Client IP is not whitelisted',
                     null,

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -752,7 +752,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         $groupsMapping = $customConfiguration->getGroupsMapping();
 
         foreach ($authenticationConditions->getBlacklistClientAddresses() as $blackListedAddress) {
-            if ($blackListedAddress !== '' && preg_match('/' . $blackListedAddress . '/', $clientIp)) {
+            if ($blackListedAddress !== '' && preg_match('/' . $blackListedAddress . '/', $clientIp) === 1) {
                 LoggerAuthentication::create()->loginFailure(
                     'Client IP is blacklisted',
                     null,
@@ -770,7 +770,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         if ($trustedClientAddresses !== []) {
             $isTrusted = false;
             foreach ($trustedClientAddresses as $trustedClientAddress) {
-                if (preg_match('/' . $trustedClientAddress . '/', $clientIp)) {
+                if (preg_match('/' . $trustedClientAddress . '/', $clientIp) === 1) {
                     $isTrusted = true;
                     break;
                 }

--- a/centreon/tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2026 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,9 @@ beforeEach(function (): void {
     $authLoggerReflection = new \ReflectionClass(LoggerAuthentication::class);
     $facade = $authLoggerReflection->newInstanceWithoutConstructor();
     $spy = new class () extends \Psr\Log\AbstractLogger {
-        public function log($level, string|\Stringable $message, array $context = []): void {}
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+        }
     };
     $authLoggerReflection->getProperty('logger')->setValue($facade, $spy);
     $authLoggerReflection->getProperty('instance')->setValue(null, $facade);

--- a/centreon/tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * Copyright 2005 - 2026 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Authentication\Domain\Provider;
+
+use Adaptation\Log\LoggerAuthentication;
+use Centreon\Domain\Contact\Interfaces\ContactServiceInterface;
+use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
+use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
+use Core\Security\Authentication\Domain\Exception\SSOAuthenticationException;
+use Core\Security\Authentication\Domain\Model\NewProviderToken;
+use Core\Security\Authentication\Domain\Provider\OpenIdProvider;
+use Core\Security\ProviderConfiguration\Domain\Model\ACLConditions;
+use Core\Security\ProviderConfiguration\Domain\Model\AuthenticationConditions;
+use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\Model\GroupsMapping;
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\AttributePath\AttributePathFetcher;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\Conditions;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\GroupsMapping as GroupsMappingSecurityAccess;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\RolesMapping;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+beforeEach(function (): void {
+    $this->provider = new OpenIdProvider(
+        $this->createMock(HttpClientInterface::class),
+        $this->createMock(UrlGeneratorInterface::class),
+        $this->createMock(ContactServiceInterface::class),
+        $this->createMock(WriteUserRepositoryInterface::class),
+        $this->createMock(Conditions::class),
+        $this->createMock(RolesMapping::class),
+        $this->createMock(GroupsMappingSecurityAccess::class),
+        $this->createMock(AttributePathFetcher::class),
+        $this->createMock(ReadVaultRepositoryInterface::class),
+        false,
+    );
+
+    $authLoggerReflection = new \ReflectionClass(LoggerAuthentication::class);
+    $facade = $authLoggerReflection->newInstanceWithoutConstructor();
+    $spy = new class () extends \Psr\Log\AbstractLogger {
+        public function log($level, string|\Stringable $message, array $context = []): void {}
+    };
+    $authLoggerReflection->getProperty('logger')->setValue($facade, $spy);
+    $authLoggerReflection->getProperty('instance')->setValue(null, $facade);
+
+    $this->callVerify = function (
+        string $clientIp,
+        array $trustedAddresses = [],
+        array $blacklistAddresses = [],
+    ): void {
+        $authConditions = new AuthenticationConditions(false, '', null, []);
+        $authRef = new \ReflectionClass($authConditions);
+        $authRef->getProperty('trustedClientAddresses')->setValue($authConditions, $trustedAddresses);
+        $authRef->getProperty('blacklistClientAddresses')->setValue($authConditions, $blacklistAddresses);
+
+        $customConfiguration = $this->createMock(CustomConfiguration::class);
+        $customConfiguration->method('getAuthenticationConditions')->willReturn($authConditions);
+
+        $aclConditions = $this->createMock(ACLConditions::class);
+        $aclConditions->method('isEnabled')->willReturn(false);
+        $customConfiguration->method('getACLConditions')->willReturn($aclConditions);
+
+        $groupsMapping = $this->createMock(GroupsMapping::class);
+        $groupsMapping->method('isEnabled')->willReturn(false);
+        $customConfiguration->method('getGroupsMapping')->willReturn($groupsMapping);
+
+        $configuration = new Configuration(1, 'openid', 'OpenID', '{}', true, false);
+        $configuration->setCustomConfiguration($customConfiguration);
+
+        $providerRef = new \ReflectionClass($this->provider);
+        $providerRef->getProperty('configuration')->setValue($this->provider, $configuration);
+        $providerRef->getProperty('providerToken')->setValue(
+            $this->provider,
+            new NewProviderToken('fake-token', new \DateTimeImmutable()),
+        );
+        $providerRef->getProperty('idTokenPayload')->setValue($this->provider, []);
+
+        $providerRef->getMethod('verifyThatClientIsAllowedToConnectOrFail')
+            ->invoke($this->provider, $clientIp);
+    };
+});
+
+afterEach(function (): void {
+    (new \ReflectionClass(LoggerAuthentication::class))->getProperty('instance')->setValue(null, null);
+});
+
+it('allows a client whose IP matches a trusted address', function (): void {
+    ($this->callVerify)('192.168.1.10', ['192\\.168\\.1\\.10']);
+    expect(true)->toBeTrue();
+});
+
+it('allows a client whose IP matches one of several trusted addresses', function (): void {
+    ($this->callVerify)('10.0.0.5', ['192\\.168\\.1\\.1', '10\\.0\\.0\\.\\d+']);
+    expect(true)->toBeTrue();
+});
+
+it('rejects a client whose IP matches none of the trusted addresses', function (): void {
+    ($this->callVerify)('172.16.0.1', ['192\\.168\\.1\\.1', '10\\.0\\.0\\.\\d+']);
+})->throws(SSOAuthenticationException::class);
+
+it('skips the trusted filter when the trusted address list is empty', function (): void {
+    ($this->callVerify)('172.16.0.1');
+    expect(true)->toBeTrue();
+});
+
+it('skips the trusted filter when all trusted addresses are empty strings', function (): void {
+    ($this->callVerify)('172.16.0.1', ['', '']);
+    expect(true)->toBeTrue();
+});
+
+it('rejects a client whose IP is blacklisted', function (): void {
+    ($this->callVerify)('192.168.1.10', [], ['192\\.168\\.1\\.10']);
+})->throws(SSOAuthenticationException::class);
+
+it('rejects a blacklisted IP even when it is also trusted', function (): void {
+    ($this->callVerify)('192.168.1.10', ['192\\.168\\.1\\.10'], ['192\\.168\\.1\\.10']);
+})->throws(SSOAuthenticationException::class);
+
+it('allows a client not on the blacklist when no trusted list is configured', function (): void {
+    ($this->callVerify)('10.0.0.5', [], ['192\\.168\\.1\\.1']);
+    expect(true)->toBeTrue();
+});

--- a/centreon/tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
@@ -119,7 +119,7 @@ it('allows a client whose IP matches one of several trusted addresses', function
 
 it('rejects a client whose IP matches none of the trusted addresses', function (): void {
     ($this->callVerify)('172.16.0.1', ['192\\.168\\.1\\.1', '10\\.0\\.0\\.\\d+']);
-})->throws(SSOAuthenticationException::class);
+})->throws(SSOAuthenticationException::class, 'Your IP is not whitelisted');
 
 it('skips the trusted filter when the trusted address list is empty', function (): void {
     ($this->callVerify)('172.16.0.1');
@@ -131,13 +131,18 @@ it('skips the trusted filter when all trusted addresses are empty strings', func
     expect(true)->toBeTrue();
 });
 
+it('filters out empty strings and still matches the remaining trusted address', function (): void {
+    ($this->callVerify)('192.168.1.10', ['', '192\\.168\\.1\\.10', '']);
+    expect(true)->toBeTrue();
+});
+
 it('rejects a client whose IP is blacklisted', function (): void {
     ($this->callVerify)('192.168.1.10', [], ['192\\.168\\.1\\.10']);
-})->throws(SSOAuthenticationException::class);
+})->throws(SSOAuthenticationException::class, 'Your IP is blacklisted');
 
 it('rejects a blacklisted IP even when it is also trusted', function (): void {
     ($this->callVerify)('192.168.1.10', ['192\\.168\\.1\\.10'], ['192\\.168\\.1\\.10']);
-})->throws(SSOAuthenticationException::class);
+})->throws(SSOAuthenticationException::class, 'Your IP is blacklisted');
 
 it('allows a client not on the blacklist when no trusted list is configured', function (): void {
     ($this->callVerify)('10.0.0.5', [], ['192\\.168\\.1\\.1']);


### PR DESCRIPTION
Fixes: [MON-201178](https://centreon.atlassian.net/browse/MON-201178)

## Description

`OpenIdProvider::verifyThatClientIsAllowedToConnectOrFail()` evaluated the *trusted client addresses* filter inversely: it rejected a client whose IP **matched** a trusted address and let every non-matching IP through. When a non-empty trusted list is configured, the connection is now rejected only when the client IP matches **none** of the entries — aligning OpenID with the WebSSO provider (`! in_array($ip, $trusted)`). The blacklist loop above is unchanged.

This logic is pre-existing on `develop`; it surfaced while reviewing the authentication-logging work.

## How to test

### Prerequisites

- A Centreon platform with an OpenID Connect provider configured (e.g. Keycloak, Azure AD).
- Access to the **Administration > Authentication > OpenID Connect** configuration page.

### Scenario 1 — Trusted client addresses (allowlist)

1. Configure an OpenID provider with a **Trusted client addresses** list containing your client IP (e.g. `192.168.1.10`).
2. Attempt to log in via OpenID from that IP.
3. **Expected:** Login succeeds (the IP is in the trusted list).
4. Attempt to log in from a different IP not in the list.
5. **Expected:** Login is rejected with "Your IP is not whitelisted".

### Scenario 2 — Blocklist client addresses

1. Configure an OpenID provider with a **Blocklist client addresses** list containing your client IP.
2. Attempt to log in via OpenID from that IP.
3. **Expected:** Login is rejected with "Your IP is blacklisted".

### Scenario 3 — No trusted list configured

1. Leave the trusted client addresses list empty.
2. Attempt to log in via OpenID from any IP.
3. **Expected:** Login succeeds (no IP filtering applied).

### Scenario 4 — Unit tests

Run the unit tests from the `centreon/` directory:

```bash
vendor/bin/pest tests/php/Core/Security/Authentication/Domain/Provider/OpenIdProviderTest.php
```

All 9 test cases (12 assertions) should pass.

## Notes

- ⚠️ **Behaviour change**: this alters which client IPs can connect when a trusted-address filter is configured — needs QA validation.

[MON-201178]: https://centreon.atlassian.net/browse/MON-201178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ