### PR TITLE
chore(ci): route tests/api CODEOWNERS to api-testing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,6 @@
 
 **/config/                              @centreon/owners-php
 **/composer.*                           @centreon/owners-php
-**/tests/api/                           @centreon/owners-php
 **/tests/php/                           @centreon/owners-php
 **/tests/clapi_export/                  @centreon/owners-php
 **/www/                                 @centreon/owners-php
@@ -38,6 +37,7 @@ tsconfig.json                           @centreon/owners-react
 *.pm                                    @centreon/owners-perl
 *.pl                                    @centreon/owners-perl
 
+**/tests/api/**                         @centreon/owners-api-testing
 **/tests/e2e/**                         @centreon/owners-cypress-e2e
 **/cypress/e2e/**                       @centreon/owners-cypress-e2e
 
@@ -55,8 +55,6 @@ dependencies/**                         @centreon/owners-pipelines
 **/unattended.sh                        @centreon/owners-pipelines
 
 **/config/features.json                 @centreon/release-management
-
-**/tests/rest_api/**                    @centreon/owners-api-testing
 
 # Security Codeowners rules
 .gitleaks.toml                @centreon/owners-security


### PR DESCRIPTION
API tests moved from `tests/rest_api/` (Postman/Newman) to `tests/api/` (Bruno) with the Postman→Bruno migration, but `CODEOWNERS` was not updated.

- Route `**/tests/api/**` to `@centreon/owners-api-testing` (was `@centreon/owners-php`).
- Remove the now-dead `**/tests/rest_api/**` rule (the folder no longer exists).

Placed after the `@owners-php` rules so the api-testing rule wins (CODEOWNERS = last match wins). No other rule matches `tests/api/` content afterwards.

Refs: MON-201639