### PR TITLE
chore(release) bump oss 24.10 2026-06-17

### DIFF
--- a/.version.centreon-web
+++ b/.version.centreon-web
@@ -1,1 +1,1 @@
-MINOR=28
+MINOR=29

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '24.10.28');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '24.10.29');
 
 --
 -- Contenu de la table `contact`


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-201317

REF #https://centreon.atlassian.net/browse/MON-201317

Bump OSS versions to 24.10 (2026-06-17):
- centreon-web: 24.10.29


[MON-201317]: https://centreon.atlassian.net/browse/MON-201317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ