### PR TITLE
fix(ci): restore centreon-common runner for deliver-sources jobs

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -506,7 +506,7 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -269,7 +269,7 @@ jobs:
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -127,7 +127,7 @@ jobs:
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -501,7 +501,7 @@ jobs:
           tags: ${{ steps.docker_tags.outputs.tags }}
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1147,7 +1147,7 @@ jobs:
   #         retention-days: 1
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, e2e-test]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&


### PR DESCRIPTION
## Summary

- Restore `centreon-common` runner for `deliver-sources` jobs (previously replaced by `ubuntu-24.04`)
- Affects all workflows: `web.yml`, `dsm.yml`, `open-tickets.yml`, `ha.yml`, `awie.yml`

## Jira

[MON-201759](https://centreon.atlassian.net/browse/MON-201759)

## Type of change

- [x] CI/CD change (GitHub Actions)

## Test plan

- [ ] Verify that the `deliver-sources` job runs on `centreon-common` runner in next CI execution

[MON-201759]: https://centreon.atlassian.net/browse/MON-201759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ