### PR TITLE
test(api): tolerate 4xx/500 on known error-case assertions

### DIFF
--- a/centreon/tests/api/web-api-workspace/collections/Media/Administrator Profile/POST -medias - Add media without file - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Media/Administrator Profile/POST -medias - Add media without file - HTTP 400.bru
@@ -11,8 +11,10 @@ post {
 }
 
 
-assert {
-  res.status: eq 500
+tests {
+  test("Add media without file returns a client error (intended 400, currently 500 - known PHP bug)", function () {
+    expect(res.status).to.be.oneOf([400, 500]);
+  });
 }
 
 settings {

--- a/centreon/tests/api/web-api-workspace/collections/Media/Editor Profile/POST -medias - Add media - HTTP 403.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Media/Editor Profile/POST -medias - Add media - HTTP 403.bru
@@ -11,8 +11,10 @@ post {
 }
 
 
-assert {
-  res.status: eq 500
+tests {
+  test("Add media as editor is forbidden (intended 403, currently 500 - known PHP bug)", function () {
+    expect(res.status).to.be.oneOf([403, 500]);
+  });
 }
 
 settings {

--- a/centreon/tests/api/web-api-workspace/collections/Service/Administrator profile/POST -services - Create service without template - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Service/Administrator profile/POST -services - Create service without template - HTTP 400.bru
@@ -17,14 +17,9 @@ body:json {
   }
 }
 
-assert {
-  res.status: eq 500
-}
-
 tests {
-  test("The service has not been created because the template is missing.", function () {
-    const body = res.getBody();
-    expect(body.message).to.match(/check command cannot be null/i);
+  test("Create service without template returns a client error (intended 400, currently 500 - known PHP bug)", function () {
+    expect(res.status).to.be.oneOf([400, 500]);
   });
 }
 


### PR DESCRIPTION
Aligns the last 3 strict `res.status: eq 500` Bruno assertions with the tolerant pattern already used across the workspace (~55 `oneOf([…, 500])`).

## Why

These error-case tests assert a hard **HTTP 500** where the backend should return a 4xx — the 500 is a known PHP bug being addressed by MON-190558. Freezing `eq 500` means the test breaks once the backend is fixed to return the proper 4xx. The files are even named "HTTP 400" / "HTTP 403", confirming the intended status.

## Change (3 collections)

- `Media` — Add media without file: `eq 500` → `oneOf([400, 500])`
- `Media` — Add media (editor): `eq 500` → `oneOf([403, 500])`
- `Service` — Create service without template: `eq 500` → `oneOf([400, 500])`, and **remove the 500 response-body assertion** (`body.message` regex) since the 500 body is not a stable contract.

Transition-safe: stays green on the current 500 and on the future 4xx. Tightening to the specific code is the medium-term follow-up (once MON-190558 stabilises the returns). centreon-modules has no 500 assertion (nothing to change there).

Refs: MON-191673

Run : https://github.com/centreon/centreon/actions/runs/28090824608