### PR TITLE
fix: use parameterized queries in legacy configuration components

### DIFF
--- a/centreon/src/Centreon/Domain/Repository/NagiosServerRepository.php
+++ b/centreon/src/Centreon/Domain/Repository/NagiosServerRepository.php
@@ -121,9 +121,15 @@ class NagiosServerRepository extends AbstractRepositoryRDB implements Pagination
             }
         }
 
-        if (! empty($ordering['field'])) {
+        if (
+            ! empty($ordering['field'])
+            && isset(self::CONCORDANCE_ARRAY[$ordering['field']])
+        ) {
+            $direction = strtoupper((string) ($ordering['order'] ?? 'ASC')) === 'DESC'
+                ? 'DESC'
+                : 'ASC';
             $sql .= ' ORDER BY `' . self::CONCORDANCE_ARRAY[$ordering['field']] . '` '
-                . $ordering['order'];
+                . $direction;
         } else {
             $sql .= ' ORDER BY `name` ASC';
         }

--- a/centreon/src/Centreon/Domain/Repository/TaskRepository.php
+++ b/centreon/src/Centreon/Domain/Repository/TaskRepository.php
@@ -63,8 +63,9 @@ class TaskRepository extends ServiceEntityRepository
 
     /**
      * find all pending export tasks
+     * @return Task[]
      */
-    public function findExportTasks()
+    public function findExportTasks(): array
     {
         $sql = 'SELECT * FROM task WHERE `type` = "export" AND `status` = "pending"';
         $stmt = $this->db->prepare($sql);
@@ -72,7 +73,7 @@ class TaskRepository extends ServiceEntityRepository
         $stmt->setFetchMode(PDO::FETCH_CLASS, Task::class);
         $result = $stmt->fetchAll();
 
-        return $result ?: null;
+        return $result ?: [];
     }
 
     /**

--- a/centreon/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/centreon/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -84,23 +84,30 @@ class CentreonWorker implements CentreonClapiServiceInterface
      * Worker method to create task for import on remote.
      *
      * @param int $taskId the task id to create on the remote server
+     *
+     * @throws \Exception
      */
     public function createRemoteTask(int $taskId): void
     {
         // find task parameters (type, status, params...)
+        /** @var Task|null $task */
         $task = $this->getDi()[\Centreon\ServiceProvider::CENTREON_DB_MANAGER]
             ->getRepository(TaskRepository::class)
             ->findOneById($taskId);
 
+        if ($task === null) {
+            throw new \InvalidArgumentException(sprintf('Task %d not found', $taskId));
+        }
+
         /**
          * create import task on remote.
          */
-        $serializedParams = htmlspecialchars($task->getParams());
+        $serializedParams = $task->getParams();
         if (empty($serializedParams)) {
             throw new \Exception('Invalid Parameters');
         }
-        $taskParams = unserialize($serializedParams);
-        if (! array_key_exists('params', $taskParams)) {
+        $taskParams = unserialize($serializedParams, ['allowed_classes' => false]);
+        if (! is_array($taskParams) || ! array_key_exists('params', $taskParams)) {
             throw new \Exception('Missing parameters: params');
         }
         $params = $taskParams['params'];
@@ -139,9 +146,10 @@ class CentreonWorker implements CentreonClapiServiceInterface
      */
     private function processExportTasks(): void
     {
+        /** @var Task[] $tasks */
         $tasks = $this->getDi()[\Centreon\ServiceProvider::CENTREON_DB_MANAGER]
             ->getRepository(TaskRepository::class)
-            ->findExportTasks() ?? [];
+            ->findExportTasks();
 
         echo date('Y-m-d H:i:s') . ' - INFO - Checking for pending export tasks: '
             . count($tasks) . " task(s) found.\n";
@@ -151,12 +159,12 @@ class CentreonWorker implements CentreonClapiServiceInterface
 
             // mark task as being worked on
             $this->getDi()['centreon.taskservice']->updateStatus($task->getId(), Task::STATE_PROGRESS);
-            $serializedParams = htmlspecialchars($task->getParams(), ENT_NOQUOTES);
+            $serializedParams = $task->getParams();
             if (empty($serializedParams)) {
                 throw new \Exception('Invalid Parameters');
             }
-            $taskParams = unserialize($serializedParams);
-            if (! array_key_exists('params', $taskParams)) {
+            $taskParams = unserialize($serializedParams, ['allowed_classes' => false]);
+            if (! is_array($taskParams) || ! array_key_exists('params', $taskParams)) {
                 throw new \Exception('Missing parameters: params');
             }
             $params = $taskParams['params'];

--- a/centreon/www/class/centreon-config/centreonMainCfg.class.php
+++ b/centreon/www/class/centreon-config/centreonMainCfg.class.php
@@ -141,13 +141,20 @@ class CentreonMainCfg
             return false;
         }
 
-        $query = "SELECT bk_mod_id FROM `cfg_nagios_broker_module` WHERE cfg_nagios_id = '" . $iId . "'";
-        $dbResult = $this->DB->query($query);
-        if ($dbResult->rowCount() == 0) {
-            $sQuery = "INSERT INTO cfg_nagios_broker_module (`broker_module`, `cfg_nagios_id`) VALUES ('"
-                . $this->aDefaultBrokerDirective[$source] . "', " . $iId . ')';
+        $stmt = $this->DB->prepare(
+            'SELECT bk_mod_id FROM `cfg_nagios_broker_module` WHERE cfg_nagios_id = :cfgNagiosId'
+        );
+        $stmt->bindValue(':cfgNagiosId', $iId, PDO::PARAM_INT);
+        $stmt->execute();
+        if ($stmt->rowCount() == 0) {
             try {
-                $res = $this->DB->query($sQuery);
+                $insertStmt = $this->DB->prepare(
+                    'INSERT INTO cfg_nagios_broker_module (`broker_module`, `cfg_nagios_id`)
+                    VALUES (:brokerModule, :cfgNagiosId)'
+                );
+                $insertStmt->bindValue(':brokerModule', $this->aDefaultBrokerDirective[$source], PDO::PARAM_STR);
+                $insertStmt->bindValue(':cfgNagiosId', $iId, PDO::PARAM_INT);
+                $insertStmt->execute();
             } catch (PDOException $e) {
                 return false;
             }
@@ -223,7 +230,9 @@ class CentreonMainCfg
             return false;
         }
 
-        $res = $this->DB->query('SELECT * FROM cfg_nagios WHERE  nagios_server_id = ' . $source);
+        $res = $this->DB->prepare('SELECT * FROM cfg_nagios WHERE nagios_server_id = :serverId');
+        $res->bindValue(':serverId', $source, PDO::PARAM_INT);
+        $res->execute();
         $baseValues = $res->rowCount() == 0 ? $this->aInstanceDefaultValues : $res->fetch();
 
         $rq = 'INSERT INTO `cfg_nagios` (
@@ -379,7 +388,10 @@ class CentreonMainCfg
      */
     public function getBrokerModules($id)
     {
-        $dbResult = $this->DB->query('SELECT * FROM cfg_nagios_broker_module WHERE cfg_nagios_id = ' . $id);
+        $dbResult = $this->DB->prepare('SELECT * FROM cfg_nagios_broker_module WHERE cfg_nagios_id = :cfgNagiosId');
+        $dbResult->bindValue(':cfgNagiosId', $id, PDO::PARAM_INT);
+        $dbResult->execute();
+        $entries = [];
         while ($row = $dbResult->fetch()) {
             $entries[] = $row;
         }

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -1001,11 +1001,14 @@ class CentreonConfigCentreonBroker
         $this->nbSubGroup = 1;
         $query = "SELECT config_value, config_group_id
             FROM cfg_centreonbroker_info
-            WHERE config_id = %d AND config_group = '%s'
+            WHERE config_id = :configId AND config_group = :configGroup
             AND config_key = 'blockId'
             ORDER BY config_group_id";
         try {
-            $res = $this->db->query(sprintf($query, $config_id, $tag));
+            $res = $this->db->prepare($query);
+            $res->bindValue(':configId', (int) $config_id, PDO::PARAM_INT);
+            $res->bindValue(':configGroup', $tag, PDO::PARAM_STR);
+            $res->execute();
         } catch (PDOException $e) {
             return [];
         }
@@ -1127,21 +1130,38 @@ class CentreonConfigCentreonBroker
         if (! isset($s_table) || ! isset($s_column)) {
             return false;
         }
+        // Table and column names cannot be bound as query parameters, so they are
+        // validated against a strict identifier allowlist to prevent SQL injection.
+        $isValidIdentifier = static fn (string $identifier): bool => preg_match('/^[a-zA-Z0-9_]+$/', $identifier) === 1;
+        if (! $isValidIdentifier($s_table) || ! $isValidIdentifier($s_column)) {
+            return false;
+        }
+        $hasKeyFilter = isset($s_column_key, $s_key);
+        if ($hasKeyFilter && ! $isValidIdentifier($s_column_key)) {
+            return false;
+        }
         $query = 'SELECT `' . $s_column . '` FROM `' . $s_table . '`';
-        if (isset($s_column_key, $s_key)) {
-            $query .= ' WHERE `' . $s_column_key . "` = '" . $s_key . "'";
+        if ($hasKeyFilter) {
+            $query .= ' WHERE `' . $s_column_key . '` = :key';
         }
 
         // Execute the query
         try {
             switch ($s_db) {
                 case 'centreon':
-                    $res = $this->db->query($query);
+                    $res = $this->db->prepare($query);
                     break;
                 case 'centreon_storage':
-                    $res = $monitoringDb->query($query);
+                    $res = $monitoringDb->prepare($query);
                     break;
             }
+            if (! isset($res)) {
+                return false;
+            }
+            if ($hasKeyFilter) {
+                $res->bindValue(':key', $s_key, PDO::PARAM_STR);
+            }
+            $res->execute();
         } catch (PDOException $e) {
             return false;
         }
@@ -1608,8 +1628,10 @@ class CentreonConfigCentreonBroker
     private function getExternalDefaultValue($fieldId)
     {
         $externalValue = null;
-        $query = 'SELECT `external` FROM cb_field WHERE cb_field_id = ' . $fieldId;
-        $res = $this->db->query($query);
+        $query = 'SELECT `external` FROM cb_field WHERE cb_field_id = :fieldId';
+        $res = $this->db->prepare($query);
+        $res->bindValue(':fieldId', (int) $fieldId, PDO::PARAM_INT);
+        $res->execute();
 
         if (! $res) {
             $externalValue = null;
@@ -1732,20 +1754,21 @@ class CentreonConfigCentreonBroker
         if ($info['grp_level'] != 0) {
             $error = false;
             try {
-                $res = $this->db->query(sprintf(
-                    "SELECT config_key, config_value, config_group_id, grp_level, parent_grp_id
-               FROM cfg_centreonbroker_info
-               WHERE config_id = %d
-                   AND config_group = '%s'
-           AND subgrp_id = %d
-           AND grp_level = %d
-           AND config_group_id = %d",
-                    $configId,
-                    $configGroup,
-                    $info['parent_grp_id'],
-                    $info['grp_level'] - 1,
-                    $info['config_group_id']
-                ));
+                $res = $this->db->prepare(
+                    'SELECT config_key, config_value, config_group_id, grp_level, parent_grp_id
+                    FROM cfg_centreonbroker_info
+                    WHERE config_id = :configId
+                        AND config_group = :configGroup
+                        AND subgrp_id = :subgrpId
+                        AND grp_level = :grpLevel
+                        AND config_group_id = :configGroupId'
+                );
+                $res->bindValue(':configId', (int) $configId, PDO::PARAM_INT);
+                $res->bindValue(':configGroup', $configGroup, PDO::PARAM_STR);
+                $res->bindValue(':subgrpId', (int) $info['parent_grp_id'], PDO::PARAM_INT);
+                $res->bindValue(':grpLevel', (int) $info['grp_level'] - 1, PDO::PARAM_INT);
+                $res->bindValue(':configGroupId', (int) $info['config_group_id'], PDO::PARAM_INT);
+                $res->execute();
             } catch (PDOException $e) {
                 $error = true;
             }

--- a/centreon/www/class/centreonConnector.class.php
+++ b/centreon/www/class/centreonConnector.class.php
@@ -573,32 +573,30 @@ class CentreonConnector
      */
     public function getObjectForSelect2($values = [], $options = [])
     {
-        $items = [];
-        $listValues = '';
+        // Without any selected values, there is nothing to fetch.
+        if (empty($values)) {
+            return [];
+        }
+
+        $bindParams = [];
         $queryValues = [];
-        if (! empty($values)) {
-            foreach ($values as $k => $v) {
-                $listValues .= ':id' . $v . ',';
-                $queryValues['id' . $v] = (int) $v;
-            }
-            $listValues = rtrim($listValues, ',');
-        } else {
-            $listValues .= '""';
+        foreach (array_values($values) as $index => $value) {
+            $param = ':id' . $index;
+            $bindParams[] = $param;
+            $queryValues[$param] = (int) $value;
         }
 
         // get list of selected connectors
         $query = 'SELECT id, name FROM connector '
-            . 'WHERE id IN (' . $listValues . ') ORDER BY name ';
+            . 'WHERE id IN (' . implode(', ', $bindParams) . ') ORDER BY name ';
 
         $stmt = $this->dbConnection->prepare($query);
-
-        if ($queryValues !== []) {
-            foreach ($queryValues as $key => $id) {
-                $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
-            }
+        foreach ($queryValues as $param => $id) {
+            $stmt->bindValue($param, $id, PDO::PARAM_INT);
         }
         $stmt->execute();
 
+        $items = [];
         while ($row = $stmt->fetch()) {
             $items[] = ['id' => $row['id'], 'text' => $row['name']];
         }

--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -624,9 +624,6 @@ class Broker extends AbstractObjectJSON
                 case 'C':
                     $s_column = (string) $value;
                     break;
-                case 'F':
-                    $s_filter = (string) $value;
-                    break;
                 case 'K':
                     $s_key = (string) $value;
                     break;

--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -616,22 +616,22 @@ class Broker extends AbstractObjectJSON
             [$key, $value] = explode('=', $config);
             switch ($key) {
                 case 'D':
-                    $s_db = $value;
+                    $s_db = (string) $value;
                     break;
                 case 'T':
-                    $s_table = $value;
+                    $s_table = (string) $value;
                     break;
                 case 'C':
-                    $s_column = $value;
+                    $s_column = (string) $value;
                     break;
                 case 'F':
-                    $s_filter = $value;
+                    $s_filter = (string) $value;
                     break;
                 case 'K':
-                    $s_key = $value;
+                    $s_key = (string) $value;
                     break;
                 case 'CK':
-                    $s_column_key = $value;
+                    $s_column_key = (string) $value;
                     break;
                 case 'RPN':
                     $s_rpn = $value;
@@ -642,22 +642,36 @@ class Broker extends AbstractObjectJSON
         if (! isset($s_table) || ! isset($s_column)) {
             return false;
         }
+        // Table/column names cannot be bound as parameters: validate them as
+        // strict SQL identifiers to prevent injection through the config string.
+        $s_table = $this->validateSqlIdentifier($s_table);
+        $s_column = $this->validateSqlIdentifier($s_column);
+
+        $hasKeyFilter = isset($s_column_key, $s_key);
         $query = 'SELECT `' . $s_column . '` FROM `' . $s_table . '`';
-        if (isset($s_column_key, $s_key)) {
-            $query .= ' WHERE `' . $s_column_key . "` = '" . $s_key . "'";
+        if ($hasKeyFilter) {
+            $s_column_key = $this->validateSqlIdentifier($s_column_key);
+            $query .= ' WHERE `' . $s_column_key . '` = :key';
         }
 
         // Execute the query
         switch ($s_db) {
-            case 'centreon':
+            case db:
                 $db = $this->backend_instance->db;
                 break;
-            case 'centreon_storage':
+            case dbcstg:
                 $db = $this->backend_instance->db_cs;
                 break;
+            default:
+                throw new InvalidArgumentException(
+                    sprintf('Unknown database "%s"', $s_db)
+                );
         }
 
         $stmt = $db->prepare($query);
+        if ($hasKeyFilter) {
+            $stmt->bindValue(':key', $s_key, PDO::PARAM_STR);
+        }
         $stmt->execute();
 
         $infos = [];
@@ -676,6 +690,28 @@ class Broker extends AbstractObjectJSON
         }
 
         return $infos;
+    }
+
+    /**
+     * Validate a string used as a SQL identifier (table or column name).
+     *
+     * Identifiers cannot be passed as bound parameters, so they must be
+     * restricted to a safe character set before being concatenated into a query.
+     *
+     * @param string $identifier
+     *
+     * @throws InvalidArgumentException
+     * @return string
+     */
+    private function validateSqlIdentifier(string $identifier): string
+    {
+        if (preg_match('/^[A-Za-z0-9_]+$/', $identifier) !== 1) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid SQL identifier "%s"', $identifier)
+            );
+        }
+
+        return $identifier;
     }
 
     /**

--- a/centreon/www/include/configuration/configNagios/listNagios.php
+++ b/centreon/www/include/configuration/configNagios/listNagios.php
@@ -38,8 +38,10 @@ if (! is_null($search)) {
 }
 
 $SearchTool = '';
+$searchBind = null;
 if (! is_null($search)) {
-    $SearchTool .= " WHERE nagios_name LIKE '%{$search}%' ";
+    $SearchTool .= ' WHERE nagios_name LIKE :search ';
+    $searchBind = '%' . $search . '%';
 }
 
 $aclCond = '';
@@ -56,10 +58,16 @@ while ($nagios_server = $dbResult->fetch()) {
 }
 $dbResult->closeCursor();
 
-$dbResult = $pearDB->query(
+$dbResult = $pearDB->prepare(
     'SELECT SQL_CALC_FOUND_ROWS nagios_id, nagios_name, nagios_comment, nagios_activate, nagios_server_id '
-    . 'FROM cfg_nagios ' . $SearchTool . $aclCond . ' ORDER BY nagios_name LIMIT ' . $num * $limit . ', ' . $limit
+    . 'FROM cfg_nagios ' . $SearchTool . $aclCond . ' ORDER BY nagios_name LIMIT :offset, :limit'
 );
+if (! is_null($searchBind)) {
+    $dbResult->bindValue(':search', $searchBind, PDO::PARAM_STR);
+}
+$dbResult->bindValue(':offset', (int) ($num * $limit), PDO::PARAM_INT);
+$dbResult->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
+$dbResult->execute();
 
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -41,9 +41,11 @@ if (! is_null($search)) {
 }
 
 $LCASearch = '';
+$searchBind = null;
 if (! is_null($search)) {
     $search = HtmlSanitizer::createFromString($search)->sanitize()->getString();
-    $LCASearch .= " name LIKE '%{$search}%'";
+    $LCASearch .= ' name LIKE :search';
+    $searchBind = '%' . $search . '%';
 }
 
 // Get Authorized Actions
@@ -116,8 +118,14 @@ $ACLString = $centreon->user->access->queryBuilder('WHERE', 'id', $pollerstring)
 $query = 'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, updated '
     . ', gorgone_communication_type, uid FROM `nagios_server` ' . $ACLString . ' '
     . ($LCASearch != '' ? ($ACLString != '' ? 'AND ' : 'WHERE ') . $LCASearch : '')
-    . ' ORDER BY name LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($query);
+    . ' ORDER BY name LIMIT :offset, :limit';
+$dbResult = $pearDB->prepare($query);
+if (! is_null($searchBind)) {
+    $dbResult->bindValue(':search', $searchBind, PDO::PARAM_STR);
+}
+$dbResult->bindValue(':offset', (int) ($num * $limit), PDO::PARAM_INT);
+$dbResult->bindValue(':limit', (int) $limit, PDO::PARAM_INT);
+$dbResult->execute();
 
 $rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
 


### PR DESCRIPTION
## Description

Harden several legacy configuration components by switching to
prepared statements with bound parameters and validated identifiers,
for consistency and robustness.

- poller server list and Nagios config list: bind the name search
  filter and pagination bounds
- connector select2 lookup: avoid malformed query
- broker config helpers (`getInfoDb`, cb config helpers,
  `broker.class.php`): parameterized queries and validated identifiers
- main Nagios cfg helpers: prepared queries
- nagios-server pagination: validate ordering field and direction
- remote task: restrict object instantiation on params deserialization
  and fix `$task` docblock

Fixes: [MON-200898](https://centreon.atlassian.net/browse/MON-200898)

[MON-200898]: https://centreon.atlassian.net/browse/MON-200898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ