### PR TITLE
feat(resources): distinct icon and left tooltip for host Service Graphs

### DIFF
--- a/centreon/packages/ui/src/Button/Icon/index.tsx
+++ b/centreon/packages/ui/src/Button/Icon/index.tsx
@@ -24,6 +24,7 @@ type Props = {
   onClick: (event) => void;
   title?: string | JSX.Element;
   tooltipClassName?: string;
+  tooltipEnterDelay?: number;
   tooltipPlacement?:
     | 'bottom'
     | 'left'
@@ -44,6 +45,7 @@ export const IconButton = ({
   ariaLabel,
   className,
   dataTestid,
+  tooltipEnterDelay,
   tooltipPlacement,
   tooltipClassName,
   ...props
@@ -53,6 +55,8 @@ export const IconButton = ({
   return (
     <Tooltip
       classes={{ tooltip: cx(classes.tooltip, tooltipClassName) }}
+      enterDelay={tooltipEnterDelay}
+      enterNextDelay={tooltipEnterDelay}
       placement={tooltipPlacement}
       title={title}
     >

--- a/centreon/www/front_src/src/Resources/Listing/columns/Graph.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/Graph.tsx
@@ -1,3 +1,4 @@
+import IconSegment from '@mui/icons-material/Segment';
 import IconGraph from '@mui/icons-material/BarChart';
 import { Paper } from '@mui/material';
 
@@ -107,7 +108,7 @@ const Graph = ({ row, endpoint }: GraphProps): ReactElement => {
 };
 
 const renderChip =
-  ({ onClick, label, className }) =>
+  ({ onClick, label, className, Icon }) =>
   (): ReactElement => (
     <IconButton
       ariaLabel={label}
@@ -115,8 +116,10 @@ const renderChip =
       onClick={onClick}
       size="small"
       title={label}
+      tooltipEnterDelay={300}
+      tooltipPlacement="left"
     >
-      <IconGraph fontSize="small" />
+      <Icon fontSize="small" />
     </IconButton>
   );
 
@@ -147,12 +150,14 @@ const GraphColumn = ({
     }
 
     const label = isHost ? labelServiceGraphs : labelGraph;
+    const Icon = isHost ? IconSegment : IconGraph;
 
     return (
       <IconColumn>
         <HoverChip
           Chip={renderChip({
             className: classes.button,
+            Icon,
             label,
             onClick: () => onClick(row)
           })}


### PR DESCRIPTION
## Description

Improves the Graph action in the Resources Status listing to make the host-level "Service Graphs" action visually distinct from the service-level "Graph" action.

## Changes

- Use a dedicated icon for the host **Service Graphs** action (Segment icon) so it no longer collides visually with the per-service Graph icon.
- Display the Graph icon tooltip on the **left** with a 300 ms delay, avoiding overlap with adjacent action icons.
- Minor `Button/Icon` support for the tooltip placement.

## Affected files

- `centreon/packages/ui/src/Button/Icon/index.tsx`
- `centreon/www/front_src/src/Resources/Listing/columns/Graph.tsx`

## Scope

Light-mode UI only, no functional/data change.