### PR TITLE
fix(ci): hand packages between jobs via artifacts instead of cache

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "Centreon packaged major version"
     required: true
   cache_key:
-    description: "The cached package key"
+    description: "The name of the run artifact holding the built package files"
     required: true
   stability:
     description: "The package stability (stable, testing, unstable)"
@@ -29,12 +29,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use cache DEB files
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - name: Download DEB files
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        path: ./*.deb
-        key: ${{ inputs.cache_key }}
-        fail-on-cache-miss: true
+        name: ${{ inputs.cache_key }}
+        path: .
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: The commit hash
     required: true
   cache_key:
-    description: The package files cache key
+    description: The name of the run artifact holding the built package files (consumed by downstream dockerize/deliver jobs)
     required: true
   rpm_gpg_key:
     description: The rpm gpg key
@@ -159,11 +159,14 @@ runs:
         done
       shell: bash
 
-    - name: Cache packages
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    # Pass packages to downstream jobs via run artifact (atomic) instead of cache
+    - name: Upload packages for downstream jobs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
+        name: ${{ inputs.cache_key }}
         path: ./*.${{ inputs.package_extension }}
-        key: ${{ inputs.cache_key }}
+        retention-days: 1
+        if-no-files-found: error
 
     # Add 'upload-artifacts' label to pull request to get packages as artifacts
     - if: inputs.upload_artifacts == 'true'

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "Centreon packaged major version"
     required: true
   cache_key:
-    description: "The cached package key"
+    description: "The name of the run artifact holding the built package files"
     required: true
   stability:
     description: "The package stability (stable, testing, unstable)"
@@ -29,12 +29,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use cache RPM files
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - name: Download RPM files
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        path: ./*.rpm
-        key: ${{ inputs.cache_key }}
-        fail-on-cache-miss: true
+        name: ${{ inputs.cache_key }}
+        path: .
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:

--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -169,13 +169,12 @@ jobs:
             echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
           fi
 
-      - name: Restore packages
+      - name: Download packages
         if: "${{ inputs.package_cache_key != '' && inputs.package_directory != '' && contains(matrix.feature, 'platform-') }}"
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ./*.${{ contains(inputs.os, 'alma') && 'rpm' || 'deb' }}
-          key: ${{ inputs.package_cache_key }}
-          fail-on-cache-miss: true
+          name: ${{ inputs.package_cache_key }}
+          path: .
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -885,12 +885,11 @@ jobs:
           registry_url: ghcr.io/${{ github.repository }}
           tag_suffix: -${{ matrix.operating_system }}
 
-      - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download ${{ steps.matrix_include.outputs.package_extension }} files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: ./*.${{ steps.matrix_include.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
-          fail-on-cache-miss: true
+          name: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
+          path: .
 
       - env:
           PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}


### PR DESCRIPTION
## Problem

The package build outputs (RPM/DEB) are passed from `package` to downstream jobs (`dockerize`, `deliver`, e2e) via `actions/cache`. The cache key embeds `github.run_id`.

GitHub's cache backend reserves a key before committing its content. If the commit step fails, the key stays **reserved but unrestorable** for the whole run. Because `run_id` is part of the key and does not change across re-run attempts, re-running the failed jobs reuses the same broken key and keeps failing with:

```
Error: Failed to restore cache entry. Exiting as fail-on-cache-miss is set.
Input key: <sha>-<run_id>-rpm-el9
```

This is the recurring AWIE delivery flakiness on EL9.

## Fix

Use `actions/upload-artifact` / `actions/download-artifact` for the package handoff instead of the cache. Artifacts commit atomically (no reserve-without-commit window) and are shared across re-run attempts.

## Scope (this branch)

Producer:
- `package-nfpm` action: `cache/save` → `upload-artifact`

Consumers (`cache/restore` → `download-artifact`):
- `rpm-delivery` / `deb-delivery` actions
- `web.yml` (dockerize)
- `cypress-e2e-parallelization.yml` (e2e package restore)

The artifact name reuses the existing key formula, so producer and consumers stay wired together with no other change. Other caches (frontend, docker slim image) are intentionally left untouched.

Companion PRs: `dev-25.10.x` (#10732) and `develop`.