### PR TITLE
fix(clapi): use prepared statements and allowlists in CLAPI SQL

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonConfigurationChange.class.php
+++ b/centreon/www/class/centreon-clapi/centreonConfigurationChange.class.php
@@ -193,9 +193,11 @@ class CentreonConfigurationChange
             return [];
         }
 
+        // Re-index on a sequential integer so the placeholder names that are
+        // concatenated into the IN (...) list cannot be influenced by array keys.
         $bindedParams = [];
-        foreach ($hostIds as $key => $hostId) {
-            $bindedParams[':host_id_' . $key] = $hostId;
+        foreach (array_values($hostIds) as $index => $hostId) {
+            $bindedParams[':host_id_' . $index] = (int) $hostId;
         }
 
         if ($shouldHostBeEnabled) {

--- a/centreon/www/class/centreon-clapi/centreonDependency.class.php
+++ b/centreon/www/class/centreon-clapi/centreonDependency.class.php
@@ -1118,18 +1118,58 @@ class CentreonDependency extends CentreonObject
      * @param array $dataField
      *
      * @throws PDOException
+     * @throws \InvalidArgumentException when the table or a column is not allowlisted
      * @return bool
      */
     protected function isExistingDependency(string $table, array $dataField): bool
     {
-        $sql = "SELECT `dependency_dep_id`
-                FROM {$table} WHERE ";
-        foreach ($dataField as $field => $value) {
-            $sql .= " {$field} = {$value} AND";
+        // The table and column names cannot be bound as parameters, so they are
+        // validated against allowlists; the values are bound as integer parameters.
+        $allowedTables = [
+            'dependency_hostgroupParent_relation',
+            'dependency_hostgroupChild_relation',
+            'dependency_servicegroupParent_relation',
+            'dependency_servicegroupChild_relation',
+            'dependency_metaserviceParent_relation',
+            'dependency_metaserviceChild_relation',
+            'dependency_hostParent_relation',
+            'dependency_hostChild_relation',
+            'dependency_serviceParent_relation',
+            'dependency_serviceChild_relation',
+        ];
+        $allowedColumns = [
+            'dependency_dep_id',
+            'hostgroup_hg_id',
+            'servicegroup_sg_id',
+            'meta_service_meta_id',
+            'host_host_id',
+            'service_service_id',
+        ];
+
+        if (! in_array($table, $allowedTables, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid dependency relation table: %s', $table));
         }
-        $sql = rtrim($sql, 'AND');
-        $res = $this->db->query($sql);
-        $row = $res->fetch();
+
+        $conditions = [];
+        $bindParams = [];
+        $index = 0;
+        foreach ($dataField as $field => $value) {
+            if (! in_array($field, $allowedColumns, true)) {
+                throw new \InvalidArgumentException(sprintf('Invalid dependency relation column: %s', $field));
+            }
+            $placeholder = ':value_' . $index;
+            $conditions[] = "{$field} = {$placeholder}";
+            $bindParams[$placeholder] = (int) $value;
+            $index++;
+        }
+
+        $sql = "SELECT `dependency_dep_id` FROM {$table} WHERE " . implode(' AND ', $conditions);
+        $stmt = $this->db->prepare($sql);
+        foreach ($bindParams as $placeholder => $value) {
+            $stmt->bindValue($placeholder, $value, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        $row = $stmt->fetch();
 
         return ! empty($row['dependency_dep_id']);
     }

--- a/centreon/www/class/centreon-clapi/centreonHost.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHost.class.php
@@ -41,6 +41,7 @@ use Centreon_Object_Service_Extended;
 use Centreon_Object_Timezone;
 use Core\Host\Domain\Model\NewHost;
 use Exception;
+use PDO;
 use PDOException;
 use Pimple\Container;
 
@@ -1412,6 +1413,7 @@ class CentreonHost extends CentreonObject
      * @param array $fields
      *
      * @throws PDOException
+     * @throws \InvalidArgumentException when a requested field is not allowlisted
      * @return array
      */
     public function getTemplateChain(
@@ -1434,17 +1436,34 @@ class CentreonHost extends CentreonObject
 
             if (empty($fields)) {
                 $fields = ! $allFields ? 'h.host_id, h.host_name' : ' * ';
+            } else {
+                // The SELECT column list cannot be bound as a parameter, so each requested
+                // column is validated against an allowlist to prevent SQL injection.
+                $allowedFields = [
+                    '*', 'h.host_id', 'h.host_name', 'host_id', 'host_name', 'command_command_id',
+                ];
+                $requestedFields = array_map('trim', explode(',', (string) $fields));
+                foreach ($requestedFields as $requestedField) {
+                    if (! in_array($requestedField, $allowedFields, true)) {
+                        throw new \InvalidArgumentException(
+                            sprintf('Invalid field requested in host template chain: %s', $requestedField)
+                        );
+                    }
+                }
+                $fields = implode(', ', $requestedFields);
             }
 
             $sql = 'SELECT ' . $fields . ' '
                 . ' FROM host h, host_template_relation htr'
                 . ' WHERE h.host_id = htr.host_tpl_id'
-                . " AND htr.host_host_id = '" . $hostId . "'"
+                . ' AND htr.host_host_id = :hostId'
                 . " AND host_activate = '1'"
                 . " AND host_register = '0'"
                 . ' ORDER BY `order` ASC';
 
-            $DBRESULT = $this->db->query($sql);
+            $DBRESULT = $this->db->prepare($sql);
+            $DBRESULT->bindValue(':hostId', (int) $hostId, PDO::PARAM_INT);
+            $DBRESULT->execute();
 
             while ($row = $DBRESULT->fetch()) {
                 if (! $allFields) {

--- a/centreon/www/class/centreon-clapi/centreonUtils.class.php
+++ b/centreon/www/class/centreon-clapi/centreonUtils.class.php
@@ -22,6 +22,7 @@
 namespace CentreonClapi;
 
 use CentreonDB;
+use PDO;
 use PDOException;
 
 /**
@@ -75,12 +76,15 @@ class CentreonUtils
         $query = 'SELECT img.img_id FROM view_img_dir dir, view_img_dir_relation rel, view_img img '
             . 'WHERE dir.dir_id = rel.dir_dir_parent_id '
             . 'AND rel.img_img_id = img.img_id '
-            . "AND img.img_path = '" . $imagename . "' "
-            . "AND dir.dir_name = '" . $dirname . "' "
+            . 'AND img.img_path = :imagename '
+            . 'AND dir.dir_name = :dirname '
             . 'LIMIT 1';
-        $res = $db->query($query);
+        $stmt = $db->prepare($query);
+        $stmt->bindValue(':imagename', $imagename, PDO::PARAM_STR);
+        $stmt->bindValue(':dirname', $dirname, PDO::PARAM_STR);
+        $stmt->execute();
         $img_id = null;
-        $row = $res->fetchRow();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if (isset($row['img_id']) && $row['img_id']) {
             $img_id = (int) $row['img_id'];
         }


### PR DESCRIPTION
## Description

Fixes SQL injection vulnerabilities in the CLAPI (command-line API) object classes of Centreon Web core (MON-200897). Input to these classes originates from CLI / CSV import, which is attacker-influenced in automation contexts.

Unprepared, concatenated SQL is replaced with bound parameters. Identifiers that PDO cannot bind (table names, column names, the `SELECT` field list, and `IN (...)` placeholder names) are validated against fixed allowlists or rebuilt from sequential integers.

## Changes

| File | Method | Fix |
|------|--------|-----|
| `centreonUtils.class.php` | `getImageId()` | `img_path` / `dir_name` bound as `:imagename` / `:dirname` instead of concatenated |
| `centreonHost.class.php` | `getTemplateChain()` | `$hostId` bound as `:hostId` (int); `$fields` SELECT list validated against an allowlist (cannot be bound) |
| `centreonDependency.class.php` | `isExistingDependency()` | `$table` and column names validated against allowlists; values bound as integer parameters |
| `centreonConfigurationChange.class.php` | `findPollersForConfigChangeFlagFromHostIds()` | `IN (...)` placeholder names rebuilt from sequential ints via `array_values()` so array keys cannot shape the query; values cast to int |

Identifiers that fail the allowlist throw `\InvalidArgumentException` (fail-closed); all internal callers pass known-good literals, so legitimate flows are unaffected.

## Testing

- `php -l` clean on all four files
- `php-cs-fixer` (legacy config) reports 0 of 4 files needing changes

## Jira

https://centreon.atlassian.net/browse/MON-200897
