### PR TITLE
fix(ci): count Bruno summary by assertion result, not HTTP status

### DIFF
--- a/.github/scripts/bruno-test-api/bruno-github-summary.js
+++ b/.github/scripts/bruno-test-api/bruno-github-summary.js
@@ -35,7 +35,7 @@ if (!fs.existsSync(mergedFile)) {
   process.exit(1);
 }
 
-const data = JSON.parse(fs.readFileSync(mergedFile, "utf-8"));
+const report = JSON.parse(fs.readFileSync(mergedFile, "utf-8"));
 
 // ------------------------
 // Global stats
@@ -45,12 +45,13 @@ let success = 0;
 let failed = 0;
 let totalTime = 0;
 
-data.forEach((block) => {
-  (block.results || []).forEach((t) => {
+report.forEach((iteration) => {
+  (iteration.results || []).forEach((requestResult) => {
     total++;
-    const status = t.response?.status;
-    totalTime += t.response?.responseTime || 0;
-    if (status >= 200 && status < 300) success++;
+    totalTime += requestResult.response?.responseTime || 0;
+    // Count by the request's overall result (assertions + tests + error),
+    // not by the HTTP status: negative-path tests legitimately expect 4xx.
+    if (requestResult.status === "pass") success++;
     else failed++;
   });
 });
@@ -112,21 +113,22 @@ html += `
 
 let row = 0;
 
-data.forEach((block) => {
-  (block.results || []).forEach((test) => {
+report.forEach((iteration) => {
+  (iteration.results || []).forEach((requestResult) => {
     row++;
     const bg = row % 2 === 0 ? "#f8fafc" : "#ffffff";
-    const status = test.response?.status ?? "-";
-    const time = test.response?.responseTime ?? "-";
-    const ok = status >= 200 && status < 300;
+    const status = requestResult.response?.status ?? "-";
+    const time = requestResult.response?.responseTime ?? "-";
+    const ok = requestResult.status === "pass";
     const color = ok ? "#16a34a" : "#dc2626";
 
-    const message = test.response?.data?.message || test.error || "";
+    const message =
+      requestResult.response?.data?.message || requestResult.error || "";
 
     html += `
 <tr style="background:${bg};">
-  <td style="padding:8px;">${test.test?.filename}</td>
-  <td style="padding:8px; text-align:center;">${test.request?.method}</td>
+  <td style="padding:8px;">${requestResult.test?.filename}</td>
+  <td style="padding:8px; text-align:center;">${requestResult.request?.method}</td>
   <td style="padding:8px; text-align:center; color:${color}; font-weight:bold;">
     ${ok ? "✅" : "❌"} ${status}
   </td>


### PR DESCRIPTION
The Bruno API test GitHub step summary computed success/failed from the **HTTP status** (`2xx` = success), so every negative-path test that legitimately asserts a `4xx` (401/403/404/409…) was shown as ❌ failed — even though the job is green and the assertions pass.

## Change

`bruno-github-summary.js`: count by the request **overall result** `requestResult.status` (which aggregates assertions + tests + error in the Bruno JSON report) instead of the HTTP code, both in the global stats and the per-row ✅/❌ (the HTTP status is still displayed alongside). Verified against a real merged report: e.g. on `Submit_Result`, 6 requests previously flagged "failed" are actually passing negative-path tests.

Also renamed the vague variables `data` / `block` / `t` to `report` / `iteration` / `requestResult` for readability.

Refs: MON-201631
Run : https://github.com/centreon/centreon/actions/runs/28090786027