### PR TITLE
fix(api): validate identifiers and add missing execute calls in legacy endpoints

### DIFF
--- a/centreon/www/api/class/centreon_configuration_objects.class.php
+++ b/centreon/www/api/class/centreon_configuration_objects.class.php
@@ -21,6 +21,7 @@
 
 require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
 require_once __DIR__ . '/webService.class.php';
+require_once __DIR__ . '/../../include/common/common-Func.php';
 
 /**
  * Class
@@ -52,7 +53,7 @@ class CentreonConfigurationObjects extends CentreonWebService
 
         // Get Object targeted
         if (isset($this->arguments['field'])) {
-            $field = $this->arguments['field'];
+            $field = sanitizeSqlIdentifier($this->arguments['field']);
         } else {
             throw new RestBadRequestException('Bad parameters field');
         }
@@ -155,9 +156,14 @@ class CentreonConfigurationObjects extends CentreonWebService
                 $explodedValues = rtrim($explodedValues, ',');
             }
 
-            $query = "SELECT {$externalObject['id']}, {$externalObject['name']} "
-                . "FROM {$externalObject['table']} "
-                . "WHERE {$externalObject['comparator']} "
+            $safeId = sanitizeSqlIdentifier($externalObject['id']);
+            $safeName = sanitizeSqlIdentifier($externalObject['name']);
+            $safeTable = sanitizeSqlIdentifier($externalObject['table']);
+            $safeComparator = sanitizeSqlIdentifier($externalObject['comparator']);
+
+            $query = "SELECT {$safeId}, {$safeName} "
+                . "FROM {$safeTable} "
+                . "WHERE {$safeComparator} "
                 . "IN ({$explodedValues})";
 
             if (! empty($externalObject['additionalComparator'])) {
@@ -172,7 +178,7 @@ class CentreonConfigurationObjects extends CentreonWebService
             }
 
             while ($row = $stmt->fetch()) {
-                $tmpValues[] = ['id' => $row[$externalObject['id']], 'text' => $row[$externalObject['name']]];
+                $tmpValues[] = ['id' => $row[$safeId], 'text' => $row[$safeName]];
             }
         }
 
@@ -187,10 +193,11 @@ class CentreonConfigurationObjects extends CentreonWebService
     {
         $additonalQueryComparator = '';
         foreach ($additonalComparator as $field => $value) {
+            $safeField = sanitizeSqlIdentifier($field);
             if (is_null($value)) {
-                $additonalQueryComparator .= 'AND ' . $field . ' IS NULL ';
+                $additonalQueryComparator .= ' AND ' . $safeField . ' IS NULL ';
             } else {
-                $additonalQueryComparator .= 'AND ' . $field . ' = ' . $value;
+                $additonalQueryComparator .= ' AND ' . $safeField . ' = ' . (int) $value;
             }
         }
 
@@ -212,22 +219,23 @@ class CentreonConfigurationObjects extends CentreonWebService
             throw new RestBadRequestException('Error, id must be numerical');
         }
         $tmpValues = [];
-        $fields = [];
-        $fields[] = $field;
+
+        $safeField = sanitizeSqlIdentifier($field);
+        $fields = [$safeField];
         if (isset($currentObject['additionalField'])) {
-            $fields[] = $currentObject['additionalField'];
+            $fields[] = sanitizeSqlIdentifier($currentObject['additionalField']);
         }
 
         // Getting Current Values
         $queryValuesRetrieval = 'SELECT ' . implode(', ', $fields) . ' '
-            . 'FROM ' . $currentObject['table'] . ' '
-            . 'WHERE ' . $currentObject['id'] . ' = :id';
+            . 'FROM ' . sanitizeSqlIdentifier($currentObject['table']) . ' '
+            . 'WHERE ' . sanitizeSqlIdentifier($currentObject['id']) . ' = :id';
 
         $stmt = $this->pearDB->prepare($queryValuesRetrieval);
         $stmt->bindParam(':id', $id, PDO::PARAM_INT);
         $stmt->execute();
         while ($row = $stmt->fetch()) {
-            $tmpValue = $row[$field];
+            $tmpValue = $row[$safeField];
             if (isset($currentObject['additionalField'])) {
                 $tmpValue .= '-' . $row[$currentObject['additionalField']];
             }
@@ -248,21 +256,21 @@ class CentreonConfigurationObjects extends CentreonWebService
     {
         $tmpValues = [];
 
-        $fields = [];
-        $fields[] = $relationObject['field'];
+        $safeField = sanitizeSqlIdentifier($relationObject['field']);
+        $fields = [$safeField];
         if (isset($relationObject['additionalField'])) {
-            $fields[] = $relationObject['additionalField'];
+            $fields[] = sanitizeSqlIdentifier($relationObject['additionalField']);
         }
 
         $queryValuesRetrieval = 'SELECT ' . implode(', ', $fields) . ' '
-            . 'FROM ' . $relationObject['table'] . ' '
-            . 'WHERE ' . $relationObject['comparator'] . ' = :id';
+            . 'FROM ' . sanitizeSqlIdentifier($relationObject['table']) . ' '
+            . 'WHERE ' . sanitizeSqlIdentifier($relationObject['comparator']) . ' = :id';
         $stmt = $this->pearDB->prepare($queryValuesRetrieval);
         $stmt->bindParam(':id', $id, PDO::PARAM_INT);
         $stmt->execute();
         while ($row = $stmt->fetch()) {
-            if (! empty($row[$relationObject['field']])) {
-                $tmpValue = $row[$relationObject['field']];
+            if (! empty($row[$safeField])) {
+                $tmpValue = $row[$safeField];
                 if (isset($relationObject['additionalField'])) {
                     $tmpValue .= '-' . $row[$relationObject['additionalField']];
                 }

--- a/centreon/www/api/class/centreon_realtime_base.class.php
+++ b/centreon/www/api/class/centreon_realtime_base.class.php
@@ -21,6 +21,7 @@
 
 require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
 require_once __DIR__ . '/webService.class.php';
+require_once __DIR__ . '/../../include/common/common-Func.php';
 
 /**
  * Class
@@ -56,13 +57,13 @@ class CentreonRealtimeBase extends CentreonWebService
 
         // Get Object targeted
         if (isset($this->arguments['field'])) {
-            $field = $this->arguments['field'];
+            $field = sanitizeSqlIdentifier($this->arguments['field']);
         } else {
             throw new RestBadRequestException('Bad parameters field');
         }
 
         // Get Object targeted
-        if (isset($this->arguments['target'])) {
+        if (isset($this->arguments['target']) && preg_match('/^[a-zA-Z]+$/', $this->arguments['target'])) {
             $target = ucfirst($this->arguments['target']);
         } else {
             throw new RestBadRequestException('Bad parameters target');
@@ -162,9 +163,14 @@ class CentreonRealtimeBase extends CentreonWebService
                 $explodedValues = rtrim($explodedValues, ',');
             }
 
-            $query = "SELECT {$externalObject['id']}, {$externalObject['name']} "
-                . "FROM {$externalObject['table']} "
-                . "WHERE {$externalObject['comparator']} "
+            $safeId = sanitizeSqlIdentifier($externalObject['id']);
+            $safeName = sanitizeSqlIdentifier($externalObject['name']);
+            $safeTable = sanitizeSqlIdentifier($externalObject['table']);
+            $safeComparator = sanitizeSqlIdentifier($externalObject['comparator']);
+
+            $query = "SELECT {$safeId}, {$safeName} "
+                . "FROM {$safeTable} "
+                . "WHERE {$safeComparator} "
                 . "IN ({$explodedValues})";
             $stmt = $this->pearDB->prepare($query);
 
@@ -176,7 +182,7 @@ class CentreonRealtimeBase extends CentreonWebService
             $stmt->execute();
 
             while ($row = $stmt->fetch()) {
-                $tmpValues[] = ['id' => $row[$externalObject['id']], 'text' => $row[$externalObject['name']]];
+                $tmpValues[] = ['id' => $row[$safeId], 'text' => $row[$safeName]];
             }
         }
 
@@ -187,28 +193,34 @@ class CentreonRealtimeBase extends CentreonWebService
      * @param $currentObject
      * @param $id
      * @param $field
+     *
+     * @throws RestBadRequestException
      * @return array
      */
     protected function retrieveSimpleValues($currentObject, $id, $field)
     {
+        if (! is_numeric($id)) {
+            throw new RestBadRequestException('Error, id must be numerical');
+        }
         $tmpValues = [];
 
-        $fields = [];
-        $fields[] = $field;
+        $safeField = sanitizeSqlIdentifier($field);
+        $fields = [$safeField];
         if (isset($currentObject['additionalField'])) {
-            $fields[] = $currentObject['additionalField'];
+            $fields[] = sanitizeSqlIdentifier($currentObject['additionalField']);
         }
 
         // Getting Current Values
         $queryValuesRetrieval = 'SELECT ' . implode(', ', $fields) . ' '
-            . 'FROM ' . $currentObject['table'] . ' '
-            . 'WHERE ' . $currentObject['id'] . ' = :objectId';
+            . 'FROM ' . sanitizeSqlIdentifier($currentObject['table']) . ' '
+            . 'WHERE ' . sanitizeSqlIdentifier($currentObject['id']) . ' = :objectId';
 
         $stmt = $this->pearDB->prepare($queryValuesRetrieval);
         $stmt->bindParam(':objectId', $id, PDO::PARAM_INT);
+        $stmt->execute();
 
         while ($row = $stmt->fetch()) {
-            $tmpValue = $row[$field];
+            $tmpValue = $row[$safeField];
             if (isset($currentObject['additionalField'])) {
                 $tmpValue .= '-' . $row[$currentObject['additionalField']];
             }
@@ -227,21 +239,22 @@ class CentreonRealtimeBase extends CentreonWebService
     {
         $tmpValues = [];
 
-        $fields = [];
-        $fields[] = $relationObject['field'];
+        $safeField = sanitizeSqlIdentifier($relationObject['field']);
+        $fields = [$safeField];
         if (isset($relationObject['additionalField'])) {
-            $fields[] = $relationObject['additionalField'];
+            $fields[] = sanitizeSqlIdentifier($relationObject['additionalField']);
         }
 
         $queryValuesRetrieval = 'SELECT ' . implode(', ', $fields) . ' '
-            . 'FROM ' . $relationObject['table'] . ' '
-            . 'WHERE ' . $relationObject['comparator'] . ' = :comparatorId';
+            . 'FROM ' . sanitizeSqlIdentifier($relationObject['table']) . ' '
+            . 'WHERE ' . sanitizeSqlIdentifier($relationObject['comparator']) . ' = :comparatorId';
         $stmt = $this->pearDB->prepare($queryValuesRetrieval);
         $stmt->bindParam(':comparatorId', $id, PDO::PARAM_INT);
+        $stmt->execute();
 
         while ($row = $stmt->fetch()) {
-            if (! empty($row[$relationObject['field']])) {
-                $tmpValue = $row[$relationObject['field']];
+            if (! empty($row[$safeField])) {
+                $tmpValue = $row[$safeField];
                 if (isset($relationObject['additionalField'])) {
                     $tmpValue .= '-' . $row[$relationObject['additionalField']];
                 }

--- a/centreon/www/include/common/common-Func.php
+++ b/centreon/www/include/common/common-Func.php
@@ -2145,3 +2145,13 @@ function signalConfigurationChange(
 
     definePollersToUpdated(array_merge($pollerIds, $previousPollers));
 }
+
+function sanitizeSqlIdentifier(string $name): string
+{
+    $name = trim($name);
+    if ($name === '' || preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $name) !== 1) {
+        throw new InvalidArgumentException("Invalid SQL identifier: {$name}");
+    }
+
+    return $name;
+}


### PR DESCRIPTION
## Description

Backport of #10737 to dev-24.10.x.

- Add `sanitizeSqlIdentifier()` allowlist function to validate SQL identifiers before interpolation
- Add missing `preg_match` guard on `$target` parameter in `centreon_realtime_base`
- Validate `$field` user input as a safe SQL identifier in both API classes
- Add missing `$stmt->execute()` calls in `centreon_realtime_base` (`retrieveSimpleValues` and `retrieveRelatedValues`)
- Add `is_numeric($id)` check in `centreon_realtime_base::retrieveSimpleValues()`
- Sanitize field names and cast values in `processAdditionalComparator()`

**Fixes** MON-201431

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

- Open any host/service configuration form and verify that Select2 dropdowns (contacts, hostgroups, templates, categories) still populate correctly
- Test realtime monitoring views that use the realtime API

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).