### PR TITLE
fix(ci): run cypress in a shell step so e2e spec/tags env vars expand

### DIFF
--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -252,11 +252,6 @@ jobs:
         shell: bash
 
       - name: Cypress end-to-end testing
-        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
-        with:
-          command: pnpm run cypress:run --browser electron --spec "features/**/$FEATURE.feature" --env tags="$TEST_TAGS"
-          install: false
-          working-directory: ${{ env.WORKING_DIRECTORY }}
         env:
           FEATURE: ${{ matrix.feature }}
           TEST_TAGS: ${{ inputs.test_tags }}
@@ -269,6 +264,8 @@ jobs:
           CYPRESS_STABILITY: ${{ inputs.stability }}
           CYPRESS_TARGET_STABILITY: ${{ inputs.target_stability }}
           CYPRESS_IS_CLOUD: ${{ inputs.is_cloud }}
+        run: |
+          pnpm run cypress:run --browser electron --spec "features/**/$FEATURE.feature" --env tags="$TEST_TAGS"
 
       - name: Ensure logs directory exists
         env:


### PR DESCRIPTION
Fixes: [MON-201280](https://centreon.atlassian.net/browse/MON-201280)

## Description

The GHA hardening in #10684 moved the Cypress spec and tags into env vars (`$FEATURE` / `$TEST_TAGS`) but kept them inside `cypress-io/github-action`'s `command:` input. That action tokenizes the command and executes it **without a shell**, so the variables never expanded — every Cypress E2E job on `develop` (centreon-web, open-tickets, awie, …) failed at the run step with:

> Can't run because no spec files were found.
> We searched for specs matching this glob pattern:
> `.../tests/e2e/"features/**/$FEATURE.feature"`

## Fix

Run Cypress in a plain `run:` step instead. The job already defaults `shell: bash` and `working-directory`, so bash expands the env vars at runtime while the dynamic values stay in `env:` (out of the command body) — preserving the template-injection hardening intent of #10684. The `run:` body contains no `${{ }}` interpolation.

Note: the Jira's suggested `bash -c '…'` wrapper would **not** work — the action's `argument-vector` parser preserves the literal quotes, so bash would receive the whole script as one quoted word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-201280]: https://centreon.atlassian.net/browse/MON-201280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ