### PR TITLE
test(e2e): tear down docker stack when startContainers fails (backport 25.10)

### DIFF
--- a/centreon-awie/tests/e2e/tasks.ts
+++ b/centreon-awie/tests/e2e/tasks.ts
@@ -226,6 +226,15 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
+        // Best-effort teardown: keep the original startup error if cleanup fails.
+        try {
+          await dockerEnvironment?.down();
+        } catch (teardownError) {
+          console.error(teardownError);
+        } finally {
+          dockerEnvironment = null;
+        }
+
         throw error;
       }
     },

--- a/centreon-open-tickets/tests/e2e/tasks.ts
+++ b/centreon-open-tickets/tests/e2e/tasks.ts
@@ -226,6 +226,15 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
+        // Best-effort teardown: keep the original startup error if cleanup fails.
+        try {
+          await dockerEnvironment?.down();
+        } catch (teardownError) {
+          console.error(teardownError);
+        } finally {
+          dockerEnvironment = null;
+        }
+
         throw error;
       }
     },

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -260,6 +260,15 @@ export default (on: Cypress.PluginEvents): void => {
           console.error(error.message);
         }
 
+        // Best-effort teardown: keep the original startup error if cleanup fails.
+        try {
+          await dockerEnvironment?.down();
+        } catch (teardownError) {
+          console.error(teardownError);
+        } finally {
+          dockerEnvironment = null;
+        }
+
         throw error;
       }
     },


### PR DESCRIPTION
Backport of #10748 (MON-177477) to `dev-25.10.x`.

Best-effort teardown of the docker stack when `startContainers` fails (try/catch around `dockerEnvironment.down()` in the error path of `tasks.ts`), applied to the three `tasks.ts` files (awie, open-tickets, js-config cypress). Clean cherry-pick, no conflicts.

Refs: MON-201570