### PR TITLE
fix(docker): restore /usr/share directories to fix update-alternative…

### DIFF
--- a/.github/docker/centreon-web/alma9/Dockerfile
+++ b/.github/docker/centreon-web/alma9/Dockerfile
@@ -57,7 +57,6 @@ systemctl stop snmpd
 systemctl stop crond
 
 dnf clean all
-rm -rf /usr/share/doc /usr/share/man /usr/share/info
 
 EOF
 

--- a/.github/docker/centreon-web/bookworm/Dockerfile
+++ b/.github/docker/centreon-web/bookworm/Dockerfile
@@ -62,7 +62,6 @@ systemctl stop snmpd
 systemctl stop cron
 
 apt-get clean
-rm -rf /usr/share/doc /usr/share/man /usr/share/info
 
 EOF
 


### PR DESCRIPTION
…s issue

## Description

* restore previously removed /usr/share directories so that update-alternatives does not fail when doing symlinks there

**Fixes** #MON-201452
