### PR TITLE
refactor(shared): promote listing criteria contracts to the shared kernel

### DIFF
--- a/centreon/phpstan.new.baseline.neon
+++ b/centreon/phpstan.new.baseline.neon
@@ -1,0 +1,19 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Trait App\\Shared\\Domain\\Repository\\PaginableCriteriaTrait is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/App/Shared/Domain/Repository/PaginableCriteriaTrait.php
+
+		-
+			message: '#^Trait App\\Shared\\Domain\\Repository\\SearchableCriteriaTrait is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/App/Shared/Domain/Repository/SearchableCriteriaTrait.php
+
+		-
+			message: '#^Trait App\\Shared\\Infrastructure\\Dbal\\DbalCriteriaApplierTrait is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTrait.php

--- a/centreon/phpstan.new.neon
+++ b/centreon/phpstan.new.neon
@@ -1,5 +1,6 @@
 includes:
     - ../php-tools/phpstan/config/common.neon
+    - phpstan.new.baseline.neon
 
 parameters:
 

--- a/centreon/src/App/Shared/Domain/Repository/PaginableCriteria.php
+++ b/centreon/src/App/Shared/Domain/Repository/PaginableCriteria.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+/**
+ * Pagination capability for a listing criteria, symmetric to {@see SortableCriteria}.
+ *
+ * Immutable: {@see self::withPagination()} returns a new instance. Pull in
+ * {@see PaginableCriteriaTrait} for the default implementation.
+ */
+interface PaginableCriteria
+{
+    /**
+     * @throws \InvalidArgumentException when $page or $itemsPerPage is not a positive integer
+     */
+    public function withPagination(int $page, int $itemsPerPage): static;
+
+    public function getPagination(): ?Pagination;
+}

--- a/centreon/src/App/Shared/Domain/Repository/PaginableCriteriaTrait.php
+++ b/centreon/src/App/Shared/Domain/Repository/PaginableCriteriaTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+/**
+ * Default {@see PaginableCriteria} implementation, symmetric to {@see SortableCriteriaTrait}.
+ */
+trait PaginableCriteriaTrait
+{
+    private ?Pagination $pagination = null;
+
+    /**
+     * @throws \InvalidArgumentException when $page or $itemsPerPage is not a positive integer
+     */
+    public function withPagination(int $page, int $itemsPerPage): static
+    {
+        $clone = clone $this;
+        $clone->pagination = new Pagination($page, $itemsPerPage);
+
+        return $clone;
+    }
+
+    public function getPagination(): ?Pagination
+    {
+        return $this->pagination;
+    }
+}

--- a/centreon/src/App/Shared/Domain/Repository/Pagination.php
+++ b/centreon/src/App/Shared/Domain/Repository/Pagination.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * Immutable pagination request: a 1-based page and a strictly positive page size.
+ *
+ * The zero-based {@see self::getOffset()} is what a repository feeds to a
+ * SQL {@code LIMIT ... OFFSET ...} clause.
+ */
+final readonly class Pagination
+{
+    /**
+     * @throws \InvalidArgumentException when $page or $itemsPerPage is not a positive integer
+     */
+    public function __construct(
+        public int $page,
+        public int $itemsPerPage,
+    ) {
+        Assert::positiveInteger($page, 'Page must be a positive integer, got %s.');
+        Assert::positiveInteger($itemsPerPage, 'Items per page must be a positive integer, got %s.');
+    }
+
+    /**
+     * Zero-based index of the first item of the requested page.
+     */
+    public function getOffset(): int
+    {
+        return ($this->page - 1) * $this->itemsPerPage;
+    }
+}

--- a/centreon/src/App/Shared/Domain/Repository/SearchCondition.php
+++ b/centreon/src/App/Shared/Domain/Repository/SearchCondition.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * Immutable search condition: filter a field with an operator against a value.
+ *
+ * Scalar operators (eq, lk, gt, …) carry a single string value; list operators
+ * (in, nin) carry a non-empty list of strings.
+ */
+final readonly class SearchCondition
+{
+    /**
+     * @param string|list<string> $value a single value for scalar operators, a non-empty list for IN / NOT_IN
+     *
+     * @throws \InvalidArgumentException when $field is empty, or $value does not match the operator arity
+     */
+    public function __construct(
+        public string $field,
+        public SearchOperatorEnum $operator,
+        public string|array $value,
+    ) {
+        Assert::notEmpty($field, 'Search field must not be empty.');
+
+        if ($operator->expectsList()) {
+            Assert::isList($value, sprintf('Operator "%s" expects a list of values.', $operator->value));
+            Assert::notEmpty($value, sprintf('Operator "%s" expects a non-empty list of values.', $operator->value));
+        } else {
+            Assert::string($value, sprintf('Operator "%s" expects a single string value.', $operator->value));
+        }
+    }
+}

--- a/centreon/src/App/Shared/Domain/Repository/SearchOperatorEnum.php
+++ b/centreon/src/App/Shared/Domain/Repository/SearchOperatorEnum.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+/**
+ * Canonical set of search operators a configuration listing may expose.
+ *
+ * A given listing only allows a subset of these operators (see
+ * {@see SearchableCriteria::allowedOperators()}); any operator outside that subset
+ * is rejected when building the criteria.
+ */
+enum SearchOperatorEnum: string
+{
+    case EQUAL = 'eq';
+    case NOT_EQUAL = 'neq';
+    case LIKE = 'lk';
+    case NOT_LIKE = 'nlk';
+    case GREATER_THAN = 'gt';
+    case GREATER_THAN_OR_EQUAL = 'gte';
+    case LESS_THAN = 'lt';
+    case LESS_THAN_OR_EQUAL = 'lte';
+    case IN = 'in';
+    case NOT_IN = 'nin';
+
+    /**
+     * Whether this operator filters against a list of values (IN / NOT_IN)
+     * rather than a single value.
+     */
+    public function expectsList(): bool
+    {
+        return match ($this) {
+            self::IN, self::NOT_IN => true,
+            default => false,
+        };
+    }
+}

--- a/centreon/src/App/Shared/Domain/Repository/SearchableCriteria.php
+++ b/centreon/src/App/Shared/Domain/Repository/SearchableCriteria.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+/**
+ * Search capability for a listing criteria, symmetric to {@see SortableCriteria}.
+ *
+ * Immutable: {@see self::withSearch()} returns a new instance and rejects any
+ * operator outside {@see self::allowedOperators()}. Pull in
+ * {@see SearchableCriteriaTrait} for the default implementation.
+ */
+interface SearchableCriteria
+{
+    /**
+     * @param string|list<string> $value a single value for scalar operators, a non-empty list for IN / NOT_IN
+     *
+     * @throws \InvalidArgumentException when the operator is unknown or not allowed, the field is empty,
+     *                                   or the value does not match the operator arity
+     */
+    public function withSearch(string $field, SearchOperatorEnum|string $operator, string|array $value): static;
+
+    /**
+     * @return list<SearchCondition>
+     */
+    public function getSearch(): array;
+
+    /**
+     * Operators this listing accepts; any other operator is rejected by {@see self::withSearch()}.
+     *
+     * @return list<SearchOperatorEnum>
+     */
+    public function allowedOperators(): array;
+}

--- a/centreon/src/App/Shared/Domain/Repository/SearchableCriteriaTrait.php
+++ b/centreon/src/App/Shared/Domain/Repository/SearchableCriteriaTrait.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * Default {@see SearchableCriteria} implementation, symmetric to {@see SortableCriteriaTrait}.
+ *
+ * The using class must implement {@see SearchableCriteria::allowedOperators()}.
+ */
+trait SearchableCriteriaTrait
+{
+    /** @var list<SearchCondition> */
+    private array $search = [];
+
+    /**
+     * @return list<SearchOperatorEnum>
+     */
+    abstract public function allowedOperators(): array;
+
+    /**
+     * @param string|list<string> $value a single value for scalar operators, a non-empty list for IN / NOT_IN
+     *
+     * @throws \InvalidArgumentException when the operator is unknown or not allowed, the field is empty,
+     *                                   or the value does not match the operator arity
+     */
+    public function withSearch(string $field, SearchOperatorEnum|string $operator, string|array $value): static
+    {
+        $condition = new SearchCondition($field, $this->resolveOperator($operator), $value);
+
+        $clone = clone $this;
+        $clone->search[] = $condition;
+
+        return $clone;
+    }
+
+    /**
+     * @return list<SearchCondition>
+     */
+    public function getSearch(): array
+    {
+        return $this->search;
+    }
+
+    /**
+     * @throws \InvalidArgumentException when the operator is unknown or not allowed for this listing
+     */
+    private function resolveOperator(SearchOperatorEnum|string $operator): SearchOperatorEnum
+    {
+        if (is_string($operator)) {
+            $resolved = SearchOperatorEnum::tryFrom($operator);
+            Assert::notNull($resolved, sprintf('Unknown search operator "%s".', $operator));
+            $operator = $resolved;
+        }
+
+        Assert::inArray(
+            $operator,
+            $this->allowedOperators(),
+            sprintf(
+                'Operator "%s" is not allowed for this listing. Allowed operators: %s.',
+                $operator->value,
+                implode(', ', array_map(static fn (SearchOperatorEnum $allowed): string => $allowed->value, $this->allowedOperators()))
+            )
+        );
+
+        return $operator;
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTrait.php
+++ b/centreon/src/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTrait.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Dbal;
+
+use App\Shared\Domain\Repository\Pagination;
+use App\Shared\Domain\Repository\SearchableCriteria;
+use App\Shared\Domain\Repository\SearchCondition;
+use App\Shared\Domain\Repository\SearchOperatorEnum;
+use App\Shared\Domain\Repository\SortableCriteria;
+use App\Shared\Domain\Repository\SortDirectionEnum;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Webmozart\Assert\Assert;
+
+/**
+ * Infrastructure counterpart to the domain listing criteria contracts
+ * ({@see SearchableCriteria}, {@see SortableCriteria}, {@see PaginableCriteria}).
+ *
+ * Centralizes the operator-to-SQL translation, the field-to-column mapping and the
+ * sort / pagination / count boilerplate so each Dbal listing repository only has to
+ * supply its base query, table alias and count expression.
+ */
+trait DbalCriteriaApplierTrait
+{
+    /**
+     * Apply each search condition of the criteria as a WHERE clause, mapping the
+     * API field to its SQL column via {@see SortableCriteria::getFieldMapping()}.
+     * Unmapped fields are skipped.
+     */
+    private function applySearch(QueryBuilder $queryBuilder, string $alias, SearchableCriteria&SortableCriteria $criteria): void
+    {
+        $mapping = $criteria->getFieldMapping();
+        $index = 0;
+
+        foreach ($criteria->getSearch() as $condition) {
+            $column = $mapping[$condition->field] ?? null;
+            if ($column === null) {
+                continue;
+            }
+
+            $this->applySearchCondition($queryBuilder, $alias, $column, $condition, $index);
+            $index++;
+        }
+    }
+
+    private function applySearchCondition(
+        QueryBuilder $queryBuilder,
+        string $alias,
+        string $column,
+        SearchCondition $condition,
+        int $index,
+    ): void {
+        $parameter = 'search_' . $index;
+        $qualified = $alias . '.' . $column;
+
+        switch ($condition->operator) {
+            case SearchOperatorEnum::EQUAL:
+                $queryBuilder->andWhere("{$qualified} = :{$parameter}")->setParameter($parameter, $this->scalarValue($condition->value));
+                break;
+            case SearchOperatorEnum::NOT_EQUAL:
+                $queryBuilder->andWhere("{$qualified} != :{$parameter}")->setParameter($parameter, $this->scalarValue($condition->value));
+                break;
+            case SearchOperatorEnum::LIKE:
+                $queryBuilder->andWhere("{$qualified} LIKE :{$parameter}")->setParameter($parameter, '%' . $this->scalarValue($condition->value) . '%');
+                break;
+            case SearchOperatorEnum::NOT_LIKE:
+                $queryBuilder->andWhere("{$qualified} NOT LIKE :{$parameter}")->setParameter($parameter, '%' . $this->scalarValue($condition->value) . '%');
+                break;
+            case SearchOperatorEnum::IN:
+                $queryBuilder->andWhere("{$qualified} IN (:{$parameter})")
+                    ->setParameter($parameter, $this->listValue($condition->value), ArrayParameterType::STRING);
+                break;
+            case SearchOperatorEnum::NOT_IN:
+                $queryBuilder->andWhere("{$qualified} NOT IN (:{$parameter})")
+                    ->setParameter($parameter, $this->listValue($condition->value), ArrayParameterType::STRING);
+                break;
+            default:
+                // Comparison operators (gt, gte, lt, lte) are part of the canonical
+                // enum but are never allowed by the listings built on this trait, so
+                // they cannot reach this point. Fail loudly if a listing's
+                // allowedOperators() and this switch ever drift apart, rather than
+                // silently emitting an unfiltered query.
+                throw new \LogicException(sprintf(
+                    'Operator "%s" reached the repository but is not handled by this listing.',
+                    $condition->operator->value,
+                ));
+        }
+    }
+
+    /**
+     * Apply the requested sort as ORDER BY clauses. When the criteria carries no
+     * sort, fall back to $fallbackColumn ASC so pagination stays deterministic
+     * across pages (MySQL has no implicit row order). Pass null to skip the fallback.
+     */
+    private function applySort(
+        QueryBuilder $queryBuilder,
+        string $alias,
+        SortableCriteria $criteria,
+        ?string $fallbackColumn = null,
+    ): void {
+        $mapping = $criteria->getFieldMapping();
+        $applied = false;
+
+        foreach ($criteria->getSort() as $field => $direction) {
+            $column = $mapping[$field] ?? null;
+            if ($column === null) {
+                continue;
+            }
+
+            $queryBuilder->addOrderBy($alias . '.' . $column, $direction === SortDirectionEnum::DESC ? 'DESC' : 'ASC');
+            $applied = true;
+        }
+
+        if (! $applied && $fallbackColumn !== null) {
+            $queryBuilder->addOrderBy($alias . '.' . $fallbackColumn, 'ASC');
+        }
+    }
+
+    private function applyPagination(QueryBuilder $queryBuilder, Pagination $pagination): void
+    {
+        $queryBuilder->setFirstResult($pagination->getOffset())
+            ->setMaxResults($pagination->itemsPerPage);
+    }
+
+    /**
+     * Count the rows matching the current query, ignoring its sort and
+     * pagination. Counted on a clone so the listing query keeps its
+     * sort / pagination — SQL_CALC_FOUND_ROWS is deprecated in MySQL 8.x, so we
+     * run a dedicated COUNT instead.
+     *
+     * @param string $countExpression the COUNT expression to select, e.g. 'COUNT(DISTINCT t.id)'
+     *
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function countMatching(QueryBuilder $queryBuilder, string $countExpression): int
+    {
+        $countQb = clone $queryBuilder;
+
+        $count = $countQb
+            ->resetOrderBy()
+            ->select($countExpression)
+            ->setFirstResult(0)
+            ->setMaxResults(null)
+            ->executeQuery()
+            ->fetchOne();
+
+        Assert::numeric($count);
+
+        return (int) $count;
+    }
+
+    /**
+     * Scalar operators (eq, neq, lk, nlk) carry a single string value, as guaranteed by
+     * {@see SearchCondition}'s constructor.
+     *
+     * @param string|list<string> $value
+     */
+    private function scalarValue(string|array $value): string
+    {
+        Assert::string($value);
+
+        return $value;
+    }
+
+    /**
+     * List operators (in, nin) carry a non-empty list of string values, as guaranteed by
+     * {@see SearchCondition}'s constructor.
+     *
+     * @param string|list<string> $value
+     *
+     * @return list<string>
+     */
+    private function listValue(string|array $value): array
+    {
+        Assert::isArray($value);
+
+        return $value;
+    }
+}

--- a/centreon/tests/php/App/Shared/Domain/Repository/Double/FakeCriteria.php
+++ b/centreon/tests/php/App/Shared/Domain/Repository/Double/FakeCriteria.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Domain\Repository\Double;
+
+use App\Shared\Domain\Repository\PaginableCriteria;
+use App\Shared\Domain\Repository\PaginableCriteriaTrait;
+use App\Shared\Domain\Repository\SearchableCriteria;
+use App\Shared\Domain\Repository\SearchableCriteriaTrait;
+use App\Shared\Domain\Repository\SearchOperatorEnum;
+use App\Shared\Domain\Repository\SortableCriteria;
+use App\Shared\Domain\Repository\SortableCriteriaTrait;
+
+/**
+ * Minimal concrete criteria composing the three listing capabilities, used to
+ * exercise the reusable foundation. Allows EQUAL, LIKE, IN and NOT_IN: GREATER_THAN
+ * stays out so the "operator not allowed" path can be covered, IN / NOT_IN exercise
+ * list operators.
+ */
+final class FakeCriteria implements PaginableCriteria, SearchableCriteria, SortableCriteria
+{
+    use PaginableCriteriaTrait;
+    use SearchableCriteriaTrait;
+    use SortableCriteriaTrait;
+
+    public function allowedOperators(): array
+    {
+        return [
+            SearchOperatorEnum::EQUAL,
+            SearchOperatorEnum::LIKE,
+            SearchOperatorEnum::IN,
+            SearchOperatorEnum::NOT_IN,
+        ];
+    }
+
+    public function getFieldMapping(): array
+    {
+        return ['name' => 'ba_name', 'id' => 'ba_id'];
+    }
+}

--- a/centreon/tests/php/App/Shared/Domain/Repository/PaginableCriteriaTest.php
+++ b/centreon/tests/php/App/Shared/Domain/Repository/PaginableCriteriaTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Domain\Repository;
+
+use PHPUnit\Framework\TestCase;
+use Tests\App\Shared\Domain\Repository\Double\FakeCriteria;
+
+/**
+ * UNIT-03 (immutability) for the pagination capability.
+ */
+final class PaginableCriteriaTest extends TestCase
+{
+    public function testWithPaginationReturnsANewInstance(): void
+    {
+        $original = new FakeCriteria();
+        $paginated = $original->withPagination(2, 10);
+
+        self::assertNotSame($original, $paginated);
+        self::assertNull($original->getPagination());
+        self::assertNotNull($paginated->getPagination());
+        self::assertSame(2, $paginated->getPagination()->page);
+        self::assertSame(10, $paginated->getPagination()->getOffset());
+    }
+}

--- a/centreon/tests/php/App/Shared/Domain/Repository/PaginationTest.php
+++ b/centreon/tests/php/App/Shared/Domain/Repository/PaginationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Domain\Repository;
+
+use App\Shared\Domain\Repository\Pagination;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * UNIT-01 — pagination computation (page / limit / offset) and bounds.
+ */
+final class PaginationTest extends TestCase
+{
+    public function testOffsetForSecondPage(): void
+    {
+        $pagination = new Pagination(page: 2, itemsPerPage: 10);
+
+        self::assertSame(2, $pagination->page);
+        self::assertSame(10, $pagination->itemsPerPage);
+        self::assertSame(10, $pagination->getOffset());
+    }
+
+    public function testOffsetOfFirstPageIsZero(): void
+    {
+        self::assertSame(0, (new Pagination(page: 1, itemsPerPage: 25))->getOffset());
+    }
+
+    /**
+     * @return iterable<string, array{int, int, int}>
+     */
+    public static function offsetProvider(): iterable
+    {
+        yield 'page 1 / limit 10' => [1, 10, 0];
+
+        yield 'page 3 / limit 10' => [3, 10, 20];
+
+        yield 'page 5 / limit 50' => [5, 50, 200];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('offsetProvider')]
+    public function testOffsetComputation(int $page, int $itemsPerPage, int $expectedOffset): void
+    {
+        self::assertSame($expectedOffset, (new Pagination($page, $itemsPerPage))->getOffset());
+    }
+
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function outOfBoundsProvider(): iterable
+    {
+        yield 'page below 1' => [0, 10];
+
+        yield 'negative page' => [-1, 10];
+
+        yield 'zero items per page' => [1, 0];
+
+        yield 'negative items per page' => [1, -5];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('outOfBoundsProvider')]
+    public function testRejectsOutOfBoundsValues(int $page, int $itemsPerPage): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Pagination($page, $itemsPerPage);
+    }
+}

--- a/centreon/tests/php/App/Shared/Domain/Repository/SearchableCriteriaTest.php
+++ b/centreon/tests/php/App/Shared/Domain/Repository/SearchableCriteriaTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Domain\Repository;
+
+use App\Shared\Domain\Repository\SearchOperatorEnum;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Shared\Domain\Repository\Double\FakeCriteria;
+
+/**
+ * UNIT-02 (allowed / rejected operators) and UNIT-03 (immutability) for the search capability.
+ */
+final class SearchableCriteriaTest extends TestCase
+{
+    public function testAllowedOperatorsAreAccepted(): void
+    {
+        $criteria = (new FakeCriteria())
+            ->withSearch('name', SearchOperatorEnum::EQUAL, 'Ping')
+            ->withSearch('name', 'lk', 'Ba%');
+
+        $conditions = $criteria->getSearch();
+
+        self::assertCount(2, $conditions);
+        self::assertSame(SearchOperatorEnum::EQUAL, $conditions[0]->operator);
+        self::assertSame('Ping', $conditions[0]->value);
+        self::assertSame(SearchOperatorEnum::LIKE, $conditions[1]->operator);
+    }
+
+    public function testRejectsOperatorNotAllowedForListing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        // GREATER_THAN is a valid operator but not allowed by FakeCriteria.
+        (new FakeCriteria())->withSearch('name', SearchOperatorEnum::GREATER_THAN, '10');
+    }
+
+    public function testRejectsUnknownOperatorString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeCriteria())->withSearch('name', 'unknown', 'value');
+    }
+
+    public function testListOperatorAcceptsListOfValues(): void
+    {
+        $condition = (new FakeCriteria())
+            ->withSearch('id', SearchOperatorEnum::IN, ['1', '2', '3'])
+            ->getSearch()[0];
+
+        self::assertSame(SearchOperatorEnum::IN, $condition->operator);
+        self::assertSame(['1', '2', '3'], $condition->value);
+    }
+
+    public function testNotInListOperatorAcceptsListOfValues(): void
+    {
+        $condition = (new FakeCriteria())
+            ->withSearch('id', SearchOperatorEnum::NOT_IN, ['1', '2'])
+            ->getSearch()[0];
+
+        self::assertSame(SearchOperatorEnum::NOT_IN, $condition->operator);
+        self::assertSame(['1', '2'], $condition->value);
+    }
+
+    public function testListOperatorRejectsScalarValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeCriteria())->withSearch('id', SearchOperatorEnum::IN, '1');
+    }
+
+    public function testListOperatorRejectsEmptyList(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeCriteria())->withSearch('id', SearchOperatorEnum::IN, []);
+    }
+
+    public function testRejectsEmptyField(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeCriteria())->withSearch('', SearchOperatorEnum::EQUAL, 'Ping');
+    }
+
+    public function testScalarOperatorRejectsListValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeCriteria())->withSearch('name', SearchOperatorEnum::EQUAL, ['Ping']);
+    }
+
+    public function testWithSearchReturnsANewInstance(): void
+    {
+        $original = new FakeCriteria();
+        $searched = $original->withSearch('name', SearchOperatorEnum::EQUAL, 'Ping');
+
+        self::assertNotSame($original, $searched);
+        self::assertSame([], $original->getSearch());
+        self::assertCount(1, $searched->getSearch());
+    }
+}

--- a/centreon/tests/php/App/Shared/Domain/Repository/SortableCriteriaTest.php
+++ b/centreon/tests/php/App/Shared/Domain/Repository/SortableCriteriaTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Domain\Repository;
+
+use App\Shared\Domain\Repository\SortDirectionEnum;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Shared\Domain\Repository\Double\FakeCriteria;
+
+/**
+ * UNIT-02 (direction validation) and UNIT-03 (immutability) for the sort capability.
+ */
+final class SortableCriteriaTest extends TestCase
+{
+    public function testAcceptsBothDirectionsAsStrings(): void
+    {
+        $criteria = (new FakeCriteria())
+            ->withSort('name', 'ASC')
+            ->withSort('id', 'DESC');
+
+        self::assertSame(
+            ['name' => SortDirectionEnum::ASC, 'id' => SortDirectionEnum::DESC],
+            $criteria->getSort()
+        );
+    }
+
+    public function testRejectsInvalidDirectionString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeCriteria())->withSort('name', 'sideways');
+    }
+
+    public function testWithSortReturnsANewInstance(): void
+    {
+        $original = new FakeCriteria();
+        $sorted = $original->withSort('name', SortDirectionEnum::DESC);
+
+        self::assertNotSame($original, $sorted);
+        self::assertSame([], $original->getSort());
+        self::assertSame(['name' => SortDirectionEnum::DESC], $sorted->getSort());
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTraitTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTraitTest.php
@@ -1,0 +1,314 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Dbal;
+
+use App\Shared\Domain\Repository\Pagination;
+use App\Shared\Domain\Repository\SearchCondition;
+use App\Shared\Domain\Repository\SearchOperatorEnum;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Shared\Domain\Repository\Double\FakeCriteria;
+use Tests\App\Shared\Infrastructure\Dbal\Double\CriteriaApplierProbe;
+
+/**
+ * Exercises the shared operator-to-SQL translation and the sort / pagination /
+ * count boilerplate against a real in-memory SQLite connection, so the generated
+ * SQL is asserted both as text ({@see QueryBuilder::getSQL()}) and by execution.
+ */
+final class DbalCriteriaApplierTraitTest extends TestCase
+{
+    private Connection $connection;
+
+    private CriteriaApplierProbe $applier;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $this->connection->executeStatement('CREATE TABLE ba (ba_id INTEGER PRIMARY KEY, ba_name TEXT NOT NULL)');
+        $this->connection->executeStatement(
+            "INSERT INTO ba (ba_id, ba_name) VALUES (1, 'Alpha'), (2, 'Beta'), (3, 'Gamma'), (4, 'Delta'), (5, 'Epsilon')"
+        );
+
+        $this->applier = new CriteriaApplierProbe();
+    }
+
+    public function testEqualOperatorBuildsExactMatch(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::EQUAL, 'Alpha'), 0);
+
+        self::assertStringContainsString('t.ba_name = :search_0', $queryBuilder->getSQL());
+        self::assertSame(['search_0' => 'Alpha'], $queryBuilder->getParameters());
+    }
+
+    public function testNotEqualOperatorBuildsInequality(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::NOT_EQUAL, 'Alpha'), 0);
+
+        self::assertStringContainsString('t.ba_name != :search_0', $queryBuilder->getSQL());
+    }
+
+    public function testNotEqualOperatorExcludesMatchingValue(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::NOT_EQUAL, 'Alpha'), 0);
+
+        // Every seeded row except "Alpha".
+        self::assertSame(4, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testLikeOperatorWrapsValueWithWildcards(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::LIKE, 'lph'), 0);
+
+        self::assertStringContainsString('t.ba_name LIKE :search_0', $queryBuilder->getSQL());
+        self::assertSame(['search_0' => '%lph%'], $queryBuilder->getParameters());
+    }
+
+    public function testNotLikeOperatorWrapsValueWithWildcards(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::NOT_LIKE, 'lph'), 0);
+
+        self::assertStringContainsString('t.ba_name NOT LIKE :search_0', $queryBuilder->getSQL());
+        self::assertSame(['search_0' => '%lph%'], $queryBuilder->getParameters());
+    }
+
+    public function testInOperatorBuildsListClause(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_id', new SearchCondition('id', SearchOperatorEnum::IN, ['1', '2']), 0);
+
+        self::assertStringContainsString('t.ba_id IN (:search_0)', $queryBuilder->getSQL());
+        self::assertSame(['search_0' => ['1', '2']], $queryBuilder->getParameters());
+    }
+
+    public function testNotInOperatorBuildsListClause(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_id', new SearchCondition('id', SearchOperatorEnum::NOT_IN, ['1', '2']), 0);
+
+        self::assertStringContainsString('t.ba_id NOT IN (:search_0)', $queryBuilder->getSQL());
+    }
+
+    public function testInOperatorMatchesListedValues(): void
+    {
+        $criteria = (new FakeCriteria())->withSearch('name', SearchOperatorEnum::IN, ['Alpha', 'Beta']);
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->search($queryBuilder, 't', $criteria);
+
+        // Only the two listed names match; verifies the bound-list expansion executes.
+        self::assertSame(2, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testNotInOperatorExcludesListedValues(): void
+    {
+        $criteria = (new FakeCriteria())->withSearch('name', SearchOperatorEnum::NOT_IN, ['Alpha', 'Beta']);
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->search($queryBuilder, 't', $criteria);
+
+        // The five seeded rows minus the two excluded names.
+        self::assertSame(3, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testIndexDisambiguatesSuccessiveConditions(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::EQUAL, 'Alpha'), 0);
+        $this->applier->searchCondition($queryBuilder, 't', 'ba_name', new SearchCondition('name', SearchOperatorEnum::LIKE, 'Be'), 1);
+
+        self::assertSame(['search_0' => 'Alpha', 'search_1' => '%Be%'], $queryBuilder->getParameters());
+    }
+
+    public function testComparisonOperatorFailsLoudly(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        $this->applier->searchCondition(
+            $this->baseQuery(),
+            't',
+            'ba_id',
+            new SearchCondition('id', SearchOperatorEnum::GREATER_THAN, '10'),
+            0,
+        );
+    }
+
+    public function testSearchMapsApiFieldsToColumnsAndSkipsUnmappedOnes(): void
+    {
+        $criteria = (new FakeCriteria())
+            ->withSearch('name', SearchOperatorEnum::EQUAL, 'Alpha')
+            ->withSearch('unmapped', SearchOperatorEnum::EQUAL, 'ignored');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->search($queryBuilder, 't', $criteria);
+
+        // 'name' maps to 'ba_name'; 'unmapped' has no column and is skipped.
+        self::assertStringContainsString('t.ba_name = :search_0', $queryBuilder->getSQL());
+        self::assertSame(['search_0' => 'Alpha'], $queryBuilder->getParameters());
+    }
+
+    public function testSearchWithoutConditionsLeavesQueryUnfiltered(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->search($queryBuilder, 't', new FakeCriteria());
+
+        self::assertStringNotContainsString('WHERE', $queryBuilder->getSQL());
+        // All five seeded rows remain reachable.
+        self::assertSame(5, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testSearchAppliesEachMappedConditionWithItsOwnParameter(): void
+    {
+        $criteria = (new FakeCriteria())
+            ->withSearch('name', SearchOperatorEnum::EQUAL, 'Alpha')
+            ->withSearch('name', SearchOperatorEnum::LIKE, 'et');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->search($queryBuilder, 't', $criteria);
+
+        $sql = $queryBuilder->getSQL();
+        // Both mapped conditions land, AND-combined, each with a distinct parameter index.
+        self::assertStringContainsString('t.ba_name = :search_0', $sql);
+        self::assertStringContainsString('t.ba_name LIKE :search_1', $sql);
+        self::assertSame(['search_0' => 'Alpha', 'search_1' => '%et%'], $queryBuilder->getParameters());
+    }
+
+    public function testSortAppliesRequestedDirections(): void
+    {
+        $criteria = (new FakeCriteria())->withSort('name', 'DESC');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->sort($queryBuilder, 't', $criteria, 'ba_id');
+
+        self::assertStringContainsString('ORDER BY t.ba_name DESC', $queryBuilder->getSQL());
+    }
+
+    public function testSortAppliesExplicitAscendingDirection(): void
+    {
+        $criteria = (new FakeCriteria())->withSort('name', 'ASC');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->sort($queryBuilder, 't', $criteria, 'ba_id');
+
+        self::assertStringContainsString('ORDER BY t.ba_name ASC', $queryBuilder->getSQL());
+    }
+
+    public function testSortAppliesMultipleFieldsInRequestedOrder(): void
+    {
+        $criteria = (new FakeCriteria())
+            ->withSort('name', 'ASC')
+            ->withSort('id', 'DESC');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->sort($queryBuilder, 't', $criteria, 'ba_id');
+
+        self::assertStringContainsString('ORDER BY t.ba_name ASC, t.ba_id DESC', $queryBuilder->getSQL());
+    }
+
+    public function testSortFallsBackWhenNoSortRequested(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->sort($queryBuilder, 't', new FakeCriteria(), 'ba_id');
+
+        self::assertStringContainsString('ORDER BY t.ba_id ASC', $queryBuilder->getSQL());
+    }
+
+    public function testSortWithoutFallbackLeavesQueryUnordered(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->sort($queryBuilder, 't', new FakeCriteria(), null);
+
+        self::assertStringNotContainsString('ORDER BY', $queryBuilder->getSQL());
+    }
+
+    public function testPaginationSetsLimitAndOffset(): void
+    {
+        $queryBuilder = $this->baseQuery();
+        $this->applier->paginate($queryBuilder, new Pagination(page: 3, itemsPerPage: 10));
+
+        self::assertSame(20, $queryBuilder->getFirstResult());
+        self::assertSame(10, $queryBuilder->getMaxResults());
+    }
+
+    public function testCountMatchingIgnoresSortAndPagination(): void
+    {
+        $criteria = (new FakeCriteria())->withSort('name', 'ASC');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->sort($queryBuilder, 't', $criteria, 'ba_id');
+        $this->applier->paginate($queryBuilder, new Pagination(page: 1, itemsPerPage: 2));
+
+        // The five seeded rows are all counted, regardless of the LIMIT 2.
+        self::assertSame(5, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testCountMatchingReflectsSearchFilter(): void
+    {
+        $criteria = (new FakeCriteria())->withSearch('name', SearchOperatorEnum::LIKE, 'lph');
+
+        $queryBuilder = $this->baseQuery();
+        $this->applier->search($queryBuilder, 't', $criteria);
+
+        // Only "Alpha" contains the substring "lph".
+        self::assertSame(1, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testCountMatchingDeduplicatesJoinedRows(): void
+    {
+        // A one-to-many join inflates the row set (five joined rows for two parents);
+        // COUNT(DISTINCT t.ba_id) must still report the distinct parent count, which is
+        // the reason countMatching takes an explicit count expression.
+        $this->connection->executeStatement('CREATE TABLE ba_tag (ba_id INTEGER, tag TEXT)');
+        $this->connection->executeStatement(
+            "INSERT INTO ba_tag (ba_id, tag) VALUES (1, 'x'), (1, 'y'), (1, 'z'), (2, 'x'), (2, 'y')"
+        );
+
+        $queryBuilder = $this->baseQuery()->innerJoin('t', 'ba_tag', 'g', 't.ba_id = g.ba_id');
+
+        self::assertSame(2, $this->applier->count($queryBuilder, 'COUNT(DISTINCT t.ba_id)'));
+    }
+
+    public function testCountMatchingRejectsNonNumericResult(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/numeric/i');
+
+        // A non-aggregate text expression yields a non-numeric value; the guard must
+        // reject it rather than silently cast it to 0.
+        $this->applier->count($this->baseQuery(), 't.ba_name');
+    }
+
+    private function baseQuery(): QueryBuilder
+    {
+        return $this->connection->createQueryBuilder()
+            ->select('t.ba_id', 't.ba_name')
+            ->from('ba', 't');
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Dbal/Double/CriteriaApplierProbe.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Dbal/Double/CriteriaApplierProbe.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Dbal\Double;
+
+use App\Shared\Domain\Repository\Pagination;
+use App\Shared\Domain\Repository\SearchableCriteria;
+use App\Shared\Domain\Repository\SearchCondition;
+use App\Shared\Domain\Repository\SortableCriteria;
+use App\Shared\Infrastructure\Dbal\DbalCriteriaApplierTrait;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * Exposes the otherwise private {@see DbalCriteriaApplierTrait} methods so the
+ * trait can be exercised in isolation.
+ */
+final class CriteriaApplierProbe
+{
+    use DbalCriteriaApplierTrait;
+
+    public function search(QueryBuilder $queryBuilder, string $alias, SearchableCriteria&SortableCriteria $criteria): void
+    {
+        $this->applySearch($queryBuilder, $alias, $criteria);
+    }
+
+    public function searchCondition(QueryBuilder $queryBuilder, string $alias, string $column, SearchCondition $condition, int $index): void
+    {
+        $this->applySearchCondition($queryBuilder, $alias, $column, $condition, $index);
+    }
+
+    public function sort(QueryBuilder $queryBuilder, string $alias, SortableCriteria $criteria, ?string $fallbackColumn = null): void
+    {
+        $this->applySort($queryBuilder, $alias, $criteria, $fallbackColumn);
+    }
+
+    public function paginate(QueryBuilder $queryBuilder, Pagination $pagination): void
+    {
+        $this->applyPagination($queryBuilder, $pagination);
+    }
+
+    public function count(QueryBuilder $queryBuilder, string $countExpression): int
+    {
+        return $this->countMatching($queryBuilder, $countExpression);
+    }
+}


### PR DESCRIPTION
## Jira ticket

Fixes: [MON-201532](https://centreon.atlassian.net/browse/MON-201532)

## Description

Promote the listing criteria contracts that lived in centreon-bam into the centreon/centreon shared kernel, alongside the existing `SortableCriteria`:

- `App\Shared\Domain\Repository\` gains `Pagination`, `PaginableCriteria` (+ `PaginableCriteriaTrait`), `SearchableCriteria` (+ `SearchableCriteriaTrait`), `SearchCondition` and `SearchOperatorEnum`.
- New `App\Shared\Infrastructure\Dbal\DbalCriteriaApplierTrait` centralizes the operator-to-SQL translation (`eq` / `neq` / `lk` / `nlk` / `in` / `nin`) and the sort / pagination / count boilerplate, so every future Dbal listing repository builds on a single foundation instead of re-implementing the same six-case switch.

Follow-up raised during review of centreon-modules#8420. This is the centreon side of the change; the centreon-bam PR consumes these contracts and drops its local duplicates.

## How to test

- `composer rector:diff:fix` && `composer cs:diff:fix` — no changes needed.
- `vendor/bin/phpunit tests/php/App/Shared/Domain/Repository tests/php/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTraitTest.php` — 34 tests green.
- `composer stan` scoped to the new files — no errors.


[MON-201532]: https://centreon.atlassian.net/browse/MON-201532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ