### PR TITLE
fix(service): improve input handling in service and servicegroup screens

### DIFF
--- a/centreon/lib/Centreon/Object/Relation/Service/Template/Host.php
+++ b/centreon/lib/Centreon/Object/Relation/Service/Template/Host.php
@@ -89,15 +89,23 @@ class Centreon_Object_Relation_Service_Template_Host extends Centreon_Object_Rel
         if (! isset($this->firstObject) || ! isset($this->secondObject)) {
             throw new Exception('Unsupported method on this object');
         }
+        $identifierPattern = '/^[a-zA-Z_][a-zA-Z0-9_.]*$/';
+
         $fString = '';
         $sString = '';
         foreach ($firstTableParams as $fparams) {
+            if (preg_match($identifierPattern, $fparams) !== 1) {
+                throw new Exception('Invalid column name');
+            }
             if ($fString != '') {
                 $fString .= ',';
             }
             $fString .= 'h.' . $fparams;
         }
         foreach ($secondTableParams as $sparams) {
+            if (preg_match($identifierPattern, $sparams) !== 1) {
+                throw new Exception('Invalid column name');
+            }
             if ($fString != '' || $sString != '') {
                 $sString .= ',';
             }
@@ -110,14 +118,21 @@ class Centreon_Object_Relation_Service_Template_Host extends Centreon_Object_Rel
         $filterTab = [];
         if (count($filters)) {
             foreach ($filters as $key => $rawvalue) {
-                $sql .= " {$filterType} {$key} LIKE ? ";
+                if (preg_match($identifierPattern, $key) !== 1) {
+                    throw new Exception('Invalid filter key');
+                }
+                $safeFilterType = strtoupper($filterType) === 'AND' ? 'AND' : 'OR';
+                $sql .= " {$safeFilterType} {$key} LIKE ? ";
                 $value = trim($rawvalue);
                 $value = str_replace('_', "\_", $value);
                 $value = str_replace(' ', "\ ", $value);
                 $filterTab[] = $value;
             }
         }
-        if (isset($order, $sort)   && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+        if (isset($order, $sort) && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
+            if (preg_match($identifierPattern, $order) !== 1) {
+                throw new Exception('Invalid order column');
+            }
             $sql .= " ORDER BY {$order} {$sort} ";
         }
         if (isset($count) && $count != -1) {

--- a/centreon/src/Centreon/Infrastructure/CentreonLegacyDB/ServiceEntityRepository.php
+++ b/centreon/src/Centreon/Infrastructure/CentreonLegacyDB/ServiceEntityRepository.php
@@ -119,6 +119,15 @@ abstract class ServiceEntityRepository
      */
     protected function updateRelationData(array $list, int $id, string $tableName, string $columnA, string $columnB)
     {
+        $identifierPattern = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
+        if (
+            preg_match($identifierPattern, $tableName) !== 1
+            || preg_match($identifierPattern, $columnA) !== 1
+            || preg_match($identifierPattern, $columnB) !== 1
+        ) {
+            throw new \InvalidArgumentException('Invalid SQL identifier');
+        }
+
         $listExists = [];
         $listAdd = [];
         $listRemove = [];

--- a/centreon/src/Core/Infrastructure/RealTime/Repository/Service/DbReadServiceRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/Service/DbReadServiceRepository.php
@@ -58,11 +58,19 @@ class DbReadServiceRepository extends AbstractRepositoryDRB implements ReadServi
             return null;
         }
 
+        $bindValues = [];
+        $tokens = [];
+        foreach ($accessGroupIds as $index => $groupId) {
+            $key = ':acl_group_' . $index;
+            $tokens[] = $key;
+            $bindValues[$key] = (int) $groupId;
+        }
+
         $accessGroupRequest = ' INNER JOIN `:dbstg`.`centreon_acl` AS service_acl
             ON service_acl.service_id = s.service_id AND service_acl.host_id = s.host_id
-            AND service_acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+            AND service_acl.group_id IN (' . implode(',', $tokens) . ') ';
 
-        return $this->findService($hostId, $serviceId, $accessGroupRequest);
+        return $this->findService($hostId, $serviceId, $accessGroupRequest, $bindValues);
     }
 
     /**
@@ -74,12 +82,20 @@ class DbReadServiceRepository extends AbstractRepositoryDRB implements ReadServi
             return false;
         }
 
+        $bindValues = [];
+        $tokens = [];
+        foreach ($accessGroupIds as $index => $groupId) {
+            $key = ':acl_group_' . $index;
+            $tokens[] = $key;
+            $bindValues[$key] = (int) $groupId;
+        }
+
         $request = '
             SELECT COUNT(s.service_id) AS total, 1 AS REALTIME
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`centreon_acl` AS service_acl
             ON service_acl.service_id = s.service_id AND service_acl.host_id = s.host_id
-            AND service_acl.group_id IN (' . implode(',', $accessGroupIds) . ')
+            AND service_acl.group_id IN (' . implode(',', $tokens) . ')
             WHERE s.service_id = :service_id AND s.host_id = :host_id AND s.enabled = 1
         ';
 
@@ -87,6 +103,9 @@ class DbReadServiceRepository extends AbstractRepositoryDRB implements ReadServi
 
         $statement->bindValue(':service_id', $serviceId, \PDO::PARAM_INT);
         $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+        foreach ($bindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
 
         $statement->execute();
 
@@ -97,10 +116,11 @@ class DbReadServiceRepository extends AbstractRepositoryDRB implements ReadServi
      * @param int $hostId
      * @param int $serviceId
      * @param string|null $accessGroupRequest
+     * @param array<string, int> $additionalBindValues
      *
      * @return Service|null
      */
-    private function findService(int $hostId, int $serviceId, ?string $accessGroupRequest = null): ?Service
+    private function findService(int $hostId, int $serviceId, ?string $accessGroupRequest = null, array $additionalBindValues = []): ?Service
     {
         $request = "SELECT
                 1 AS REALTIME,
@@ -151,6 +171,9 @@ class DbReadServiceRepository extends AbstractRepositoryDRB implements ReadServi
 
         $statement->bindValue(':service_id', $serviceId, \PDO::PARAM_INT);
         $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+        foreach ($additionalBindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
 
         $statement->execute();
 

--- a/centreon/src/Core/Infrastructure/RealTime/Repository/Servicegroup/DbReadServicegroupRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/Servicegroup/DbReadServicegroupRepository.php
@@ -60,22 +60,31 @@ class DbReadServicegroupRepository extends AbstractRepositoryDRB implements Read
             return $servicegroups;
         }
 
+        $bindValues = [];
+        $tokens = [];
+        foreach ($accessGroupIds as $index => $groupId) {
+            $key = ':acl_group_' . $index;
+            $tokens[] = $key;
+            $bindValues[$key] = (int) $groupId;
+        }
+
         $aclRequest = ' INNER JOIN `:dbstg`.`centreon_acl` AS acl
             ON acl.host_id = ssg.host_id
             AND acl.service_id = ssg.service_id
-            AND acl.group_id IN (' . implode(',', $accessGroupIds) . ') ';
+            AND acl.group_id IN (' . implode(',', $tokens) . ') ';
 
-        return $this->findServicegroups($hostId, $serviceId, $aclRequest);
+        return $this->findServicegroups($hostId, $serviceId, $aclRequest, $bindValues);
     }
 
     /**
      * @param int $hostId
      * @param int $serviceId
      * @param string|null $aclRequest
+     * @param array<string, int> $additionalBindValues
      *
      * @return Servicegroup[]
      */
-    private function findServicegroups(int $hostId, int $serviceId, ?string $aclRequest = null): array
+    private function findServicegroups(int $hostId, int $serviceId, ?string $aclRequest = null, array $additionalBindValues = []): array
     {
         $request = 'SELECT DISTINCT 1 AS REALTIME, sg.servicegroup_id, sg.name AS `servicegroup_name`
             FROM `:dbstg`.`services_servicegroups` AS ssg
@@ -90,6 +99,9 @@ class DbReadServicegroupRepository extends AbstractRepositoryDRB implements Read
         $statement = $this->db->prepare($this->translateDbName($request));
         $statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
         $statement->bindValue(':serviceId', $serviceId, \PDO::PARAM_INT);
+        foreach ($additionalBindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
         $statement->execute();
 
         $servicegroups = [];

--- a/centreon/www/class/centreonPerformanceService.class.php
+++ b/centreon/www/class/centreonPerformanceService.class.php
@@ -60,24 +60,43 @@ class CentreonPerformanceService
         $serviceDescription = isset($filters['service']) === false ? '' : $filters['service'];
 
         if (isset($filters['page_limit'], $filters['page'])) {
-            $limit = ($filters['page'] - 1) * $filters['page_limit'];
-            $range = 'LIMIT ' . $limit . ',' . $filters['page_limit'];
+            $limit = (int) (($filters['page'] - 1) * $filters['page_limit']);
+            $range = 'LIMIT ' . $limit . ',' . (int) $filters['page_limit'];
         } else {
             $range = '';
         }
 
-        if (isset($filters['hostgroup'])) {
+        $filterBindValues = [];
+        if (isset($filters['hostgroup']) && $filters['hostgroup'] !== []) {
+            $hgTokens = [];
+            foreach ($filters['hostgroup'] as $idx => $hgId) {
+                $key = ':hg_' . $idx;
+                $hgTokens[] = $key;
+                $filterBindValues[$key] = (int) $hgId;
+            }
             $additionnalTables .= ',hosts_hostgroups hg ';
             $additionnalCondition .= 'AND (hg.host_id = i.host_id AND hg.hostgroup_id IN ('
-                . implode(',', array_map(intval(...), $filters['hostgroup'])) . ')) ';
+                . implode(',', $hgTokens) . ')) ';
         }
-        if (isset($filters['servicegroup'])) {
+        if (isset($filters['servicegroup']) && $filters['servicegroup'] !== []) {
+            $sgTokens = [];
+            foreach ($filters['servicegroup'] as $idx => $sgId) {
+                $key = ':sg_' . $idx;
+                $sgTokens[] = $key;
+                $filterBindValues[$key] = (int) $sgId;
+            }
             $additionnalTables .= ',services_servicegroups sg ';
             $additionnalCondition .= 'AND (sg.host_id = i.host_id AND sg.service_id = i.service_id '
-                . 'AND sg.servicegroup_id IN (' . implode(',', array_map(intval(...), $filters['servicegroup'])) . ')) ';
+                . 'AND sg.servicegroup_id IN (' . implode(',', $sgTokens) . ')) ';
         }
-        if (isset($filters['host'])) {
-            $additionnalCondition .= 'AND i.host_id IN (' . implode(',', array_map(intval(...), $filters['host'])) . ') ';
+        if (isset($filters['host']) && $filters['host'] !== []) {
+            $hostTokens = [];
+            foreach ($filters['host'] as $idx => $hostId) {
+                $key = ':host_' . $idx;
+                $hostTokens[] = $key;
+                $filterBindValues[$key] = (int) $hostId;
+            }
+            $additionnalCondition .= 'AND i.host_id IN (' . implode(',', $hostTokens) . ') ';
         }
 
         $virtualServicesCondition = $this->getVirtualServicesCondition($additionnalCondition);
@@ -103,9 +122,12 @@ class CentreonPerformanceService
 
         $stmt = $this->dbMon->prepare($query);
         $stmt->bindValue(':serviceDesc', '%' . $serviceDescription . '%');
+        foreach ($filterBindValues as $key => $value) {
+            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+        }
         $stmt->execute();
         $serviceList = [];
-        while ($data = $stmt->fetch()) {
+        while ($data = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $serviceCompleteName = $data['fullname'];
             $serviceCompleteId = $data['host_id'] . '-' . $data['service_id'];
             $serviceList[] = ['id' => $serviceCompleteId, 'text' => $serviceCompleteName];

--- a/centreon/www/class/centreonPerformanceService.class.php
+++ b/centreon/www/class/centreonPerformanceService.class.php
@@ -99,13 +99,13 @@ class CentreonPerformanceService
             $additionnalCondition .= 'AND i.host_id IN (' . implode(',', $hostTokens) . ') ';
         }
 
-        $virtualServicesCondition = $this->getVirtualServicesCondition($additionnalCondition);
+        $virtualServicesCondition = $this->getVirtualServicesCondition($additionnalCondition, $additionnalTables);
 
         $query = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT fullname, host_id, service_id, index_id '
             . 'FROM ( '
             . '( SELECT CONCAT(i.host_name, " - ", i.service_description) as fullname, '
             . 'i.host_id, i.service_id, m.index_id '
-            . 'FROM index_data i, metrics m ' . (! $this->aclObj->admin ? ', centreon_acl acl ' : '')
+            . 'FROM index_data i, metrics m ' . $additionnalTables . (! $this->aclObj->admin ? ', centreon_acl acl ' : '')
             . 'WHERE i.id = m.index_id '
             . 'AND i.host_name NOT LIKE "\_Module\_%" '
             . (! $this->aclObj->admin
@@ -138,10 +138,11 @@ class CentreonPerformanceService
 
     /**
      * @param string $additionnalCondition
+     * @param string $additionnalTables
      *
      * @return string
      */
-    private function getVirtualServicesCondition($additionnalCondition)
+    private function getVirtualServicesCondition($additionnalCondition, $additionnalTables = '')
     {
         // First, get virtual services for metaservices
         $metaServiceCondition = '';
@@ -162,7 +163,7 @@ class CentreonPerformanceService
 
         $virtualServicesCondition = 'UNION ALL ('
             . 'SELECT CONCAT("Meta - ", s.display_name) as fullname, i.host_id, i.service_id, m.index_id '
-            . 'FROM index_data i, metrics m, services s '
+            . 'FROM index_data i, metrics m, services s ' . $additionnalTables
             . 'WHERE i.id = m.index_id '
             . $additionnalCondition
             . $metaServiceCondition
@@ -177,7 +178,7 @@ class CentreonPerformanceService
                     $virtualServicesCondition .= 'UNION ALL ('
                         . 'SELECT CONCAT("' . $hostname . ' - ", s.display_name) as fullname, i.host_id, '
                         . 'i.service_id, m.index_id '
-                        . 'FROM index_data i, metrics m, services s '
+                        . 'FROM index_data i, metrics m, services s ' . $additionnalTables
                         . 'WHERE i.id = m.index_id '
                         . $additionnalCondition
                         . 'AND s.service_id IN (' . implode(',', $virtualServiceIds) . ') '

--- a/centreon/www/class/centreonPerformanceService.class.php
+++ b/centreon/www/class/centreonPerformanceService.class.php
@@ -69,15 +69,15 @@ class CentreonPerformanceService
         if (isset($filters['hostgroup'])) {
             $additionnalTables .= ',hosts_hostgroups hg ';
             $additionnalCondition .= 'AND (hg.host_id = i.host_id AND hg.hostgroup_id IN ('
-                . implode(',', $filters['hostgroup']) . ')) ';
+                . implode(',', array_map(intval(...), $filters['hostgroup'])) . ')) ';
         }
         if (isset($filters['servicegroup'])) {
             $additionnalTables .= ',services_servicegroups sg ';
             $additionnalCondition .= 'AND (sg.host_id = i.host_id AND sg.service_id = i.service_id '
-                . 'AND sg.servicegroup_id IN (' . implode(',', $filters['servicegroup']) . ')) ';
+                . 'AND sg.servicegroup_id IN (' . implode(',', array_map(intval(...), $filters['servicegroup'])) . ')) ';
         }
         if (isset($filters['host'])) {
-            $additionnalCondition .= 'AND i.host_id IN (' . implode(',', $filters['host']) . ') ';
+            $additionnalCondition .= 'AND i.host_id IN (' . implode(',', array_map(intval(...), $filters['host'])) . ') ';
         }
 
         $virtualServicesCondition = $this->getVirtualServicesCondition($additionnalCondition);
@@ -96,14 +96,16 @@ class CentreonPerformanceService
             . ') '
             . $virtualServicesCondition
             . ') as t_union '
-            . 'WHERE fullname LIKE "%' . $serviceDescription . '%" '
+            . 'WHERE fullname LIKE :serviceDesc '
             . 'GROUP BY host_id, service_id '
             . 'ORDER BY fullname '
             . $range;
 
-        $DBRESULT = $this->dbMon->query($query);
+        $stmt = $this->dbMon->prepare($query);
+        $stmt->bindValue(':serviceDesc', '%' . $serviceDescription . '%');
+        $stmt->execute();
         $serviceList = [];
-        while ($data = $DBRESULT->fetchRow()) {
+        while ($data = $stmt->fetch()) {
             $serviceCompleteName = $data['fullname'];
             $serviceCompleteId = $data['host_id'] . '-' . $data['service_id'];
             $serviceList[] = ['id' => $serviceCompleteId, 'text' => $serviceCompleteName];

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -393,19 +393,25 @@ class CentreonService
         preg_match_all($pattern, $string, $matches);
         $i = 0;
         while (isset($matches[1][$i])) {
-            $rq = "SELECT svc_macro_value
-                FROM on_demand_macro_service
-                WHERE svc_svc_id = '" . $svc_id . "' AND svc_macro_name LIKE '" . $matches[1][$i] . "'";
-            $DBRES = $this->db->query($rq);
-            while ($row = $DBRES->fetchRow()) {
+            $stmt = $this->db->prepare(
+                'SELECT svc_macro_value FROM on_demand_macro_service
+                WHERE svc_svc_id = :svcId AND svc_macro_name LIKE :macroName'
+            );
+            $stmt->bindValue(':svcId', (int) $svc_id, PDO::PARAM_INT);
+            $stmt->bindValue(':macroName', $matches[1][$i]);
+            $stmt->execute();
+            while ($row = $stmt->fetch()) {
                 $string = str_replace($matches[1][$i], $row['svc_macro_value'], $string);
             }
             $i++;
         }
         if ($i) {
-            $rq2 = "SELECT service_template_model_stm_id FROM service WHERE service_id = '" . $svc_id . "'";
-            $DBRES2 = $this->db->query($rq2);
-            while ($row2 = $DBRES2->fetchRow()) {
+            $stmt2 = $this->db->prepare(
+                'SELECT service_template_model_stm_id FROM service WHERE service_id = :svcId'
+            );
+            $stmt2->bindValue(':svcId', (int) $svc_id, PDO::PARAM_INT);
+            $stmt2->execute();
+            while ($row2 = $stmt2->fetch()) {
                 if (! isset($antiLoop) || ! $antiLoop) {
                     $string = $this->replaceMacroInString(
                         $row2['service_template_model_stm_id'],
@@ -1431,7 +1437,7 @@ class CentreonService
         $rq .= '(service_service_id, esi_notes, esi_notes_url, esi_action_url, esi_icon_image,
             esi_icon_image_alt, graph_id) ';
         $rq .= 'VALUES ';
-        $rq .= "('" . $aDatas['service_service_id'] . "', ";
+        $rq .= "('" . (int) $aDatas['service_service_id'] . "', ";
         isset($aDatas['esi_notes']) ? $rq .= "'" . CentreonDB::escape($aDatas['esi_notes']) . "'," : $rq .= 'NULL, ';
         isset($aDatas['esi_notes_url'])
             ? $rq .= "'" . CentreonDB::escape($aDatas['esi_notes_url']) . "'," : $rq .= 'NULL, ';
@@ -1583,7 +1589,7 @@ class CentreonService
         $rq .= 'service_activate = ';
         isset($ret['service_activate']['service_activate']) && $ret['service_activate']['service_activate'] != null
             ? $rq .= "'" . $ret['service_activate']['service_activate'] . "' " : $rq .= 'NULL ';
-        $rq .= "WHERE service_id = '" . $service_id . "'";
+        $rq .= 'WHERE service_id = ' . (int) $service_id;
 
         $DBRESULT = $this->db->query($rq);
 
@@ -1613,7 +1619,7 @@ class CentreonService
 
         if ($updateFields !== []) {
             $query .= implode(',', $updateFields)
-                . 'WHERE service_service_id = "' . $service_id . '" ';
+                . 'WHERE service_service_id = ' . (int) $service_id . ' ';
             try {
                 $this->db->query($query);
             } catch (PDOException $e) {

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -395,7 +395,7 @@ class CentreonService
         while (isset($matches[1][$i])) {
             $stmt = $this->db->prepare(
                 'SELECT svc_macro_value FROM on_demand_macro_service
-                WHERE svc_svc_id = :svcId AND svc_macro_name LIKE :macroName'
+                WHERE svc_svc_id = :svcId AND svc_macro_name = :macroName'
             );
             $stmt->bindValue(':svcId', (int) $svc_id, PDO::PARAM_INT);
             $stmt->bindValue(':macroName', $matches[1][$i]);

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -400,7 +400,7 @@ class CentreonService
             $stmt->bindValue(':svcId', (int) $svc_id, PDO::PARAM_INT);
             $stmt->bindValue(':macroName', $matches[1][$i]);
             $stmt->execute();
-            while ($row = $stmt->fetch()) {
+            while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                 $string = str_replace($matches[1][$i], $row['svc_macro_value'], $string);
             }
             $i++;
@@ -411,7 +411,7 @@ class CentreonService
             );
             $stmt2->bindValue(':svcId', (int) $svc_id, PDO::PARAM_INT);
             $stmt2->execute();
-            while ($row2 = $stmt2->fetch()) {
+            while ($row2 = $stmt2->fetch(PDO::FETCH_ASSOC)) {
                 if (! isset($antiLoop) || ! $antiLoop) {
                     $string = $this->replaceMacroInString(
                         $row2['service_template_model_stm_id'],

--- a/centreon/www/class/centreonServicegroups.class.php
+++ b/centreon/www/class/centreonServicegroups.class.php
@@ -74,7 +74,7 @@ class CentreonServicegroups
         $stmt->bindValue(':sgId', (int) $sgId, PDO::PARAM_INT);
         $stmt->bindValue(':sgId2', (int) $sgId, PDO::PARAM_INT);
         $stmt->execute();
-        while ($row = $stmt->fetch()) {
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $services[] = [$row['host_host_id'], $row['service_service_id']];
         }
 

--- a/centreon/www/class/centreonServicegroups.class.php
+++ b/centreon/www/class/centreonServicegroups.class.php
@@ -60,21 +60,23 @@ class CentreonServicegroups
         $services = [];
         $query = 'SELECT host_host_id, service_service_id '
             . 'FROM servicegroup_relation '
-            . 'WHERE servicegroup_sg_id = ' . $sgId . ' '
+            . 'WHERE servicegroup_sg_id = :sgId '
             . 'AND host_host_id IS NOT NULL '
             . 'UNION '
             . 'SELECT hgr.host_host_id, hsr.service_service_id '
             . 'FROM servicegroup_relation sgr, host_service_relation hsr, hostgroup_relation hgr '
-            . 'WHERE sgr.servicegroup_sg_id = ' . $sgId . ' '
+            . 'WHERE sgr.servicegroup_sg_id = :sgId2 '
             . 'AND sgr.hostgroup_hg_id = hsr.hostgroup_hg_id '
             . 'AND hsr.service_service_id = sgr.service_service_id '
             . 'AND sgr.hostgroup_hg_id = hgr.hostgroup_hg_id ';
 
-        $res = $this->DB->query($query);
-        while ($row = $res->fetchRow()) {
+        $stmt = $this->DB->prepare($query);
+        $stmt->bindValue(':sgId', (int) $sgId, PDO::PARAM_INT);
+        $stmt->bindValue(':sgId2', (int) $sgId, PDO::PARAM_INT);
+        $stmt->execute();
+        while ($row = $stmt->fetch()) {
             $services[] = [$row['host_host_id'], $row['service_service_id']];
         }
-        $res->closeCursor();
 
         return $services;
     }

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -41,16 +41,23 @@ if (isset($_POST['searchMS']) || isset($_GET['searchMS'])) {
 }
 
 // Meta Service list
+$searchBindValues = [];
 $rq = 'SELECT SQL_CALC_FOUND_ROWS * FROM meta_service ';
 if ($search) {
-    $rq .= "WHERE meta_name LIKE '%" . $search . "%' "
+    $rq .= 'WHERE meta_name LIKE :searchName '
         . $acl->queryBuilder('AND', 'meta_id', $metaStr);
+    $searchBindValues[':searchName'] = '%' . $search . '%';
 } else {
     $rq .= $acl->queryBuilder('WHERE', 'meta_id', $metaStr);
 }
-$rq .= ' ORDER BY meta_name LIMIT ' . $num * $limit . ', ' . $limit;
+$rq .= ' ORDER BY meta_name LIMIT ' . (int) ($num * $limit) . ', ' . (int) $limit;
 
-$dbResult = $pearDB->query($rq);
+$stmt = $pearDB->prepare($rq);
+foreach ($searchBindValues as $param => $value) {
+    $stmt->bindValue($param, $value);
+}
+$stmt->execute();
+$dbResult = $stmt;
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 
 include './include/common/checkPagination.php';

--- a/centreon/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/centreon/www/include/configuration/configObject/service/listServiceByHost.php
@@ -78,16 +78,19 @@ if (isset($_POST['search']) || isset($_GET['search'])) {
 }
 
 $searchH_SQL = '';
+$searchBindValues = [];
 if ($searchH) {
-    $searchH_SQL .= "AND (host.host_name LIKE '%" . $pearDB->escape($searchH)
-        . "%' OR host_alias LIKE '%" . $pearDB->escape($searchH) . "%' OR host_address LIKE '%"
-        . $pearDB->escape($searchH) . "%')";
+    $searchH_SQL = 'AND (host.host_name LIKE :searchH1 OR host_alias LIKE :searchH2 OR host_address LIKE :searchH3)';
+    $searchBindValues[':searchH1'] = '%' . $searchH . '%';
+    $searchBindValues[':searchH2'] = '%' . $searchH . '%';
+    $searchBindValues[':searchH3'] = '%' . $searchH . '%';
 }
 
 $searchS_SQL = '';
 if ($searchS) {
-    $searchS_SQL .= "AND (sv.service_alias LIKE '%" . $pearDB->escape($searchS)
-        . "%' OR sv.service_description LIKE '%" . $pearDB->escape($searchS) . "%')";
+    $searchS_SQL = 'AND (sv.service_alias LIKE :searchS1 OR sv.service_description LIKE :searchS2)';
+    $searchBindValues[':searchS1'] = '%' . $searchS . '%';
+    $searchBindValues[':searchS2'] = '%' . $searchS . '%';
 }
 
 // Host Status Filter
@@ -167,17 +170,27 @@ $rq_body = $queryFieldsToSelect
     . $queryWhereClause
     . ' ORDER BY host.host_name, service_description';
 
-$dbResult = $pearDB->query(
+$stmt = $pearDB->prepare(
     'SELECT SQL_CALC_FOUND_ROWS ' . $distinct . $rq_body
-    . ' LIMIT ' . $num * $limit . ', ' . $limit
+    . ' LIMIT ' . (int) ($num * $limit) . ', ' . (int) $limit
 );
+foreach ($searchBindValues as $param => $value) {
+    $stmt->bindValue($param, $value);
+}
+$stmt->execute();
+$dbResult = $stmt;
 
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 
 if (! ($dbResult->rowCount())) {
-    $dbResult = $pearDB->query(
-        'SELECT ' . $distinct . $rq_body . ' LIMIT ' . (floor($rows / $limit) * $limit) . ', ' . $limit
+    $stmt2 = $pearDB->prepare(
+        'SELECT ' . $distinct . $rq_body . ' LIMIT ' . (int) (floor($rows / $limit) * $limit) . ', ' . (int) $limit
     );
+    foreach ($searchBindValues as $param => $value) {
+        $stmt2->bindValue($param, $value);
+    }
+    $stmt2->execute();
+    $dbResult = $stmt2;
 }
 
 include './include/common/checkPagination.php';

--- a/centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+++ b/centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
@@ -76,7 +76,7 @@ if (isset($_GET['cmdId'], $_GET['svcId'], $_GET['svcTplId'], $_GET['o'])) {
             );
             $stmt4->bindValue(':svcTplId', (int) $svcTplId, PDO::PARAM_INT);
             $stmt4->execute();
-            $row4 = $stmt4->fetch();
+            $row4 = $stmt4->fetch(PDO::FETCH_ASSOC);
             if (isset($row4['command_command_id']) && $row4['command_command_id']) {
                 $cmdId = $row4['command_command_id'];
                 break;

--- a/centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+++ b/centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
@@ -69,11 +69,14 @@ if (isset($_GET['cmdId'], $_GET['svcId'], $_GET['svcTplId'], $_GET['o'])) {
     $tab = [];
     if (! $cmdId && $svcTplId) {
         while (1) {
-            $query4 = "SELECT service_template_model_stm_id, command_command_id, command_command_id_arg 
-                            FROM `service` 
-                            WHERE service_id = '" . $svcTplId . "'";
-            $res4 = $db->query($query4);
-            $row4 = $res4->fetchRow();
+            $stmt4 = $db->prepare(
+                'SELECT service_template_model_stm_id, command_command_id, command_command_id_arg
+                FROM `service`
+                WHERE service_id = :svcTplId'
+            );
+            $stmt4->bindValue(':svcTplId', (int) $svcTplId, PDO::PARAM_INT);
+            $stmt4->execute();
+            $row4 = $stmt4->fetch();
             if (isset($row4['command_command_id']) && $row4['command_command_id']) {
                 $cmdId = $row4['command_command_id'];
                 break;

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -38,23 +38,30 @@ if (isset($_POST['searchSC']) || isset($_GET['searchSC'])) {
     $search = $centreon->historySearch[$url]['search'] ?? null;
 }
 
-$searchTool = null;
+$searchTool = '';
+$searchBindValues = [];
 if ($search) {
-    $searchTool .= "WHERE (sc_name LIKE '%" . $search . "%' "
-    . "OR sc_description LIKE '%" . $search . "%') ";
+    $searchTool = 'WHERE (sc_name LIKE :searchName OR sc_description LIKE :searchDesc) ';
+    $searchBindValues[':searchName'] = '%' . $search . '%';
+    $searchBindValues[':searchDesc'] = '%' . $search . '%';
 }
 
 $aclCond = '';
 if (! $oreon->user->admin && $scString != "''") {
-    $clause = is_null($searchTool) ? ' WHERE ' : ' AND ';
+    $clause = $searchTool === '' ? ' WHERE ' : ' AND ';
     $aclCond .= $acl->queryBuilder($clause, 'sc_id', $scString);
 }
 
 // Services Categories Lists
-$dbResult = $pearDB->query(
+$stmt = $pearDB->prepare(
     'SELECT SQL_CALC_FOUND_ROWS * FROM service_categories ' . $searchTool . $aclCond
-    . 'ORDER BY sc_name LIMIT ' . $num * $limit . ', ' . $limit
+    . 'ORDER BY sc_name LIMIT ' . (int) ($num * $limit) . ', ' . (int) $limit
 );
+foreach ($searchBindValues as $param => $value) {
+    $stmt->bindValue($param, $value);
+}
+$stmt->execute();
+$dbResult = $stmt;
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 
 include './include/common/checkPagination.php';

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
@@ -54,12 +54,19 @@ $rq .= ' WHERE ((SELECT DISTINCT COUNT(*)
                     FROM dependency_servicegroupChild_relation dsgpr
                     WHERE dsgpr.dependency_dep_id = dep.dep_id ' . $aclCond . ') > 0)';
 // Search Case
+$searchBindValues = [];
 if ($search) {
-    $rq .= " AND (dep_name LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8')
-        . "%' OR dep_description LIKE '%" . htmlentities($search, ENT_QUOTES, 'UTF-8') . "%')";
+    $rq .= ' AND (dep_name LIKE :searchName OR dep_description LIKE :searchDesc)';
+    $searchBindValues[':searchName'] = '%' . $search . '%';
+    $searchBindValues[':searchDesc'] = '%' . $search . '%';
 }
-$rq .= ' ORDER BY dep_name, dep_description LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($rq);
+$rq .= ' ORDER BY dep_name, dep_description LIMIT ' . (int) ($num * $limit) . ', ' . (int) $limit;
+$stmt = $pearDB->prepare($rq);
+foreach ($searchBindValues as $param => $value) {
+    $stmt->bindValue($param, $value);
+}
+$stmt->execute();
+$dbResult = $stmt;
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 
 include './include/common/checkPagination.php';

--- a/centreon/www/include/monitoring/status/Services/service.php
+++ b/centreon/www/include/monitoring/status/Services/service.php
@@ -574,9 +574,9 @@ $tpl->display('service.ihtml');
     function preInit() {
         _keyPrefix = '<?= $keyPrefix; ?>';
         _tm = <?= $tM; ?>;
-        _o = '<?= $o; ?>';
+        _o = '<?= htmlspecialchars($o, ENT_QUOTES, 'UTF-8'); ?>';
         _defaultStatusFilter = '<?=  htmlspecialchars($defaultStatusFilter, ENT_QUOTES, 'UTF-8'); ?>';
-        _defaultStatusService = '<?= $defaultStatusService; ?>';
+        _defaultStatusService = '<?= htmlspecialchars($defaultStatusService, ENT_QUOTES, 'UTF-8'); ?>';
         sSetOrderInMemory = '<?= $sSetOrderInMemory; ?>';
 
         if (_defaultStatusService !== '') {


### PR DESCRIPTION
## Description

Improve input handling across service and servicegroup configuration and monitoring screens.

Changes include:
- Use prepared statements with bind parameters for search queries (LIKE clauses)
- Parameterize ID values in WHERE clauses instead of string concatenation
- Use named bind tokens for IN() clauses instead of raw array interpolation
- Add empty array guards to prevent invalid `IN ()` SQL syntax
- Use explicit `FETCH_ASSOC` mode on all prepared statement fetch calls
- Validate SQL identifiers with regex in ORM layer
- Escape JS output with `htmlspecialchars()` in monitoring service status page
- Cast LIMIT values to `(int)` for pagination queries

Fixes: [MON-200892](https://centreon.atlassian.net/browse/MON-200892)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

- Navigate to Configuration > Services > Services by Host: verify search works, pagination works, no SQL errors
- Navigate to Configuration > Services > Meta Services: verify search filtering
- Navigate to Configuration > Services > Categories: verify search and listing
- Navigate to Configuration > Notifications > Servicegroups: verify dependency listing with search
- Navigate to Monitoring > Status Details > Services: verify JS variables are properly escaped (inspect source)
- Verify that empty filter arrays (e.g. empty hostgroup filter in performance service API) do not cause SQL errors

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-200892]: https://centreon.atlassian.net/browse/MON-200892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ