### PR TITLE
fix(test): awie: remove deleted features path from PHP lint configs (MON-161534)

### DIFF
--- a/centreon-awie/.php-cs-fixer.conf.php
+++ b/centreon-awie/.php-cs-fixer.conf.php
@@ -32,7 +32,6 @@ return [
             'rector.legacy.php',
         ],
         'directories' => [
-            'features',
             'www',
         ],
         'skip' => [],

--- a/centreon-awie/phpstan.legacy.neon
+++ b/centreon-awie/phpstan.legacy.neon
@@ -14,7 +14,6 @@ parameters:
         - rector.legacy.php
 
     paths:
-        - features
         - www
 
     ignoreErrors:

--- a/centreon-awie/rector.conf.php
+++ b/centreon-awie/rector.conf.php
@@ -25,7 +25,6 @@ return [
     'legacy' => [
         'paths' => [
             // directories
-            'features',
             'www',
             // files
             '.php-cs-fixer.conf.php',


### PR DESCRIPTION
## Description

Follow-up to the AWIE E2E pipeline PR (#10693), which removed the legacy Behat `centreon-awie/features/` directory. Three PHP lint/quality configs still referenced that now-deleted path, breaking `backend-lint` on `develop` (PHPStan: `Path .../centreon-awie/features does not exist`).

Removes the `features` entry (keeping `www`) from:
- `centreon-awie/phpstan.legacy.neon` (`paths`) — the one that actually failed
- `centreon-awie/.php-cs-fixer.conf.php` (`directories`)
- `centreon-awie/rector.conf.php` (`paths`)

php-cs-fixer/rector run on the diff so they did not fail on the merge push, but are fixed too to avoid breakage on a full run.

Refs: MON-161534