### PR TITLE
chore(release) bump oss 25.10 2026-06-17

### DIFF
--- a/.version.centreon-open-tickets
+++ b/.version.centreon-open-tickets
@@ -1,1 +1,1 @@
-MINOR=8
+MINOR=9

--- a/.version.centreon-web
+++ b/.version.centreon-web
@@ -1,1 +1,1 @@
-MINOR=15
+MINOR=16

--- a/centreon-open-tickets/widgets/open-tickets/configs.xml
+++ b/centreon-open-tickets/widgets/open-tickets/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>This widget is associated to the Open Tickets Module and allows for selecting hosts or services events for which to create tickets in your favorite ITSM tools. This widget can also list already created tickets with their ID and datetime.</description>
-  <version>25.10.8</version>
+  <version>25.10.9</version>
   <keywords>centreon, widget, tickets</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/open-tickets/resources/centreon-logo.png</thumbnail>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-open-tickets']['rname'] = 'Centreon Open Tickets';
 $module_conf['centreon-open-tickets']['name'] = 'centreon-open-tickets';
-$module_conf['centreon-open-tickets']['mod_release'] = '25.10.8';
+$module_conf['centreon-open-tickets']['mod_release'] = '25.10.9';
 $module_conf['centreon-open-tickets']['infos'] = 'Centreon Open Tickets is a community module developed to '
     . "create tickets to your favorite ITSM tools using API.
 
@@ -36,7 +36,7 @@ Regarding the widget configuration, it is possible to see the created tickets by
 $module_conf['centreon-open-tickets']['is_removeable'] = '1';
 $module_conf['centreon-open-tickets']['author'] = 'Centreon';
 $module_conf['centreon-open-tickets']['stability'] = 'stable';
-$module_conf['centreon-open-tickets']['last_update'] = '2026-05-25';
+$module_conf['centreon-open-tickets']['last_update'] = '2026-06-17';
 $module_conf['centreon-open-tickets']['images'] = [
     'images/image1.png',
     'images/image2.png',

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '25.10.15');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '25.10.16');
 
 --
 -- Contenu de la table `contact`


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-201318

Bump OSS versions to 25.10 (2026-06-17):
- centreon-open-tickets: 25.10.9
- centreon-web: 25.10.16
