### PR TITLE
fix(agent-configuration): handle empty CMA certificate columns as null

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
@@ -186,8 +186,8 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
             ->setParameter('poller_id', $poller->id()->value);
 
         $row = $qb->executeQuery()->fetchAssociative() ?: [];
-        $certSha = $row['certificate_sha'] ?? null;
-        $certCn = $row['certificate_cn'] ?? null;
+        $certSha = ($row['certificate_sha'] ?? '') !== '' ? $row['certificate_sha'] : null;
+        $certCn = ($row['certificate_cn'] ?? '') !== '' ? $row['certificate_cn'] : null;
         $poller->addPollerCMACertificates(
             new PollerCMACertificates(
                 certificateSha: is_string($certSha) ? new CMACertificateSHA($certSha) : null,


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/10723 to dev-25.10.x

