### PR TITLE
fix(broker): prevent config wipe on save failure

### DIFF
--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -854,7 +854,11 @@ class CentreonConfigCentreonBroker
                 $this->db->commitTransaction();
             }
         } catch (Throwable $e) {
-            if ($ownTransaction && $this->db->isTransactionActive()) {
+            if (! $ownTransaction) {
+                throw $e;
+            }
+
+            if ($this->db->isTransactionActive()) {
                 $this->db->rollBackTransaction();
             }
 
@@ -1322,6 +1326,8 @@ class CentreonConfigCentreonBroker
         $featureFlagManager = $kernel->getContainer()->get(FeatureFlags::class);
 
         $vaultConfiguration = $readVaultConfigurationRepository->find();
+        $writeVaultRepository = null;
+        $oldVaultUuids = [];
         if ($featureFlagManager->isEnabled('vault_broker') && $vaultConfiguration !== null) {
             /** @var ReadVaultRepositoryInterface $readVaultRepository */
             $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
@@ -1329,17 +1335,20 @@ class CentreonConfigCentreonBroker
             $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
             $writeVaultRepository->setCustomPath(AbstractVaultRepository::BROKER_VAULT_PATH);
             $this->retrievePasswordsFromVault($values, $readVaultRepository);
-            deleteBrokerConfigsFromVault($writeVaultRepository, [$configId]);
+
+            // Capture UUIDs now; deletion is deferred to after the API loop succeeds.
+            $oldVaultUuids = retrieveMultipleBrokerConfigUuidsFromDatabase([$configId]);
         }
 
         $deleteQuery = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
             . $configId
             . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua\_parameter\_%"' : '');
+        $rollbackDeleteQuery = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = ' . $configId;
 
-        // Capture the rows about to be deleted so we can restore them if the re-insert API calls fail.
-        // The DELETE and the INSERTs run on different DB connections (legacy PDO vs Symfony kernel),
-        // so a single transaction cannot make this atomic — we use a compensating restore instead.
-        $backup = $this->backupBrokerInfos($configId, $keepLuaParameters);
+        // The API re-inserts run on a separate DB connection, so we cannot use a transaction.
+        // Backup all rows and restore them on failure; rollback wipes the lua scope too in case
+        // partial lua rows were committed by the API.
+        $backup = $this->backupBrokerInfos($configId);
         $this->db->query($deleteQuery);
 
         [$groups_infos] = $this->getGroupsInfos($values);
@@ -1385,13 +1394,26 @@ class CentreonConfigCentreonBroker
                 }
             }
         } catch (Throwable $th) {
-            // Some API calls may have already committed inserts on the Symfony connection; remove
-            // those partial rows with the same scoped DELETE, then restore the original backup so
-            // the table is left exactly as it was before the save attempt.
-            $this->db->query($deleteQuery);
+            // Capture new vault UUIDs before wiping the partial rows (the lookup reads from DB).
+            $partialVaultUuids = $writeVaultRepository !== null
+                ? retrieveMultipleBrokerConfigUuidsFromDatabase([$configId])
+                : [];
+
+            $this->db->query($rollbackDeleteQuery);
             $this->restoreBrokerInfos($backup);
 
+            // Drop only the new UUIDs — $oldVaultUuids are still referenced by the restored rows.
+            foreach ($partialVaultUuids as $uuid) {
+                if (! in_array($uuid, $oldVaultUuids, true)) {
+                    $writeVaultRepository->delete($uuid);
+                }
+            }
+
             throw $th;
+        }
+
+        foreach ($oldVaultUuids as $uuid) {
+            $writeVaultRepository->delete($uuid);
         }
     }
 
@@ -1665,10 +1687,14 @@ class CentreonConfigCentreonBroker
     private function getExternalDefaultValue($fieldId)
     {
         $externalValue = null;
-        $query = 'SELECT `external` FROM cb_field WHERE cb_field_id = :fieldId';
-        $res = $this->db->prepare($query);
-        $res->bindValue(':fieldId', (int) $fieldId, PDO::PARAM_INT);
-        $res->execute();
+        try {
+            $query = 'SELECT `external` FROM cb_field WHERE cb_field_id = :fieldId';
+            $res = $this->db->prepare($query);
+            $res->bindValue(':fieldId', (int) $fieldId, PDO::PARAM_INT);
+            $res->execute();
+        } catch (PDOException) {
+            return null;
+        }
 
         if (! $res) {
             $externalValue = null;
@@ -1986,28 +2012,20 @@ class CentreonConfigCentreonBroker
      * if the subsequent re-insert API calls fail.
      *
      * @param int $configId
-     * @param bool $keepLuaParameters when true, lua_parameter__ rows are excluded (they are not deleted)
      *
      * @return array<int,array<string,mixed>>
      */
-    private function backupBrokerInfos(int $configId, bool $keepLuaParameters): array
+    private function backupBrokerInfos(int $configId): array
     {
-        $query = 'SELECT config_id, config_key, config_value, config_group, config_group_id,'
+        $stmt = $this->db->prepare(
+            'SELECT config_id, config_key, config_value, config_group, config_group_id,'
             . ' grp_level, subgrp_id, parent_grp_id, fieldIndex'
-            . ' FROM cfg_centreonbroker_info WHERE config_id = :configId';
-        if ($keepLuaParameters) {
-            $query .= ' AND config_key NOT LIKE "lua\_parameter\_%"';
-        }
+            . ' FROM cfg_centreonbroker_info WHERE config_id = :configId'
+        );
+        $stmt->bindValue(':configId', $configId, PDO::PARAM_INT);
+        $stmt->execute();
 
-        try {
-            $stmt = $this->db->prepare($query);
-            $stmt->bindValue(':configId', $configId, PDO::PARAM_INT);
-            $stmt->execute();
-
-            return $stmt->fetchAll(PDO::FETCH_ASSOC);
-        } catch (PDOException) {
-            return [];
-        }
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -765,9 +765,14 @@ class CentreonConfigCentreonBroker
      */
     public function updateConfig(int $id, array $values)
     {
-        // Insert the Centreon Broker configuration
-        $query = '';
+        $ownTransaction = ! $this->db->isTransactionActive();
+
         try {
+            if ($ownTransaction) {
+                $this->db->startTransaction();
+            }
+
+            // Update the Centreon Broker configuration
             $stmt = $this->db->prepare(
                 <<<'SQL'
                     UPDATE cfg_centreonbroker SET
@@ -820,26 +825,23 @@ class CentreonConfigCentreonBroker
                 ? $stmt->bindValue(':pool_size', null, PDO::PARAM_NULL)
                 : $stmt->bindValue(':pool_size', (int) $values['pool_size'], PDO::PARAM_INT);
             $stmt->execute();
-        } catch (PDOException $e) {
-            return false;
-        }
 
-        // Log
-        $logs = $this->getLogsOption();
-        $deleteStmt = $this->db->prepare(
-            <<<'SQL'
-                DELETE FROM cfg_centreonbroker_log WHERE id_centreonbroker = :config_id
-                SQL
-        );
-        $deleteStmt->bindValue(':config_id', $id, PDO::PARAM_INT);
-        $deleteStmt->execute();
+            // Log
+            $logs = $this->getLogsOption();
+            $deleteStmt = $this->db->prepare(
+                <<<'SQL'
+                    DELETE FROM cfg_centreonbroker_log WHERE id_centreonbroker = :config_id
+                    SQL
+            );
+            $deleteStmt->bindValue(':config_id', $id, PDO::PARAM_INT);
+            $deleteStmt->execute();
 
-        $queryLog = 'INSERT INTO cfg_centreonbroker_log (id_centreonbroker, id_log, id_level) VALUES ';
-        foreach (array_keys($logs) as $logId) {
-            $queryLog .= '(:id_centreonbroker, :log_' . $logId . ', :level_' . $logId . '), ';
-        }
-        $queryLog = rtrim($queryLog, ', ');
-        try {
+            $queryLog = 'INSERT INTO cfg_centreonbroker_log (id_centreonbroker, id_log, id_level) VALUES ';
+            foreach (array_keys($logs) as $logId) {
+                $queryLog .= '(:id_centreonbroker, :log_' . $logId . ', :level_' . $logId . '), ';
+            }
+            $queryLog = rtrim($queryLog, ', ');
+
             $stmt = $this->db->prepare($queryLog);
             $stmt->bindValue(':id_centreonbroker', (int) $id, PDO::PARAM_INT);
             foreach ($logs as $logId => $logName) {
@@ -847,7 +849,15 @@ class CentreonConfigCentreonBroker
                 $stmt->bindValue(':level_' . $logId, (int) $values['log_' . $logName], PDO::PARAM_INT);
             }
             $stmt->execute();
-        } catch (PDOException $e) {
+
+            if ($ownTransaction) {
+                $this->db->commitTransaction();
+            }
+        } catch (Throwable $e) {
+            if ($ownTransaction && $this->db->isTransactionActive()) {
+                $this->db->rollBackTransaction();
+            }
+
             return false;
         }
 
@@ -1322,10 +1332,15 @@ class CentreonConfigCentreonBroker
             deleteBrokerConfigsFromVault($writeVaultRepository, [$configId]);
         }
 
-        $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
+        $deleteQuery = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
             . $configId
             . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua\_parameter\_%"' : '');
-        $this->db->query($query);
+
+        // Capture the rows about to be deleted so we can restore them if the re-insert API calls fail.
+        // The DELETE and the INSERTs run on different DB connections (legacy PDO vs Symfony kernel),
+        // so a single transaction cannot make this atomic — we use a compensating restore instead.
+        $backup = $this->backupBrokerInfos($configId, $keepLuaParameters);
+        $this->db->query($deleteQuery);
 
         [$groups_infos] = $this->getGroupsInfos($values);
 
@@ -1349,24 +1364,34 @@ class CentreonConfigCentreonBroker
             $parameters['base_uri'] = $basePath;
         }
 
-        foreach ($groups_infos as $tag => $groups) {
-            $parameters['tag'] = $tag === 'input' ? 'inputs' : 'outputs';
-            $url = $router->generate(
-                'AddBrokerInputOutput',
-                $parameters,
-                Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
-            );
+        try {
+            foreach ($groups_infos as $tag => $groups) {
+                $parameters['tag'] = $tag === 'input' ? 'inputs' : 'outputs';
+                $url = $router->generate(
+                    'AddBrokerInputOutput',
+                    $parameters,
+                    Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
+                );
 
-            foreach ($groups as $group) {
-                $payload = $this->buildPayload($group);
-                $response = $client->request($url, 'POST', $sessionCookie, $payload);
+                foreach ($groups as $group) {
+                    $payload = $this->buildPayload($group);
+                    $response = $client->request($url, 'POST', $sessionCookie, $payload);
 
-                if ($response['status_code'] !== 201) {
-                    $message = $response['content']['message'] ?? 'Unexpected return status';
+                    if ($response['status_code'] !== 201) {
+                        $message = $response['content']['message'] ?? 'Unexpected return status';
 
-                    throw new Exception($message);
+                        throw new Exception($message);
+                    }
                 }
             }
+        } catch (Throwable $th) {
+            // Some API calls may have already committed inserts on the Symfony connection; remove
+            // those partial rows with the same scoped DELETE, then restore the original backup so
+            // the table is left exactly as it was before the save attempt.
+            $this->db->query($deleteQuery);
+            $this->restoreBrokerInfos($backup);
+
+            throw $th;
         }
     }
 
@@ -1953,6 +1978,80 @@ class CentreonConfigCentreonBroker
                     $value = $vaultValue[$parameterKey] ?? $value;
                 }
             }
+        }
+    }
+
+    /**
+     * Fetch broker info records that are about to be deleted, so they can be restored
+     * if the subsequent re-insert API calls fail.
+     *
+     * @param int $configId
+     * @param bool $keepLuaParameters when true, lua_parameter__ rows are excluded (they are not deleted)
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function backupBrokerInfos(int $configId, bool $keepLuaParameters): array
+    {
+        $query = 'SELECT config_id, config_key, config_value, config_group, config_group_id,'
+            . ' grp_level, subgrp_id, parent_grp_id, fieldIndex'
+            . ' FROM cfg_centreonbroker_info WHERE config_id = :configId';
+        if ($keepLuaParameters) {
+            $query .= ' AND config_key NOT LIKE "lua\_parameter\_%"';
+        }
+
+        try {
+            $stmt = $this->db->prepare($query);
+            $stmt->bindValue(':configId', $configId, PDO::PARAM_INT);
+            $stmt->execute();
+
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } catch (PDOException) {
+            return [];
+        }
+    }
+
+    /**
+     * Re-insert broker info records previously captured by {@see backupBrokerInfos}.
+     *
+     * @param array<int,array<string,mixed>> $backup
+     */
+    private function restoreBrokerInfos(array $backup): void
+    {
+        if ($backup === []) {
+            return;
+        }
+
+        $stmt = $this->db->prepare(
+            'INSERT INTO cfg_centreonbroker_info'
+            . ' (config_id, config_key, config_value, config_group, config_group_id,'
+            . ' grp_level, subgrp_id, parent_grp_id, fieldIndex)'
+            . ' VALUES (:config_id, :config_key, :config_value, :config_group, :config_group_id,'
+            . ' :grp_level, :subgrp_id, :parent_grp_id, :fieldIndex)'
+        );
+
+        foreach ($backup as $record) {
+            $stmt->bindValue(':config_id', (int) $record['config_id'], PDO::PARAM_INT);
+            $stmt->bindValue(':config_key', $record['config_key'], PDO::PARAM_STR);
+            $stmt->bindValue(':config_value', $record['config_value'], PDO::PARAM_STR);
+            $stmt->bindValue(':config_group', $record['config_group'], PDO::PARAM_STR);
+            $stmt->bindValue(':config_group_id', (int) $record['config_group_id'], PDO::PARAM_INT);
+            $stmt->bindValue(':grp_level', (int) $record['grp_level'], PDO::PARAM_INT);
+            $stmt->bindValue(
+                ':subgrp_id',
+                $record['subgrp_id'] !== null ? (int) $record['subgrp_id'] : null,
+                $record['subgrp_id'] !== null ? PDO::PARAM_INT : PDO::PARAM_NULL
+            );
+            $stmt->bindValue(
+                ':parent_grp_id',
+                $record['parent_grp_id'] !== null ? (int) $record['parent_grp_id'] : null,
+                $record['parent_grp_id'] !== null ? PDO::PARAM_INT : PDO::PARAM_NULL
+            );
+            $stmt->bindValue(
+                ':fieldIndex',
+                $record['fieldIndex'] !== null ? (int) $record['fieldIndex'] : null,
+                $record['fieldIndex'] !== null ? PDO::PARAM_INT : PDO::PARAM_NULL
+            );
+            $stmt->execute();
         }
     }
 }


### PR DESCRIPTION
## Description

Saving a broker configuration deleted all rows from  `cfg_centreonbroker_info` before re-inserting them through API calls on a separate DB connection. Any failure mid-loop left the table empty or partially populated, destroying the existing configuration.

- Capture the rows about to be deleted, wrap the re-insert loop in a `try/catch`, and on failure remove any partially committed inserts before restoring the backup so the table is left exactly as it was before the save attempt.

- Wrap the `UPDATE` `cfg_centreonbroker` and `DELETE/INSERT` `cfg_centreonbroker_log` statements in a single transaction so the two tables stay consistent if either step fails.

[MON-197840](https://centreon.atlassian.net/browse/MON-197840)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-197840]: https://centreon.atlassian.net/browse/MON-197840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ