### PR TITLE
feat(ci): add artifact attestations for build provenance (RPM, DEB, containers)

### DIFF
--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -315,7 +315,6 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository }}/centreon-web-dependencies-collect
           subject-digest: ${{ steps.build-dependencies-collect.outputs.digest }}
-          push-to-registry: true
 
       - name: Build and push web image
         id: build-web
@@ -351,7 +350,6 @@ jobs:
         with:
           subject-name: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.distrib }}
           subject-digest: ${{ steps.build-web.outputs.digest }}
-          push-to-registry: true
 
       - name: Build and push OSS image
         id: build-oss
@@ -391,4 +389,3 @@ jobs:
         with:
           subject-name: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}
           subject-digest: ${{ steps.build-oss.outputs.digest }}
-          push-to-registry: true

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -311,7 +311,7 @@ jobs:
             ghcr.io/${{ github.repository }}/centreon-web-dependencies-collect:${{ inputs.release_bundle_tag }}-${{ matrix.distrib }}
 
       - name: Attest dependencies collect image
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository }}/centreon-web-dependencies-collect
           subject-digest: ${{ steps.build-dependencies-collect.outputs.digest }}
@@ -347,7 +347,7 @@ jobs:
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.distrib }}:${{ inputs.release_bundle_tag }}
 
       - name: Attest web image
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.distrib }}
           subject-digest: ${{ steps.build-web.outputs.digest }}
@@ -387,7 +387,7 @@ jobs:
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}:${{ inputs.release_bundle_tag }}
 
       - name: Attest OSS image
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}
           subject-digest: ${{ steps.build-oss.outputs.digest }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -141,6 +141,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
+      id-token: write
+      attestations: write
       contents: read
       packages: write
     strategy:
@@ -275,6 +277,7 @@ jobs:
             ghcr.io/${{ github.repository }}/centreon-web-dependencies:${{ inputs.release_bundle_tag }}-${{ matrix.distrib }}
 
       - name: Build dependencies collect image
+        id: build-dependencies-collect
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
@@ -307,7 +310,15 @@ jobs:
             ghcr.io/${{ github.repository }}/centreon-web-dependencies-collect:${{ needs.check-inputs.outputs.major_version }}-${{ needs.check-inputs.outputs.edition }}-latest-${{ matrix.distrib }}
             ghcr.io/${{ github.repository }}/centreon-web-dependencies-collect:${{ inputs.release_bundle_tag }}-${{ matrix.distrib }}
 
+      - name: Attest dependencies collect image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}/centreon-web-dependencies-collect
+          subject-digest: ${{ steps.build-dependencies-collect.outputs.digest }}
+          push-to-registry: true
+
       - name: Build and push web image
+        id: build-web
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: .github/docker/centreon-web/${{ matrix.distrib }}/Dockerfile
@@ -335,7 +346,15 @@ jobs:
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.distrib }}:${{ needs.check-inputs.outputs.major_version }}.${{ steps.export-minor-versions.outputs.web_minor_version }}-${{ needs.check-inputs.outputs.edition }}
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.distrib }}:${{ inputs.release_bundle_tag }}
 
+      - name: Attest web image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.distrib }}
+          subject-digest: ${{ steps.build-web.outputs.digest }}
+          push-to-registry: true
+
       - name: Build and push OSS image
+        id: build-oss
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: .github/docker/centreon-web/${{ matrix.distrib }}/Dockerfile.oss
@@ -366,3 +385,10 @@ jobs:
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}:${{ needs.check-inputs.outputs.major_version }}-latest
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}:${{ needs.check-inputs.outputs.major_version }}-${{ needs.check-inputs.outputs.edition }}-latest
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}:${{ inputs.release_bundle_tag }}
+
+      - name: Attest OSS image
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-oss-${{ matrix.distrib }}
+          subject-digest: ${{ steps.build-oss.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1107,7 +1107,6 @@ jobs:
         with:
           subject-name: docker.centreon.com/centreon/${{ env.project }}-${{ matrix.operating_system }}
           subject-digest: ${{ steps.build-web.outputs.digest }}
-          push-to-registry: true
 
       - name: Store slim image in local archive
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -912,10 +912,51 @@ jobs:
           is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
+  attest-packages:
+    needs: [get-environment, changes, package]
+    if: |
+      needs.changes.outputs.trigger_packaging == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      github.event.pull_request.head.repo.fork != true &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      needs.get-environment.outputs.stability != 'stable'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_extension: rpm
+            distrib: el9
+          - package_extension: rpm
+            distrib: el10
+          - package_extension: deb
+            distrib: trixie
+    name: attest ${{ matrix.distrib }}
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Restore ${{ matrix.package_extension }} packages from cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ./*.${{ matrix.package_extension }}
+          key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          fail-on-cache-miss: true
+
+      - name: Attest ${{ matrix.distrib }} packages
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "./*.${{ matrix.package_extension }}"
+
   dockerize:
     runs-on: ubuntu-24.04
     needs: [get-environment, changes, package]
     permissions:
+      id-token: write
+      attestations: write
       contents: read
       packages: read
       actions: write
@@ -1038,6 +1079,7 @@ jobs:
             type=raw,value=${{ steps.image_tag.outputs.additional_tag }},enable=${{ steps.image_tag.outputs.additional_tag != '' }}
 
       - name: Build and push web image
+        id: build-web
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -1058,6 +1100,14 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest web image
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: docker.centreon.com/centreon/${{ env.project }}-${{ matrix.operating_system }}
+          subject-digest: ${{ steps.build-web.outputs.digest }}
+          push-to-registry: true
 
       - name: Store slim image in local archive
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -947,7 +947,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Attest ${{ matrix.distrib }} packages
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: "./*.${{ matrix.package_extension }}"
 
@@ -1103,7 +1103,7 @@ jobs:
 
       - name: Attest web image
         if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: docker.centreon.com/centreon/${{ env.project }}-${{ matrix.operating_system }}
           subject-digest: ${{ steps.build-web.outputs.digest }}


### PR DESCRIPTION
## Summary

- New `attest-packages` job in `web.yml`: runs on host runner (outside the packaging container), restores RPM/DEB artifacts from cache, and calls `actions/attest-build-provenance@v4.1.0` for each distrib (el9, el10, trixie).
- `dockerize` job in `web.yml`: add `id-token: write` + `attestations: write` permissions, attest the web container image after push.
- `dockerize-stable-web` job in `docker-stable.yml`: same permissions + attest steps for `centreon-web-dependencies-collect`, `centreon-web`, and `centreon-oss` images.

## Context

Part of the JFrog → Pulp migration (MON-199319). JFrog build-info used to link artifacts to their source commit, branch, and run ID. `actions/attest-build-provenance` provides a GitHub-native, cryptographic equivalent (SLSA provenance) for all artifacts — packages and container images.

**Verification (once merged):**
```bash
gh attestation verify centreon-web-25.04.1-1.el9.noarch.rpm --repo centreon/centreon
```

## Notes

- The `attest-packages` job only runs when `pull_request.head.repo.fork != true` (OIDC not available on forks).
- `docker-stable.yml`: the `centreon-web-dependencies` image is skipped (built with `load: true`, not pushed to a registry).

## Test plan

- [x] Trigger `web.yml` on a branch → check that `attest-packages` runs and passes for all 3 distribs
- [ ] Verify attestation: `gh attestation verify <package> --repo centreon/centreon`
- [ ] Trigger `docker-stable.yml` on a test tag → check that attest steps pass for all 3 images
- [ ] Confirm forks are not broken (attest steps skipped cleanly)

Jira: [MON-201566](https://centreon.atlassian.net/browse/MON-201566)
Epic: [MON-199319](https://centreon.atlassian.net/browse/MON-199319)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-201566]: https://centreon.atlassian.net/browse/MON-201566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ