### PR TITLE
fix(test): give OneLoginSettingsFormatterTest a request stack

### DIFF
--- a/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatterTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatterTest.php
@@ -29,6 +29,8 @@ use Core\Security\ProviderConfiguration\Domain\SAML\Model\RequestedAuthnContextC
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -60,15 +62,11 @@ class OneLoginSettingsFormatterTest extends TestCase
 
         $this->formatter = new OneLoginSettingsFormatter($this->urlGenerator);
 
-        // OneLoginSettingsFormatter resolves the SP entityId from the current request host
-        // (HttpUrlTrait::getHost(), which reads the HTTP_HOST/REQUEST_SCHEME server variables).
-        $_SERVER['HTTP_HOST'] = 'centreon.example.com';
-        $_SERVER['REQUEST_SCHEME'] = 'https';
-    }
+        // OneLoginSettingsFormatter resolves the SP entityId from the current request (HttpUrlTrait).
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('https://centreon.example.com/centreon'));
 
-    protected function tearDown(): void
-    {
-        unset($_SERVER['HTTP_HOST'], $_SERVER['REQUEST_SCHEME']);
+        $this->formatter->setHttpServerBag($requestStack);
     }
 
     public function testFormatMapsStoredConfigurationToOneLoginSettings(): void


### PR DESCRIPTION
Fixes [MON-201574](https://centreon.atlassian.net/browse/MON-201574).

## Problem

On `dev-25.10.x`, `OneLoginSettingsFormatterTest` fails (2 tests) in `backend-unit-test`:

```
RuntimeException: Unable to resolve HTTP host: no current request available in the request stack
  at src/Core/Infrastructure/Common/Api/HttpUrlTrait.php:48
  src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php:60
```

## Cause

#10711 migrated `HttpUrlTrait::getHost()` from reading `$_SERVER['HTTP_HOST']` / `['REQUEST_SCHEME']` to resolving the host from the current request in the `RequestStack` (it now throws when no request is available). That production change was backported to `dev-25.10.x`, **but the accompanying test adaptation was not**: `OneLoginSettingsFormatterTest` still set `$_SERVER` and built the formatter without a request, so `getHost()` threw — turning `backend-unit-test` red on the branch and on every PR targeting it.

## Fix

Mirror `develop`: push a `Request` onto a `RequestStack` and inject it via `setHttpServerBag()` instead of setting `$_SERVER`. `HttpUrlTrait` itself is already identical between `develop` and `dev-25.10.x`, so only the test needs updating (1 file).


[MON-201574]: https://centreon.atlassian.net/browse/MON-201574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ