### PR TITLE
chore(test): e2e: remove vestigial ESLint/Prettier

### DIFF
--- a/centreon-open-tickets/tests/e2e/.eslintrc.js
+++ b/centreon-open-tickets/tests/e2e/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  extends: [
-    './node_modules/@centreon/js-config/eslint/react/typescript.eslintrc.js',
-    'plugin:cypress/recommended',
-  ],
-};

--- a/centreon-open-tickets/tests/e2e/common.ts
+++ b/centreon-open-tickets/tests/e2e/common.ts
@@ -1,4 +1,3 @@
-/* eslint-disable cypress/no-unnecessary-waiting */
 interface ActionClapi {
   action: string;
   object?: string;

--- a/centreon-open-tickets/tests/e2e/configuration.ts
+++ b/centreon-open-tickets/tests/e2e/configuration.ts
@@ -1,6 +1,3 @@
-/* eslint-disable import/extensions */
-/* eslint-disable import/no-unresolved */
-
 import { execSync } from 'child_process';
 
 import { defineConfig } from 'cypress';

--- a/centreon-open-tickets/tests/e2e/package.json
+++ b/centreon-open-tickets/tests/e2e/package.json
@@ -26,8 +26,6 @@
     "@types/cypress-cucumber-preprocessor": "^4.0.5",
     "@types/node": "^24.10.0",
     "@types/ramda": "0.31.1",
-    "@typescript-eslint/eslint-plugin": "^8.46.2",
-    "@typescript-eslint/parser": "^8.46.2",
     "cross-env": "^10.1.0",
     "cypress": "~15.5.0",
     "cypress-cucumber-preprocessor": "^4.3.1",

--- a/centreon-open-tickets/tests/e2e/plugins.ts
+++ b/centreon-open-tickets/tests/e2e/plugins.ts
@@ -1,7 +1,3 @@
-/* eslint-disable default-param-last */
-/* eslint-disable global-require */
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable no-param-reassign */
 import fs from 'fs';
 import path from 'path';
 

--- a/centreon-open-tickets/tests/e2e/plugins/index.ts
+++ b/centreon-open-tickets/tests/e2e/plugins/index.ts
@@ -1,8 +1,3 @@
-/* eslint-disable default-param-last */
-/* eslint-disable global-require */
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable no-param-reassign */
-
 import { execSync } from 'child_process';
 import Docker from 'dockerode';
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';

--- a/centreon-open-tickets/tests/e2e/pnpm-lock.yaml
+++ b/centreon-open-tickets/tests/e2e/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.3.11
       '@centreon/js-config':
         specifier: 26.3.1
-        version: 26.3.1(@babel/core@7.28.5)(@types/eslint@9.6.1)(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(mocha@11.7.4)(prettier@3.5.3)(typescript@5.9.3)
+        version: 26.3.1(@babel/core@7.28.5)(@types/eslint@9.6.1)(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(mocha@11.7.4)(prettier@3.5.3)(typescript@5.9.3)
       '@cypress/webpack-batteries-included-preprocessor':
         specifier: ^4.0.2
         version: 4.0.2(@cypress/webpack-preprocessor@6.0.4(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(babel-loader@10.0.0(@babel/core@7.28.5)(webpack@5.102.1(@swc/core@1.9.3)(esbuild@0.25.12)))(webpack@5.102.1(@swc/core@1.9.3)(esbuild@0.25.12)))(@swc/core@1.9.3)(esbuild@0.25.12)(typescript@5.9.3)
@@ -44,12 +44,6 @@ importers:
       '@types/ramda':
         specifier: 0.31.1
         version: 0.31.1
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.46.2
-        version: 8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.46.2
-        version: 8.46.2(eslint@8.57.1)(typescript@5.9.3)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -1496,14 +1490,6 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.46.2':
-    resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.46.2
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/experimental-utils@5.62.0':
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1535,13 +1521,6 @@ packages:
     resolution: {integrity: sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.46.2':
-    resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@5.62.0':
@@ -1590,6 +1569,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3566,10 +3546,6 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -6389,7 +6365,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.11':
     optional: true
 
-  '@centreon/js-config@26.3.1(@babel/core@7.28.5)(@types/eslint@9.6.1)(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(mocha@11.7.4)(prettier@3.5.3)(typescript@5.9.3)':
+  '@centreon/js-config@26.3.1(@babel/core@7.28.5)(@types/eslint@9.6.1)(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(mocha@11.7.4)(prettier@3.5.3)(typescript@5.9.3)':
     dependencies:
       '@badeball/cypress-cucumber-preprocessor': 23.2.1(@babel/core@7.28.5)(cypress@15.5.0)(typescript@5.9.3)
       '@bahmutov/cypress-esbuild-preprocessor': 2.2.7(esbuild@0.21.5)
@@ -6412,7 +6388,7 @@ snapshots:
       eslint-plugin-babel: 5.3.1(eslint@8.57.1)
       eslint-plugin-hooks: 0.4.3
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      eslint-plugin-jest: 26.9.0(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-node: 11.1.0(eslint@8.57.1)
       eslint-plugin-prefer-arrow-functions: 3.9.1(eslint@8.57.1)(typescript@5.9.3)
@@ -7185,23 +7161,6 @@ snapshots:
       '@types/node': 24.10.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.46.2
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
@@ -7244,18 +7203,6 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.46.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
-
-  '@typescript-eslint/type-utils@8.46.2(eslint@8.57.1)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@8.57.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/types@5.62.0': {}
 
@@ -9170,12 +9117,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3):
+  eslint-plugin-jest@26.9.0(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9859,8 +9804,6 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:

--- a/centreon-open-tickets/tests/e2e/tasks.ts
+++ b/centreon-open-tickets/tests/e2e/tasks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
 import path from 'path';


### PR DESCRIPTION
E2E suites lint with **Biome** (`biome check` / `biome ci` in the `lint*` scripts). The legacy ESLint/Prettier setup is no longer invoked by any script, so its dependencies, config files, and `eslint-disable` comments are dead weight.

## Changes (centreon-open-tickets e2e suite)

- Remove unused devDependencies: `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`
- Remove the dead `.eslintrc.js`
- Remove stale `eslint-disable` comments from the suite sources
- Regenerate `pnpm-lock.yaml`

The `centreon/tests/e2e` (web) and `centreon-awie` suites were already clean.

## Validation

- `biome check ./features` is clean for the suite (the CI lint gate is unaffected)
- Intentionally separate from the Cypress 15 alignment (MON-160580): one PR = one intent

Refs: MON-201390