### PR TITLE
fix(agent-configuration): handle empty CMA certificate columns as null

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
@@ -372,8 +372,8 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
             ->setParameter('poller_id', $poller->id()->value);
 
         $row = $qb->executeQuery()->fetchAssociative() ?: [];
-        $certSha = $row['certificate_sha'] ?? null;
-        $certCn = $row['certificate_cn'] ?? null;
+        $certSha = ($row['certificate_sha'] ?? '') !== '' ? $row['certificate_sha'] : null;
+        $certCn = ($row['certificate_cn'] ?? '') !== '' ? $row['certificate_cn'] : null;
         $poller->addPollerCMACertificates(
             new PollerCMACertificates(
                 certificateSha: is_string($certSha) ? new CMACertificateSHA($certSha) : null,


### PR DESCRIPTION
## Description

The agent installation-command endpoint (`GET /api/latest/configuration/agent-configurations/installation-command/{pollerId}`) failed with `Expected a value to contain between 1 and 255 characters. Got: ""` when a poller's `instances.cma_certificate_sha` / `cma_certificate_cn` columns held empty strings (`''`) instead of `NULL`.

In `DbalPollerRepository::loadCmaCertificates()` the certificate values were guarded only by `is_string(...)`. An empty string is still a string, so it was passed into the `CMACertificateSHA` / `CMACertificateCN` value objects, whose constructors assert a 1–255 character length — raising the error.

This change normalizes empty strings to `null` before constructing the value objects, so empty certificates are treated as absent (matching the existing `NULL` handling and the install-command factory's null guards).

Not a regression: the faulty guard has existed since the feature was introduced (#10170, 25.10).

> Note: no unit test added — the affected method reads directly from the DB and has no existing test harness (`DbalPollerRepository` is not unit-tested). Existing provider/factory tests are unaffected.

Fixes: [MON-201387](https://centreon.atlassian.net/browse/MON-201387)

[MON-201387]: https://centreon.atlassian.net/browse/MON-201387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ