### PR TITLE
fix(AgentConfiguration): update CMA install command for Windows

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/InstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/InstallationCommandFactory.php
@@ -42,10 +42,12 @@ final readonly class InstallationCommandFactory
 
     public function generateCommandForLinux(): string
     {
+        $version = $this->majorMinorVersion();
+
         if ($this->isCloudPlatform && $this->poller->isCentral) {
             return sprintf(
                 'curl -fsSL ' . self::LINUX_INSTALL_SCRIPT_URL . ' -o install_cma.sh && sudo chmod +x install_cma.sh && sudo ./install_cma.sh -e "engine-%s-%s.euwest1.centreon.cloud:443"',
-                $this->platformVersion,
+                $version,
                 $this->baseUri,
                 $this->organisationName
             );
@@ -53,7 +55,7 @@ final readonly class InstallationCommandFactory
 
         $command = sprintf(
             'curl -fsSL ' . self::LINUX_INSTALL_SCRIPT_URL . ' -o install_cma.sh && sudo chmod +x install_cma.sh && sudo ./install_cma.sh -e "%s:%s"',
-            $this->platformVersion,
+            $version,
             $this->poller->address->value,
             $this->agentConfigurationPort
         );
@@ -63,18 +65,20 @@ final readonly class InstallationCommandFactory
 
     public function generateCommandForWindows(): string
     {
+        $version = $this->majorMinorVersion();
+
         if ($this->isCloudPlatform && $this->poller->isCentral) {
             return sprintf(
                 'curl ' . self::WINDOWS_INSTALL_SCRIPT_URL . ' -o install_cma.ps1 ; powershell -ExecutionPolicy Bypass -File .\install_cma.ps1 -endpoint "engine-%s-%s.euwest1.centreon.cloud:443"',
-                $this->platformVersion,
+                $version,
                 $this->baseUri,
                 $this->organisationName
             );
         }
 
         $command = sprintf(
-            'curl -fsSL ' . self::WINDOWS_INSTALL_SCRIPT_URL . ' -o install_cma.ps1 ; .\install_cma.ps1 -endpoint "%s:%s"',
-            $this->platformVersion,
+            'curl ' . self::WINDOWS_INSTALL_SCRIPT_URL . ' -o install_cma.ps1 ; powershell -ExecutionPolicy Bypass -File .\install_cma.ps1 -endpoint "%s:%s"',
+            $version,
             $this->poller->address->value,
             $this->agentConfigurationPort
         );
@@ -98,6 +102,13 @@ final readonly class InstallationCommandFactory
         }
 
         return $flags;
+    }
+
+    private function majorMinorVersion(): string
+    {
+        $parts = explode('.', $this->platformVersion);
+
+        return $parts[0] . '.' . ($parts[1] ?? '0');
     }
 
     private function buildWindowsCertificateFlags(): string

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
@@ -47,7 +47,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
         self::assertResponseIsSuccessful();
         self::assertMatchesResourceItemJsonSchema(InstallationCommandResource::class);
 
-        $version = $this->getPlatformVersion();
+        $version = $this->getPlatformMajorMinorVersion();
         $data = $response->toArray();
         $expectedLinux = sprintf(
             'curl -fsSL https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/%s-latest/agent/installer/scripts_linux/install_cma.sh -o install_cma.sh && sudo chmod +x install_cma.sh && sudo ./install_cma.sh -e "%s:%d" -f "%s" -N "%s"',
@@ -58,7 +58,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
             self::CERTIFICATE_CN
         );
         $expectedWindows = sprintf(
-            'curl -fsSL https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/%s-latest/agent/installer/install_cma.ps1 -o install_cma.ps1 ; .\install_cma.ps1 -endpoint "%s:%d" -fingerprint "%s" -commonname "%s"',
+            'curl https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/%s-latest/agent/installer/install_cma.ps1 -o install_cma.ps1 ; powershell -ExecutionPolicy Bypass -File .\install_cma.ps1 -endpoint "%s:%d" -fingerprint "%s" -commonname "%s"',
             $version,
             self::POLLER_ADDRESS,
             self::AGENT_PORT,
@@ -80,7 +80,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
         $response = $this->request('GET', sprintf('%s/%d', self::BASE_ENDPOINT, $pollerId));
         self::assertResponseIsSuccessful();
 
-        $version = $this->getPlatformVersion();
+        $version = $this->getPlatformMajorMinorVersion();
         $data = $response->toArray();
         $expectedLinux = sprintf(
             'curl -fsSL https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/%s-latest/agent/installer/scripts_linux/install_cma.sh -o install_cma.sh && sudo chmod +x install_cma.sh && sudo ./install_cma.sh -e "%s:%d"',
@@ -89,7 +89,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
             self::AGENT_PORT,
         );
         $expectedWindows = sprintf(
-            'curl -fsSL https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/%s-latest/agent/installer/install_cma.ps1 -o install_cma.ps1 ; .\install_cma.ps1 -endpoint "%s:%d"',
+            'curl https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/%s-latest/agent/installer/install_cma.ps1 -o install_cma.ps1 ; powershell -ExecutionPolicy Bypass -File .\install_cma.ps1 -endpoint "%s:%d"',
             $version,
             self::POLLER_ADDRESS,
             self::AGENT_PORT,
@@ -156,14 +156,15 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
         ];
     }
 
-    private function getPlatformVersion(): string
+    private function getPlatformMajorMinorVersion(): string
     {
         /** @var Connection $connection */
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
 
         $version = $connection->fetchOne("SELECT `value` FROM `informations` WHERE `key` = 'version'");
+        $parts = explode('.', is_string($version) ? $version : '');
 
-        return is_string($version) ? $version : '';
+        return $parts[0] . '.' . ($parts[1] ?? '0');
     }
 
     private function insertPoller(string $name): int

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/InstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/InstallationCommandFactoryTest.php
@@ -46,6 +46,7 @@ use PHPUnit\Framework\TestCase;
 final class InstallationCommandFactoryTest extends TestCase
 {
     private const PLATFORM_VERSION = '24.10.0';
+    private const EXPECTED_URL_VERSION = '24.10';
     private const DEFAULT_PORT = 4317;
     private const POLLER_ADDRESS = '192.168.1.100';
 
@@ -64,7 +65,7 @@ final class InstallationCommandFactoryTest extends TestCase
         $command = $factory->generateCommandForLinux();
 
         self::assertStringContainsString('install_cma.sh', $command);
-        self::assertStringContainsString(self::PLATFORM_VERSION, $command);
+        self::assertStringContainsString(self::EXPECTED_URL_VERSION . '-latest', $command);
         self::assertStringContainsString(self::POLLER_ADDRESS . ':' . self::DEFAULT_PORT, $command);
         self::assertStringNotContainsString('-f ', $command);
         self::assertStringNotContainsString('-N ', $command);
@@ -85,7 +86,7 @@ final class InstallationCommandFactoryTest extends TestCase
         $command = $factory->generateCommandForWindows();
 
         self::assertStringContainsString('install_cma.ps1', $command);
-        self::assertStringContainsString(self::PLATFORM_VERSION, $command);
+        self::assertStringContainsString(self::EXPECTED_URL_VERSION . '-latest', $command);
         self::assertStringContainsString(self::POLLER_ADDRESS . ':' . self::DEFAULT_PORT, $command);
         self::assertStringNotContainsString('-fingerprint ', $command);
         self::assertStringNotContainsString('-commonname ', $command);
@@ -224,7 +225,7 @@ final class InstallationCommandFactoryTest extends TestCase
         $command = $factory->generateCommandForLinux();
 
         self::assertStringContainsString('engine-' . $site . '-' . $organisation . '.euwest1.centreon.cloud:443', $command);
-        self::assertStringContainsString(self::PLATFORM_VERSION, $command);
+        self::assertStringContainsString(self::EXPECTED_URL_VERSION . '-latest', $command);
         self::assertStringNotContainsString(self::POLLER_ADDRESS, $command);
     }
 
@@ -246,7 +247,7 @@ final class InstallationCommandFactoryTest extends TestCase
 
         self::assertStringContainsString('engine-' . $site . '-' . $organisation . '.euwest1.centreon.cloud:443', $command);
         self::assertStringContainsString('powershell -ExecutionPolicy Bypass -File', $command);
-        self::assertStringContainsString(self::PLATFORM_VERSION, $command);
+        self::assertStringContainsString(self::EXPECTED_URL_VERSION . '-latest', $command);
         self::assertStringNotContainsString(self::POLLER_ADDRESS, $command);
     }
 
@@ -326,8 +327,8 @@ final class InstallationCommandFactoryTest extends TestCase
         $linuxCommand = $factory->generateCommandForLinux();
         $windowsCommand = $factory->generateCommandForWindows();
 
-        self::assertStringContainsString($version . '-latest', $linuxCommand);
-        self::assertStringContainsString($version . '-latest', $windowsCommand);
+        self::assertStringContainsString('25.04-latest', $linuxCommand);
+        self::assertStringContainsString('25.04-latest', $windowsCommand);
     }
 
     public function testLinuxCommandContainsCorrectScriptUrl(): void
@@ -400,8 +401,10 @@ final class InstallationCommandFactoryTest extends TestCase
 
         $command = $factory->generateCommandForWindows();
 
+        self::assertStringNotContainsString('-fsSL', $command);
+        self::assertStringContainsString('curl ', $command);
         self::assertStringContainsString('-o install_cma.ps1', $command);
-        self::assertStringContainsString('.\\install_cma.ps1 -endpoint', $command);
+        self::assertStringContainsString('powershell -ExecutionPolicy Bypass -File .\\install_cma.ps1 -endpoint', $command);
     }
 
     private function createPoller(bool $isCentral, ?string $sha = null, ?string $certificateCn = null): Poller


### PR DESCRIPTION
## Description

Fix three issues in the CMA installation command generated for Windows pollers:

- Remove `-fsSL` curl flag (not appropriate for Windows/PowerShell)
- Add `powershell -ExecutionPolicy Bypass -File` to properly invoke the install script
- Truncate the platform version to major.minor (e.g. `25.10` instead of `25.10.12`) so the GitHub tag URL resolves correctly

The cloud central poller path already had the correct Windows command structure; this fix aligns the on-premise/remote poller path.

Fixes: [MON-199890](https://centreon.atlassian.net/browse/MON-199890)

## How this pull request can be tested ?

1. Deploy a Centreon platform with CMA agent-initiated connection configured
2. Call `GET /api/latest/configuration/agent-configurations/installation-command/{pollerId}`
3. Verify the `windows_installation_command` field:
   - URL contains `xx.xx-latest` (not `xx.xx.xx-latest`)
   - No `-fsSL` flag
   - Script invoked with `powershell -ExecutionPolicy Bypass -File .\install_cma.ps1`
4. Verify the `linux_installation_command` field still contains `-fsSL` and correct version

[MON-199890]: https://centreon.atlassian.net/browse/MON-199890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ