### PR TITLE
fix(timeperiod): use prepared statements and validate ORDER BY (MON-200895)

### DIFF
--- a/centreon/src/CentreonUser/Domain/Repository/TimeperiodRepository.php
+++ b/centreon/src/CentreonUser/Domain/Repository/TimeperiodRepository.php
@@ -105,7 +105,15 @@ class TimeperiodRepository extends AbstractRepositoryRDB implements PaginationRe
         }
 
         if (! empty($ordering['field'])) {
-            $sql .= ' ORDER BY `' . $ordering['field'] . '` ' . $ordering['order'];
+            // ORDER BY column and direction cannot be bound as parameters, so they
+            // must be validated against a fixed allowlist to prevent SQL injection.
+            $allowedFields = ['tp_id', 'tp_name', 'tp_alias'];
+            $field = (string) $ordering['field'];
+
+            if (in_array($field, $allowedFields, true)) {
+                $order = mb_strtoupper((string) ($ordering['order'] ?? 'ASC')) === 'DESC' ? 'DESC' : 'ASC';
+                $sql .= ' ORDER BY `' . $field . '` ' . $order;
+            }
         }
 
         if ($limit !== null) {

--- a/centreon/www/class/centreonTimeperiod.class.php
+++ b/centreon/www/class/centreonTimeperiod.class.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 /**
  * Class
  *
@@ -83,20 +87,21 @@ class CentreonTimeperiod
     /**
      * @param string $name
      *
-     * @throws PDOException
+     * @throws ConnectionException
      * @return string
      */
     public function getTimperiodIdByName($name)
     {
-        $query = "SELECT tp_id FROM timeperiod 
-                WHERE tp_name = '" . $this->db->escape($name) . "'";
+        $query = 'SELECT tp_id FROM timeperiod WHERE tp_name = :name';
 
-        $res = $this->db->query($query);
+        $row = $this->db->fetchAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::string('name', $name)])
+        );
 
-        if (! $res->rowCount()) {
+        if ($row === false) {
             return null;
         }
-        $row = $res->fetchRow();
 
         return $row['tp_id'];
     }
@@ -104,19 +109,19 @@ class CentreonTimeperiod
     /**
      * @param int $tpId
      *
-     * @throws PDOException
+     * @throws ConnectionException
      * @return string
      */
     public function getTimeperiodException($tpId)
     {
-        $query = 'SELECT `exception_id` FROM `timeperiod_exceptions`
-                WHERE `timeperiod_id` = ' . (int) $tpId;
-        $res = $this->db->query($query);
-        if (! $res->rowCount()) {
+        $query = 'SELECT `exception_id` FROM `timeperiod_exceptions` WHERE `timeperiod_id` = :timeperiodId';
+        $row = $this->db->fetchAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::int('timeperiodId', (int) $tpId)])
+        );
+        if ($row === false) {
             return null;
         }
-
-        $row = $res->fetchRow();
 
         return $row['exception_id'];
     }
@@ -132,20 +137,26 @@ class CentreonTimeperiod
         $sQuery = 'INSERT INTO `timeperiod` '
             . '(`tp_name`, `tp_alias`, `tp_sunday`, `tp_monday`, `tp_tuesday`, `tp_wednesday`, '
             . '`tp_thursday`, `tp_friday`, `tp_saturday`) '
-            . "VALUES ('" . $parameters['name'] . "',"
-            . "'" . $parameters['alias'] . "',"
-            . "'" . $parameters['sunday'] . "',"
-            . "'" . $parameters['monday'] . "',"
-            . "'" . $parameters['tuesday'] . "',"
-            . "'" . $parameters['wednesday'] . "',"
-            . "'" . $parameters['thursday'] . "',"
-            . "'" . $parameters['friday'] . "',"
-            . "'" . $parameters['saturday'] . "')";
+            . 'VALUES (:name, :alias, :sunday, :monday, :tuesday, :wednesday, '
+            . ':thursday, :friday, :saturday)';
 
         try {
-            $this->db->query($sQuery);
-        } catch (PDOException $e) {
-            throw new Exception('Error while insert timeperiod ' . $parameters['name']);
+            $this->db->insert(
+                $sQuery,
+                QueryParameters::create([
+                    QueryParameter::string('name', $parameters['name']),
+                    QueryParameter::string('alias', $parameters['alias']),
+                    QueryParameter::string('sunday', $parameters['sunday']),
+                    QueryParameter::string('monday', $parameters['monday']),
+                    QueryParameter::string('tuesday', $parameters['tuesday']),
+                    QueryParameter::string('wednesday', $parameters['wednesday']),
+                    QueryParameter::string('thursday', $parameters['thursday']),
+                    QueryParameter::string('friday', $parameters['friday']),
+                    QueryParameter::string('saturday', $parameters['saturday']),
+                ])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while insert timeperiod ' . $parameters['name'], 0, $e);
         }
     }
 
@@ -161,20 +172,33 @@ class CentreonTimeperiod
     public function update($tp_id, $parameters): void
     {
 
-        $sQuery = "UPDATE `timeperiod` SET `tp_alias` = '" . $parameters['alias'] . "', "
-            . "`tp_sunday` = '" . $parameters['sunday'] . "',"
-            . "`tp_monday` = '" . $parameters['monday'] . "',"
-            . "`tp_tuesday` = '" . $parameters['tuesday'] . "',"
-            . "`tp_wednesday` = '" . $parameters['wednesday'] . "',"
-            . "`tp_thursday` = '" . $parameters['thursday'] . "',"
-            . "`tp_friday` = '" . $parameters['friday'] . "',"
-            . "`tp_saturday` = '" . $parameters['saturday'] . "'"
-            . ' WHERE `tp_id` = ' . $tp_id;
+        $sQuery = 'UPDATE `timeperiod` SET `tp_alias` = :alias, '
+            . '`tp_sunday` = :sunday,'
+            . '`tp_monday` = :monday,'
+            . '`tp_tuesday` = :tuesday,'
+            . '`tp_wednesday` = :wednesday,'
+            . '`tp_thursday` = :thursday,'
+            . '`tp_friday` = :friday,'
+            . '`tp_saturday` = :saturday'
+            . ' WHERE `tp_id` = :tpId';
 
         try {
-            $this->db->query($sQuery);
-        } catch (PDOException $e) {
-            throw new Exception('Error while update timeperiod ' . $parameters['name']);
+            $this->db->update(
+                $sQuery,
+                QueryParameters::create([
+                    QueryParameter::string('alias', $parameters['alias']),
+                    QueryParameter::string('sunday', $parameters['sunday']),
+                    QueryParameter::string('monday', $parameters['monday']),
+                    QueryParameter::string('tuesday', $parameters['tuesday']),
+                    QueryParameter::string('wednesday', $parameters['wednesday']),
+                    QueryParameter::string('thursday', $parameters['thursday']),
+                    QueryParameter::string('friday', $parameters['friday']),
+                    QueryParameter::string('saturday', $parameters['saturday']),
+                    QueryParameter::int('tpId', (int) $tp_id),
+                ])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while update timeperiod ' . $parameters['name'], 0, $e);
         }
     }
 
@@ -187,17 +211,22 @@ class CentreonTimeperiod
      */
     public function setTimeperiodException($tpId, $parameters): void
     {
-        foreach ($parameters as $exception) {
-            $sQuery = 'INSERT INTO `timeperiod_exceptions` '
-                . '(`timeperiod_id`, `days`, `timerange`) '
-                . 'VALUES (' . (int) $tpId . ','
-                . "'" . $exception['days'] . "',"
-                . "'" . $exception['timerange'] . "')";
+        $sQuery = 'INSERT INTO `timeperiod_exceptions` '
+            . '(`timeperiod_id`, `days`, `timerange`) '
+            . 'VALUES (:timeperiodId, :days, :timerange)';
 
+        foreach ($parameters as $exception) {
             try {
-                $this->db->query($sQuery);
-            } catch (PDOException $e) {
-                throw new Exception('Error while insert timeperiod exception' . $tpId);
+                $this->db->insert(
+                    $sQuery,
+                    QueryParameters::create([
+                        QueryParameter::int('timeperiodId', (int) $tpId),
+                        QueryParameter::string('days', $exception['days']),
+                        QueryParameter::string('timerange', $exception['timerange']),
+                    ])
+                );
+            } catch (ConnectionException $e) {
+                throw new Exception('Error while insert timeperiod exception' . $tpId, 0, $e);
             }
         }
     }
@@ -213,12 +242,18 @@ class CentreonTimeperiod
     {
         $sQuery = 'INSERT INTO `timeperiod_include_relations` '
             . '(`timeperiod_id`,`timeperiod_include_id`) '
-            . 'VALUES (' . (int) $timeperiodId . ',' . (int) $depId . ')';
+            . 'VALUES (:timeperiodId, :timeperiodIncludeId)';
 
         try {
-            $this->db->query($sQuery);
-        } catch (PDOException $e) {
-            throw new Exception('Error while insert timeperiod dependency' . $timeperiodId);
+            $this->db->insert(
+                $sQuery,
+                QueryParameters::create([
+                    QueryParameter::int('timeperiodId', (int) $timeperiodId),
+                    QueryParameter::int('timeperiodIncludeId', (int) $depId),
+                ])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while insert timeperiod dependency' . $timeperiodId, 0, $e);
         }
     }
 
@@ -230,12 +265,15 @@ class CentreonTimeperiod
      */
     public function deleteTimeperiodException($tpId): void
     {
-        $sQuery = 'DELETE FROM `timeperiod_exceptions` WHERE `timeperiod_id` = ' . (int) $tpId;
+        $sQuery = 'DELETE FROM `timeperiod_exceptions` WHERE `timeperiod_id` = :timeperiodId';
 
         try {
-            $res = $this->db->query($sQuery);
-        } catch (PDOException $e) {
-            throw new Exception('Error while delete timeperiod exception' . $tpId);
+            $this->db->delete(
+                $sQuery,
+                QueryParameters::create([QueryParameter::int('timeperiodId', (int) $tpId)])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while delete timeperiod exception' . $tpId, 0, $e);
         }
     }
 
@@ -247,12 +285,15 @@ class CentreonTimeperiod
      */
     public function deleteTimeperiodInclude($tpId): void
     {
-        $sQuery = 'DELETE FROM `timeperiod_include_relations` WHERE `timeperiod_id` = ' . (int) $tpId;
+        $sQuery = 'DELETE FROM `timeperiod_include_relations` WHERE `timeperiod_id` = :timeperiodId';
 
         try {
-            $this->db->query($sQuery);
-        } catch (PDOException $e) {
-            throw new Exception('Error while delete timeperiod include' . $tpId);
+            $this->db->delete(
+                $sQuery,
+                QueryParameters::create([QueryParameter::int('timeperiodId', (int) $tpId)])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while delete timeperiod include' . $tpId, 0, $e);
         }
     }
 
@@ -264,13 +305,15 @@ class CentreonTimeperiod
      */
     public function deleteTimeperiodByName($tp_name): void
     {
-        $sQuery = 'DELETE FROM timeperiod '
-            . 'WHERE tp_name = "' . $this->db->escape($tp_name) . '"';
+        $sQuery = 'DELETE FROM timeperiod WHERE tp_name = :name';
 
         try {
-            $this->db->query($sQuery);
-        } catch (PDOException $e) {
-            throw new Exception('Error while delete timperiod ' . $tp_name);
+            $this->db->delete(
+                $sQuery,
+                QueryParameters::create([QueryParameter::string('name', $tp_name)])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while delete timperiod ' . $tp_name, 0, $e);
         }
     }
 
@@ -286,8 +329,10 @@ class CentreonTimeperiod
     public function getLinkedHostsByName($timeperiodName, $register = false)
     {
         $registerClause = '';
+        $queryParameters = [QueryParameter::string('name', $timeperiodName)];
         if ($register === '0' || $register === '1') {
-            $registerClause = 'AND h.host_register = "' . $register . '" ';
+            $registerClause = 'AND h.host_register = :register ';
+            $queryParameters[] = QueryParameter::string('register', $register);
         }
 
         $linkedHosts = [];
@@ -295,15 +340,15 @@ class CentreonTimeperiod
             . 'FROM host h, timeperiod t '
             . 'WHERE (h.timeperiod_tp_id = t.tp_id OR h.timeperiod_tp_id2 = t.tp_id) '
             . $registerClause
-            . 'AND t.tp_name = "' . $this->db->escape($timeperiodName) . '" ';
+            . 'AND t.tp_name = :name ';
 
         try {
-            $result = $this->db->query($query);
-        } catch (PDOException $e) {
-            throw new Exception('Error while getting linked hosts of ' . $timeperiodName);
+            $rows = $this->db->fetchAllAssociative($query, QueryParameters::create($queryParameters));
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while getting linked hosts of ' . $timeperiodName, 0, $e);
         }
 
-        while ($row = $result->fetchRow()) {
+        foreach ($rows as $row) {
             $linkedHosts[] = $row['host_name'];
         }
 
@@ -322,8 +367,10 @@ class CentreonTimeperiod
     public function getLinkedServicesByName($timeperiodName, $register = false)
     {
         $registerClause = '';
+        $queryParameters = [QueryParameter::string('name', $timeperiodName)];
         if ($register === '0' || $register === '1') {
-            $registerClause = 'AND s.service_register = "' . $register . '" ';
+            $registerClause = 'AND s.service_register = :register ';
+            $queryParameters[] = QueryParameter::string('register', $register);
         }
 
         $linkedServices = [];
@@ -331,15 +378,15 @@ class CentreonTimeperiod
             . 'FROM service s, timeperiod t '
             . 'WHERE (s.timeperiod_tp_id = t.tp_id OR s.timeperiod_tp_id2 = t.tp_id) '
             . $registerClause
-            . 'AND t.tp_name = "' . $this->db->escape($timeperiodName) . '" ';
+            . 'AND t.tp_name = :name ';
 
         try {
-            $result = $this->db->query($query);
-        } catch (PDOException $e) {
-            throw new Exception('Error while getting linked services of ' . $timeperiodName);
+            $rows = $this->db->fetchAllAssociative($query, QueryParameters::create($queryParameters));
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while getting linked services of ' . $timeperiodName, 0, $e);
         }
 
-        while ($row = $result->fetchRow()) {
+        foreach ($rows as $row) {
             $linkedServices[] = $row['service_description'];
         }
 
@@ -359,15 +406,18 @@ class CentreonTimeperiod
         $query = 'SELECT DISTINCT c.contact_name '
             . 'FROM contact c, timeperiod t '
             . 'WHERE (c.timeperiod_tp_id = t.tp_id OR c.timeperiod_tp_id2 = t.tp_id) '
-            . 'AND t.tp_name = "' . $this->db->escape($timeperiodName) . '" ';
+            . 'AND t.tp_name = :name ';
 
         try {
-            $result = $this->db->query($query);
-        } catch (PDOException $e) {
-            throw new Exception('Error while getting linked contacts of ' . $timeperiodName);
+            $rows = $this->db->fetchAllAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::string('name', $timeperiodName)])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while getting linked contacts of ' . $timeperiodName, 0, $e);
         }
 
-        while ($row = $result->fetchRow()) {
+        foreach ($rows as $row) {
             $linkedContacts[] = $row['contact_name'];
         }
 
@@ -389,21 +439,27 @@ class CentreonTimeperiod
             . 'FROM timeperiod t1, timeperiod_include_relations tir1, timeperiod t2 '
             . 'WHERE t1.tp_id = tir1.timeperiod_id '
             . 'AND t2.tp_id = tir1.timeperiod_include_id '
-            . 'AND t2.tp_name = "' . $this->db->escape($timeperiodName) . '" '
+            . 'AND t2.tp_name = :name1 '
             . 'UNION '
             . 'SELECT DISTINCT t3.tp_name '
             . 'FROM timeperiod t3, timeperiod_include_relations tir2, timeperiod t4 '
             . 'WHERE t3.tp_id = tir2.timeperiod_include_id '
             . 'AND t4.tp_id = tir2.timeperiod_id '
-            . 'AND t4.tp_name = "' . $this->db->escape($timeperiodName) . '" ';
+            . 'AND t4.tp_name = :name2 ';
 
         try {
-            $result = $this->db->query($query);
-        } catch (PDOException $e) {
-            throw new Exception('Error while getting linked timeperiods of ' . $timeperiodName);
+            $rows = $this->db->fetchAllAssociative(
+                $query,
+                QueryParameters::create([
+                    QueryParameter::string('name1', $timeperiodName),
+                    QueryParameter::string('name2', $timeperiodName),
+                ])
+            );
+        } catch (ConnectionException $e) {
+            throw new Exception('Error while getting linked timeperiods of ' . $timeperiodName, 0, $e);
         }
 
-        while ($row = $result->fetchRow()) {
+        foreach ($rows as $row) {
             $linkedTimeperiods[] = $row['tp_name'];
         }
 

--- a/centreon/www/class/centreonTimeperiod.class.php
+++ b/centreon/www/class/centreonTimeperiod.class.php
@@ -330,9 +330,9 @@ class CentreonTimeperiod
     {
         $registerClause = '';
         $queryParameters = [QueryParameter::string('name', $timeperiodName)];
-        if ($register === '0' || $register === '1') {
+        if ((string) $register === '0' || (string) $register === '1') {
             $registerClause = 'AND h.host_register = :register ';
-            $queryParameters[] = QueryParameter::string('register', $register);
+            $queryParameters[] = QueryParameter::string('register', (string) $register);
         }
 
         $linkedHosts = [];
@@ -368,9 +368,9 @@ class CentreonTimeperiod
     {
         $registerClause = '';
         $queryParameters = [QueryParameter::string('name', $timeperiodName)];
-        if ($register === '0' || $register === '1') {
+        if ((string) $register === '0' || (string) $register === '1') {
             $registerClause = 'AND s.service_register = :register ';
-            $queryParameters[] = QueryParameter::string('register', $register);
+            $queryParameters[] = QueryParameter::string('register', (string) $register);
         }
 
         $linkedServices = [];

--- a/centreon/www/class/centreonTimeperiodRenderer.class.php
+++ b/centreon/www/class/centreonTimeperiodRenderer.class.php
@@ -19,6 +19,9 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 /**
  * Class
  *
@@ -61,7 +64,7 @@ class CentreonTimeperiodRenderer
      * @param int $tpid
      * @param string $inex
      *
-     * @throws PDOException
+     * @throws ConnectionException
      */
     public function __construct($db, $tpid, $inex)
     {
@@ -70,15 +73,17 @@ class CentreonTimeperiodRenderer
         $this->timeline = $dayTab;
         $this->db = $db;
         $this->tpid = $tpid;
-        $query = "SELECT tp_name, tp_alias, tp_monday, tp_tuesday, tp_wednesday, tp_thursday, tp_friday,
+        $query = 'SELECT tp_name, tp_alias, tp_monday, tp_tuesday, tp_wednesday, tp_thursday, tp_friday,
             tp_saturday, tp_sunday
             FROM timeperiod
-            WHERE tp_id = '" . $tpid . "'";
-        $res = $this->db->query($query);
-        if (! $res->rowCount()) {
+            WHERE tp_id = :tpId';
+        $row = $this->db->fetchAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::int('tpId', (int) $tpid)])
+        );
+        if ($row === false) {
             throw new Exception('Timeperiod not found');
         }
-        $row = $res->fetchRow();
         $this->tpname = $row['tp_name'];
         $this->tpalias = $row['tp_alias'];
         foreach ($this->timerange as $key => $val) {
@@ -310,16 +315,19 @@ class CentreonTimeperiodRenderer
     /**
      * Update Inclusions
      *
-     * @throws PDOException
+     * @throws ConnectionException
      * @return void
      */
     protected function updateInclusions()
     {
-        $query = "SELECT timeperiod_include_id
+        $query = 'SELECT timeperiod_include_id
         		  FROM timeperiod_include_relations
-        		  WHERE timeperiod_id= '" . $this->tpid . "'";
-        $res = $this->db->query($query);
-        while ($row = $res->fetchRow()) {
+        		  WHERE timeperiod_id = :tpId';
+        $rows = $this->db->fetchAllAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::int('tpId', (int) $this->tpid)])
+        );
+        foreach ($rows as $row) {
             $inctp = new CentreonTimeperiodRenderer($this->db, $row['timeperiod_include_id'], 1);
             $this->updateTimeRange($inctp->timerange);
             foreach ($inctp->exceptionList as $key => $val) {
@@ -331,20 +339,26 @@ class CentreonTimeperiodRenderer
     /**
      * Update Exclusions
      *
-     * @throws PDOException
+     * @throws ConnectionException
      * @return void
      */
     protected function updateExclusions()
     {
-        $query = "SELECT * FROM timeperiod_exceptions WHERE timeperiod_id='" . $this->tpid . "'";
-        $DBRESULT = $this->db->query($query);
-        while ($row = $DBRESULT->fetchRow()) {
+        $query = 'SELECT * FROM timeperiod_exceptions WHERE timeperiod_id = :tpId';
+        $rows = $this->db->fetchAllAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::int('tpId', (int) $this->tpid)])
+        );
+        foreach ($rows as $row) {
             $excep = $this->getException($row['timeperiod_id'], $this->tpname, $row['days'], $row['timerange']);
             $this->exceptionList[] = $excep;
         }
-        $query = "SELECT timeperiod_exclude_id FROM timeperiod_exclude_relations WHERE timeperiod_id='" . $this->tpid . "'";
-        $DBRESULT = $this->db->query($query);
-        while ($row = $DBRESULT->fetchRow()) {
+        $query = 'SELECT timeperiod_exclude_id FROM timeperiod_exclude_relations WHERE timeperiod_id = :tpId';
+        $rows = $this->db->fetchAllAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::int('tpId', (int) $this->tpid)])
+        );
+        foreach ($rows as $row) {
             $extp = new CentreonTimePeriodRenderer($this->db, $row['timeperiod_exclude_id'], 0);
             $this->updateTimeRange($extp->timerange);
         }


### PR DESCRIPTION
## Description

Fixes the SQL injection vulnerabilities reported in [MON-200895](https://centreon.atlassian.net/browse/MON-200895) in the **timeperiod** configuration and rendering code. All unprepared SQL statements in the affected files are migrated to bound parameters via the database connection interface (`QueryParameters` / `QueryParameter`), and the `ORDER BY` token — which cannot be bound — is validated against an allowlist.

## Changes

- **`src/CentreonUser/Domain/Repository/TimeperiodRepository.php`** — `getPaginationList()`: validate the `ORDER BY` field against an allowlist (`tp_id`, `tp_name`, `tp_alias`) and normalize the direction to `ASC`/`DESC`, instead of concatenating raw `$ordering['field']` / `$ordering['order']`. (`sortf` comes straight from the request.)
- **`www/class/centreonTimeperiod.class.php`** — convert every raw query to the connection interface with bound parameters:
  - `insert()`, `update()` (now casts `tp_id` to `int`), `setTimeperiodException()` — the HIGH-priority vectors.
  - `getTimperiodIdByName()`, `getTimeperiodException()`, `setTimeperiodDependency()`, `deleteTimeperiodException()`, `deleteTimeperiodInclude()`, `deleteTimeperiodByName()` and the four `getLinked*ByName()` reads (the `register` flag is bound too).
  - `catch (PDOException)` → `catch (ConnectionException)` (what the typed methods throw), chaining the original as `previous`.
- **`www/class/centreonTimeperiodRenderer.class.php`** — bind `tp_id` in `__construct()` (MEDIUM vector), `updateInclusions()` and `updateExclusions()`.

Logging is unchanged on purpose: the connection-interface methods already write structured DB logs internally before throwing `ConnectionException`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## Testing

**Functional (UI):** Configuration → Users → Time Periods
- Create a time period with weekly ranges + an exception → save → reopen and confirm values persisted (`insert` + `setTimeperiodException`).
- Edit alias and a day range → save (`update`). Add include/exclude relations. Delete a time period.
- Open a time period with includes/exclusions to render the timeline (Renderer recursion).
- Sort the list by name/alias, asc & desc (repository `ORDER BY`).

**Security (injection no longer works):**
- Enter `a',(SELECT 1))-- -` in a name/alias and pass `sortf=tp_name);DROP…` to the list — values are stored/displayed literally, the sort is ignored or defaulted, and no SQL error or extra query is executed.

**Static:** `php -l` clean on all three files; `php-cs-fixer` (legacy + core configs) clean.


[MON-200895]: https://centreon.atlassian.net/browse/MON-200895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ