### PR TITLE
fix(web): import debounce in Extensions filter

### DIFF
--- a/centreon/www/front_src/src/Extensions/Filter/index.tsx
+++ b/centreon/www/front_src/src/Extensions/Filter/index.tsx
@@ -24,6 +24,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import CloseIcon from '@mui/icons-material/Close';
 import { ClickAwayListener, MenuItem, Paper, Popper } from '@mui/material';
+import debounce from '@mui/utils/debounce';
 
 import {
   IconButton,


### PR DESCRIPTION
Fixes a runtime regression on `dev-25.10.x`: the Extension Manager page crashes with `ReferenceError: debounce is not defined`, which breaks every e2e test that loads it (e.g. `Menu/01-extensions-manager`, and cascades to suites needing the modules list).

## Root cause

`centreon/www/front_src/src/Extensions/Filter/index.tsx` calls `debounce()` (line ~106) but does not import it. Introduced by #10660 (merged 2026-06-19), which added the `debounce()` usage on `dev-25.10.x` without the `import debounce from '@mui/utils/debounce';` line. `develop` (#10619) and `dev-24.10.x` both have the import — only `dev-25.10.x` was affected.

The frontend build is transpile-only (no full type-check), so the missing import compiled fine and only failed at runtime.

run dev-25.10.x failed : https://github.com/centreon/centreon-modules/actions/runs/27961329925/job/82753358706

## Change

Add the missing `import debounce from '@mui/utils/debounce';` (aligned with develop / 24.10). One line.

Refs: MON-201575