### PR TITLE
test(e2e): tear down docker stack when startContainers fails

### DIFF
--- a/centreon-awie/tests/e2e/tasks.ts
+++ b/centreon-awie/tests/e2e/tasks.ts
@@ -227,12 +227,11 @@ export default (on: Cypress.PluginEvents): void => {
 
         // Best-effort teardown: keep the original startup error if cleanup fails.
         try {
-          if (dockerEnvironment !== null) {
-            await dockerEnvironment.down();
-            dockerEnvironment = null;
-          }
+          await dockerEnvironment?.down();
         } catch (teardownError) {
           console.error(teardownError);
+        } finally {
+          dockerEnvironment = null;
         }
 
         throw error;

--- a/centreon-awie/tests/e2e/tasks.ts
+++ b/centreon-awie/tests/e2e/tasks.ts
@@ -225,10 +225,14 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
-        // Tear down the partially-started stack so the CI runner frees resources now.
-        if (dockerEnvironment !== null) {
-          await dockerEnvironment.down();
-          dockerEnvironment = null;
+        // Best-effort teardown: keep the original startup error if cleanup fails.
+        try {
+          if (dockerEnvironment !== null) {
+            await dockerEnvironment.down();
+            dockerEnvironment = null;
+          }
+        } catch (teardownError) {
+          console.error(teardownError);
         }
 
         throw error;

--- a/centreon-awie/tests/e2e/tasks.ts
+++ b/centreon-awie/tests/e2e/tasks.ts
@@ -225,6 +225,12 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
+        // Tear down the partially-started stack so the CI runner frees resources now.
+        if (dockerEnvironment !== null) {
+          await dockerEnvironment.down();
+          dockerEnvironment = null;
+        }
+
         throw error;
       }
     },

--- a/centreon-open-tickets/tests/e2e/tasks.ts
+++ b/centreon-open-tickets/tests/e2e/tasks.ts
@@ -226,6 +226,12 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
+        // Tear down the partially-started stack so the CI runner frees resources now.
+        if (dockerEnvironment !== null) {
+          await dockerEnvironment.down();
+          dockerEnvironment = null;
+        }
+
         throw error;
       }
     },

--- a/centreon-open-tickets/tests/e2e/tasks.ts
+++ b/centreon-open-tickets/tests/e2e/tasks.ts
@@ -226,10 +226,14 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
-        // Tear down the partially-started stack so the CI runner frees resources now.
-        if (dockerEnvironment !== null) {
-          await dockerEnvironment.down();
-          dockerEnvironment = null;
+        // Best-effort teardown: keep the original startup error if cleanup fails.
+        try {
+          if (dockerEnvironment !== null) {
+            await dockerEnvironment.down();
+            dockerEnvironment = null;
+          }
+        } catch (teardownError) {
+          console.error(teardownError);
         }
 
         throw error;

--- a/centreon-open-tickets/tests/e2e/tasks.ts
+++ b/centreon-open-tickets/tests/e2e/tasks.ts
@@ -228,12 +228,11 @@ export default (on: Cypress.PluginEvents): void => {
 
         // Best-effort teardown: keep the original startup error if cleanup fails.
         try {
-          if (dockerEnvironment !== null) {
-            await dockerEnvironment.down();
-            dockerEnvironment = null;
-          }
+          await dockerEnvironment?.down();
         } catch (teardownError) {
           console.error(teardownError);
+        } finally {
+          dockerEnvironment = null;
         }
 
         throw error;

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -240,6 +240,12 @@ export default (on: Cypress.PluginEvents): void => {
       } catch (error) {
         console.error(error);
 
+        // Tear down the partially-started stack so the CI runner frees resources now.
+        if (dockerEnvironment !== null) {
+          await dockerEnvironment.down();
+          dockerEnvironment = null;
+        }
+
         throw error;
       }
     },

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -242,12 +242,11 @@ export default (on: Cypress.PluginEvents): void => {
 
         // Best-effort teardown: keep the original startup error if cleanup fails.
         try {
-          if (dockerEnvironment !== null) {
-            await dockerEnvironment.down();
-            dockerEnvironment = null;
-          }
+          await dockerEnvironment?.down();
         } catch (teardownError) {
           console.error(teardownError);
+        } finally {
+          dockerEnvironment = null;
         }
 
         throw error;

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -240,10 +240,14 @@ export default (on: Cypress.PluginEvents): void => {
       } catch (error) {
         console.error(error);
 
-        // Tear down the partially-started stack so the CI runner frees resources now.
-        if (dockerEnvironment !== null) {
-          await dockerEnvironment.down();
-          dockerEnvironment = null;
+        // Best-effort teardown: keep the original startup error if cleanup fails.
+        try {
+          if (dockerEnvironment !== null) {
+            await dockerEnvironment.down();
+            dockerEnvironment = null;
+          }
+        } catch (teardownError) {
+          console.error(teardownError);
         }
 
         throw error;


### PR DESCRIPTION
## Problem

When `startContainers` throws (e.g. `web-1` fails its health check), the partially-started compose stack stays up until the test process exits — the `catch` only logs and rethrows. On busy CI runners this needlessly holds resources.

## Fix

Tear the stack down in the `catch` before rethrowing, reusing the same `dockerEnvironment.down()` already used by `stopContainers`:

```ts
if (dockerEnvironment !== null) {
  await dockerEnvironment.down();
  dockerEnvironment = null;
}
```

Applied to:
- `packages/js-config/cypress/e2e/tasks.ts` — shared runner, covers the main `centreon-web` e2e
- `centreon-awie/tests/e2e/tasks.ts`
- `centreon-open-tickets/tests/e2e/tasks.ts`

The error is still rethrown so Cypress fails as before. Companion of centreon-modules#8503 (same change for the 9 module runners).

Ref: MON-177477