### PR TITLE
fix(E2E): update password input selector to use type attribute (backport 25.10)

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -259,7 +259,7 @@ Cypress.Commands.add(
         cy.getByLabel({ label: 'Alias', tag: 'input' }).type(
           `{selectAll}{backspace}${credential.login}`
         );
-        cy.getByLabel({ label: 'Password', tag: 'input' }).type(
+        cy.get('input[type="password"]').type(
           `{selectAll}{backspace}${credential.password}`
         );
       })


### PR DESCRIPTION
Backport to **dev-25.10.x** of the login password-input selector fix (PR #9077), cherry-picked from develop (commit 70cc3ae4b).

Replaces the language-dependent `getByLabel({ label: 'Password' })` selector with `input[type="password"]` so the login E2E command no longer fails on FR-locale environments.

Refs: MON-201348