### PR TITLE
test(e2e): cover upgrade with central broker not linked to cbd (backport 25.10)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade.feature
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade.feature
@@ -5,6 +5,7 @@ Feature: Upgrade platform from major version A to major version B
   @TEST_MON-22198
   Scenario Outline: Administrator performs a platform update procedure
     Given a running platform in major '<major_from>' with '<version_from>' version
+    And the central broker is '<broker_link>' to the cbd daemon
     When administrator updates packages to current version
     And administrator runs the update procedure
     Then monitoring should be up and running after update procedure is complete to current version
@@ -14,6 +15,6 @@ Feature: Upgrade platform from major version A to major version B
     Then Poller configuration should be fully generated
 
     Examples:
-      | major_from | version_from    |
-      | n - 1      | last stable     |
-      | n - 1      | last stable - 1 |
+      | major_from | version_from    | broker_link |
+      | n - 1      | last stable     | linked      |
+      | n - 1      | last stable - 1 | not linked  |

--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
@@ -295,6 +295,23 @@ EOF`,
   }
 );
 
+Given(
+  'the central broker is {string} to the cbd daemon',
+  (brokerLink: string) => {
+    // HA platforms default to the central broker NOT linked to the cbd daemon
+    // (daemon = 0). The upgrade must still locate the broker configuration.
+    if (brokerLink !== 'linked' && brokerLink !== 'not linked') {
+      throw new Error(`Unsupported broker_link value: ${brokerLink}`);
+    }
+    const daemon = brokerLink === 'linked' ? '1' : '0';
+
+    cy.requestOnDatabase({
+      database: 'centreon',
+      query: `UPDATE cfg_centreonbroker SET daemon = '${daemon}' WHERE config_name = 'central-broker-master'`
+    });
+  }
+);
+
 afterEach(() => {
   cy.visitEmptyPage().stopContainer({ name: 'web' });
 });


### PR DESCRIPTION
Backport of [centreon/centreon#10674](https://github.com/centreon/centreon/pull/10674) to `dev-25.10.x` — [MON-201249](https://centreon.atlassian.net/browse/MON-201249).

E2E non-regression test covering a platform upgrade when the central broker is **not linked to the cbd daemon** (`daemon = 0`, the HA default) — the condition behind the upgrade failure of the bug.

The corresponding fix is already merged on `dev-25.10.x` ([#10646](https://github.com/centreon/centreon/pull/10646), [MON-201241](https://centreon.atlassian.net/browse/MON-201241)), so this test guards that fix on 25.10.

Clean cherry-pick (`02-platform-upgrade.feature` parameterized with a `broker_link` column + a step setting `cfg_centreonbroker.daemon`). biome (1.9.4) / gherkin-lint clean on the changed files.


[MON-201249]: https://centreon.atlassian.net/browse/MON-201249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-201241]: https://centreon.atlassian.net/browse/MON-201241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ