### PR TITLE
chore(test): e2e: remove vestigial ESLint/Prettier (25.10)

### DIFF
--- a/centreon-awie/tests/e2e/.eslintrc.js
+++ b/centreon-awie/tests/e2e/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  extends: [
-    './node_modules/@centreon/js-config/eslint/react/typescript.eslintrc.js',
-    'plugin:cypress/recommended',
-  ],
-};

--- a/centreon-awie/tests/e2e/package.json
+++ b/centreon-awie/tests/e2e/package.json
@@ -26,8 +26,6 @@
     "@types/cypress-cucumber-preprocessor": "^4.0.5",
     "@types/node": "^20.11.27",
     "@types/ramda": "0.29.11",
-    "@typescript-eslint/eslint-plugin": "^8.17.0",
-    "@typescript-eslint/parser": "^8.16.0",
     "cross-env": "^7.0.3",
     "cypress": "~13.16.0",
     "cypress-cucumber-preprocessor": "^4.3.1",

--- a/centreon-awie/tests/e2e/pnpm-lock.yaml
+++ b/centreon-awie/tests/e2e/pnpm-lock.yaml
@@ -13,22 +13,22 @@ importers:
         version: 20.1.2(@cypress/browserify-preprocessor@3.0.2)(cypress@13.16.1)(typescript@5.8.2)
       '@bahmutov/cypress-esbuild-preprocessor':
         specifier: ^2.2.3
-        version: 2.2.4(esbuild@0.21.5)
+        version: 2.2.4(esbuild@0.23.1)
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
       '@centreon/js-config':
         specifier: 24.12.1
-        version: 24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)
+        version: 24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)
       '@cypress/webpack-preprocessor':
         specifier: ^6.0.2
-        version: 6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+        version: 6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.2.3
-        version: 0.2.3(esbuild@0.21.5)
+        version: 0.2.3(esbuild@0.23.1)
       '@esbuild-plugins/node-modules-polyfill':
         specifier: ^0.2.2
-        version: 0.2.2(esbuild@0.21.5)
+        version: 0.2.2(esbuild@0.23.1)
       '@swc/core':
         specifier: ^1.9.3
         version: 1.11.11
@@ -44,12 +44,6 @@ importers:
       '@types/ramda':
         specifier: 0.29.11
         version: 0.29.11
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.17.0
-        version: 8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/parser':
-        specifier: ^8.16.0
-        version: 8.27.0(eslint@8.57.1)(typescript@5.8.2)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -97,7 +91,7 @@ importers:
         version: 1.1.2
       swc-loader:
         specifier: ^0.2.3
-        version: 0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+        version: 0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       tar-fs:
         specifier: ^3.0.6
         version: 3.0.8
@@ -109,7 +103,7 @@ importers:
         version: 5.8.2
       webpack:
         specifier: ^5.96.1
-        version: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+        version: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
 
 packages:
 
@@ -1543,14 +1537,6 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.27.0':
-    resolution: {integrity: sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
   '@typescript-eslint/experimental-utils@5.62.0':
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1575,13 +1561,6 @@ packages:
   '@typescript-eslint/scope-manager@8.27.0':
     resolution: {integrity: sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/type-utils@8.27.0':
-    resolution: {integrity: sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
 
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
@@ -1629,13 +1608,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@8.27.0':
-    resolution: {integrity: sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1650,6 +1622,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/rspack-resolver-binding-darwin-arm64@1.2.2':
     resolution: {integrity: sha512-i7z0B+C0P8Q63O/5PXJAzeFtA1ttY3OR2VSJgGv18S+PFNwD98xHgAgPOT1H5HIV6jlQP8Avzbp09qxJUdpPNw==}
@@ -5994,6 +5967,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@bahmutov/cypress-esbuild-preprocessor@2.2.4(esbuild@0.23.1)':
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      esbuild: 0.23.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@balena/dockerignore@1.0.2': {}
 
   '@biomejs/biome@1.9.4':
@@ -6031,7 +6011,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@centreon/js-config@24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)':
+  '@centreon/js-config@24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)':
     dependencies:
       '@badeball/cypress-cucumber-preprocessor': 20.1.2(@cypress/browserify-preprocessor@3.0.2)(cypress@13.16.1)(typescript@5.8.2)
       '@bahmutov/cypress-esbuild-preprocessor': 2.2.4(esbuild@0.21.5)
@@ -6054,7 +6034,7 @@ snapshots:
       eslint-plugin-babel: 5.3.1(eslint@8.57.1)
       eslint-plugin-hooks: 0.4.3
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
+      eslint-plugin-jest: 26.9.0(eslint@8.57.1)(typescript@5.8.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-node: 11.1.0(eslint@8.57.1)
       eslint-plugin-prefer-arrow-functions: 3.6.2(eslint@8.57.1)(typescript@5.8.2)
@@ -6242,15 +6222,15 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))':
+  '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       bluebird: 3.7.1
       debug: 4.4.0(supports-color@8.1.1)
       lodash: 4.17.21
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6281,9 +6261,19 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
 
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.23.1)':
+    dependencies:
+      esbuild: 0.23.1
+
   '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.21.5)':
     dependencies:
       esbuild: 0.21.5
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.23.1)':
+    dependencies:
+      esbuild: 0.23.1
       escape-string-regexp: 4.0.0
       rollup-plugin-node-polyfills: 0.2.1
 
@@ -6756,23 +6746,6 @@ snapshots:
       '@types/node': 20.17.24
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/visitor-keys': 8.27.0
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.8.2)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
@@ -6807,17 +6780,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.27.0
       '@typescript-eslint/visitor-keys': 8.27.0
-
-  '@typescript-eslint/type-utils@8.27.0(eslint@8.57.1)(typescript@5.8.2)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      debug: 4.4.0(supports-color@8.1.1)
-      eslint: 8.57.1
-      ts-api-utils: 2.0.1(typescript@5.8.2)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/types@5.62.0': {}
 
@@ -6888,17 +6850,6 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.19.1
       '@typescript-eslint/types': 8.19.1
       '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.8.2)
-      eslint: 8.57.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.27.0(eslint@8.57.1)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.8.2)
       eslint: 8.57.1
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -7278,12 +7229,12 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)):
+  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
 
   babel-plugin-add-module-exports@1.0.4: {}
 
@@ -8554,12 +8505,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2):
+  eslint-plugin-jest@26.9.0(eslint@8.57.1)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10656,11 +10605,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)):
+  swc-loader@0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)):
     dependencies:
       '@swc/core': 1.11.11
       '@swc/counter': 0.1.3
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
 
   synckit@0.9.2:
     dependencies:
@@ -10710,17 +10659,17 @@ snapshots:
 
   tcomb@3.2.29: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.11.11)(esbuild@0.21.5)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.11.11)(esbuild@0.23.1)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
     optionalDependencies:
       '@swc/core': 1.11.11
-      esbuild: 0.21.5
+      esbuild: 0.23.1
 
   terser@5.39.0:
     dependencies:
@@ -11031,7 +10980,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5):
+  webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -11053,7 +11002,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.11)(esbuild@0.21.5)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.11)(esbuild@0.23.1)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/centreon-open-tickets/tests/e2e/.eslintrc.js
+++ b/centreon-open-tickets/tests/e2e/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  extends: [
-    './node_modules/@centreon/js-config/eslint/react/typescript.eslintrc.js',
-    'plugin:cypress/recommended',
-  ],
-};

--- a/centreon-open-tickets/tests/e2e/package.json
+++ b/centreon-open-tickets/tests/e2e/package.json
@@ -26,8 +26,6 @@
     "@types/cypress-cucumber-preprocessor": "^4.0.5",
     "@types/node": "^20.11.27",
     "@types/ramda": "0.29.11",
-    "@typescript-eslint/eslint-plugin": "^8.17.0",
-    "@typescript-eslint/parser": "^8.16.0",
     "cross-env": "^7.0.3",
     "cypress": "~13.16.0",
     "cypress-cucumber-preprocessor": "^4.3.1",

--- a/centreon-open-tickets/tests/e2e/pnpm-lock.yaml
+++ b/centreon-open-tickets/tests/e2e/pnpm-lock.yaml
@@ -13,22 +13,22 @@ importers:
         version: 20.1.2(@cypress/browserify-preprocessor@3.0.2)(cypress@13.16.1)(typescript@5.8.2)
       '@bahmutov/cypress-esbuild-preprocessor':
         specifier: ^2.2.3
-        version: 2.2.4(esbuild@0.21.5)
+        version: 2.2.4(esbuild@0.23.1)
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
       '@centreon/js-config':
         specifier: 24.12.1
-        version: 24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)
+        version: 24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)
       '@cypress/webpack-preprocessor':
         specifier: ^6.0.2
-        version: 6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+        version: 6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.2.3
-        version: 0.2.3(esbuild@0.21.5)
+        version: 0.2.3(esbuild@0.23.1)
       '@esbuild-plugins/node-modules-polyfill':
         specifier: ^0.2.2
-        version: 0.2.2(esbuild@0.21.5)
+        version: 0.2.2(esbuild@0.23.1)
       '@swc/core':
         specifier: ^1.9.3
         version: 1.11.11
@@ -44,12 +44,6 @@ importers:
       '@types/ramda':
         specifier: 0.29.11
         version: 0.29.11
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.17.0
-        version: 8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/parser':
-        specifier: ^8.16.0
-        version: 8.27.0(eslint@8.57.1)(typescript@5.8.2)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -97,7 +91,7 @@ importers:
         version: 1.1.2
       swc-loader:
         specifier: ^0.2.3
-        version: 0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+        version: 0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       tar-fs:
         specifier: ^3.0.6
         version: 3.0.8
@@ -109,7 +103,7 @@ importers:
         version: 5.8.2
       webpack:
         specifier: ^5.96.1
-        version: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+        version: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
 
 packages:
 
@@ -1543,14 +1537,6 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.27.0':
-    resolution: {integrity: sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
   '@typescript-eslint/experimental-utils@5.62.0':
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1575,13 +1561,6 @@ packages:
   '@typescript-eslint/scope-manager@8.27.0':
     resolution: {integrity: sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/type-utils@8.27.0':
-    resolution: {integrity: sha512-wVArTVcz1oJOIEJxui/nRhV0TXzD/zMSOYi/ggCfNq78EIszddXcJb7r4RCp/oBrjt8n9A0BSxRMKxHftpDxDA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
 
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
@@ -1629,13 +1608,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@8.27.0':
-    resolution: {integrity: sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.9.0'
-
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1650,6 +1622,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/rspack-resolver-binding-darwin-arm64@1.2.2':
     resolution: {integrity: sha512-i7z0B+C0P8Q63O/5PXJAzeFtA1ttY3OR2VSJgGv18S+PFNwD98xHgAgPOT1H5HIV6jlQP8Avzbp09qxJUdpPNw==}
@@ -5994,6 +5967,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@bahmutov/cypress-esbuild-preprocessor@2.2.4(esbuild@0.23.1)':
+    dependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+      esbuild: 0.23.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@balena/dockerignore@1.0.2': {}
 
   '@biomejs/biome@1.9.4':
@@ -6031,7 +6011,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@centreon/js-config@24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)':
+  '@centreon/js-config@24.12.1(@cypress/browserify-preprocessor@3.0.2)(@types/eslint@9.6.1)(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(mocha@10.8.2)(prettier@3.5.3)(typescript@5.8.2)':
     dependencies:
       '@badeball/cypress-cucumber-preprocessor': 20.1.2(@cypress/browserify-preprocessor@3.0.2)(cypress@13.16.1)(typescript@5.8.2)
       '@bahmutov/cypress-esbuild-preprocessor': 2.2.4(esbuild@0.21.5)
@@ -6054,7 +6034,7 @@ snapshots:
       eslint-plugin-babel: 5.3.1(eslint@8.57.1)
       eslint-plugin-hooks: 0.4.3
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
-      eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
+      eslint-plugin-jest: 26.9.0(eslint@8.57.1)(typescript@5.8.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-node: 11.1.0(eslint@8.57.1)
       eslint-plugin-prefer-arrow-functions: 3.6.2(eslint@8.57.1)(typescript@5.8.2)
@@ -6242,15 +6222,15 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))':
+  '@cypress/webpack-preprocessor@6.0.2(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)))(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)
-      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+      babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       bluebird: 3.7.1
       debug: 4.4.0(supports-color@8.1.1)
       lodash: 4.17.21
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6281,9 +6261,19 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
 
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.23.1)':
+    dependencies:
+      esbuild: 0.23.1
+
   '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.21.5)':
     dependencies:
       esbuild: 0.21.5
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.23.1)':
+    dependencies:
+      esbuild: 0.23.1
       escape-string-regexp: 4.0.0
       rollup-plugin-node-polyfills: 0.2.1
 
@@ -6756,23 +6746,6 @@ snapshots:
       '@types/node': 20.17.24
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/type-utils': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/visitor-keys': 8.27.0
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.8.2)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
@@ -6807,17 +6780,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.27.0
       '@typescript-eslint/visitor-keys': 8.27.0
-
-  '@typescript-eslint/type-utils@8.27.0(eslint@8.57.1)(typescript@5.8.2)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.27.0(eslint@8.57.1)(typescript@5.8.2)
-      debug: 4.4.0(supports-color@8.1.1)
-      eslint: 8.57.1
-      ts-api-utils: 2.0.1(typescript@5.8.2)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/types@5.62.0': {}
 
@@ -6888,17 +6850,6 @@ snapshots:
       '@typescript-eslint/scope-manager': 8.19.1
       '@typescript-eslint/types': 8.19.1
       '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.8.2)
-      eslint: 8.57.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.27.0(eslint@8.57.1)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.27.0
-      '@typescript-eslint/types': 8.27.0
-      '@typescript-eslint/typescript-estree': 8.27.0(typescript@5.8.2)
       eslint: 8.57.1
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -7278,12 +7229,12 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)):
+  babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
       schema-utils: 4.3.0
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
 
   babel-plugin-add-module-exports@1.0.4: {}
 
@@ -8554,12 +8505,10 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2):
+  eslint-plugin-jest@26.9.0(eslint@8.57.1)(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.27.0(@typescript-eslint/parser@8.27.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10656,11 +10605,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)):
+  swc-loader@0.2.6(@swc/core@1.11.11)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)):
     dependencies:
       '@swc/core': 1.11.11
       '@swc/counter': 0.1.3
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
 
   synckit@0.9.2:
     dependencies:
@@ -10710,17 +10659,17 @@ snapshots:
 
   tcomb@3.2.29: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.11.11)(esbuild@0.21.5)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.11.11)(esbuild@0.23.1)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.21.5)
+      webpack: 5.98.0(@swc/core@1.11.11)(esbuild@0.23.1)
     optionalDependencies:
       '@swc/core': 1.11.11
-      esbuild: 0.21.5
+      esbuild: 0.23.1
 
   terser@5.39.0:
     dependencies:
@@ -11031,7 +10980,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5):
+  webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -11053,7 +11002,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.11)(esbuild@0.21.5)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.21.5))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.11)(esbuild@0.23.1)(webpack@5.98.0(@swc/core@1.11.11)(esbuild@0.23.1))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
Backport of #10741 to `dev-25.10.x`.

Removes the vestigial ESLint/Prettier devDependencies and `.eslintrc.js` from the `centreon-awie` and `centreon-open-tickets` e2e suites (lint is already `biome check` on this branch), and regenerates their `pnpm-lock.yaml`. The main `centreon/tests/e2e` suite is already clean on this branch.

Ref: MON-201563