### PR TITLE
refactor(ui): overlay the filters divider with the listing loader

### DIFF
--- a/centreon/packages/ui/src/Listing/index.tsx
+++ b/centreon/packages/ui/src/Listing/index.tsx
@@ -1,4 +1,4 @@
-import { Box, LinearProgress, Table, TableBody } from '@mui/material';
+import { Box, Divider, LinearProgress, Table, TableBody } from '@mui/material';
 
 import { ListingVariant } from '@centreon/ui-context';
 
@@ -499,11 +499,10 @@ const Listing = <
 
   return (
     <div className="h-full w-full overflow-hidden">
-      {loading && rows.length > 0 && (
-        <LinearProgress className="w-full h-[3px]" />
-      )}
-      {(!loading || (loading && rows.length < 1)) && (
-        <div className="w-full h-[3px]" />
+      {loading && rows.length > 0 ? (
+        <LinearProgress className="w-full h-[1px]" />
+      ) : (
+        <Divider />
       )}
       <div
         className="bg-[none] flex flex-col h-full w-full"

--- a/centreon/packages/ui/src/ListingPage/index.tsx
+++ b/centreon/packages/ui/src/ListingPage/index.tsx
@@ -12,13 +12,11 @@ import ListingSkeleton from './ListingSkeleton';
 const useStyles = makeStyles()((theme) => {
   return {
     filters: {
-      borderBottom: `1px solid ${theme.palette.divider}`,
       margin: theme.spacing(0, 3)
     },
     listing: {
       margin: theme.spacing(0, 3),
-      overflowY: 'auto',
-      paddingTop: theme.spacing(1)
+      overflowY: 'auto'
     },
     page: {
       display: 'grid',


### PR DESCRIPTION
## Description

Collapses the filters/listing boundary and the loading bar into a single line in the shared `ListingPage` / `Listing` components, removing ~20px of dead space between the search row and the action bar.

## Changes

- `ListingPage`: drop the `borderBottom` on the filters block and the `paddingTop` on the listing so they butt directly together.
- `Listing`: keep the `LinearProgress` while data is loading (now sitting right under the filters, reading as both divider and progress indicator), and render a plain MUI `Divider` in the same slot when not loading. Loader thinned to 1px to match the divider thickness.

## Affected files

- `centreon/packages/ui/src/Listing/index.tsx`
- `centreon/packages/ui/src/ListingPage/index.tsx`

## Scope

Shared component — applies to every page that mounts `ListingPage` (Resources Status, Commands, HostGroups, etc.). UI only, no functional/data change.