### PR TITLE
perf(ci): speed up PHPStan step with persistent result cache

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -139,6 +139,7 @@ jobs:
         id: changed-php
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           files: |
             **/*.php
 
@@ -160,37 +161,41 @@ jobs:
           echo "Run of these PHP-CS-Fixer tests: cs:legacy on diff" && set -e
           composer cs:diff
 
+      - name: Restore PHPStan result cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: centreon-awie/.phpstan-cache
+          # Unique per run (sha) so the evolving result cache is re-saved every run;
+          # head_ref is the real branch name on pull_request (ref_name would be "N/merge").
+          key: phpstan-cache-awie-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-cache-awie-${{ github.head_ref || github.ref_name }}-
+            phpstan-cache-awie-
+
       - name: 🔍 PHPStan checks
         working-directory: centreon-awie
         run: |
-          echo "Run of these PHPStan tests: stan:legacy" && set -e
+          echo "Run of these PHPStan tests: stan:legacy"
 
-          pids=()
-          statuses=()
+          exit_code=0
 
           run_task() {
-            name=$1
-            shift
-            "$@" -- --no-progress
-            result=$?
-            if [ $result -eq 0 ]; then
-              echo "✅ PHPStan $name: Success"
+            task=$1                  # e.g. legacy
+            cache_dir=${task//:/-}
+            # PHPStan has no --tmp-dir flag; its tmp dir defaults to sys_get_temp_dir()/phpstan
+            # and sys_get_temp_dir() honours $TMPDIR. Point each task at its own dir so its
+            # result cache (resultCache.php) is isolated and persisted across runs.
+            task_tmp="${PWD}/.phpstan-cache/${cache_dir}"
+            mkdir -p "${task_tmp}"
+            if TMPDIR="${task_tmp}" composer "stan:${task}" -- --no-progress; then
+              echo "✅ PHPStan ${task}: Success"
             else
-              echo "❌ PHPStan $name: Failed"
-            fi
-            return $result
-          }
-
-          # Start tasks in background
-          run_task legacy composer stan:legacy & pids+=($!)
-
-          # Wait for all, and record if any failed
-          exit_code=0
-          for pid in "${pids[@]}"; do
-            if ! wait "$pid"; then
+              echo "❌ PHPStan ${task}: Failed"
               exit_code=1
             fi
-          done
+          }
+
+          run_task legacy
 
           exit $exit_code
 

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -140,6 +140,7 @@ jobs:
         id: changed-php
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           files: |
             **/*.php
 
@@ -161,37 +162,41 @@ jobs:
           echo "Run of these PHP-CS-Fixer tests: cs:legacy on diff" && set -e
           composer cs:diff
 
+      - name: Restore PHPStan result cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: centreon-dsm/.phpstan-cache
+          # Unique per run (sha) so the evolving result cache is re-saved every run;
+          # head_ref is the real branch name on pull_request (ref_name would be "N/merge").
+          key: phpstan-cache-dsm-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-cache-dsm-${{ github.head_ref || github.ref_name }}-
+            phpstan-cache-dsm-
+
       - name: 🔍 PHPStan checks
         working-directory: centreon-dsm
         run: |
-          echo "Run of these PHPStan tests: stan:legacy" && set -e
+          echo "Run of these PHPStan tests: stan:legacy"
 
-          pids=()
-          statuses=()
+          exit_code=0
 
           run_task() {
-             name=$1
-             shift
-             "$@" -- --no-progress
-             result=$?
-             if [ $result -eq 0 ]; then
-               echo "✅ PHPStan $name: Success"
-             else
-               echo "❌ PHPStan $name: Failed"
-             fi
-             return $result
-          }
-
-          # Start tasks in background
-          run_task legacy composer stan:legacy & pids+=($!)
-
-          # Wait for all, and record if any failed
-          exit_code=0
-          for pid in "${pids[@]}"; do
-            if ! wait "$pid"; then
+            task=$1                  # e.g. legacy
+            cache_dir=${task//:/-}
+            # PHPStan has no --tmp-dir flag; its tmp dir defaults to sys_get_temp_dir()/phpstan
+            # and sys_get_temp_dir() honours $TMPDIR. Point each task at its own dir so its
+            # result cache (resultCache.php) is isolated and persisted across runs.
+            task_tmp="${PWD}/.phpstan-cache/${cache_dir}"
+            mkdir -p "${task_tmp}"
+            if TMPDIR="${task_tmp}" composer "stan:${task}" -- --no-progress; then
+              echo "✅ PHPStan ${task}: Success"
+            else
+              echo "❌ PHPStan ${task}: Failed"
               exit_code=1
             fi
-          done
+          }
+
+          run_task legacy
 
           exit $exit_code
 

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -160,6 +160,7 @@ jobs:
         id: changed-php
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           files: |
             **/*.php
 
@@ -181,39 +182,45 @@ jobs:
           echo "Run of these PHP-CS-Fixer tests: cs:legacy on diff" && set -e
           composer cs:diff
 
+      - name: Restore PHPStan result cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: centreon-open-tickets/.phpstan-cache
+          # Unique per run (sha) so the evolving result cache is re-saved every run;
+          # head_ref is the real branch name on pull_request (ref_name would be "N/merge").
+          key: phpstan-cache-open-tickets-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-cache-open-tickets-${{ github.head_ref || github.ref_name }}-
+            phpstan-cache-open-tickets-
+
       - name: 🔍 PHPStan checks
         working-directory: centreon-open-tickets
         run: |
-          echo "Run of these PHPStan tests: stan:legacy:www, stan:legacy:src, stan:legacy:test" && set -e
+          echo "Run of these PHPStan tests: stan:legacy:www, stan:legacy:src, stan:legacy:test"
 
-          pids=()
-          statuses=()
+          exit_code=0
 
           run_task() {
-            name=$1
-            shift
-            "$@" -- --no-progress
-            result=$?
-            if [ $result -eq 0 ]; then
-              echo "✅ PHPStan $name: Success"
+            task=$1                  # e.g. legacy:src
+            cache_dir=${task//:/-}   # e.g. legacy-src
+            # PHPStan has no --tmp-dir flag; its tmp dir defaults to sys_get_temp_dir()/phpstan
+            # and sys_get_temp_dir() honours $TMPDIR. Point each task at its own dir so their
+            # result caches (resultCache.php) don't clobber each other across runs.
+            task_tmp="${PWD}/.phpstan-cache/${cache_dir}"
+            mkdir -p "${task_tmp}"
+            if TMPDIR="${task_tmp}" composer "stan:${task}" -- --no-progress; then
+              echo "✅ PHPStan ${task}: Success"
             else
-              echo "❌ PHPStan $name: Failed"
-            fi
-            return $result
-          }
-
-          # Start tasks in background
-          run_task legacy:www composer stan:legacy:www & pids+=($!)
-          run_task legacy:src composer stan:legacy:src & pids+=($!)
-          run_task legacy:test composer stan:legacy:test & pids+=($!)
-
-          # Wait for all, and record if any failed
-          exit_code=0
-          for pid in "${pids[@]}"; do
-            if ! wait "$pid"; then
+              echo "❌ PHPStan ${task}: Failed"
               exit_code=1
             fi
-          done
+          }
+
+          # Run sequentially: each PHPStan run already parallelises internally, so chaining
+          # them avoids the CPU oversubscription the previous background fan-out caused.
+          run_task legacy:www
+          run_task legacy:src
+          run_task legacy:test
 
           exit $exit_code
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -181,6 +181,7 @@ jobs:
         id: get_changed_files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           files: |
             centreon/www/install/php/Update-**.php
 
@@ -541,6 +542,7 @@ jobs:
         id: changed-php
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          use_rest_api: ${{ github.event_name == 'pull_request' }}
           files: |
             **/*.php
 
@@ -562,43 +564,53 @@ jobs:
           echo "Run of these PHP-CS-Fixer tests: cs:legacy, cs:core, cs:new on diff" && set -e
           composer cs:diff
 
+      - name: Restore PHPStan result cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: centreon/.phpstan-cache
+          # Unique per run (sha) so the evolving result cache is re-saved every run;
+          # head_ref is the real branch name on pull_request (ref_name would be "N/merge").
+          key: phpstan-cache-web-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-cache-web-${{ github.head_ref || github.ref_name }}-
+            phpstan-cache-web-
+
       - name: 🔍 PHPStan checks
         working-directory: centreon
         run: |
-          echo "Run of these PHPStan tests: stan:legacy:www, stan:legacy:src, stan:legacy:test, stan:core, stan:core:test, stan:new, stan:new:test" && set -e
+          echo "Run of these PHPStan tests: stan:legacy:www, stan:legacy:src, stan:legacy:test, stan:core:src, stan:core:test, stan:new:src, stan:new:test"
 
-          pids=()
-          statuses=()
-
-          run_task() {
-            name=$1
-            shift
-            "$@" -- --no-progress
-            result=$?
-            if [ $result -eq 0 ]; then
-              echo "✅ PHPStan $name: Success"
-            else
-              echo "❌ PHPStan $name: Failed"
-            fi
-            return $result
-          }
-
-          # Start tasks in background
-          run_task legacy:www composer stan:legacy:www & pids+=($!)
-          run_task legacy:src composer stan:legacy:src & pids+=($!)
-          run_task legacy:test composer stan:legacy:test & pids+=($!)
-          run_task core:src composer stan:core:src & pids+=($!)
-          run_task core:test composer stan:core:test & pids+=($!)
-          run_task new:src composer stan:new:src & pids+=($!)
-          run_task new:test composer stan:new:test & pids+=($!)
-
-          # Wait for all, and record if any failed
           exit_code=0
-          for pid in "${pids[@]}"; do
-            if ! wait "$pid"; then
+
+          # Run every task even if one fails, then exit non-zero if any failed.
+          # Each task uses its own tmp dir so its result cache (resultCache.php) does
+          # not collide with the others. The whole .phpstan-cache directory is persisted
+          # across CI runs, so only changed files (and their dependents) get re-analysed.
+          run_task() {
+            task=$1                  # e.g. core:src
+            cache_dir=${task//:/-}   # e.g. core-src
+            # PHPStan has no --tmp-dir flag; its tmp dir defaults to sys_get_temp_dir()/phpstan
+            # and sys_get_temp_dir() honours $TMPDIR. Point each task at its own dir so their
+            # result caches (resultCache.php) don't clobber each other across runs.
+            task_tmp="${PWD}/.phpstan-cache/${cache_dir}"
+            mkdir -p "${task_tmp}"
+            if TMPDIR="${task_tmp}" composer "stan:${task}" -- --no-progress; then
+              echo "✅ PHPStan ${task}: Success"
+            else
+              echo "❌ PHPStan ${task}: Failed"
               exit_code=1
             fi
-          done
+          }
+
+          # Run sequentially: each PHPStan run already parallelises internally, so chaining
+          # them avoids the CPU oversubscription the previous background fan-out caused.
+          run_task legacy:www
+          run_task legacy:src
+          run_task legacy:test
+          run_task core:src
+          run_task core:test
+          run_task new:src
+          run_task new:test
 
           exit $exit_code
 


### PR DESCRIPTION
Refs: MON-201056

Backport of #10661 to `dev-24.10.x`.

## Changes

### PHPStan result cache + sequential execution
For each backend-lint job (`awie`, `dsm`, `open-tickets`, `web`):
- Run the PHPStan tasks **sequentially** instead of the background fan-out (`& pids+=($!)`). Each PHPStan run already parallelises internally, so the fan-out only oversubscribed the runner CPU.
- Give each task its own `TMPDIR` (PHPStan has no `--tmp-dir` flag; its tmp dir defaults to `sys_get_temp_dir()/phpstan` and `sys_get_temp_dir()` honours `$TMPDIR`) so their result caches (`resultCache.php`) don't clobber each other.
- Persist the `.phpstan-cache` directory across CI runs via `actions/cache`, so only changed files and their dependents are re-analysed. Cache key namespaced per workflow so one can't restore another's cache.

### tj-actions/changed-files via REST API on PR
Add `use_rest_api: ${{ github.event_name == 'pull_request' }}` so changed files are fetched through the GitHub REST API on `pull_request` events (no reliance on local git history depth); push events keep the git-based detection.

## Notes
- Clean cherry-pick from `dev-25.10.x` — no adaptation needed for this branch.
- The first run on a branch is cold; the gain shows from the second push onward. PHPStan self-invalidates the cache when the PHP/PHPStan version, `composer.lock` or config change.
