### PR TITLE
fix(e2e): check monitored services against resources table (MON-175020)

### DIFF
--- a/centreon/tests/e2e/commons.ts
+++ b/centreon/tests/e2e/commons.ts
@@ -135,10 +135,10 @@ interface MonitoredService {
 }
 
 const checkServicesAreMonitored = (services: Array<MonitoredService>): void => {
-  cy.log('Checking services in database');
+  cy.log('Checking services in resources table database');
 
   let query =
-    'SELECT COUNT(s.service_id) AS count_services from services as s WHERE s.enabled=1 AND (';
+    'SELECT COUNT(r.resource_id) AS count_services from resources as r WHERE r.enabled = 1 AND r.type = 0 AND (';
   const conditions: Array<string> = [];
   services.forEach(
     ({
@@ -149,22 +149,22 @@ const checkServicesAreMonitored = (services: Array<MonitoredService>): void => {
       inDowntime = null,
       statusType = ''
     }) => {
-      let condition = `(s.description = '${name}'`;
+      let condition = `(r.name = '${name}'`;
       if (output !== '') {
-        condition += ` AND s.output LIKE '%${output}%'`;
+        condition += ` AND r.output LIKE '%${output}%'`;
       }
       if (status !== '') {
-        condition += ` AND s.state = ${getStatusNumberFromString(status)}`;
+        condition += ` AND r.status = ${getStatusNumberFromString(status)}`;
       }
       if (acknowledged !== null) {
-        condition += ` AND s.acknowledged = ${acknowledged === true ? 1 : 0}`;
+        condition += ` AND r.acknowledged = ${acknowledged === true ? 1 : 0}`;
       }
       if (inDowntime !== null) {
-        condition += ` AND s.scheduled_downtime_depth = ${inDowntime === true ? 1 : 0
+        condition += ` AND r.in_downtime = ${inDowntime === true ? 1 : 0
           }`;
       }
       if (statusType !== '') {
-        condition += ` AND s.state_type = ${getStatusTypeNumberFromString(
+        condition += ` AND r.status_confirmed = ${getStatusTypeNumberFromString(
           statusType
         )}`;
       }

--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
@@ -27,7 +27,6 @@ Feature: Creating a Notification Rule
       | contact_settings | resource_type                           |
       | two contacts     | host group and services for these hosts |
 
-  @ignore
   @TEST_MON-33204
   Scenario Outline: Creating a large volume Notification Rule for <contact_settings>
     Given a minimum of 1000 services linked to a host group and '<contact_settings>'


### PR DESCRIPTION
## Context

The `@TEST_MON-33204` scenario ("large volume Notification Rule", 1000 services via CLAPI) was disabled with `@ignore` because it timed out systematically. The check helper `checkServicesAreMonitored` polls the legacy `centreon_storage.services` table, which lags behind the unified `resources` table that the UI actually reads (observed: 13 rows in `services` vs 975 shown in the UI, 487 expected).

Per a remark on ticket, the helper should query the `resources` table.

## Changes

- `checkServicesAreMonitored` now queries `resources` (with `type = 0` to count services only), mapping columns:

  | services | resources |
  |---|---|
  | `service_id` | `resource_id` |
  | `description` | `name` |
  | `state` | `status` |
  | `state_type` | `status_confirmed` |
  | `scheduled_downtime_depth` | `in_downtime` |
  | `output` / `acknowledged` / `enabled` | same |

- Re-enable the `@TEST_MON-33204` scenario (removed `@ignore`).

## Notes

- Draft: opened to let CI run the re-enabled scenario and confirm the resources table is in sync in time.
- Point to watch: service names are matched without host context (parity with the previous query). If the exact count (487) is flaky, we may need to add `parent_name` to disambiguate services sharing a name across hosts.

Refs: MON-175020