### PR TITLE
fix(saml): send the authenticated NameID (+ format/qualifiers/SessionIndex) in the SLO LogoutRequest

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -220,7 +220,7 @@ paths:
         '302':
           description: "Found"
   /authentication/logout:
-    post:
+    get:
       tags:
         - Authentication
       summary: "Logout Session"

--- a/centreon/doc/php/auth-provider.md
+++ b/centreon/doc/php/auth-provider.md
@@ -1,0 +1,141 @@
+# Authentication providers
+
+Centreon ships five authentication providers. This doc gives each one's configuration keys and flow, then digs into the SAML logout behavior every dev trips on. For how auth events are logged, see [`logging.md`](./logging.md).
+
+## Table of contents
+
+1. [Overview](#1-overview)
+2. [SAML](#2-saml)
+3. [OpenID Connect](#3-openid-connect)
+4. [Web SSO](#4-web-sso)
+5. [LDAP](#5-ldap)
+6. [Gotchas](#6-gotchas)
+
+---
+
+## 1. Overview
+
+The four "modern" providers implement `ProviderAuthenticationInterface` and converge on the `Login` use case; LDAP still runs through the legacy `centreonAuth` path. Two bounded contexts split the concerns: **`Authentication`** (the login/logout runtime) and **`ProviderConfiguration`** (the stored settings).
+
+| Provider | `Provider::*` | Settings storage | Logout |
+|---|---|---|---|
+| Local | `local` | `ProviderConfiguration` (JSON) | local session only |
+| LDAP | `ldap` | legacy `auth_ressource` tables | local session only |
+| OpenID Connect | `openid` | `ProviderConfiguration` (JSON) | optional end-session redirect |
+| SAML 2.0 | `saml` | `ProviderConfiguration` (JSON) | optional SLO round-trip |
+| Web SSO | `web-sso` | `ProviderConfiguration` (JSON) | local session only |
+
+All `ProviderConfiguration` providers share the same building blocks: `auto_import` (create the contact on first login), and `authentication_conditions` / `roles_mapping` / `groups_mapping` (security access validated against the IdP claims/attributes).
+
+---
+
+## 2. SAML
+
+Centreon is the SAML **Service Provider** wrapping [`onelogin/php-saml`](https://github.com/SAML-Toolkits/php-saml) `~4.3.1`; the customer's IdP holds the identities. Three endpoints (`config/routes/Centreon/authentication.yaml`):
+
+| Route | Method | Path | Role |
+|---|---|---|---|
+| `…_login_saml` | GET | `/login/saml` | build the `AuthnRequest`, 302 to the IdP |
+| `…_saml_acs` | POST | `/saml/acs` | Assertion Consumer Service — consume the IdP response |
+| `…_callback_sls` | GET | `/saml/sls` | Single Logout Service — IdP logout callback |
+
+The toolkit `OneLogin\Saml2\Auth` is always built through `SamlAuthFactoryInterface`, so the flow stays mockable.
+
+### Configuration keys
+
+Stored as JSON, rehydrated into `…\Domain\SAML\Model\CustomConfiguration`:
+
+| Key | Meaning |
+|---|---|
+| `entity_id_url` | IdP entityId / issuer — **also the logout `NameID` fallback ([§2 trap](#the-logout-nameid-trap))** |
+| `remote_login_url` | IdP SSO URL (`AuthnRequest` target) |
+| `logout_from_url` | IdP SLO URL (`LogoutRequest` target) |
+| `logout_from` | `false` = local logout only; `true` = also log out of the IdP |
+| `certificate` | IdP signing x509 cert |
+| `user_id_attribute` | assertion attribute carrying the Centreon login |
+| `requested_authn_context` (+ `_comparison`) | request an authn context (`exact`/`minimum`/`maximum`/`better`) |
+| `auto_import` (+ `contact_template`, `email_bind_attribute`, `fullname_bind_attribute`) | create the contact from the assertion |
+
+`OneLoginSettingsFormatter::format()` maps these onto the toolkit settings. Two facts are load-bearing:
+
+- **`sp.entityId` is the host Centreon is reached on** (`HttpUrlTrait::getHost()`, resolved live from the request) — it must match the **Audience** declared on the IdP, or the ACS rejects the response.
+- **`idp.entityId` (= `entity_id_url`) is not just the issuer** — it is what php-saml emits as the logout `NameID` when none is provided (see below).
+
+### Login & logout flow
+
+On the ACS step, `SAML::authenticateOrFail()` validates the `SAMLResponse`, reads the login from `user_id_attribute`, then stores the identifiers a future `LogoutRequest` needs in the **native** session (`$_SESSION['saml']`): `samlNameId`, `samlSessionIndex`, `samlNameIdFormat`, `samlNameIdNameQualifier`, `samlNameIdSPNameQualifier`.
+
+`LogoutSession` runs the SAML logout **before** local invalidation (because `logout()` reads `$_SESSION['saml']`): it forwards the five identifiers to `Auth::logout()` and redirects to the IdP SLO URL; the IdP then calls `/saml/sls`, which invalidates the local session.
+
+### The logout `NameID` trap
+
+When `OneLogin\Saml2\LogoutRequest` is built with an **empty `nameId`**, php-saml silently substitutes the IdP entityId:
+
+```php
+// vendor/onelogin/php-saml/src/Saml2/LogoutRequest.php (~L94-101)
+} else {
+    $nameId = $idpData['entityId'];      // ← fallback
+    $nameIdFormat = Constants::NAMEID_ENTITY;
+}
+```
+
+So a missing `NameID` produces a `LogoutRequest` that identifies *the IdP itself* instead of the user — and SLO does nothing. **It hides easily:** tolerant IdPs (e.g. Keycloak) accept a wrong `NameID`, while strict IdPs (e.g. OneLogin) validate it against the one issued at authentication — so the bug only surfaces against a strict IdP, which is the one to test SLO with.
+
+**Fix:** capture the real `NameID` + format + qualifiers + `SessionIndex` at ACS time and forward them to `Auth::logout()`. The format/qualifiers matter too — some IdPs reject a `LogoutRequest` whose `NameID` shape differs from the assertion.
+
+> **OneLogin SLO URL subtlety:** OneLogin's SLO endpoint URL often uses a *numeric app id* while its SSO endpoint uses a UUID — `logout_from_url` is **not** derived from `remote_login_url`. Copy each from the IdP separately, or the `LogoutRequest` goes nowhere.
+
+---
+
+## 3. OpenID Connect
+
+Provider `OpenId` (authorization-code flow). Config (`…\Domain\OpenId\Model\CustomConfiguration`):
+
+| Key | Meaning |
+|---|---|
+| `client_id` / `client_secret` | OIDC client credentials |
+| `base_url` | issuer base; every endpoint below is appended to it |
+| `authorization_endpoint` / `token_endpoint` | auth-code exchange |
+| `introspection_token_endpoint` / `userinfo_endpoint` | resolve the user |
+| `end_session_endpoint` | logout (RP-initiated) |
+| `connection_scopes` | requested scopes |
+| `login_claim` | claim carrying the Centreon login |
+| `authentication_type` | how client creds are sent (`client_secret_post` / `_basic`) |
+| `verify_peer` | TLS peer verification toggle |
+| `auto_import` (+ template / bind attrs) | create the contact from the claims |
+
+**Logout** (`OpenId::logout($idToken, $stay)`) redirects to `base_url + end_session_endpoint` with `post_logout_redirect_uri` and `id_token_hint`. The `id_token` must be **captured before** the local session is invalidated, then the redirect happens **after** — the reverse of SAML's ordering (`logout()` does not read the session, so there is no `/saml/sls`-style callback).
+
+---
+
+## 4. Web SSO
+
+Trusts a user pre-authenticated by an upstream reverse proxy — there is no redirect dance. Config (`…\Domain\WebSSO\Model\CustomConfiguration`):
+
+| Key | Meaning |
+|---|---|
+| `login_header_attribute` | request header carrying the authenticated login |
+| `pattern_matching_login` / `pattern_replace_login` | regex to extract the login from the header value |
+| `trusted_client_addresses` | client IPs allowed to assert a header identity |
+| `blacklist_client_addresses` | client IPs always refused |
+
+Because the trust is purely network-based, the IP allow/block lists are the security boundary — a misconfigured proxy that lets a client set the header is an auth bypass. Logout clears the local session only.
+
+---
+
+## 5. LDAP
+
+LDAP is the one provider still handled by the **legacy** `centreonAuth` / `centreonAuth.LDAP` path, not the DDD providers. Its settings live in the legacy `auth_ressource` / `auth_ressource_host` / `auth_ressource_info` tables (configured in the UI, no provider REST API): bind DN + password, host/port, search base and filters, plus per-resource flags such as `ldap_auto_import` and `ldap_store_password`.
+
+Login goes through the local form (the password is verified by binding against the directory); logout clears the local session only.
+
+---
+
+## 6. Gotchas
+
+- **`getHost()` needs a live request.** It resolves the SAML `sp.entityId` from `RequestStack` and throws when there is none. In a unit test, inject one (`$formatter->setHttpServerBag($requestStack)`) instead of faking `$_SERVER`.
+- **SAML `sp.entityId` must equal the IdP Audience** — reach Centreon on the host declared on the IdP.
+- **php-saml 4.x rejects SHA-1** signatures (*Signature validation failed*) — sign with SHA-256 on the IdP.
+- **Two sessions.** SAML identifiers live in the native `$_SESSION['saml']`; the Centreon user lives in the Symfony session.
+- **Logout ordering differs by provider.** SAML logs out before local invalidation (it reads the session); OpenID captures the `id_token`, invalidates, then redirects. Not interchangeable.
+- **Build SAML `Auth` through `SamlAuthFactoryInterface`**, never `new Auth(...)`, to keep the flow testable.

--- a/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApi.php
+++ b/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApi.php
@@ -30,10 +30,11 @@ use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFact
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
+use Core\Security\Authentication\Domain\Exception\SSOAuthenticationException;
 use Core\Security\Authentication\Domain\Model\NewProviderToken;
 use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
-use Security\Domain\Authentication\Exceptions\ProviderException;
 use Security\Domain\Authentication\Model\LocalProvider;
 use Security\Encryption;
 
@@ -46,16 +47,16 @@ class AuthenticateApi
      * @param ProviderAuthenticationFactoryInterface $providerFactory
      */
     public function __construct(
-        private WriteTokenRepositoryInterface $writeTokenRepository,
-        private ProviderAuthenticationFactoryInterface $providerFactory,
+        private readonly WriteTokenRepositoryInterface $writeTokenRepository,
+        private readonly ProviderAuthenticationFactoryInterface $providerFactory,
     ) {
     }
 
     /**
      * @param AuthenticateApiRequest $request
      * @param AuthenticateApiResponse $response
-     * @throws AuthenticationException
-     * @throws ProviderException
+     *
+     * @throws \Exception
      */
     public function execute(AuthenticateApiRequest $request, AuthenticateApiResponse $response): void
     {
@@ -100,6 +101,8 @@ class AuthenticateApi
      *
      * @param ProviderAuthenticationInterface $localProvider
      * @param AuthenticateApiRequest $request
+     *
+     * @throws SSOAuthenticationException
      */
     private function authenticateOrFail(
         ProviderAuthenticationInterface $localProvider,

--- a/centreon/src/Core/Security/Authentication/Application/Provider/ProviderAuthenticationFactoryInterface.php
+++ b/centreon/src/Core/Security/Authentication/Application/Provider/ProviderAuthenticationFactoryInterface.php
@@ -23,12 +23,16 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\Provider;
 
-use Security\Domain\Authentication\Exceptions\ProviderException;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
 
 interface ProviderAuthenticationFactoryInterface
 {
     /**
+     * @param string $providerType
+     *
      * @throws ProviderException
+     *
+     * @return ProviderAuthenticationInterface
      */
     public function create(string $providerType): ProviderAuthenticationInterface;
 }

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
@@ -33,6 +33,9 @@ use Core\Application\Common\UseCase\ErrorAuthenticationConditionsResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Application\Common\UseCase\UnauthorizedResponse;
+use Core\Common\Domain\Exception\ExceptionFormatter;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Repository\ReadTokenRepositoryInterface;
@@ -42,12 +45,16 @@ use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInte
 use Core\Security\Authentication\Domain\Exception\AclConditionsException;
 use Core\Security\Authentication\Domain\Exception\AuthenticationConditionsException;
 use Core\Security\Authentication\Domain\Exception\AuthenticationException;
+use Core\Security\Authentication\Domain\Exception\OpenIdException;
 use Core\Security\Authentication\Domain\Exception\PasswordExpiredException;
+use Core\Security\Authentication\Domain\Exception\SamlException;
 use Core\Security\Authentication\Domain\Exception\SSOAuthenticationException;
 use Core\Security\Authentication\Domain\Model\NewProviderToken;
 use Core\Security\Authentication\Infrastructure\Provider\AclUpdaterInterface;
 use Core\Security\Authentication\Infrastructure\Provider\OpenId;
+use Core\Security\Authentication\Infrastructure\Provider\SAML;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration as SamlCustomConfiguration;
 use Security\Domain\Authentication\Model\Session;
 use Security\Encryption;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -56,41 +63,23 @@ final class Login
 {
     use LoggerTrait;
 
-    /** @var ProviderAuthenticationInterface */
     private ProviderAuthenticationInterface $provider;
 
-    /**
-     * @param ProviderAuthenticationFactoryInterface $providerFactory
-     * @param RequestStack $requestStack
-     * @param DataStorageEngineInterface $dataStorageEngine
-     * @param WriteSessionRepositoryInterface $sessionRepository
-     * @param ReadTokenRepositoryInterface $readTokenRepository
-     * @param WriteTokenRepositoryInterface $writeTokenRepository
-     * @param WriteSessionTokenRepositoryInterface $writeSessionTokenRepository
-     * @param AclUpdaterInterface $aclUpdater
-     * @param MenuServiceInterface $menuService
-     * @param string $defaultRedirectUri
-     * @param ThirdPartyLoginForm $thirdPartyLoginForm
-     */
     public function __construct(
-        private ProviderAuthenticationFactoryInterface $providerFactory,
-        private RequestStack $requestStack,
-        private DataStorageEngineInterface $dataStorageEngine,
-        private WriteSessionRepositoryInterface $sessionRepository,
-        private ReadTokenRepositoryInterface $readTokenRepository,
-        private WriteTokenRepositoryInterface $writeTokenRepository,
-        private WriteSessionTokenRepositoryInterface $writeSessionTokenRepository,
-        private AclUpdaterInterface $aclUpdater,
-        private MenuServiceInterface $menuService,
-        private string $defaultRedirectUri,
+        private readonly ProviderAuthenticationFactoryInterface $providerFactory,
+        private readonly RequestStack $requestStack,
+        private readonly DataStorageEngineInterface $dataStorageEngine,
+        private readonly WriteSessionRepositoryInterface $writeSessionRepository,
+        private readonly ReadTokenRepositoryInterface $readTokenRepository,
+        private readonly WriteTokenRepositoryInterface $writeTokenRepository,
+        private readonly WriteSessionTokenRepositoryInterface $writeSessionTokenRepository,
+        private readonly AclUpdaterInterface $aclUpdater,
+        private readonly MenuServiceInterface $menuService,
+        private readonly string $defaultRedirectUri,
         private readonly ThirdPartyLoginForm $thirdPartyLoginForm,
     ) {
     }
 
-    /**
-     * @param LoginRequest $loginRequest
-     * @param PresenterInterface $presenter
-     */
     public function __invoke(LoginRequest $loginRequest, PresenterInterface $presenter): void
     {
         try {
@@ -109,7 +98,7 @@ final class Login
 
             $this->updateACL($user);
 
-            if ($this->sessionRepository->start($this->provider->getLegacySession())) {
+            if ($this->writeSessionRepository->start($this->provider->getLegacySession())) {
                 if ($this->readTokenRepository->hasAuthenticationTokensByToken($this->requestStack->getSession()->getId()) === false) {
                     if ($loginRequest->providerName === Provider::SAML && $this->thirdPartyLoginForm->isActive()) {
                         $this->createAuthenticationTokens(
@@ -137,7 +126,10 @@ final class Login
                             $request->getSession()
                                 ->set('openid_id_token', $provider->getTokenForSession());
                         } catch (SSOAuthenticationException $e) {
-                            throw new AuthenticationException('OpenID authentication failed: ' . $e->getMessage(), previous: $e);
+                            throw new AuthenticationException(
+                                'OpenID authentication failed: ' . $e->getMessage(),
+                                previous: $e
+                            );
                         }
 
                         $this->createAuthenticationTokens(
@@ -157,6 +149,18 @@ final class Login
                         $loginRequest->clientIp
                     );
                 }
+            } else {
+                // If we fail to create the session, we need to log out from the IDP if needed
+                // For SAML
+                if ($loginRequest->providerName === Provider::SAML) {
+                    $this->samlLogoutAfterLoginFailure();
+                }
+                // For OpenID
+                if ($loginRequest->providerName === Provider::OPENID) {
+                    $idToken = $this->requestStack->getSession()->get('openid_id_token') ?? '';
+                    $isLogin = $this->requestStack->getSession()->get('isLogin') ?? false;
+                    $this->openIdLogoutAfterLoginFailure($idToken, $isLogin);
+                }
             }
 
             $redirectionInfo = $this->getRedirectionInfo($user, $loginRequest->refererQueryParameters);
@@ -167,27 +171,39 @@ final class Login
                 )
             );
         } catch (PasswordExpiredException $exception) {
-            $this->info('The password expired', ['trace' => (string) $exception]);
+            $this->info('The password expired', ['exception' => ExceptionFormatter::format($exception)]);
             $response = new PasswordExpiredResponse($exception->getMessage());
             $response->setBody(['password_is_expired' => true]);
             $presenter->setResponseStatus($response);
 
             return;
         } catch (AuthenticationException $exception) {
-            $this->error('An error occurred during authentication', ['trace' => (string) $exception]);
+            $this->error(
+                message: 'An error occurred during authentication',
+                context: ['exception' => ExceptionFormatter::format($exception)]
+            );
             $presenter->setResponseStatus(new UnauthorizedResponse($exception->getMessage()));
 
             return;
         } catch (AclConditionsException $exception) {
-            $this->error('An error occured while matching your ACL conditions', ['trace' => (string) $exception]);
+            $this->error(
+                message: 'An error occured while matching your ACL conditions',
+                context: ['exception' => ExceptionFormatter::format($exception)]
+            );
             $presenter->setResponseStatus(new ErrorAclConditionsResponse($exception->getMessage()));
-        } catch (AuthenticationConditionsException $ex) {
-            $this->error('An error occured while matching your authentication conditions', ['trace' => (string) $ex]);
-            $presenter->setResponseStatus(new ErrorAuthenticationConditionsResponse($ex->getMessage()));
+        } catch (AuthenticationConditionsException $exception) {
+            $this->error(
+                message: 'An error occured while matching your authentication conditions',
+                context: ['exception' => ExceptionFormatter::format($exception)]
+            );
+            $presenter->setResponseStatus(new ErrorAuthenticationConditionsResponse($exception->getMessage()));
 
             return;
-        } catch (\Throwable $ex) {
-            $this->error('An error occurred during authentication', ['trace' => (string) $ex]);
+        } catch (\Throwable $exception) {
+            $this->error(
+                message: 'An error occurred during authentication',
+                context: ['exception' => ExceptionFormatter::format($exception)]
+            );
             $presenter->setResponseStatus(new ErrorResponse('An error occurred during authentication'));
 
             return;
@@ -203,7 +219,7 @@ final class Login
      * @param NewProviderToken|null $providerRefreshToken
      * @param string|null $clientIp
      *
-     * @throws AuthenticationException
+     * @throws AuthenticationException|RepositoryException
      */
     private function createAuthenticationTokens(
         string $sessionToken,
@@ -212,11 +228,14 @@ final class Login
         ?NewProviderToken $providerRefreshToken,
         ?string $clientIp,
     ): void {
-
         $isAlreadyInTransaction = $this->dataStorageEngine->isAlreadyinTransaction();
 
         if (! $isAlreadyInTransaction) {
-            $this->dataStorageEngine->startTransaction();
+            try {
+                $this->dataStorageEngine->startTransaction();
+            } catch (\Exception $e) {
+                throw new RepositoryException('Could not start transaction', previous: $e);
+            }
         }
 
         try {
@@ -234,7 +253,11 @@ final class Login
             }
         } catch (\Exception) {
             if (! $isAlreadyInTransaction) {
-                $this->dataStorageEngine->rollbackTransaction();
+                try {
+                    $this->dataStorageEngine->rollbackTransaction();
+                } catch (\Exception $e) {
+                    throw new RepositoryException('Could not rollback transaction', previous: $e);
+                }
             }
 
             throw AuthenticationException::notAuthenticated();
@@ -322,11 +345,67 @@ final class Login
         return $refererRedirectionPage;
     }
 
-    /**
-     * @param ContactInterface $user
-     */
     private function updateACL(ContactInterface $user): void
     {
         $this->aclUpdater->updateForProviderAndUser($this->provider, $user);
+    }
+
+    private function openIdLogoutAfterLoginFailure(string $idToken, bool $isLogin): void
+    {
+        /** @var OpenId $provider */
+        $provider = $this->provider;
+        $configuration = $provider->getConfiguration();
+        if ($configuration->isActive()) {
+            try {
+                $provider->logout($idToken, $isLogin);
+            } catch (OpenIdException $e) {
+                ExceptionLogger::create()->log(
+                    throwable: $e,
+                    context: [
+                        'user_id' => $this->provider->getAuthenticatedUser()?->getId() ?? 'unknown',
+                        'provider' => Provider::OPENID,
+                        'action' => 'OpenID logout failed after centreon login failure',
+                    ]
+                );
+            }
+        }
+        try {
+            $this->writeSessionRepository->invalidate();
+        } catch (RepositoryException $e) {
+            ExceptionLogger::create()->log(
+                throwable: $e,
+                context: [
+                    'user_id' => $provider->getAuthenticatedUser()?->getId() ?? 'unknown',
+                    'provider' => Provider::OPENID,
+                    'action' => 'Invalidate session failed after OpenID logout',
+                ]
+            );
+        }
+    }
+
+    private function samlLogoutAfterLoginFailure(): void
+    {
+        /** @var SAML $provider */
+        $provider = $this->provider;
+        $configuration = $provider->getConfiguration();
+        /** @var SamlCustomConfiguration $customConfiguration */
+        $customConfiguration = $configuration->getCustomConfiguration();
+        if (
+            $configuration->isActive()
+            && $customConfiguration->getLogoutFrom() === SamlCustomConfiguration::LOGOUT_FROM_CENTREON_AND_IDP
+        ) {
+            try {
+                $provider->logout(); // The redirection is done here by the IDP
+            } catch (SamlException $e) {
+                ExceptionLogger::create()->log(
+                    throwable: $e,
+                    context: [
+                        'user_id' => $provider->getAuthenticatedUser()?->getId() ?? 'unknown',
+                        'provider' => Provider::SAML,
+                        'action' => 'SAML logout failed after centreon login failure',
+                    ]
+                );
+            }
+        }
     }
 }

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/LoginResponse.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/LoginResponse.php
@@ -26,7 +26,7 @@ namespace Core\Security\Authentication\Application\UseCase\Login;
 use Core\Application\Common\UseCase\ResponseStatusInterface;
 use Exception;
 
-final class LoginResponse implements ResponseStatusInterface
+final readonly class LoginResponse implements ResponseStatusInterface
 {
     /**
      * @param string $redirectUri
@@ -34,9 +34,9 @@ final class LoginResponse implements ResponseStatusInterface
      * @param Exception|null $exception
      */
     public function __construct(
-        private readonly string $redirectUri,
-        private readonly bool $redirectIsReact,
-        private readonly ?Exception $exception = null,
+        private string $redirectUri,
+        private bool $redirectIsReact,
+        private ?Exception $exception = null,
     ) {
     }
 

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/PasswordExpiredResponse.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/PasswordExpiredResponse.php
@@ -28,8 +28,7 @@ use Core\Application\Common\UseCase\UnauthorizedResponse;
 
 final class PasswordExpiredResponse extends UnauthorizedResponse implements BodyResponseInterface
 {
-    /** @var mixed */
-    private $body;
+    private mixed $body;
 
     /**
      * @inheritDoc

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/ThirdPartyLoginForm.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/ThirdPartyLoginForm.php
@@ -23,7 +23,11 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\UseCase\Login;
 
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -65,6 +69,9 @@ final class ThirdPartyLoginForm
      * The value is forwarded to the IDP to get it back after auth.
      *
      * @param Request $request
+     *
+     * @throws BadRequestException
+     * @return string
      */
     public function getReturnUrlBeforeAuth(Request $request): string
     {
@@ -79,6 +86,11 @@ final class ThirdPartyLoginForm
     /**
      * Retrieve the redirectUrl after auth from the IDP information.
      * For SAML, this is the request parameter RelayState.
+     *
+     * @throws InvalidParameterException
+     * @throws MissingMandatoryParametersException
+     * @throws RouteNotFoundException
+     * @return string
      */
     public function getReturnUrlAfterAuth(): string
     {
@@ -91,6 +103,11 @@ final class ThirdPartyLoginForm
 
     /**
      * Tells whether the authentication was initiated by a third party login form in our context.
+     *
+     * @throws InvalidParameterException
+     * @throws MissingMandatoryParametersException
+     * @throws RouteNotFoundException
+     * @return bool
      */
     public function isActive(): bool
     {
@@ -104,7 +121,11 @@ final class ThirdPartyLoginForm
 
         // We want to avoid possible loop redirects because the use of the RelayState in the SAML case is a bit hacky.
         $ourACS = $this->urlGenerator
-            ->generate('centreon_application_authentication_login_saml', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            ->generate(
+                'centreon_application_authentication_login_saml',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
 
         return $this->isActive = $returnTo !== $ourACS;
     }

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/LogoutSession/LogoutSession.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/LogoutSession/LogoutSession.php
@@ -23,19 +23,31 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\UseCase\LogoutSession;
 
-use Centreon\Domain\Log\LoggerTrait;
 use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
+use Core\Security\Authentication\Domain\Exception\OpenIdException;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
+use Core\Security\Authentication\Domain\Exception\SamlException;
+use Core\Security\Authentication\Infrastructure\Provider\OpenId;
+use Core\Security\Authentication\Infrastructure\Provider\SAML;
+use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration as SamlCustomConfiguration;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class LogoutSession
 {
-    use LoggerTrait;
-
     /**
      * @param WriteSessionRepositoryInterface $writeSessionRepository
+     * @param ProviderAuthenticationFactoryInterface $providerFactory
+     * @param RequestStack $requestStack
      */
     public function __construct(
         private readonly WriteSessionRepositoryInterface $writeSessionRepository,
+        private readonly ProviderAuthenticationFactoryInterface $providerFactory,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -47,15 +59,77 @@ class LogoutSession
         mixed $token,
         LogoutSessionPresenterInterface $presenter,
     ): void {
-        $this->info('Processing session logout...');
-
         if ($token === null || is_string($token) === false) {
-            $this->debug('Try to logout without token');
-            $presenter->setResponseStatus(new ErrorResponse(_('No session token provided')));
+            $presenter->setResponseStatus(new ErrorResponse(message: _('No session token provided')));
 
             return;
         }
 
-        $this->writeSessionRepository->invalidate();
+        $session = $this->requestStack->getSession();
+        $centreon = $session->get('centreon');
+        $authType = $centreon->user->authType ?? null;
+        // Captured before invalidation because the session is wiped below.
+        $idToken = $session->get('openid_id_token') ?? '';
+
+        // SAML: the LogoutRequest reads the SAML identifiers still held in session ($_SESSION['saml']),
+        // so it must run BEFORE the local invalidation. With LOGOUT_FROM_CENTREON_AND_IDP it redirects to
+        // the IdP (header + exit); the local session is then invalidated on the IdP callback (/saml/sls).
+        if ($authType === Provider::SAML) {
+            $this->logoutFromSaml();
+        }
+
+        try {
+            $this->writeSessionRepository->invalidate();
+        } catch (RepositoryException $e) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(message: _('An error occurred during session logout'), exception: $e),
+            );
+        }
+
+        // OpenID: idToken was captured above and logout() does not read the session, so we invalidate the
+        // local session first, then redirect to the end-session endpoint (header + exit). OpenID has no
+        // callback equivalent to /saml/sls, hence the local session must be wiped before redirecting.
+        if ($authType === Provider::OPENID) {
+            $this->logoutFromOpenId(is_string($idToken) ? $idToken : '');
+        }
+    }
+
+    private function logoutFromSaml(): void
+    {
+        try {
+            /** @var SAML $provider */
+            $provider = $this->providerFactory->create(Provider::SAML);
+            $configuration = $provider->getConfiguration();
+            /** @var SamlCustomConfiguration $customConfiguration */
+            $customConfiguration = $configuration->getCustomConfiguration();
+            if (
+                $configuration->isActive()
+                && $customConfiguration->getLogoutFrom() === SamlCustomConfiguration::LOGOUT_FROM_CENTREON_AND_IDP
+            ) {
+                $provider->logout(); // The redirection to the IdP is done here (header + exit)
+            }
+        } catch (ProviderException|SamlException $e) {
+            ExceptionLogger::create()->log(
+                throwable: $e,
+                context: ['provider' => Provider::SAML, 'action' => 'User-initiated SAML logout'],
+            );
+        }
+    }
+
+    private function logoutFromOpenId(string $idToken): void
+    {
+        try {
+            /** @var OpenId $provider */
+            $provider = $this->providerFactory->create(Provider::OPENID);
+            if ($provider->getConfiguration()->isActive()) {
+                // $stay = false so the user is redirected to the OIDC end-session endpoint (header + exit).
+                $provider->logout($idToken, false);
+            }
+        } catch (ProviderException|OpenIdException $e) {
+            ExceptionLogger::create()->log(
+                throwable: $e,
+                context: ['provider' => Provider::OPENID, 'action' => 'User-initiated OpenID logout'],
+            );
+        }
     }
 }

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/LogoutSession/SAML/LogoutFromIdp.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/LogoutSession/SAML/LogoutFromIdp.php
@@ -23,33 +23,32 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\UseCase\LogoutSession\SAML;
 
-use Centreon\Domain\Log\LoggerTrait;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
+use Core\Security\Authentication\Domain\Exception\SamlException;
 use Core\Security\Authentication\Infrastructure\Provider\SAML;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 
-class LogoutFromIdp
+readonly class LogoutFromIdp
 {
-    use LoggerTrait;
-
-    /**
-     * @param WriteSessionRepositoryInterface $writeSessionRepository
-     * @param ProviderAuthenticationFactoryInterface $providerFactory
-     */
     public function __construct(
-        private readonly WriteSessionRepositoryInterface $writeSessionRepository,
-        private readonly ProviderAuthenticationFactoryInterface $providerFactory,
+        private ProviderAuthenticationFactoryInterface $providerFactory,
     ) {
     }
 
+    /**
+     * @throws SamlException
+     * @throws ProviderException
+     */
     public function __invoke(): void
     {
-        session_start();
-        $this->info('SAML SLS invoked');
+        // /saml/sls is the IdP callback endpoint: the IdP calls it with a SAMLRequest (IdP-initiated SLO)
+        // or a SAMLResponse (response to a Centreon-initiated SLO). We only process that callback here;
+        // initiating the LogoutRequest is the responsibility of the LogoutSession use case.
         /** @var SAML $provider */
         $provider = $this->providerFactory->create(Provider::SAML);
-        $this->writeSessionRepository->invalidate();
-        $provider->handleCallbackLogoutResponse();
+        if ($provider->getConfiguration()->isActive()) {
+            $provider->handleCallbackLogoutResponse();
+        }
     }
 }

--- a/centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
@@ -25,9 +25,14 @@ namespace Core\Security\Authentication\Domain\Exception;
 
 class AuthenticationException extends \Exception
 {
-    public static function notAuthenticated(?\Throwable $throwable = null): self
+    /**
+     * @param \Throwable|null $previous
+     *
+     * @return self
+     */
+    public static function notAuthenticated(?\Throwable $previous = null): self
     {
-        return new self(_('Authentication failed'), previous: $throwable);
+        return new self(_('Authentication failed'), previous: $previous);
     }
 
     public static function userBlocked(): self

--- a/centreon/src/Core/Security/Authentication/Domain/Exception/OpenIdException.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Exception/OpenIdException.php
@@ -21,27 +21,17 @@
 
 declare(strict_types=1);
 
-namespace Core\Security\Authentication\Application\Repository;
+namespace Core\Security\Authentication\Domain\Exception;
 
-use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Domain\Exception\BusinessLogicException;
 
-interface WriteSessionRepositoryInterface
+class OpenIdException extends BusinessLogicException
 {
-    /**
-     * Invalidate a session.
-     *
-     * @throws RepositoryException
-     */
-    public function invalidate(): void;
-
-    /**
-     * Start a session (included the legacy session).
-     *
-     * @param \Centreon $legacySession
-     *
-     * @throws RepositoryException
-     *
-     * @return bool
-     */
-    public function start(\Centreon $legacySession): bool;
+    public function __construct(
+        string $message,
+        array $context = [],
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, self::ERROR_CODE_INTERNAL, $context, $previous);
+    }
 }

--- a/centreon/src/Core/Security/Authentication/Domain/Exception/ProviderException.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Exception/ProviderException.php
@@ -28,12 +28,28 @@ class ProviderException extends \Exception
     /**
      * Exception thrown when a Provider class was unexpected.
      *
-     * @param class-string $class
+     * @param string $class
      *
      * @return self
      */
     public static function unexpectedProvider(string $class): self
     {
         return new self(sprintf(_('Must not Happen, got unexpected Provider type %s'), $class));
+    }
+
+    /**
+     * Exception thrown when the configuration of a provider could not be retrieved.
+     *
+     * @param string $providerConfigurationName
+     * @param \Throwable $e
+     *
+     * @return self
+     */
+    public static function errorWhileSearchingConfiguration(string $providerConfigurationName, \Throwable $e): self
+    {
+        return new self(
+            sprintf(_("Error while searching provider configuration: '%s'"), $providerConfigurationName),
+            previous: $e
+        );
     }
 }

--- a/centreon/src/Core/Security/Authentication/Domain/Exception/SamlException.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Exception/SamlException.php
@@ -21,27 +21,17 @@
 
 declare(strict_types=1);
 
-namespace Core\Security\Authentication\Application\Repository;
+namespace Core\Security\Authentication\Domain\Exception;
 
-use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Domain\Exception\BusinessLogicException;
 
-interface WriteSessionRepositoryInterface
+class SamlException extends BusinessLogicException
 {
-    /**
-     * Invalidate a session.
-     *
-     * @throws RepositoryException
-     */
-    public function invalidate(): void;
-
-    /**
-     * Start a session (included the legacy session).
-     *
-     * @param \Centreon $legacySession
-     *
-     * @throws RepositoryException
-     *
-     * @return bool
-     */
-    public function start(\Centreon $legacySession): bool;
+    public function __construct(
+        string $message,
+        array $context = [],
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, self::ERROR_CODE_INTERNAL, $context, $previous);
+    }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/LoginController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/LoginController.php
@@ -24,11 +24,15 @@ declare(strict_types=1);
 namespace Core\Security\Authentication\Infrastructure\Api\Login\SAML;
 
 use Centreon\Application\Controller\AbstractController;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Core\Security\Authentication\Application\UseCase\Login\ThirdPartyLoginForm;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
+use Core\Security\Authentication\Domain\Exception\SamlException;
 use Core\Security\Authentication\Infrastructure\Provider\ProviderAuthenticationFactory;
 use Core\Security\Authentication\Infrastructure\Provider\SAML;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 
 final class LoginController extends AbstractController
@@ -45,10 +49,23 @@ final class LoginController extends AbstractController
     ) {
     }
 
+    /**
+     * @param Request $request
+     *
+     * @throws BadRequestException
+     * @throws ProviderException
+     * @throws SamlException
+     */
     public function __invoke(Request $request): void
     {
-        /** @var SAML $provider */
-        $provider = $this->providerAuthenticationFactory->create(Provider::SAML);
-        $provider->login($this->thirdPartyLoginForm->getReturnUrlBeforeAuth($request));
+        try {
+            /** @var SAML $provider */
+            $provider = $this->providerAuthenticationFactory->create(Provider::SAML);
+            $provider->login($this->thirdPartyLoginForm->getReturnUrlBeforeAuth($request));
+        } catch (BadRequestException|ProviderException|SamlException $e) {
+            ExceptionLogger::create()->log($e);
+
+            throw $e; // TODO: improve error handling to have a response and not an exception
+        }
     }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/SLSController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/SLSController.php
@@ -25,9 +25,11 @@ namespace Core\Security\Authentication\Infrastructure\Api\Login\SAML;
 
 use Centreon\Application\Controller\AbstractController;
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Core\Security\Authentication\Application\UseCase\LogoutSession\SAML\LogoutFromIdp;
-use OneLogin\Saml2\Error;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
+use Core\Security\Authentication\Domain\Exception\SamlException;
 
 final class SLSController extends AbstractController
 {
@@ -37,11 +39,25 @@ final class SLSController extends AbstractController
     /**
      * @param LogoutFromIdp $usecase
      *
-     * @throws Error
+     * @throws ProviderException
+     * @throws SamlException
      */
     public function __invoke(LogoutFromIdp $usecase): void
     {
         $this->info('SAML SLS invoked');
-        $usecase();
+
+        // The IdP callback relies on the native PHP session ($_SESSION['LogoutRequestID']).
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        try {
+            $usecase();
+        } catch (ProviderException|SamlException $e) {
+            ExceptionLogger::create()->log($e);
+
+            // TODO: improve error handling to have a response and not an exception
+            throw $e;
+        }
     }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/LogoutSession/LogoutSessionController.php
@@ -24,9 +24,13 @@ declare(strict_types=1);
 namespace Core\Security\Authentication\Infrastructure\Api\LogoutSession;
 
 use Centreon\Application\Controller\AbstractController;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Core\Security\Authentication\Application\UseCase\LogoutSession\LogoutSession;
 use Core\Security\Authentication\Application\UseCase\LogoutSession\LogoutSessionPresenterInterface;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 
 final class LogoutSessionController extends AbstractController
@@ -38,6 +42,7 @@ final class LogoutSessionController extends AbstractController
      * @param Request $request
      * @param LogoutSessionPresenterInterface $presenter
      *
+     * @throws BadRequestException
      * @return object
      */
     public function __invoke(
@@ -45,7 +50,7 @@ final class LogoutSessionController extends AbstractController
         Request $request,
         LogoutSessionPresenterInterface $presenter,
     ): object {
-        $basePath = ltrim($request->getBasePath(), '/');
+        $basePath = mb_ltrim($request->getBasePath(), '/');
         $sessionName = session_name() ?: 'PHPSESSID';
 
         $sessionId = null;
@@ -59,6 +64,14 @@ final class LogoutSessionController extends AbstractController
         }
 
         $useCase($sessionId, $presenter);
+
+        // TODO: response is not used, should we return a response ? (we return a redirection to login page)
+        $response = $presenter->getResponseStatus();
+        if ($response instanceof ResponseStatusInterface) {
+            if ($response instanceof ErrorResponse && ! is_null($response->getException())) {
+                ExceptionLogger::create()->log($response->getException());
+            }
+        }
 
         return $this->redirect($this->getBaseUrl() . '/login');
     }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
@@ -31,6 +31,7 @@ use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInte
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
 use Core\Security\Authentication\Domain\Exception\AclConditionsException;
 use Core\Security\Authentication\Domain\Exception\AuthenticationConditionsException;
+use Core\Security\Authentication\Domain\Exception\OpenIdException;
 use Core\Security\Authentication\Domain\Exception\SSOAuthenticationException;
 use Core\Security\Authentication\Domain\Model\AuthenticationTokens;
 use Core\Security\Authentication\Domain\Model\NewProviderToken;
@@ -59,9 +60,9 @@ class OpenId implements ProviderAuthenticationInterface
      * @param OpenIdProvider $provider
      */
     public function __construct(
-        private Container $dependencyInjector,
-        private RequestStack $requestStack,
-        private OpenIdProviderInterface $provider,
+        private readonly Container $dependencyInjector,
+        private readonly RequestStack $requestStack,
+        private readonly OpenIdProviderInterface $provider,
     ) {
     }
 
@@ -318,6 +319,9 @@ class OpenId implements ProviderAuthenticationInterface
         return $this->provider->getAclConditionsMatches();
     }
 
+    /**
+     * @throws SSOAuthenticationException
+     */
     public function getTokenForSession(): ?string
     {
         return $this->provider->getTokenForSession();
@@ -327,16 +331,16 @@ class OpenId implements ProviderAuthenticationInterface
      * Redirect the user to the OIDC end-session endpoint
      *
      * @param string $idToken
+     * @param bool $stay
      *
-     * @throws Exception
-     *
+     * @throws OpenIdException
      * @return string|null
      */
     public function logout(string $idToken, bool $stay = false): string|null
     {
         $request = $this->requestStack->getCurrentRequest();
         if ($request === null) {
-            throw new Exception('Request is not available for OpenID logout');
+            throw new OpenIdException('Request is not available for OpenID logout');
         }
 
         /** @var CustomConfiguration $customConfig */
@@ -345,7 +349,7 @@ class OpenId implements ProviderAuthenticationInterface
         $endSessionEndpoint = $customConfig->getEndSessionEndpoint();
 
         if (empty($baseUrl) || empty($endSessionEndpoint)) {
-            throw new Exception('Missing required OpenID configuration for logout');
+            throw new OpenIdException('Missing required OpenID configuration for logout');
         }
 
         $endSessionUrl = $baseUrl . $endSessionEndpoint;
@@ -370,8 +374,12 @@ class OpenId implements ProviderAuthenticationInterface
             }
 
             exit;
-        } catch (Exception $e) {
-            throw new Exception('Failed to redirect to logout URL: ' . $e->getMessage(), previous: $e);
+        } catch (Throwable $e) {
+            throw new OpenIdException(
+                message: 'Failed to redirect to logout URL: ' . $e->getMessage(),
+                context: ['logout_url' => $logoutUrl],
+                previous: $e
+            );
         }
     }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/ProviderAuthenticationFactory.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/ProviderAuthenticationFactory.php
@@ -26,9 +26,9 @@ namespace Core\Security\Authentication\Infrastructure\Provider;
 use Core\Common\Domain\Exception\RepositoryException;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
+use Core\Security\Authentication\Domain\Exception\ProviderException;
 use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
-use Security\Domain\Authentication\Exceptions\ProviderException;
 
 readonly class ProviderAuthenticationFactory implements ProviderAuthenticationFactoryInterface
 {
@@ -51,13 +51,13 @@ readonly class ProviderAuthenticationFactory implements ProviderAuthenticationFa
             Provider::OPENID => $this->openId,
             Provider::WEB_SSO => $this->webSSO,
             Provider::SAML => $this->saml,
-            default => throw ProviderException::providerConfigurationNotFound($providerType),
+            default => throw ProviderException::unexpectedProvider($providerType),
         };
 
         try {
             $provider->setConfiguration($this->readConfigurationRepository->getConfigurationByType($providerType));
         } catch (RepositoryException $e) {
-            throw ProviderException::findProviderConfiguration($providerType, $e);
+            throw ProviderException::errorWhileSearchingConfiguration($providerType, $e);
         }
 
         return $provider;

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -30,12 +30,16 @@ use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use CentreonSession;
 use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Domain\Configuration\User\Model\NewUser;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
+use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
 use Core\Security\Authentication\Domain\Exception\AclConditionsException;
 use Core\Security\Authentication\Domain\Exception\AuthenticationConditionsException;
+use Core\Security\Authentication\Domain\Exception\SamlException;
 use Core\Security\Authentication\Domain\Exception\SSOAuthenticationException;
 use Core\Security\Authentication\Domain\Model\AuthenticationTokens;
 use Core\Security\Authentication\Domain\Model\NewProviderToken;
@@ -69,9 +73,6 @@ class SAML implements ProviderAuthenticationInterface
     /** @var Configuration */
     private Configuration $configuration;
 
-    /** @var Centreon */
-    private Centreon $legacySession;
-
     /** @var string */
     private string $username;
 
@@ -81,16 +82,6 @@ class SAML implements ProviderAuthenticationInterface
     /** @var Auth|null */
     private ?Auth $auth = null;
 
-    /**
-     * @param Container $dependencyInjector
-     * @param ContactRepositoryInterface $contactRepository
-     * @param LoginLoggerInterface $loginLogger
-     * @param WriteUserRepositoryInterface $userRepository
-     * @param Conditions $conditions
-     * @param RolesMapping $rolesMapping
-     * @param GroupsMappingSecurityAccess $groupsMapping
-     * @param SettingsFormatterInterface $formatter
-     */
     public function __construct(
         private readonly Container $dependencyInjector,
         private readonly ContactRepositoryInterface $contactRepository,
@@ -100,6 +91,8 @@ class SAML implements ProviderAuthenticationInterface
         private readonly RolesMapping $rolesMapping,
         private readonly GroupsMappingSecurityAccess $groupsMapping,
         private readonly SettingsFormatterInterface $formatter,
+        private readonly WriteSessionRepositoryInterface $writeSessionRepository,
+        private readonly SamlAuthFactoryInterface $authFactory,
     ) {
     }
 
@@ -117,7 +110,7 @@ class SAML implements ProviderAuthenticationInterface
         $this->loginLogger->info(Provider::SAML, 'authenticate the user through SAML');
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
-        $this->auth = new Auth($this->formatter->format($customConfiguration));
+        $this->auth = $this->authFactory->create($this->formatter->format($customConfiguration));
         $auth = $this->auth;
         $auth->processResponse($_SESSION['AuthNRequestID'] ?? null);
         $errors = $auth->getErrors();
@@ -157,12 +150,17 @@ class SAML implements ProviderAuthenticationInterface
         }
 
         $this->username = $attrs[0];
+
         CentreonSession::writeSessionClose('saml', [
             'samlSessionIndex' => $auth->getSessionIndex(),
             'samlNameId' => $auth->getNameId(),
+            'samlNameIdFormat' => $auth->getNameIdFormat() ?: null,
+            'samlNameIdNameQualifier' => $auth->getNameIdNameQualifier() ?: null,
+            'samlNameIdSPNameQualifier' => $auth->getNameIdSPNameQualifier() ?: null,
         ]);
 
         $this->loginLogger->info(Provider::SAML, 'checking security access rules');
+
         $this->conditions->validate($this->configuration, $auth->getAttributes());
         $this->rolesMapping->validate($this->configuration, $auth->getAttributes());
         $this->groupsMapping->validate($this->configuration, $auth->getAttributes());
@@ -170,6 +168,7 @@ class SAML implements ProviderAuthenticationInterface
 
     /**
      * @throws SSOAuthenticationException
+     * @throws Exception
      *
      * @return ContactInterface
      */
@@ -281,9 +280,8 @@ class SAML implements ProviderAuthenticationInterface
         ];
 
         $this->authenticatedUser = $user;
-        $this->legacySession = new Centreon($sessionUserInfos);
 
-        return $this->legacySession;
+        return new Centreon($sessionUserInfos);
     }
 
     /**
@@ -409,45 +407,152 @@ class SAML implements ProviderAuthenticationInterface
     /**
      * @param string $returnTo
      *
-     * @throws Error
+     * @throws SamlException
      */
     public function login(string $returnTo = ''): void
     {
-        $auth = new Auth($this->formatter->format($this->configuration->getCustomConfiguration()));
-        $auth->login($returnTo ?: null);
+        try {
+            $auth = $this->authFactory->create($this->formatter->format($this->configuration->getCustomConfiguration()));
+        } catch (Throwable $e) {
+            throw new SamlException(
+                message: 'SAML Auth initialization failed: ' . $e->getMessage(),
+                context: [
+                    'configuration_id' => $this->configuration->getId(),
+                    'configuration_name' => $this->configuration->getName(),
+                    'configuration_type' => $this->configuration->getType(),
+                ],
+                previous: $e
+            );
+        }
+        try {
+            $auth->login($returnTo ?: null);
+        } catch (Throwable $e) {
+            throw new SamlException(
+                message: 'SAML login failed: ' . $e->getMessage(),
+                context: [
+                    'configuration_id' => $this->configuration->getId(),
+                    'configuration_name' => $this->configuration->getName(),
+                    'configuration_type' => $this->configuration->getType(),
+                    'return_to' => $returnTo,
+                ],
+                previous: $e
+            );
+        }
     }
 
     /**
-     * @throws Error
+     * @throws SamlException
+     * @return void
      */
     public function logout(): void
     {
         $returnTo = '/login';
-        $parameters = [];
-        $nameId = null;
-        $sessionIndex = null;
 
-        if (isset($_SESSION['saml']['samlNameId'])) {
-            $nameId = $_SESSION['saml']['samlNameId'];
+        $samlNameId = $_SESSION['saml']['samlNameId'] ?? null;
+        $samlSessionIndex = $_SESSION['saml']['samlSessionIndex'] ?? null;
+        $samlNameIdFormat = $_SESSION['saml']['samlNameIdFormat'] ?? null;
+        $samlNameIdNameQualifier = $_SESSION['saml']['samlNameIdNameQualifier'] ?? null;
+        $samlNameIdSPNameQualifier = $_SESSION['saml']['samlNameIdSPNameQualifier'] ?? null;
+
+        $this->loginLogger->info(Provider::SAML, 'logout from SAML and redirect');
+
+        try {
+            $auth = $this->authFactory->create($this->formatter->format($this->configuration->getCustomConfiguration()));
+        } catch (Throwable $e) {
+            throw new SamlException(
+                message: 'SAML Auth initialization failed: ' . $e->getMessage(),
+                context: [
+                    'configuration_id' => $this->configuration->getId(),
+                    'configuration_name' => $this->configuration->getName(),
+                    'configuration_type' => $this->configuration->getType(),
+                ],
+                previous: $e
+            );
         }
 
-        if (isset($_SESSION['saml']['samlSessionIndex'])) {
-            $sessionIndex = $_SESSION['saml']['samlSessionIndex'];
+        try {
+            $auth->logout(
+                returnTo: $returnTo,
+                nameId: $samlNameId,
+                sessionIndex: $samlSessionIndex,
+                nameIdFormat: $samlNameIdFormat,
+                nameIdNameQualifier: $samlNameIdNameQualifier,
+                nameIdSPNameQualifier: $samlNameIdSPNameQualifier
+            );
+        } catch (Throwable $e) {
+            throw new SamlException(
+                message: 'SAML logout failed: ' . $e->getMessage(),
+                context: [
+                    'configuration_id' => $this->configuration->getId(),
+                    'configuration_name' => $this->configuration->getName(),
+                    'configuration_type' => $this->configuration->getType(),
+                    'saml_name_id' => $samlNameId,
+                    'saml_session_index' => $samlSessionIndex,
+                    'saml_name_id_format' => $samlNameIdFormat,
+                    'saml_name_id_name_qualifier' => $samlNameIdNameQualifier,
+                    'saml_name_id_sp_name_qualifier' => $samlNameIdSPNameQualifier,
+                ],
+                previous: $e
+            );
         }
-
-        $this->info('logout from SAML and redirect');
-        $auth = new Auth($this->formatter->format($this->configuration->getCustomConfiguration()));
-        $auth->logout($returnTo, $parameters, $nameId, $sessionIndex);
     }
 
+    /**
+     * @throws SamlException
+     * @return void
+     */
     public function handleCallbackLogoutResponse(): void
     {
         $this->info('SAML SLS invoked');
 
-        $auth = new Auth($this->formatter->format($this->configuration->getCustomConfiguration()));
+        try {
+            $auth = $this->authFactory->create($this->formatter->format($this->configuration->getCustomConfiguration()));
+        } catch (Throwable $e) {
+            throw new SamlException(
+                message: 'SAML Auth initialization failed: ' . $e->getMessage(),
+                context: [
+                    'configuration_id' => $this->configuration->getId(),
+                    'configuration_name' => $this->configuration->getName(),
+                    'configuration_type' => $this->configuration->getType(),
+                ],
+                previous: $e
+            );
+        }
+
         $requestID = isset($_SESSION, $_SESSION['LogoutRequestID']) ? $_SESSION['LogoutRequestID'] : null;
 
-        $auth->processSLO(true, $requestID, false, null, true);
+        try {
+            $auth->processSLO(
+                keepLocalSession: false,
+                requestId: $requestID,
+                cbDeleteSession: function (): void {
+                    try {
+                        $this->writeSessionRepository->invalidate();
+                    } catch (RepositoryException $e) {
+                        ExceptionLogger::create()->log(
+                            throwable: $e,
+                            context: [
+                                'user_id' => $this->getAuthenticatedUser()?->getId() ?? 'unknown',
+                                'provider' => Provider::SAML,
+                                'action' => 'Invalidate session failed during SAML SLS logout',
+                            ]
+                        );
+                    }
+                },
+                stay: true
+            );
+        } catch (Throwable $e) {
+            throw new SamlException(
+                message: 'SAML SLS processing failed: ' . $e->getMessage(),
+                context: [
+                    'configuration_id' => $this->configuration->getId(),
+                    'configuration_name' => $this->configuration->getName(),
+                    'configuration_type' => $this->configuration->getType(),
+                    'request_id' => $requestID,
+                ],
+                previous: $e
+            );
+        }
 
         // Avoid 'Open Redirect' attacks
         if (isset($_GET['RelayState']) && Utils::getSelfURL() !== $_GET['RelayState']) {

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SamlAuthFactory.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SamlAuthFactory.php
@@ -21,27 +21,14 @@
 
 declare(strict_types=1);
 
-namespace Core\Security\Authentication\Application\Repository;
+namespace Core\Security\Authentication\Infrastructure\Provider;
 
-use Core\Common\Domain\Exception\RepositoryException;
+use OneLogin\Saml2\Auth;
 
-interface WriteSessionRepositoryInterface
+final class SamlAuthFactory implements SamlAuthFactoryInterface
 {
-    /**
-     * Invalidate a session.
-     *
-     * @throws RepositoryException
-     */
-    public function invalidate(): void;
-
-    /**
-     * Start a session (included the legacy session).
-     *
-     * @param \Centreon $legacySession
-     *
-     * @throws RepositoryException
-     *
-     * @return bool
-     */
-    public function start(\Centreon $legacySession): bool;
+    public function create(array $settings): Auth
+    {
+        return new Auth($settings);
+    }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SamlAuthFactoryInterface.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SamlAuthFactoryInterface.php
@@ -21,27 +21,19 @@
 
 declare(strict_types=1);
 
-namespace Core\Security\Authentication\Application\Repository;
+namespace Core\Security\Authentication\Infrastructure\Provider;
 
-use Core\Common\Domain\Exception\RepositoryException;
+use OneLogin\Saml2\Auth;
 
-interface WriteSessionRepositoryInterface
+interface SamlAuthFactoryInterface
 {
     /**
-     * Invalidate a session.
+     * @param array<string,mixed> $settings
      *
-     * @throws RepositoryException
+     * @throws \OneLogin\Saml2\Error
+     * @throws \Exception
+     *
+     * @return Auth
      */
-    public function invalidate(): void;
-
-    /**
-     * Start a session (included the legacy session).
-     *
-     * @param \Centreon $legacySession
-     *
-     * @throws RepositoryException
-     *
-     * @return bool
-     */
-    public function start(\Centreon $legacySession): bool;
+    public function create(array $settings): Auth;
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
@@ -23,31 +23,22 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Infrastructure\Repository;
 
-use Centreon\Domain\Log\LoggerTrait;
-use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
+use Core\Common\Domain\Exception\RepositoryException;
 use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
 use Core\Security\Authentication\Application\Repository\WriteSessionTokenRepositoryInterface;
-use Core\Security\Authentication\Infrastructure\Provider\OpenId;
-use Core\Security\Authentication\Infrastructure\Provider\SAML;
-use Core\Security\ProviderConfiguration\Domain\Model\Provider;
-use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration as OpenIdCustomConfiguration;
-use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration;
 use Exception;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class WriteSessionRepository implements WriteSessionRepositoryInterface
 {
-    use LoggerTrait;
-
     /**
      * @param RequestStack $requestStack
      * @param WriteSessionTokenRepositoryInterface $writeSessionTokenRepository
-     * @param ProviderAuthenticationFactoryInterface $providerFactory
      */
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly WriteSessionTokenRepositoryInterface $writeSessionTokenRepository,
-        private readonly ProviderAuthenticationFactoryInterface $providerFactory,
     ) {
     }
 
@@ -56,71 +47,61 @@ class WriteSessionRepository implements WriteSessionRepositoryInterface
      */
     public function invalidate(): void
     {
-        $session = $this->requestStack->getSession();
-        $idToken = $session->get('openid_id_token') ?? '';
+        try {
+            $session = $this->requestStack->getSession();
+        } catch (SessionNotFoundException $e) {
+            throw new RepositoryException(
+                message: 'No session found to invalidate: ' . $e->getMessage(),
+                previous: $e
+            );
+        }
+
         $sessionId = $session->getId();
-        $this->writeSessionTokenRepository->deleteSession($sessionId);
-        $centreon = $session->get('centreon');
+
+        try {
+            $this->writeSessionTokenRepository->deleteSession($sessionId);
+        } catch (Exception $e) {
+            throw new RepositoryException(
+                message: 'Could not delete session token: ' . $e->getMessage(),
+                context: ['session_id' => $sessionId],
+                previous: $e
+            );
+        }
+
         $session->invalidate();
-
-        if ($centreon && $centreon->user->authType === Provider::SAML) {
-            /** @var SAML $provider */
-            $provider = $this->providerFactory->create(Provider::SAML);
-            $configuration = $provider->getConfiguration();
-            /** @var CustomConfiguration $customConfiguration */
-            $customConfiguration = $configuration->getCustomConfiguration();
-            if (
-                $configuration->isActive()
-                && $customConfiguration->getLogoutFrom() === CustomConfiguration::LOGOUT_FROM_CENTREON_AND_IDP
-            ) {
-                $this->info('Logout from Centreon and SAML IDP...');
-                $provider->logout(); // The redirection is done here by the IDP
-            }
-        }
-
-        if ($centreon && $centreon->user->authType === Provider::OPENID) {
-            /** @var OpenId $provider */
-            $provider = $this->providerFactory->create(Provider::OPENID);
-            $configuration = $provider->getConfiguration();
-            /** @var OpenIdCustomConfiguration $customConfiguration */
-            $customConfiguration = $configuration->getCustomConfiguration();
-            $isLogin = $this->requestStack->getSession()->get('isLogin') ?? false;
-            if ($configuration->isActive()) {
-                try {
-                    $provider->logout($idToken, $isLogin);
-                } catch (Exception $e) {
-                    $this->error('OpenID logout failed: ' . $e->getMessage(), [
-                        'exception' => $e,
-                    ]);
-                }
-            }
-        }
     }
 
     /**
-     * Start a session (included the legacy session).
-     *
-     * @param \Centreon $legacySession
-     *
-     * @return bool
+     * @inheritDoc
      */
     public function start(\Centreon $legacySession): bool
     {
-        if ($this->requestStack->getSession()->isStarted()) {
+        try {
+            $session = $this->requestStack->getSession();
+        } catch (SessionNotFoundException $e) {
+            throw new RepositoryException(
+                message: 'No session found: ' . $e->getMessage(),
+                previous: $e
+            );
+        }
+
+        if ($session->isStarted()) {
             return true;
         }
 
-        $this->info('[AUTHENTICATE] Starting Centreon Session');
-        $this->requestStack->getSession()->start();
-        $this->requestStack->getSession()->set('centreon', $legacySession);
-        $this->requestStack->getSession()->set('isLogin', true);
-        $_SESSION['centreon'] = $legacySession;
-
-        $isSessionStarted = $this->requestStack->getSession()->isStarted();
-        if ($isSessionStarted === false) {
-            $this->invalidate();
+        try {
+            $session->start();
+        } catch (\RuntimeException $e) {
+            throw new RepositoryException(
+                message: 'Could not start session: ' . $e->getMessage(),
+                previous: $e
+            );
         }
 
-        return $isSessionStarted;
+        $session->set('centreon', $legacySession);
+        $session->set('isLogin', true);
+        $_SESSION['centreon'] = $legacySession;
+
+        return $session->isStarted();
     }
 }

--- a/centreon/src/Security/WebSSOAuthenticator.php
+++ b/centreon/src/Security/WebSSOAuthenticator.php
@@ -32,6 +32,8 @@ use Centreon\Domain\Option\Interfaces\OptionServiceInterface;
 use Centreon\Domain\Platform\Interfaces\PlatformRepositoryInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Centreon\Domain\VersionHelper;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Core\Security\Authentication\Application\Provider\{
     ProviderAuthenticationFactoryInterface,
@@ -51,13 +53,11 @@ use DateTimeImmutable;
 use FOS\RestBundle\View\View;
 use Security\Domain\Authentication\Interfaces\{AuthenticationServiceInterface, SessionRepositoryInterface};
 use Security\Domain\Authentication\Model\Session;
-use Symfony\Component\HttpFoundation\{Request, Response};
+use Symfony\Component\HttpFoundation\{Exception\SessionNotFoundException, Request, Response};
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\{
     AuthenticationException,
-    BadCredentialsException,
     CredentialsExpiredException,
-    SessionUnavailableException,
     UserNotFoundException
 };
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -75,30 +75,21 @@ class WebSSOAuthenticator extends AbstractAuthenticator
     private ProviderAuthenticationInterface $provider;
 
     /**
-     * @param AuthenticationServiceInterface $authenticationService
-     * @param SessionRepositoryInterface $sessionRepository
-     * @param DataStorageEngineInterface $dataStorageEngine
-     * @param OptionServiceInterface $optionService
-     * @param WriteTokenRepositoryInterface $writeTokenRepository
-     * @param WriteSessionRepositoryInterface $writeSessionRepository
-     * @param ProviderAuthenticationFactoryInterface $providerFactory
-     * @param ContactRepositoryInterface $contactRepository
-     * @param MenuServiceInterface $menuService
-     * @param PlatformRepositoryInterface $platformRepository
+     * @throws \Exception
      */
     public function __construct(
-        private AuthenticationServiceInterface $authenticationService,
-        private SessionRepositoryInterface $sessionRepository,
-        private DataStorageEngineInterface $dataStorageEngine,
-        private OptionServiceInterface $optionService,
-        private WriteTokenRepositoryInterface $writeTokenRepository,
-        private WriteSessionRepositoryInterface $writeSessionRepository,
-        private ProviderAuthenticationFactoryInterface $providerFactory,
-        private ContactRepositoryInterface $contactRepository,
-        private MenuServiceInterface $menuService,
-        private PlatformRepositoryInterface $platformRepository,
+        private readonly AuthenticationServiceInterface $authenticationService,
+        private readonly SessionRepositoryInterface $sessionRepository,
+        private readonly DataStorageEngineInterface $dataStorageEngine,
+        private readonly OptionServiceInterface $optionService,
+        private readonly WriteTokenRepositoryInterface $writeTokenRepository,
+        private readonly WriteSessionRepositoryInterface $writeSessionRepository,
+        private readonly ProviderAuthenticationFactoryInterface $providerFactory,
+        private readonly ContactRepositoryInterface $contactRepository,
+        private readonly MenuServiceInterface $menuService,
+        private readonly PlatformRepositoryInterface $platformRepository,
     ) {
-        /** @var string */
+        /** @var string $webVersion */
         $webVersion = $this->platformRepository->getWebVersion();
         if (VersionHelper::compare($webVersion, self::MINIMUM_SUPPORTED_VERSION, VersionHelper::GE)) {
             $this->provider = $this->providerFactory->create(Provider::WEB_SSO);
@@ -107,10 +98,12 @@ class WebSSOAuthenticator extends AbstractAuthenticator
 
     /**
      * @inheritDoc
+     *
+     * @throws \Exception
      */
     public function supports(Request $request): bool
     {
-        /** @var string */
+        /** @var string $webVersion */
         $webVersion = $this->platformRepository->getWebVersion();
         // We skip all API calls
         if (
@@ -130,6 +123,8 @@ class WebSSOAuthenticator extends AbstractAuthenticator
 
     /**
      * @inheritDoc
+     *
+     * @throws SSOAuthenticationException
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
@@ -151,49 +146,98 @@ class WebSSOAuthenticator extends AbstractAuthenticator
      *
      * @param Request $request
      *
-     * @throws SSOAuthenticationException
-     * @throws CentreonAuthenticationException
+     * @throws AuthenticationException
      *
      * @return SelfValidatingPassport
      */
     public function authenticate(Request $request): SelfValidatingPassport
     {
         try {
-            $this->info('Starting authentication with WebSSO');
+            $session = $request->getSession();
+        } catch (SessionNotFoundException $e) {
+            ExceptionLogger::create()->log(
+                throwable: $e,
+                context: [
+                    'action' => 'Getting session from request',
+                    'client_ip' => $request->getClientIp() ?? 'unknown',
+                ]
+            );
+
+            throw new AuthenticationException(
+                message: 'Authentication by WebSSO failed: ' . $e->getMessage(),
+                previous: $e
+            );
+        }
+
+        $this->info('Starting authentication with WebSSO');
+
+        try {
             $this->provider->authenticateOrFail(
                 LoginRequest::createForSSO($request->getClientIp() ?? '')
             );
-
-            $user = $this->provider->findUserOrFail();
-            $this->createSession($request, $this->provider);
-            $this->info(
-                'Authenticated successfully',
-                ['user' => $user->getAlias(), 'sessionId' => $request->getSession()->getId()]
+        } catch (SSOAuthenticationException $e) {
+            ExceptionLogger::create()->log(
+                throwable: $e,
+                context: [
+                    'user_id' => $this->provider->getAuthenticatedUser()?->getId() ?? 'unknown',
+                    'provider' => $this->provider->getConfiguration()->getType(),
+                    'action' => 'WebSSO Authentication by provider',
+                    'client_ip' => $request->getClientIp() ?? 'unknown',
+                ]
             );
 
-            // getRedirectionUri() expects ONLY a string as its second parameter
-            $referer = $request->headers->get('referer', '');
-            if (! empty($referer)) {
-                $referer = parse_url($referer, PHP_URL_QUERY);
-                if (! is_string($referer)) {
-                    $referer = '';
-                }
-            }
-
-            View::createRedirect(
-                $this->getRedirectionUri(
-                    $this->provider->getAuthenticatedUser(),
-                    $referer
-                ),
-                200
+            throw new AuthenticationException(
+                message: 'Authentication by WebSSO failed because authentication by provider failed: ' . $e->getMessage(),
+                previous: $e
             );
-        } catch (SSOAuthenticationException $exception) {
-            throw new AuthenticationException($exception->getMessage(), $exception->getCode());
         }
+
+        $user = $this->provider->findUserOrFail();
+
+        try {
+            $this->createSession($request, $this->provider);
+        } catch (CentreonAuthenticationException $centreonAuthenticationException) {
+            ExceptionLogger::create()->log(
+                throwable: $centreonAuthenticationException,
+                context: [
+                    'user_id' => $this->provider->getAuthenticatedUser()?->getId() ?? 'unknown',
+                    'provider' => $this->provider->getConfiguration()->getType(),
+                    'action' => 'Creating session',
+                    'client_ip' => $request->getClientIp() ?? 'unknown',
+                ]
+            );
+
+            throw new AuthenticationException(
+                message: 'Authentication by WebSSO failed because creating session failed: ' . $centreonAuthenticationException->getMessage(),
+                previous: $centreonAuthenticationException
+            );
+        }
+
+        $this->info(
+            'Authenticated successfully',
+            ['user' => $user->getAlias(), 'sessionId' => $session->getId()]
+        );
+
+        // getRedirectionUri() expects ONLY a string as its second parameter
+        $referer = $request->headers->get('referer', '');
+        if (! empty($referer)) {
+            $referer = parse_url($referer, PHP_URL_QUERY);
+            if (! is_string($referer)) {
+                $referer = '';
+            }
+        }
+
+        View::createRedirect(
+            $this->getRedirectionUri(
+                $this->provider->getAuthenticatedUser(),
+                $referer
+            ),
+            200
+        );
 
         return new SelfValidatingPassport(
             new UserBadge(
-                $request->getSession()->getId(),
+                $session->getId(),
                 function ($userIdentifier) {
                     return $this->getUser($userIdentifier);
                 }
@@ -206,10 +250,9 @@ class WebSSOAuthenticator extends AbstractAuthenticator
      *
      * @param string $sessionId
      *
-     * @throws BadCredentialsException
-     * @throws SessionUnavailableException
      * @throws ContactDisabledException
-     *
+     * @throws CredentialsExpiredException
+     * @throws UserNotFoundException
      * @return UserInterface
      */
     private function getUser(string $sessionId): UserInterface
@@ -238,31 +281,49 @@ class WebSSOAuthenticator extends AbstractAuthenticator
      * @param Request $request
      * @param ProviderAuthenticationInterface $provider
      *
-     * @throws \Centreon\Domain\Authentication\Exception\AuthenticationException
+     * @throws CentreonAuthenticationException
+     * @return void
      */
     private function createSession(Request $request, ProviderAuthenticationInterface $provider): void
     {
         $this->debug('Creating session');
 
-        if ($this->writeSessionRepository->start($provider->getLegacySession())) {
-            $sessionId = $request->getSession()->getId();
+        try {
+            $successStartSession = $this->writeSessionRepository->start($provider->getLegacySession());
+        } catch (RepositoryException $e) {
+            throw CentreonAuthenticationException::notAuthenticated($e);
+        }
 
-            // @todo: why are we not using findUserOrFail()?
-            $authenticatedUser = $provider->getAuthenticatedUser();
-            if ($authenticatedUser === null) {
-                throw new \Centreon\Domain\Authentication\Exception\AuthenticationException(
-                    'No authenticated user could be found for provider'
-                );
+        if (! $successStartSession) {
+            try {
+                $this->writeSessionRepository->invalidate();
+            } catch (RepositoryException $e) {
+                throw CentreonAuthenticationException::notAuthenticated($e);
             }
 
-            $this->createTokenIfNotExist(
-                $sessionId,
-                $provider->getConfiguration()->getId(),
-                $authenticatedUser,
-                $request->getClientIp() ?? '' // @todo: what should happen if no IP was found?
-            );
-            $request->headers->set('Set-Cookie', session_name() . '=' . $sessionId);
+            throw CentreonAuthenticationException::notAuthenticated();
         }
+
+        try {
+            $sessionId = $request->getSession()->getId();
+        } catch (SessionNotFoundException $e) {
+            throw CentreonAuthenticationException::notAuthenticated($e);
+        }
+
+        // @todo: why are we not using findUserOrFail()?
+        $authenticatedUser = $provider->getAuthenticatedUser();
+        if ($authenticatedUser === null) {
+            throw CentreonAuthenticationException::notAuthenticated();
+        }
+
+        $this->createTokenIfNotExist(
+            $sessionId,
+            $provider->getConfiguration()->getId(),
+            $authenticatedUser,
+            $request->getClientIp() ?? '' // @todo: what should happen if no IP was found?
+        );
+
+        $request->headers->set('Set-Cookie', session_name() . '=' . $sessionId);
     }
 
     /**
@@ -273,7 +334,7 @@ class WebSSOAuthenticator extends AbstractAuthenticator
      * @param ContactInterface $user
      * @param string $clientIp
      *
-     * @throws \Centreon\Domain\Authentication\Exception\AuthenticationException
+     * @throws CentreonAuthenticationException
      */
     private function createTokenIfNotExist(
         string $sessionId,
@@ -281,26 +342,30 @@ class WebSSOAuthenticator extends AbstractAuthenticator
         ContactInterface $user,
         string $clientIp,
     ): void {
-        $this->info('creating token');
-        $authenticationTokens = $this->authenticationService->findAuthenticationTokensByToken(
-            $sessionId
-        );
-        if ($authenticationTokens === null) {
-            $sessionExpireOption = $this->optionService->findSelectedOptions(['session_expire']);
-            $sessionExpirationDelay = (int) $sessionExpireOption[0]->getValue();
-            $token = new ProviderToken(
-                $webSSOConfigurationId,
-                $sessionId,
-                new DateTimeImmutable(),
-                (new DateTimeImmutable())->add(new DateInterval('PT' . $sessionExpirationDelay . 'M'))
+        try {
+            $this->info('creating token');
+            $authenticationTokens = $this->authenticationService->findAuthenticationTokensByToken(
+                $sessionId
             );
-            $this->createAuthenticationTokens(
-                $sessionId,
-                $user,
-                $token,
-                null,
-                $clientIp,
-            );
+            if ($authenticationTokens === null) {
+                $sessionExpireOption = $this->optionService->findSelectedOptions(['session_expire']);
+                $sessionExpirationDelay = (int) $sessionExpireOption[0]->getValue();
+                $token = new ProviderToken(
+                    $webSSOConfigurationId,
+                    $sessionId,
+                    new DateTimeImmutable(),
+                    (new DateTimeImmutable())->add(new DateInterval('PT' . $sessionExpirationDelay . 'M'))
+                );
+                $this->createAuthenticationTokens(
+                    $sessionId,
+                    $user,
+                    $token,
+                    null,
+                    $clientIp,
+                );
+            }
+        } catch (\Exception $exception) {
+            throw CentreonAuthenticationException::notAuthenticated(previous: $exception);
         }
     }
 
@@ -324,10 +389,11 @@ class WebSSOAuthenticator extends AbstractAuthenticator
     ): void {
         $isAlreadyInTransaction = $this->dataStorageEngine->isAlreadyinTransaction();
 
-        if (! $isAlreadyInTransaction) {
-            $this->dataStorageEngine->startTransaction();
-        }
         try {
+            if (! $isAlreadyInTransaction) {
+                $this->dataStorageEngine->startTransaction();
+            }
+
             $session = new Session($sessionToken, $contact->getId(), $clientIp);
             $this->sessionRepository->addSession($session);
             $this->writeTokenRepository->createAuthenticationTokens(
@@ -340,15 +406,16 @@ class WebSSOAuthenticator extends AbstractAuthenticator
             if (! $isAlreadyInTransaction) {
                 $this->dataStorageEngine->commitTransaction();
             }
-        } catch (\Exception $ex) {
-            $this->error('Unable to create authentication tokens', [
-                'trace' => $ex->getTraceAsString(),
-            ]);
+        } catch (\Exception $exception) {
             if (! $isAlreadyInTransaction) {
-                $this->dataStorageEngine->rollbackTransaction();
+                try {
+                    $this->dataStorageEngine->rollbackTransaction();
+                } catch (\Exception $rollbackException) {
+                    throw CentreonAuthenticationException::notAuthenticated(previous: $rollbackException);
+                }
             }
 
-            throw CentreonAuthenticationException::notAuthenticated();
+            throw CentreonAuthenticationException::notAuthenticated(previous: $exception);
         }
     }
 

--- a/centreon/tests/php/Core/Security/Authentication/Application/UseCase/LogoutSession/LogoutSessionTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Application/UseCase/LogoutSession/LogoutSessionTest.php
@@ -24,13 +24,17 @@ declare(strict_types=1);
 namespace Tests\Core\Security\Authentication\Application\UseCase\LogoutSession;
 
 use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Common\Domain\Exception\RepositoryException;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
-use Core\Security\Authentication\Application\Repository\ReadTokenRepositoryInterface;
 use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteSessionTokenRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Application\UseCase\LogoutSession\LogoutSession;
 use Core\Security\Authentication\Application\UseCase\LogoutSession\LogoutSessionPresenterInterface;
+use Core\Security\Authentication\Infrastructure\Provider\OpenId;
+use Core\Security\Authentication\Infrastructure\Provider\SAML;
+use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration as SamlCustomConfiguration;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -38,73 +42,181 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class LogoutSessionTest extends TestCase
 {
-    /** @var WriteSessionTokenRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $writeSessionTokenRepository;
-
-    /** @var WriteSessionRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject */
+    /** @var WriteSessionRepositoryInterface&MockObject */
     private $writeSessionRepository;
 
-    /** @var WriteTokenRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $writeTokenRepository;
+    /** @var ProviderAuthenticationFactoryInterface&MockObject */
+    private $providerFactory;
 
-    /** @var LogoutSessionPresenterInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $logoutSessionPresenter;
+    /** @var RequestStack&MockObject */
+    private $requestStack;
 
-    /** @var ReadTokenRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private ReadTokenRepositoryInterface $readTokenRepository;
+    /** @var LogoutSessionPresenterInterface&MockObject */
+    private $presenter;
 
-    /** @var ProviderAuthenticationFactoryInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private ProviderAuthenticationFactoryInterface $providerFactory;
-
-    /** @var RequestStack&\PHPUnit\Framework\MockObject\MockObject */
-    private RequestStack $requestStack;
-
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $this->writeSessionTokenRepository = $this->createMock(WriteSessionTokenRepositoryInterface::class);
         $this->writeSessionRepository = $this->createMock(WriteSessionRepositoryInterface::class);
-        $this->writeTokenRepository = $this->createMock(WriteTokenRepositoryInterface::class);
-        $this->logoutSessionPresenter = $this->createMock(LogoutSessionPresenterInterface::class);
-        $this->readTokenRepository = $this->createMock(ReadTokenRepositoryInterface::class);
         $this->providerFactory = $this->createMock(ProviderAuthenticationFactoryInterface::class);
         $this->requestStack = $this->createMock(RequestStack::class);
+        $this->presenter = $this->createMock(LogoutSessionPresenterInterface::class);
     }
 
-    /**
-     * test Logout.
-     */
-    public function testLogout(): void
+    public function testReturnsErrorWhenTokenIsMissing(): void
     {
-        $logoutSession = new LogoutSession(
-            $this->writeSessionRepository,
-        );
-
-        $session = new Session(new MockArraySessionStorage());
-        $session->setId('session_abcd');
-        $this->requestStack
-            ->expects($this->any())
-            ->method('getSession')
-            ->willReturn($session);
-
-        $this->writeSessionRepository->expects($this->once())
-            ->method('invalidate');
-
-        $logoutSession('token', $this->logoutSessionPresenter);
-    }
-
-    /**
-     * test Logout with bad token.
-     */
-    public function testLogoutFailed(): void
-    {
-        $logoutSession = new LogoutSession(
-            $this->writeSessionRepository,
-        );
-
-        $this->logoutSessionPresenter->expects($this->once())
+        $this->presenter->expects($this->once())
             ->method('setResponseStatus')
             ->with(new ErrorResponse('No session token provided'));
+        $this->writeSessionRepository->expects($this->never())->method('invalidate');
+        $this->providerFactory->expects($this->never())->method('create');
 
-        $logoutSession(null, $this->logoutSessionPresenter);
+        ($this->createUseCase())(null, $this->presenter);
+    }
+
+    public function testLocalUserOnlyInvalidatesSession(): void
+    {
+        $this->requestStack->method('getSession')->willReturn($this->createSession(Provider::LOCAL));
+
+        $this->providerFactory->expects($this->never())->method('create');
+        $this->writeSessionRepository->expects($this->once())->method('invalidate');
+
+        ($this->createUseCase())('token', $this->presenter);
+    }
+
+    public function testSamlLogoutFromIdpIsTriggeredBeforeInvalidate(): void
+    {
+        $calls = [];
+        $this->requestStack->method('getSession')->willReturn($this->createSession(Provider::SAML));
+
+        $provider = $this->createSamlProvider(isActive: true, logoutFromIdp: true);
+        $provider->expects($this->once())->method('logout')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'saml_logout';
+            });
+        $this->providerFactory->method('create')->with(Provider::SAML)->willReturn($provider);
+
+        $this->writeSessionRepository->expects($this->once())->method('invalidate')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'invalidate';
+            });
+
+        ($this->createUseCase())('token', $this->presenter);
+
+        // The SAML LogoutRequest reads identifiers still held in session, so it must run first.
+        self::assertSame(['saml_logout', 'invalidate'], $calls);
+    }
+
+    public function testSamlLocalLogoutDoesNotTriggerProviderLogout(): void
+    {
+        $this->requestStack->method('getSession')->willReturn($this->createSession(Provider::SAML));
+
+        $provider = $this->createSamlProvider(isActive: true, logoutFromIdp: false);
+        $provider->expects($this->never())->method('logout');
+        $this->providerFactory->method('create')->with(Provider::SAML)->willReturn($provider);
+
+        $this->writeSessionRepository->expects($this->once())->method('invalidate');
+
+        ($this->createUseCase())('token', $this->presenter);
+    }
+
+    public function testSamlLogoutIsSkippedWhenProviderIsInactive(): void
+    {
+        $this->requestStack->method('getSession')->willReturn($this->createSession(Provider::SAML));
+
+        $provider = $this->createSamlProvider(isActive: false, logoutFromIdp: true);
+        $provider->expects($this->never())->method('logout');
+        $this->providerFactory->method('create')->with(Provider::SAML)->willReturn($provider);
+
+        $this->writeSessionRepository->expects($this->once())->method('invalidate');
+
+        ($this->createUseCase())('token', $this->presenter);
+    }
+
+    public function testOpenIdLogoutIsTriggeredAfterInvalidate(): void
+    {
+        $calls = [];
+        $this->requestStack->method('getSession')
+            ->willReturn($this->createSession(Provider::OPENID, 'id-token-xyz'));
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('isActive')->willReturn(true);
+        $provider = $this->createMock(OpenId::class);
+        $provider->method('getConfiguration')->willReturn($configuration);
+        $provider->expects($this->once())->method('logout')
+            ->with('id-token-xyz', false)
+            ->willReturnCallback(static function () use (&$calls): ?string {
+                $calls[] = 'openid_logout';
+
+                return null;
+            });
+        $this->providerFactory->method('create')->with(Provider::OPENID)->willReturn($provider);
+
+        $this->writeSessionRepository->expects($this->once())->method('invalidate')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'invalidate';
+            });
+
+        ($this->createUseCase())('token', $this->presenter);
+
+        // OpenID has no /saml/sls-like callback: the local session must be wiped before redirecting.
+        self::assertSame(['invalidate', 'openid_logout'], $calls);
+    }
+
+    public function testSetsErrorResponseWhenInvalidateFails(): void
+    {
+        $this->requestStack->method('getSession')->willReturn($this->createSession(Provider::LOCAL));
+
+        $exception = new RepositoryException('boom');
+        $this->writeSessionRepository->method('invalidate')->willThrowException($exception);
+
+        $this->presenter->expects($this->once())
+            ->method('setResponseStatus')
+            ->with(new ErrorResponse('An error occurred during session logout', exception: $exception));
+
+        ($this->createUseCase())('token', $this->presenter);
+    }
+
+    private function createUseCase(): LogoutSession
+    {
+        return new LogoutSession(
+            $this->writeSessionRepository,
+            $this->providerFactory,
+            $this->requestStack,
+        );
+    }
+
+    private function createSession(string $authType, string $idToken = ''): Session
+    {
+        $session = new Session(new MockArraySessionStorage());
+
+        $centreon = new \stdClass();
+        $centreon->user = new \stdClass();
+        $centreon->user->authType = $authType;
+        $session->set('centreon', $centreon);
+
+        if ($idToken !== '') {
+            $session->set('openid_id_token', $idToken);
+        }
+
+        return $session;
+    }
+
+    /**
+     * @return SAML&MockObject
+     */
+    private function createSamlProvider(bool $isActive, bool $logoutFromIdp): SAML
+    {
+        $customConfiguration = (new \ReflectionClass(SamlCustomConfiguration::class))
+            ->newInstanceWithoutConstructor();
+        $customConfiguration->setLogoutFrom($logoutFromIdp);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('isActive')->willReturn($isActive);
+        $configuration->method('getCustomConfiguration')->willReturn($customConfiguration);
+
+        $provider = $this->createMock(SAML::class);
+        $provider->method('getConfiguration')->willReturn($configuration);
+
+        return $provider;
     }
 }

--- a/centreon/tests/php/Core/Security/Authentication/Application/UseCase/LogoutSession/SAML/LogoutFromIdpTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Application/UseCase/LogoutSession/SAML/LogoutFromIdpTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Authentication\Application\UseCase\LogoutSession\SAML;
+
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
+use Core\Security\Authentication\Application\UseCase\LogoutSession\SAML\LogoutFromIdp;
+use Core\Security\Authentication\Infrastructure\Provider\SAML;
+use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LogoutFromIdpTest extends TestCase
+{
+    /** @var ProviderAuthenticationFactoryInterface&MockObject */
+    private $providerFactory;
+
+    protected function setUp(): void
+    {
+        $this->providerFactory = $this->createMock(ProviderAuthenticationFactoryInterface::class);
+    }
+
+    public function testProcessesCallbackWithoutInitiatingNewLogout(): void
+    {
+        $provider = $this->createProvider(isActive: true);
+        $provider->expects($this->once())->method('handleCallbackLogoutResponse');
+        $provider->expects($this->never())->method('logout');
+
+        $this->providerFactory->method('create')->with(Provider::SAML)->willReturn($provider);
+
+        (new LogoutFromIdp($this->providerFactory))();
+    }
+
+    public function testDoesNothingWhenProviderIsInactive(): void
+    {
+        $provider = $this->createProvider(isActive: false);
+        $provider->expects($this->never())->method('handleCallbackLogoutResponse');
+        $provider->expects($this->never())->method('logout');
+
+        $this->providerFactory->method('create')->with(Provider::SAML)->willReturn($provider);
+
+        (new LogoutFromIdp($this->providerFactory))();
+    }
+
+    /**
+     * @return SAML&MockObject
+     */
+    private function createProvider(bool $isActive): SAML
+    {
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('isActive')->willReturn($isActive);
+
+        $provider = $this->createMock(SAML::class);
+        $provider->method('getConfiguration')->willReturn($configuration);
+
+        return $provider;
+    }
+}

--- a/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/SAMLLogoutRequestContentTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/SAMLLogoutRequestContentTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Authentication\Infrastructure\Provider;
+
+use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
+use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
+use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
+use Core\Security\Authentication\Infrastructure\Provider\SAML;
+use Core\Security\Authentication\Infrastructure\Provider\SamlAuthFactoryInterface;
+use Core\Security\Authentication\Infrastructure\Provider\Settings\Formatter\SettingsFormatterInterface;
+use Core\Security\ProviderConfiguration\Domain\CustomConfigurationInterface;
+use Core\Security\ProviderConfiguration\Domain\LoginLoggerInterface;
+use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\Conditions;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\GroupsMapping;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\RolesMapping;
+use DOMDocument;
+use DOMElement;
+use OneLogin\Saml2\Auth;
+use OneLogin\Saml2\Constants;
+use PHPUnit\Framework\TestCase;
+use Pimple\Container;
+
+/**
+ * Regression coverage for MON-152191.
+ *
+ * The ticket symptom was that, at logout, Centreon emitted a <samlp:LogoutRequest>
+ * whose <saml:NameID> was the IdP metadata URL with Format "...nameid-format:entity",
+ * instead of the user login with the format negotiated at login. OneLogin rejected it
+ * with: NameID '...metadata/' does not match prior auth request '<login>'.
+ *
+ * Root cause: the PHP session (holding samlNameId / samlNameIdFormat) was wiped before
+ * SAML::logout() ran, so null identifiers reached OneLogin\Saml2\Auth::logout(). When the
+ * nameId is empty, php-saml falls back to the IdP entityId + NAMEID_ENTITY format
+ * (see vendor/onelogin/php-saml/src/Saml2/LogoutRequest.php).
+ *
+ * These tests assert the *content* of the LogoutRequest XML actually produced by a real
+ * OneLogin\Saml2\Auth, driven through Centreon's real SAML::logout() code path. Only
+ * Auth::redirectTo() is neutralised so the test does not exit the process; the request XML
+ * is built for real and read back through Auth::getLastRequestXML().
+ */
+class SAMLLogoutRequestContentTest extends TestCase
+{
+    private const IDP_ENTITY_ID = 'https://sso.example.com/saml-idp/abc123/metadata/';
+    private const USER_LOGIN = 'demo-yha9227';
+
+    // Throwaway self-signed certificate; OneLogin\Saml2\Settings requires an IdP certificate in
+    // strict mode, just as OneLoginSettingsFormatter always provides one from the stored config.
+    private const IDP_X509_CERT = 'MIIDBzCCAe+gAwIBAgIUez2J1H/1/vfxpusApnam3Se8LYswDQYJKoZIhvcNAQEL'
+        . 'BQAwEzERMA8GA1UEAwwIdGVzdC1pZHAwHhcNMjYwNTI5MDkzNDA2WhcNMzYwNTI2MDkzNDA2WjATMREwDwYD'
+        . 'VQQDDAh0ZXN0LWlkcDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMidM4ZwIYa9etOUftZqMfaS'
+        . 'HLlrYpsgknkKakm+U6qJrgSkNxcw+vsJIOgU/i0/wO5vBzvDGMHoh/kFqP/j6m0CuxIbBpIfWjFdcRdSNKd0'
+        . 'Tdb6ZGWqcQRoX3IFvezfsIE+QG4MYofewVQLYjbcxfwWay/dtM/6bX9p7NIKPiSky0k1o9vnXZVvEusN9X6D'
+        . 'wywH3JDxONzrqMrwnL4Nudid8qSKfPT2poHnOhl3OJ5EZxHiYGDlBlpqjA4Xnn0lFmcl62CFVPJcswDJm4/k'
+        . 'CqF+ficeWgwCfrj0yTJhUmS7jgswo0RdN4UdAyZE/75UwJmyOi6roAuEkMsZCBkEJckCAwEAAaNTMFEwHQYD'
+        . 'VR0OBBYEFFUMunxgNC2bKwg62Dr+MfGM0bYcMB8GA1UdIwQYMBaAFFUMunxgNC2bKwg62Dr+MfGM0bYcMA8G'
+        . 'A1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBADWzZ3IEkxbscQS+SnAFDytZWR6llAl1c3YSjxMo'
+        . '7emEuO87wXYukWr5AuzefTYu/OG584IUbAyM6jv8D9c6oDK4PHwP8Zekd7RabXvqAALmq682ezHIHUlhxZ/k'
+        . 'i9rvu9FHwaIkrjXZzu4ZA+m4efYkRe1Wi5UCpBizVkVgNiwOOMPKgFadkCIK62nEwR938FU5oalfzAPjM8Do'
+        . 'sGW05gQKclsOHWlMxb9UvN72jVY9wElXSjJJVEHBGUF6J2I0LPlIICGKrzoSy1hqDoJg9jZOxYLp7XGP8FL8'
+        . 'hoRyMDdwKknaZzd6HJSn14Kxj1NpVdjdt0F1IYGWP4yZS6ZuQSA=';
+
+    protected function tearDown(): void
+    {
+        unset($_SESSION['saml'], $_SESSION['LogoutRequestID']);
+    }
+
+    public function testLogoutRequestUsesUserLoginAndNegotiatedFormatWhenSessionIsPresent(): void
+    {
+        // The fixed flow: SAML::logout() runs *before* the session is invalidated, so the
+        // identifiers stored at login are still available and forwarded to php-saml.
+        $_SESSION['saml'] = [
+            'samlNameId' => self::USER_LOGIN,
+            'samlSessionIndex' => '_session-index-123',
+            'samlNameIdFormat' => Constants::NAMEID_UNSPECIFIED,
+            'samlNameIdNameQualifier' => null,
+            'samlNameIdSPNameQualifier' => null,
+        ];
+
+        $auth = $this->createRealAuthWithoutRedirect();
+        $this->createSaml($auth)->logout();
+
+        $nameId = $this->extractNameIdElement($auth->getLastRequestXML());
+
+        self::assertSame(
+            self::USER_LOGIN,
+            $nameId->textContent,
+            'The LogoutRequest NameID must be the user login, not the IdP metadata URL.'
+        );
+        self::assertNotSame(
+            Constants::NAMEID_ENTITY,
+            $nameId->getAttribute('Format'),
+            'The LogoutRequest NameID Format must not fall back to the "entity" format.'
+        );
+        // php-saml omits the Format attribute when it equals the (default) "unspecified" value.
+        self::assertFalse(
+            $nameId->hasAttribute('Format'),
+            'A NameID forwarded with the "unspecified" format is emitted without a Format attribute.'
+        );
+    }
+
+    public function testLogoutRequestFallsBackToIdpEntityWhenSessionWasWiped(): void
+    {
+        // Documents the original bug: with the session already wiped, no identifiers reach
+        // php-saml and it falls back to the IdP entityId + entity format that OneLogin rejected.
+        unset($_SESSION['saml']);
+
+        $auth = $this->createRealAuthWithoutRedirect();
+        $this->createSaml($auth)->logout();
+
+        $nameId = $this->extractNameIdElement($auth->getLastRequestXML());
+
+        self::assertSame(
+            self::IDP_ENTITY_ID,
+            $nameId->textContent,
+            'Without session identifiers, php-saml emits the IdP entityId as NameID (the bug).'
+        );
+        self::assertSame(
+            Constants::NAMEID_ENTITY,
+            $nameId->getAttribute('Format'),
+            'Without session identifiers, php-saml emits the entity NameID format (the bug).'
+        );
+    }
+
+    /**
+     * Builds a real OneLogin\Saml2\Auth (real Settings, real LogoutRequest generation) and
+     * neutralises only redirectTo() so the request is built but the process is not terminated.
+     */
+    private function createRealAuthWithoutRedirect(): Auth
+    {
+        $auth = $this->getMockBuilder(Auth::class)
+            ->setConstructorArgs([$this->oneLoginSettings()])
+            ->onlyMethods(['redirectTo'])
+            ->getMock();
+        $auth->method('redirectTo')->willReturn('');
+
+        return $auth;
+    }
+
+    /**
+     * Minimal settings matching the shape produced by OneLoginSettingsFormatter::format(),
+     * with the IdP entityId set to a metadata URL like the one reported in MON-152191.
+     *
+     * @return array<string,mixed>
+     */
+    private function oneLoginSettings(): array
+    {
+        return [
+            'strict' => true,
+            'sp' => [
+                'entityId' => 'https://centreon.example.com/centreon/api/latest/saml/metadata',
+                'assertionConsumerService' => [
+                    'url' => 'https://centreon.example.com/centreon/api/latest/saml/acs',
+                ],
+            ],
+            'idp' => [
+                'entityId' => self::IDP_ENTITY_ID,
+                'singleSignOnService' => [
+                    'url' => 'https://sso.example.com/saml-idp/abc123/sso',
+                ],
+                'singleLogoutService' => [
+                    'url' => 'https://sso.example.com/saml-idp/abc123/slo',
+                ],
+                'x509cert' => self::IDP_X509_CERT,
+            ],
+        ];
+    }
+
+    private function createSaml(Auth $auth): SAML
+    {
+        $formatter = $this->createMock(SettingsFormatterInterface::class);
+        $formatter->method('format')->willReturn([]);
+
+        $authFactory = $this->createMock(SamlAuthFactoryInterface::class);
+        $authFactory->method('create')->willReturn($auth);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getCustomConfiguration')
+            ->willReturn($this->createMock(CustomConfigurationInterface::class));
+
+        $saml = new SAML(
+            $this->createMock(Container::class),
+            $this->createMock(ContactRepositoryInterface::class),
+            $this->createMock(LoginLoggerInterface::class),
+            $this->createMock(WriteUserRepositoryInterface::class),
+            $this->createMock(Conditions::class),
+            $this->createMock(RolesMapping::class),
+            $this->createMock(GroupsMapping::class),
+            $formatter,
+            $this->createMock(WriteSessionRepositoryInterface::class),
+            $authFactory,
+        );
+        $saml->setConfiguration($configuration);
+
+        return $saml;
+    }
+
+    private function extractNameIdElement(?string $logoutRequestXml): DOMElement
+    {
+        self::assertNotEmpty($logoutRequestXml, 'No LogoutRequest XML was produced.');
+
+        $document = new DOMDocument();
+        self::assertTrue($document->loadXML($logoutRequestXml), 'The LogoutRequest XML is not parseable.');
+
+        $nameIds = $document->getElementsByTagNameNS(
+            'urn:oasis:names:tc:SAML:2.0:assertion',
+            'NameID'
+        );
+        self::assertSame(1, $nameIds->count(), 'Exactly one <saml:NameID> is expected in the LogoutRequest.');
+
+        $nameId = $nameIds->item(0);
+        self::assertInstanceOf(DOMElement::class, $nameId);
+
+        return $nameId;
+    }
+}

--- a/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/SAMLTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/SAMLTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Authentication\Infrastructure\Provider;
+
+use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
+use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
+use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
+use Core\Security\Authentication\Infrastructure\Provider\SAML;
+use Core\Security\Authentication\Infrastructure\Provider\SamlAuthFactoryInterface;
+use Core\Security\Authentication\Infrastructure\Provider\Settings\Formatter\SettingsFormatterInterface;
+use Core\Security\ProviderConfiguration\Domain\CustomConfigurationInterface;
+use Core\Security\ProviderConfiguration\Domain\LoginLoggerInterface;
+use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\Conditions;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\GroupsMapping;
+use Core\Security\ProviderConfiguration\Domain\SecurityAccess\RolesMapping;
+use OneLogin\Saml2\Auth;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Pimple\Container;
+
+class SAMLTest extends TestCase
+{
+    /** @var SettingsFormatterInterface&MockObject */
+    private $formatter;
+
+    /** @var WriteSessionRepositoryInterface&MockObject */
+    private $writeSessionRepository;
+
+    /** @var SamlAuthFactoryInterface&MockObject */
+    private $authFactory;
+
+    /** @var Auth&MockObject */
+    private $auth;
+
+    private SAML $saml;
+
+    protected function setUp(): void
+    {
+        $this->formatter = $this->createMock(SettingsFormatterInterface::class);
+        $this->formatter->method('format')->willReturn([]);
+
+        $this->writeSessionRepository = $this->createMock(WriteSessionRepositoryInterface::class);
+        $this->authFactory = $this->createMock(SamlAuthFactoryInterface::class);
+        $this->auth = $this->createMock(Auth::class);
+        $this->authFactory->method('create')->willReturn($this->auth);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getCustomConfiguration')
+            ->willReturn($this->createMock(CustomConfigurationInterface::class));
+
+        $this->saml = new SAML(
+            $this->createMock(Container::class),
+            $this->createMock(ContactRepositoryInterface::class),
+            $this->createMock(LoginLoggerInterface::class),
+            $this->createMock(WriteUserRepositoryInterface::class),
+            $this->createMock(Conditions::class),
+            $this->createMock(RolesMapping::class),
+            $this->createMock(GroupsMapping::class),
+            $this->formatter,
+            $this->writeSessionRepository,
+            $this->authFactory,
+        );
+        $this->saml->setConfiguration($configuration);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SESSION['saml'], $_SESSION['LogoutRequestID']);
+    }
+
+    public function testLogoutForwardsSamlIdentifiersFromSession(): void
+    {
+        $_SESSION['saml'] = [
+            'samlNameId' => 'name-id',
+            'samlSessionIndex' => 'session-index',
+            'samlNameIdFormat' => 'name-id-format',
+            'samlNameIdNameQualifier' => 'name-qualifier',
+            'samlNameIdSPNameQualifier' => 'sp-name-qualifier',
+        ];
+
+        $captured = [];
+        $this->auth->expects($this->once())->method('logout')
+            ->willReturnCallback(static function (
+                $returnTo = null,
+                array $parameters = [],
+                $nameId = null,
+                $sessionIndex = null,
+                $stay = false,
+                $nameIdFormat = null,
+                $nameIdNameQualifier = null,
+                $nameIdSPNameQualifier = null,
+            ) use (&$captured): ?string {
+                $captured = [
+                    'returnTo' => $returnTo,
+                    'nameId' => $nameId,
+                    'sessionIndex' => $sessionIndex,
+                    'nameIdFormat' => $nameIdFormat,
+                    'nameIdNameQualifier' => $nameIdNameQualifier,
+                    'nameIdSPNameQualifier' => $nameIdSPNameQualifier,
+                ];
+
+                return null;
+            });
+
+        $this->saml->logout();
+
+        self::assertSame([
+            'returnTo' => '/login',
+            'nameId' => 'name-id',
+            'sessionIndex' => 'session-index',
+            'nameIdFormat' => 'name-id-format',
+            'nameIdNameQualifier' => 'name-qualifier',
+            'nameIdSPNameQualifier' => 'sp-name-qualifier',
+        ], $captured);
+    }
+
+    public function testHandleCallbackLogoutResponseInvalidatesLocalSession(): void
+    {
+        $_SESSION['LogoutRequestID'] = 'request-id';
+
+        // Emulate processSLO: with keepLocalSession=false it must invoke the delete-session callback.
+        $this->auth->expects($this->once())->method('processSLO')
+            ->willReturnCallback(static function (
+                bool $keepLocalSession = false,
+                $requestId = null,
+                bool $retrieveParametersFromServer = false,
+                ?callable $cbDeleteSession = null,
+                bool $stay = false,
+            ): void {
+                if ($keepLocalSession === false && is_callable($cbDeleteSession)) {
+                    $cbDeleteSession();
+                }
+            });
+
+        $this->writeSessionRepository->expects($this->once())->method('invalidate');
+
+        $this->saml->handleCallbackLogoutResponse();
+    }
+}

--- a/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatterTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\Authentication\Infrastructure\Provider\Settings\Formatter;
+
+use Core\Security\Authentication\Infrastructure\Provider\Settings\Formatter\OneLoginSettingsFormatter;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\RequestedAuthnContextComparisonEnum;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Maps the stored SAML configuration to the settings array consumed by OneLogin\Saml2\Auth.
+ *
+ * The IdP entityId mapping is what made MON-152191 visible: at logout, when no session NameID
+ * is available, php-saml falls back to idp.entityId as the <saml:NameID>. This test pins down
+ * that idp.entityId is the configured metadata URL (and that the SLO URL is forwarded), so the
+ * value the LogoutRequest falls back to is exactly what the configuration declares.
+ */
+class OneLoginSettingsFormatterTest extends TestCase
+{
+    private const IDP_ENTITY_ID = 'https://sso.example.com/saml-idp/abc123/metadata/';
+    private const IDP_SSO_URL = 'https://sso.example.com/saml-idp/abc123/sso';
+    private const IDP_SLO_URL = 'https://sso.example.com/saml-idp/abc123/slo';
+    private const IDP_CERT = 'MIID-fake-certificate-body';
+    private const ACS_URL = 'https://centreon.example.com/centreon/api/latest/saml/acs';
+
+    private UrlGeneratorInterface&MockObject $urlGenerator;
+
+    private OneLoginSettingsFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->urlGenerator->method('generate')
+            ->with('centreon_application_authentication_saml_acs', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn(self::ACS_URL);
+
+        $this->formatter = new OneLoginSettingsFormatter($this->urlGenerator);
+
+        // OneLoginSettingsFormatter resolves the SP entityId from the current request host
+        // (HttpUrlTrait::getHost(), which reads the HTTP_HOST/REQUEST_SCHEME server variables).
+        $_SERVER['HTTP_HOST'] = 'centreon.example.com';
+        $_SERVER['REQUEST_SCHEME'] = 'https';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['HTTP_HOST'], $_SERVER['REQUEST_SCHEME']);
+    }
+
+    public function testFormatMapsStoredConfigurationToOneLoginSettings(): void
+    {
+        $settings = $this->formatter->format($this->customConfiguration());
+
+        self::assertSame(
+            [
+                'strict' => true,
+                'debug' => true,
+                'sp' => [
+                    'entityId' => 'https://centreon.example.com',
+                    'assertionConsumerService' => [
+                        'url' => self::ACS_URL,
+                    ],
+                ],
+                'idp' => [
+                    'entityId' => self::IDP_ENTITY_ID,
+                    'singleSignOnService' => [
+                        'url' => self::IDP_SSO_URL,
+                    ],
+                    'singleLogoutService' => [
+                        'url' => self::IDP_SLO_URL,
+                    ],
+                    'x509cert' => self::IDP_CERT,
+                ],
+                'security' => [
+                    'requestedAuthnContext' => true,
+                    'requestedAuthnContextComparison' => 'minimum',
+                ],
+            ],
+            $settings
+        );
+    }
+
+    public function testFormatForwardsTheIdpEntityIdAndLogoutUrlUsedByTheLogoutRequest(): void
+    {
+        $settings = $this->formatter->format($this->customConfiguration());
+
+        // idp.entityId is the value php-saml emits as NameID when no session NameID is present
+        // (the MON-152191 fallback); it must be the configured metadata URL.
+        self::assertSame(self::IDP_ENTITY_ID, $settings['idp']['entityId']);
+        // Without a Single Logout URL, OneLogin\Saml2\Auth::logout() throws and no SLO is sent.
+        self::assertSame(self::IDP_SLO_URL, $settings['idp']['singleLogoutService']['url']);
+    }
+
+    /**
+     * CustomConfiguration is final with a private constructor; build a real instance without the
+     * constructor and set only the fields the formatter reads, through its public setters.
+     */
+    private function customConfiguration(): CustomConfiguration
+    {
+        $customConfiguration = (new ReflectionClass(CustomConfiguration::class))->newInstanceWithoutConstructor();
+        $customConfiguration->setEntityIDUrl(self::IDP_ENTITY_ID);
+        $customConfiguration->setRemoteLoginUrl(self::IDP_SSO_URL);
+        $customConfiguration->setLogoutFromUrl(self::IDP_SLO_URL);
+        $customConfiguration->setPublicCertificate(self::IDP_CERT);
+        $customConfiguration->setRequestedAuthnContext(true);
+        $customConfiguration->setRequestedAuthnContextComparison(RequestedAuthnContextComparisonEnum::MINIMUM);
+
+        return $customConfiguration;
+    }
+}


### PR DESCRIPTION
Backport of #7339 to `dev-25.10.x`.

## Description

SAML/OpenID logout was broken: the IdP was never properly notified on user logout (the local session was invalidated before the provider logout could read the SAML identifiers it needs).

Concretely, the SAML `LogoutRequest` carried `NameID = <IdP metadata URL>` with `Format="...:entity"` and **no `SessionIndex`**, instead of the authenticated user's `NameID`. A strict IdP (e.g. OneLogin) rejects it with `NameID '...metadata/' does not match prior auth request`. (Keycloak is tolerant and hides the bug.)

### Changed

* SLO initiation moved out of the `WriteSessionRepository` (no business logic in the repository) into the `LogoutSession` use case
* SAML provider logout runs **before** local invalidation (reads `$_SESSION['saml']`); OpenID logout runs **after**
* `LogoutFromIdp` (`/saml/sls`) now only processes the IdP callback, instead of re-initiating a logout
* `OneLogin\Saml2\Auth` instantiation extracted behind an injectable `SamlAuthFactory` (testability)
* error handling and logging improved

### Fixed

* logout doesn't work: added the missing `samlNameIdFormat`, `nameIdNameQualifier`, `samlNameIdSPNameQualifier` to the LogoutRequest
* session invalidation ordering (was wiping the session before reading the SAML identifiers)
* `handleCallbackLogoutResponse` now invalidates the local session on the IdP callback (`keepLocalSession: false`)

## Backport notes

* Two conflicts resolved during the cherry-pick:
  * `ThirdPartyLoginForm.php`: kept only the `BadRequestException` import (the `Sensitive` attribute does not exist on this branch).
  * `SAML.php`: removed the leftover legacy logout block; the rest auto-merged onto the `LoggerTrait` logging style still used on `25.10.x` (the OWASP logging split is not present here).
* `OneLoginSettingsFormatterTest` adapted to the `25.10.x` `HttpUrlTrait::getHost()`, which resolves the SP host from `$_SERVER['HTTP_HOST']`/`REQUEST_SCHEME` (the request-stack based resolution only exists on `develop`).

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 25.10.x

## How this pull request can be tested ?

> ⚠️ Keycloak (the default dev IdP) does **not** reproduce the bug — it accepts a wrong `NameID`. Reproduce against a **strict IdP (OneLogin)** and inspect the **content of the `LogoutRequest`**, not just the visual logout.

**Automated**

* `SAMLLogoutRequestContentTest` — `LogoutRequest` `NameID` / `Format` / qualifiers / `SessionIndex`
* `OneLoginSettingsFormatterTest` — provider config → php-saml settings mapping
* `SAMLTest`, `LogoutFromIdpTest`, `LogoutSessionTest` — provider logout ordering, identifier forwarding, IdP callback handling

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
