### PR TITLE
fix(packaging): add bc as a dependency for centreon-ha (#10776)

### DIFF
--- a/centreon-ha/packaging/centreon-ha-common.yaml
+++ b/centreon-ha/packaging/centreon-ha-common.yaml
@@ -82,6 +82,7 @@ scripts:
 overrides:
   rpm:
     depends:
+      - bc
       - perl-common-sense
       - perl-Linux-Inotify2
       - rsync
@@ -91,6 +92,7 @@ overrides:
 
   deb:
     depends:
+      - bc
       - libcommon-sense-perl
       - liblinux-inotify2-perl
       - rsync


### PR DESCRIPTION
## Description

* fix packaging issue for systems that may not have bc natively installed for centreon-ha

**Fixes** #MON-201645
