### PR TITLE
MON-201437: fix(ha): allow centreon user to reload cbd-sql and cbd vi…

### DIFF
--- a/centreon-ha/etc/sudoers.d/centreon-cluster
+++ b/centreon-ha/etc/sudoers.d/centreon-cluster
@@ -27,9 +27,11 @@ CENTREON   ALL = NOPASSWD: /bin/systemctl start cbd-sql
 CENTREON   ALL = NOPASSWD: /bin/systemctl stop cbd-sql
 CENTREON   ALL = NOPASSWD: /bin/systemctl restart cbd-sql
 CENTREON   ALL = NOPASSWD: /bin/systemctl reload cbd-sql
+CENTREON   ALL = NOPASSWD: /bin/systemctl reload cbd-sql cbd
 CENTREON   ALL = NOPASSWD: /usr/bin/systemctl start cbd-sql
 CENTREON   ALL = NOPASSWD: /usr/bin/systemctl stop cbd-sql
 CENTREON   ALL = NOPASSWD: /usr/bin/systemctl restart cbd-sql
 CENTREON   ALL = NOPASSWD: /usr/bin/systemctl reload cbd-sql
+CENTREON   ALL = NOPASSWD: /usr/bin/systemctl reload cbd-sql cbd
 
 ## END: CENTREON SUDO


### PR DESCRIPTION
## Description

fix(ha): allow the `centreon` user to reload `cbd-sql` and `cbd` together in the `centreon-cluster` sudoers.d file.

Reopens #3274 / #3292 (closed) on the correct target branch.

Backports https://github.com/centreon/centreon/pull/10541

### What changed

Adds the missing NOPASSWD rule so the `centreon` user can reload both Broker units in a single `systemctl` invocation:

```
CENTREON   ALL = NOPASSWD: /usr/bin/systemctl reload cbd-sql cbd
```

### Improvement

For consistency with the existing `cbd-sql` rules — which already cover both `/bin/systemctl` and `/usr/bin/systemctl` — the `/bin/systemctl` variant of the new rule is added as well:

```
CENTREON   ALL = NOPASSWD: /bin/systemctl reload cbd-sql cbd
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 25.10.x (dev-25.10.x)

