### PR TITLE
fix(monitoringConfiguration): use bound params in filterByCriteria

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -36,6 +36,7 @@ use App\Shared\Domain\Collection;
 use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -326,7 +327,10 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             foreach ($nameCriteria as $operator => $names) {
                 if ($operator === CommandCriteria::OPERATOR_LIKE) {
                     $qb->andWhere($qb->expr()->or(...array_map(
-                        static fn (string $name): string => $qb->expr()->like('cm.command_name', '"%' . $name . '%"'),
+                        static fn (string $name): string => $qb->expr()->like(
+                            'cm.command_name',
+                            $qb->createNamedParameter('%' . $name . '%')
+                        ),
                         $names
                     )));
 
@@ -334,7 +338,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
                 }
                 $qb->andWhere($qb->expr()->in(
                     'cm.command_name',
-                    array_map(static fn (string $name): string => '"' . $name . '"', $names)
+                    $qb->createNamedParameter($names, ArrayParameterType::STRING)
                 ));
             }
         }
@@ -342,7 +346,10 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         if ($criteria->getTypes() !== []) {
             $qb->andWhere($qb->expr()->in(
                 'cm.command_type',
-                array_map(static fn (CommandTypeEnum $type): string => '"' . $type->value . '"', $criteria->getTypes())
+                $qb->createNamedParameter(
+                    array_map(static fn (CommandTypeEnum $type): int => $type->value, $criteria->getTypes()),
+                    ArrayParameterType::INTEGER
+                )
             ));
         }
 
@@ -354,7 +361,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         if ($criteria->getIds() !== []) {
             $qb->andWhere($qb->expr()->in(
                 'cm.command_id',
-                array_map(static fn (int $id): string => '"' . $id . '"', $criteria->getIds())
+                $qb->createNamedParameter($criteria->getIds(), ArrayParameterType::INTEGER)
             ));
         }
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalConnectorRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalConnectorRepository.php
@@ -33,6 +33,7 @@ use App\Shared\Domain\Collection;
 use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -177,7 +178,10 @@ final readonly class DbalConnectorRepository extends DbalRepository implements C
             foreach ($nameCriteria as $operator => $names) {
                 if ($operator === ConnectorCriteria::OPERATOR_LIKE) {
                     $qb->andWhere($qb->expr()->or(...array_map(
-                        static fn (string $name): string => $qb->expr()->like('c.name', '"%' . $name . '%"'),
+                        static fn (string $name): string => $qb->expr()->like(
+                            'c.name',
+                            $qb->createNamedParameter('%' . $name . '%')
+                        ),
                         $names
                     )));
 
@@ -185,7 +189,7 @@ final readonly class DbalConnectorRepository extends DbalRepository implements C
                 }
                 $qb->andWhere($qb->expr()->in(
                     'c.name',
-                    array_map(static fn (string $name): string => '"' . $name . '"', $names)
+                    $qb->createNamedParameter($names, ArrayParameterType::STRING)
                 ));
             }
         }
@@ -193,7 +197,10 @@ final readonly class DbalConnectorRepository extends DbalRepository implements C
             foreach ($idCriteria as $operator => $ids) {
                 if ($operator === ConnectorCriteria::OPERATOR_LIKE) {
                     $qb->andWhere($qb->expr()->or(...array_map(
-                        static fn (int $id): string => $qb->expr()->like('c.id', '"%' . $id . '%"'),
+                        static fn (int $id): string => $qb->expr()->like(
+                            'c.id',
+                            $qb->createNamedParameter('%' . $id . '%')
+                        ),
                         $ids
                     )));
 
@@ -201,7 +208,7 @@ final readonly class DbalConnectorRepository extends DbalRepository implements C
                 }
                 $qb->andWhere($qb->expr()->in(
                     'c.id',
-                    array_map(static fn (int $id): string => '"' . $id . '"', $ids)
+                    $qb->createNamedParameter($ids, ArrayParameterType::INTEGER)
                 ));
             }
         }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalGlobalMacroRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalGlobalMacroRepository.php
@@ -32,6 +32,7 @@ use App\Shared\Domain\Collection;
 use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -123,7 +124,10 @@ final readonly class DbalGlobalMacroRepository extends DbalRepository implements
             foreach ($nameCriteria as $operator => $names) {
                 if ($operator === GlobalMacroCriteria::OPERATOR_LIKE) {
                     $qb->andWhere($qb->expr()->or(...array_map(
-                        static fn (string $name): string => $qb->expr()->like('gm.resource_name', '"%' . $name . '%"'),
+                        static fn (string $name): string => $qb->expr()->like(
+                            'gm.resource_name',
+                            $qb->createNamedParameter('%' . $name . '%')
+                        ),
                         $names
                     )));
 
@@ -131,7 +135,7 @@ final readonly class DbalGlobalMacroRepository extends DbalRepository implements
                 }
                 $qb->andWhere($qb->expr()->in(
                     'gm.resource_name',
-                    array_map(static fn (string $name): string => '"' . $name . '"', $names)
+                    $qb->createNamedParameter($names, ArrayParameterType::STRING)
                 ));
             }
         }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalStandardMacroRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalStandardMacroRepository.php
@@ -30,6 +30,7 @@ use App\Shared\Domain\Collection;
 use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -99,7 +100,10 @@ final readonly class DbalStandardMacroRepository extends DbalRepository implemen
             foreach ($nameCriteria as $operator => $names) {
                 if ($operator === StandardMacroCriteria::OPERATOR_LIKE) {
                     $qb->andWhere($qb->expr()->or(...array_map(
-                        static fn (string $name): string => $qb->expr()->like('sm.macro_name', '"%' . $name . '%"'),
+                        static fn (string $name): string => $qb->expr()->like(
+                            'sm.macro_name',
+                            $qb->createNamedParameter('%' . $name . '%')
+                        ),
                         $names
                     )));
 
@@ -107,7 +111,7 @@ final readonly class DbalStandardMacroRepository extends DbalRepository implemen
                 }
                 $qb->andWhere($qb->expr()->in(
                     'sm.macro_name',
-                    array_map(static fn (string $name): string => '"' . $name . '"', $names)
+                    $qb->createNamedParameter($names, ArrayParameterType::STRING)
                 ));
             }
         }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepositoryTest.php
@@ -29,6 +29,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Command\CommandLine;
 use App\MonitoringConfiguration\Domain\Aggregate\Command\CommandName;
 use App\MonitoringConfiguration\Domain\Aggregate\Command\CommandTypeEnum;
 use App\MonitoringConfiguration\Domain\Exception\CommandNotFoundException;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\CommandCriteria;
 use App\MonitoringConfiguration\Infrastructure\Dbal\DbalCommandRepository;
 use App\Shared\Domain\Collection;
 use Doctrine\DBAL\Connection;
@@ -133,5 +134,40 @@ final class DbalCommandRepositoryTest extends KernelTestCase
         self::assertInstanceOf(Collection::class, $commands);
         self::assertNotEmpty($commands);
         self::assertContainsOnlyInstancesOf(Command::class, $commands);
+    }
+
+    public function testFindAllWithNameLikeCriteria(): void
+    {
+        $criteria = (new CommandCriteria())->withName('disk_smb', CommandCriteria::OPERATOR_LIKE);
+
+        $commands = $this->repository->findAll($criteria);
+
+        self::assertCount(1, $commands);
+        self::assertSame('check_disk_smb', iterator_to_array($commands)[0]->name->value);
+    }
+
+    public function testFindAllWithNameEqualCriteria(): void
+    {
+        $criteria = (new CommandCriteria())->withName('check_disk_smb', CommandCriteria::OPERATOR_EQUAL);
+
+        $commands = $this->repository->findAll($criteria);
+
+        self::assertCount(1, $commands);
+        self::assertSame('check_disk_smb', iterator_to_array($commands)[0]->name->value);
+    }
+
+    /**
+     * Make sure a double quote in the filter value is bound as a parameter
+     * instead of being concatenated into the SQL string.
+     */
+    public function testFilterByCriteriaIsSafeAgainstQuoteInjection(): void
+    {
+        $payload = 'x" UNION SELECT * FROM command --';
+
+        $likeCriteria = (new CommandCriteria())->withName($payload, CommandCriteria::OPERATOR_LIKE);
+        $equalCriteria = (new CommandCriteria())->withName($payload, CommandCriteria::OPERATOR_EQUAL);
+
+        self::assertCount(0, $this->repository->findAll($likeCriteria));
+        self::assertCount(0, $this->repository->findAll($equalCriteria));
     }
 }


### PR DESCRIPTION
## Description

Replace string concatenation with `createNamedParameter` and `ArrayParameterType` in `filterByCriteria()` of :
    - `DbalCommandRepository (names, types, ids)`
    - `DbalConnectorRepository (names, ids)`
    - `DbalGlobalMacroRepository (names)`
    - `DbalStandardMacroRepository (names)`

Add integration tests covering `filterByCriteria`.

[MON-201322](https://centreon.atlassian.net/browse/MON-201322)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-201322]: https://centreon.atlassian.net/browse/MON-201322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ