### PR TITLE
feat(ci): add CI build metadata to pulp_labels on package upload

### DIFF
--- a/.github/actions/package-delivery/deliver-deb.sh
+++ b/.github/actions/package-delivery/deliver-deb.sh
@@ -112,6 +112,15 @@ fi
 
 REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
 
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
 for FILE in "${FILES[@]}"; do
   assert_not_in_stable "$FILE"
   echo "[INFO] Uploading $FILE to $POOL_PATH/ ($SUITE/main, module $MODULE_NAME)"
@@ -125,7 +134,7 @@ for FILE in "${FILES[@]}"; do
       -F "distribution=$SUITE" \
       -F "component=main" \
       -F "repository=$REPOSITORY_HREF" \
-      -F "pulp_labels={\"module\": \"$MODULE_NAME\"}" \
+      -F "pulp_labels=$PULP_LABELS" \
       "$PULP_URL/api/v3/content/deb/packages/"
   )
   wait_task "$TASK_HREF"

--- a/.github/actions/package-delivery/deliver-rpm.sh
+++ b/.github/actions/package-delivery/deliver-rpm.sh
@@ -95,6 +95,15 @@ for FILE in "${FILES[@]}"; do
   mv "$FILE" "$ARCH"
 done
 
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
 for ARCH in noarch x86_64; do
   ARCH_FILES=("$ARCH"/*.rpm)
   if [[ ${#ARCH_FILES[@]} -eq 0 ]]; then
@@ -128,7 +137,7 @@ for ARCH in noarch x86_64; do
       pulp_upload \
         -F "file=@$FILE" \
         -F "repository=$REPOSITORY_HREF" \
-        -F "pulp_labels={\"module\": \"$MODULE_NAME\"}" \
+        -F "pulp_labels=$PULP_LABELS" \
         "$PULP_URL/api/v3/content/rpm/packages/"
     )
     wait_task "$TASK_HREF"


### PR DESCRIPTION
## Summary

Extends the `pulp_labels` already set on RPM and DEB uploads (which contained only `module`) to include full CI build traceability metadata:

| Label | Value | Source |
|---|---|---|
| `module` | package module name | existing |
| `git_commit` | full commit SHA | `$GITHUB_SHA` |
| `git_ref` | branch or tag ref | `$GITHUB_REF` |
| `github_run_id` | workflow run ID | `$GITHUB_RUN_ID` |
| `github_actor` | user who triggered the build | `$GITHUB_ACTOR` |
| `github_workflow` | workflow name | `$GITHUB_WORKFLOW` |

## Files changed

- `.github/actions/package-delivery/deliver-rpm.sh`
- `.github/actions/package-delivery/deliver-deb.sh`

## Querying

```bash
# All packages from a given commit
GET /api/v3/content/rpm/packages/?pulp_label_select=git_commit=<sha>
GET /api/v3/content/deb/packages/?pulp_label_select=git_commit=<sha>

# All packages from a given CI run
GET /api/v3/content/rpm/packages/?pulp_label_select=github_run_id=<run_id>
```

## Context

Part of the JFrog → Pulp migration (MON-199319). Replaces the JFrog build-info traceability (linking artifacts to commit/branch/run) with Pulp-native labels queryable via the Pulp REST API.

Jira: [MON-201541](https://centreon.atlassian.net/browse/MON-201541)
Epic: [MON-199319](https://centreon.atlassian.net/browse/MON-199319)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-201541]: https://centreon.atlassian.net/browse/MON-201541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ