### PR TITLE
fix(legacy): improve input handling in frontend JS, HTML and test helpers

### DIFF
--- a/centreon/packages/js-config/cypress/component/configuration.js
+++ b/centreon/packages/js-config/cypress/component/configuration.js
@@ -63,8 +63,13 @@ module.exports = ({
           }
 
           // Save the testRetries object to a file in the e2e/results directory
+          const resolvedFolder = path.resolve(mainCypressFolder);
+          if (!resolvedFolder.startsWith(path.resolve(process.cwd()))) {
+            throw new Error('mainCypressFolder is outside of the project directory');
+          }
+
           const resultFilePath = path.join(
-            mainCypressFolder,
+            resolvedFolder,
             'results',
             'retries.json'
           );

--- a/centreon/packages/js-config/cypress/component/configuration.js
+++ b/centreon/packages/js-config/cypress/component/configuration.js
@@ -63,8 +63,9 @@ module.exports = ({
           }
 
           // Save the testRetries object to a file in the e2e/results directory
+          const projectRoot = path.resolve(process.cwd());
           const resolvedFolder = path.resolve(mainCypressFolder);
-          if (!resolvedFolder.startsWith(path.resolve(process.cwd()))) {
+          if (resolvedFolder !== projectRoot && !resolvedFolder.startsWith(projectRoot + path.sep)) {
             throw new Error('mainCypressFolder is outside of the project directory');
           }
 

--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -459,13 +459,14 @@ Output:\n${displayedOutput}`);
 
 interface RequestOnDatabaseProps {
   database: string;
+  params?: Array<string | number>;
   query: string;
 }
 
 Cypress.Commands.add(
   'requestOnDatabase',
-  ({ database, query }: RequestOnDatabaseProps): Cypress.Chainable => {
-    return cy.task('requestOnDatabase', { database, query });
+  ({ database, query, params }: RequestOnDatabaseProps): Cypress.Chainable => {
+    return cy.task('requestOnDatabase', { database, query, params });
   }
 );
 
@@ -1046,7 +1047,8 @@ declare global {
       }: NavigateToProps) => Cypress.Chainable;
       requestOnDatabase: ({
         database,
-        query
+        query,
+        params
       }: RequestOnDatabaseProps) => Cypress.Chainable;
       setUserTokenApiV1: ({
         login,

--- a/centreon/packages/js-config/cypress/e2e/commands/monitoring.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands/monitoring.ts
@@ -3,8 +3,6 @@
 const apiBase = '/centreon/api';
 const apiActionV1 = `${apiBase}/index.php`;
 
-const escapeSql = (value: string): string => value.replace(/'/g, "\\'");
-
 const getStatusNumberFromString = (status: string): number => {
   const statuses = {
     critical: '2',
@@ -34,12 +32,11 @@ Cypress.Commands.add(
     host,
     isForced = true
   }: ServiceCheck): Cypress.Chainable => {
-    let query = `SELECT id FROM resources WHERE name = '${escapeSql(host)}' AND type = 1`;
-
     return cy
       .requestOnDatabase({
         database: 'centreon_storage',
-        query
+        query: 'SELECT id FROM resources WHERE name = ? AND type = 1',
+        params: [host]
       })
       .then(([rows]) => {
         if (rows.length === 0) {
@@ -86,12 +83,11 @@ Cypress.Commands.add(
     isForced = true,
     service
   }: ServiceCheck): Cypress.Chainable => {
-    let query = `SELECT parent_id, id FROM resources WHERE parent_name = '${escapeSql(host)}' AND name = '${escapeSql(service)}'`;
-
     return cy
       .requestOnDatabase({
         database: 'centreon_storage',
-        query
+        query: 'SELECT parent_id, id FROM resources WHERE parent_name = ? AND name = ?',
+        params: [host, service]
       })
       .then(([rows]) => {
         if (rows.length === 0) {
@@ -183,22 +179,23 @@ Cypress.Commands.add(
     cy.log('Checking hosts in database');
 
     let query = `SELECT COUNT(d.downtime_id) AS count_downtimes FROM downtimes as d
-      INNER JOIN hosts as h ON h.host_id = d.host_id AND h.name = '${escapeSql(downtime.host)}'`;
+      INNER JOIN hosts as h ON h.host_id = d.host_id AND h.name = ?`;
+    const params: Array<string> = [downtime.host];
     if (downtime.service) {
-      query += ` INNER JOIN services as s ON s.service_id = d.service_id AND s.description = '${escapeSql(downtime.service)}'`;
+      query += ` INNER JOIN services as s ON s.service_id = d.service_id AND s.description = ?`;
+      params.push(downtime.service);
     }
     query += ` WHERE d.started=1`;
     if (!downtime.service) {
       query += ` AND d.service_id = 0`;
     }
 
-    cy.log(query);
-
     cy.waitUntil(() => {
       return cy
         .requestOnDatabase({
           database: 'centreon_storage',
-          query
+          query,
+          params
         })
         .then(([rows]) => {
           const foundDowntimesCount = rows.length ? rows[0].count_downtimes : 0;

--- a/centreon/packages/js-config/cypress/e2e/commands/monitoring.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands/monitoring.ts
@@ -3,6 +3,8 @@
 const apiBase = '/centreon/api';
 const apiActionV1 = `${apiBase}/index.php`;
 
+const escapeSql = (value: string): string => value.replace(/'/g, "\\'");
+
 const getStatusNumberFromString = (status: string): number => {
   const statuses = {
     critical: '2',
@@ -32,7 +34,7 @@ Cypress.Commands.add(
     host,
     isForced = true
   }: ServiceCheck): Cypress.Chainable => {
-    let query = `SELECT id FROM resources WHERE name = '${host}' AND type = 1`;
+    let query = `SELECT id FROM resources WHERE name = '${escapeSql(host)}' AND type = 1`;
 
     return cy
       .requestOnDatabase({
@@ -84,7 +86,7 @@ Cypress.Commands.add(
     isForced = true,
     service
   }: ServiceCheck): Cypress.Chainable => {
-    let query = `SELECT parent_id, id FROM resources WHERE parent_name = '${host}' AND name = '${service}'`;
+    let query = `SELECT parent_id, id FROM resources WHERE parent_name = '${escapeSql(host)}' AND name = '${escapeSql(service)}'`;
 
     return cy
       .requestOnDatabase({
@@ -181,9 +183,9 @@ Cypress.Commands.add(
     cy.log('Checking hosts in database');
 
     let query = `SELECT COUNT(d.downtime_id) AS count_downtimes FROM downtimes as d
-      INNER JOIN hosts as h ON h.host_id = d.host_id AND h.name = '${downtime.host}'`;
+      INNER JOIN hosts as h ON h.host_id = d.host_id AND h.name = '${escapeSql(downtime.host)}'`;
     if (downtime.service) {
-      query += ` INNER JOIN services as s ON s.service_id = d.service_id AND s.description = '${downtime.service}'`;
+      query += ` INNER JOIN services as s ON s.service_id = d.service_id AND s.description = '${escapeSql(downtime.service)}'`;
     }
     query += ` WHERE d.started=1`;
     if (!downtime.service) {

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -308,21 +308,34 @@ export default (on: Cypress.PluginEvents): void => {
       return path.join(downloadsFolder, files[0].name);
     },
     readCsvFile({ filePath }: { filePath: string }): Promise<string> {
+      const resolvedPath = path.resolve(filePath);
+      if (!resolvedPath.startsWith(path.resolve(process.cwd()))) {
+        return Promise.reject(new Error("Path is outside of the project directory"));
+      }
+
       return new Promise((resolve, reject) => {
-        fs.readFile(filePath, "utf8", (err, data) => {
+        fs.readFile(resolvedPath, "utf8", (err, data) => {
           if (err) return reject(err);
           resolve(data);
         });
       });
     },
     clearDownloadsFolder({ downloadsFolder }: { downloadsFolder: string }): null {
-      if (!fs.existsSync(downloadsFolder)) {
+      const resolvedFolder = path.resolve(downloadsFolder);
+      if (!resolvedFolder.startsWith(path.resolve(process.cwd()))) {
+        throw new Error("Path is outside of the project directory");
+      }
+
+      if (!fs.existsSync(resolvedFolder)) {
         return null;
       }
 
-      const files = fs.readdirSync(downloadsFolder);
+      const files = fs.readdirSync(resolvedFolder);
       for (const file of files) {
-        const filePath = path.join(downloadsFolder, file);
+        const filePath = path.join(resolvedFolder, file);
+        if (!filePath.startsWith(resolvedFolder)) {
+          continue;
+        }
         fs.unlinkSync(filePath);
       }
 

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -155,7 +155,7 @@ export default (on: Cypress.PluginEvents): void => {
 
       return container.getMappedPort(containerPort);
     },
-    requestOnDatabase: async ({ database, query }) => {
+    requestOnDatabase: async ({ database, query, params }) => {
       let container: StartedTestContainer | null = null;
 
       if (dockerEnvironment !== null) {
@@ -172,7 +172,9 @@ export default (on: Cypress.PluginEvents): void => {
         user: "centreon",
       });
 
-      const [rows, fields] = await client.query(query);
+      const [rows, fields] = params
+        ? await client.execute(query, params)
+        : await client.query(query);
 
       await client.end();
 
@@ -308,8 +310,9 @@ export default (on: Cypress.PluginEvents): void => {
       return path.join(downloadsFolder, files[0].name);
     },
     readCsvFile({ filePath }: { filePath: string }): Promise<string> {
+      const projectRoot = path.resolve(process.cwd());
       const resolvedPath = path.resolve(filePath);
-      if (!resolvedPath.startsWith(path.resolve(process.cwd()))) {
+      if (resolvedPath !== projectRoot && !resolvedPath.startsWith(projectRoot + path.sep)) {
         return Promise.reject(new Error("Path is outside of the project directory"));
       }
 
@@ -321,8 +324,9 @@ export default (on: Cypress.PluginEvents): void => {
       });
     },
     clearDownloadsFolder({ downloadsFolder }: { downloadsFolder: string }): null {
+      const projectRoot = path.resolve(process.cwd());
       const resolvedFolder = path.resolve(downloadsFolder);
-      if (!resolvedFolder.startsWith(path.resolve(process.cwd()))) {
+      if (resolvedFolder !== projectRoot && !resolvedFolder.startsWith(projectRoot + path.sep)) {
         throw new Error("Path is outside of the project directory");
       }
 
@@ -333,7 +337,7 @@ export default (on: Cypress.PluginEvents): void => {
       const files = fs.readdirSync(resolvedFolder);
       for (const file of files) {
         const filePath = path.join(resolvedFolder, file);
-        if (!filePath.startsWith(resolvedFolder)) {
+        if (!filePath.startsWith(resolvedFolder + path.sep)) {
           continue;
         }
         fs.unlinkSync(filePath);

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -172,13 +172,15 @@ export default (on: Cypress.PluginEvents): void => {
         user: "centreon",
       });
 
-      const [rows, fields] = params
-        ? await client.execute(query, params)
-        : await client.query(query);
+      try {
+        const [rows, fields] = params
+          ? await client.execute(query, params)
+          : await client.query(query);
 
-      await client.end();
-
-      return [rows, fields];
+        return [rows, fields];
+      } finally {
+        await client.end();
+      }
     },
     startContainer: async ({
       command,

--- a/centreon/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/GroupChip.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/GroupChip.tsx
@@ -91,7 +91,14 @@ const GroupChip = ({ group, type }: Props): JSX.Element => {
       return;
     }
 
-    window.location.href = group.configuration_uri;
+    try {
+      const resolved = new URL(group.configuration_uri, window.location.origin);
+      if (resolved.origin === window.location.origin) {
+        window.location.href = resolved.href;
+      }
+    } catch {
+      // invalid URI — do nothing
+    }
   }, [group]);
 
   const { name, id } = group;

--- a/centreon/www/front_src/src/Resources/Details/tabs/Notifications/Contacts.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Notifications/Contacts.tsx
@@ -37,6 +37,9 @@ const Contacts = ({
   noContactsMessage
 }: Props): ReactElement => {
   const goToUri = (uri: string): void => {
+    if (!uri) {
+      return;
+    }
     try {
       const resolved = new URL(uri, window.location.origin);
       if (resolved.origin === window.location.origin) {

--- a/centreon/www/front_src/src/Resources/Details/tabs/Notifications/Contacts.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Notifications/Contacts.tsx
@@ -37,7 +37,14 @@ const Contacts = ({
   noContactsMessage
 }: Props): ReactElement => {
   const goToUri = (uri: string): void => {
-    window.location.href = uri as string;
+    try {
+      const resolved = new URL(uri, window.location.origin);
+      if (resolved.origin === window.location.origin) {
+        window.location.href = resolved.href;
+      }
+    } catch {
+      // invalid URI — do nothing
+    }
   };
 
   const getConfigurationColumn = useCallback(

--- a/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/ext/geochrono/geochrono-api.js
+++ b/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/ext/geochrono/geochrono-api.js
@@ -32,6 +32,7 @@
         var includeJavascriptFile = function(filename) {
             var script = document.createElement("script");
             script.type = "text/javascript";
+            script.async = false;
             script.src = Timeline.urlPrefix + "ext/geochrono/scripts/" + filename;
             document.head.appendChild(script);
         };

--- a/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/ext/geochrono/geochrono-api.js
+++ b/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/ext/geochrono/geochrono-api.js
@@ -30,10 +30,17 @@
     
     try {
         var includeJavascriptFile = function(filename) {
-            document.write("<script src='" + Timeline.urlPrefix + "ext/geochrono/scripts/" + filename + "' type='text/javascript'></script>");
+            var script = document.createElement("script");
+            script.type = "text/javascript";
+            script.src = Timeline.urlPrefix + "ext/geochrono/scripts/" + filename;
+            document.head.appendChild(script);
         };
         var includeCssFile = function(filename) {
-            document.write("<link rel='stylesheet' href='" + Timeline.urlPrefix + "ext/geochrono/styles/" + filename + "' type='text/css'/>");
+            var link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.type = "text/css";
+            link.href = Timeline.urlPrefix + "ext/geochrono/styles/" + filename;
+            document.head.appendChild(link);
         }
         
         /*

--- a/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/scripts/timeline.js
+++ b/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/scripts/timeline.js
@@ -131,7 +131,11 @@ Timeline.loadJSON = function(url, f) {
         alert("Failed to load json data from " + url + "\n" + statusText);
     };
     var fDone = function(xmlhttp) {
-        f(JSON.parse(xmlhttp.responseText), url);
+        try {
+            f(JSON.parse(xmlhttp.responseText), url);
+        } catch (e) {
+            fError("Invalid JSON: " + e.message, 200, xmlhttp);
+        }
     };
     Timeline.XmlHttp.get(url, fError, fDone);
 };

--- a/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/scripts/timeline.js
+++ b/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/scripts/timeline.js
@@ -131,7 +131,7 @@ Timeline.loadJSON = function(url, f) {
         alert("Failed to load json data from " + url + "\n" + statusText);
     };
     var fDone = function(xmlhttp) {
-        f(eval('(' + xmlhttp.responseText + ')'), url);
+        f(JSON.parse(xmlhttp.responseText), url);
     };
     Timeline.XmlHttp.get(url, fError, fDone);
 };

--- a/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/timeline-api.js
+++ b/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/timeline-api.js
@@ -110,10 +110,17 @@ Timeline.Platform = new Object();
         })();
         
         var includeJavascriptFile = function(filename) {
-            document.write("<script src='" + Timeline.urlPrefix + "scripts/" + filename + "' type='text/javascript'></script>");
+            var script = document.createElement("script");
+            script.type = "text/javascript";
+            script.src = Timeline.urlPrefix + "scripts/" + filename;
+            document.head.appendChild(script);
         };
         var includeCssFile = function(filename) {
-            document.write("<link rel='stylesheet' href='" + Timeline.urlPrefix + "styles/" + filename + "' type='text/css'/>");
+            var link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.type = "text/css";
+            link.href = Timeline.urlPrefix + "styles/" + filename;
+            document.head.appendChild(link);
         }
         
         /*

--- a/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/timeline-api.js
+++ b/centreon/www/include/common/javascript/Timeline/src/main/webapp/api/timeline-api.js
@@ -112,6 +112,7 @@ Timeline.Platform = new Object();
         var includeJavascriptFile = function(filename) {
             var script = document.createElement("script");
             script.type = "text/javascript";
+            script.async = false;
             script.src = Timeline.urlPrefix + "scripts/" + filename;
             document.head.appendChild(script);
         };

--- a/centreon/www/include/common/javascript/jquery/plugins/jpaginator/index.html
+++ b/centreon/www/include/common/javascript/jquery/plugins/jpaginator/index.html
@@ -34,7 +34,7 @@
             maxBtnRight:'#test1_m_right',
             minSlidesForSlider:5,
             onPageClicked: function(a,num) {
-                $("#page1").html("demo1 - page : "+num);
+                $("#page1").text("demo1 - page : "+num);
             }
       	});
       
@@ -50,7 +50,7 @@
             withAcceleration:false,
             minSlidesForSlider:10,
             onPageClicked: function(a,num) {
-                $("#page2").html("demo2 - page : "+num);
+                $("#page2").text("demo2 - page : "+num);
             }
       	});
       
@@ -64,7 +64,7 @@
             maxBtnRight:'#test3_m_right',
         		coeffAcceleration:5,
             onPageClicked: function(a,num) {
-                $("#page3").html("demo3 - page : "+num);
+                $("#page3").text("demo3 - page : "+num);
             }
       	});
       

--- a/centreon/www/include/home/customViews/widgetParam.html
+++ b/centreon/www/include/home/customViews/widgetParam.html
@@ -112,8 +112,9 @@
             url: triggerSource,
             data: {data: triggerValue},
             success: function (response) {
+                var xmlDoc = (typeof response === 'string') ? jQuery.parseXML(response) : response;
                 jQuery("[name=param_" + targetId + "]").find('option').remove().end();
-                jQuery(response).find('option').each(function () {
+                jQuery(xmlDoc).find('option').each(function () {
                     jQuery("[name=param_" + targetId + "]").append(new Option(jQuery(this).find('label').text(),
                         triggerValue + '-' + jQuery(this).find('id').text(), true, true));
                 });


### PR DESCRIPTION
## Description

Remediate client-side security findings in frontend JS/TS/HTML files:

- Replace `eval()` with `JSON.parse()` in vendored SIMILE Timeline library
- Replace `document.write` with `createElement`/`appendChild` in Timeline bootstrap files
- Use safe XML parsing (`jQuery.parseXML`) instead of raw `jQuery(response)` in widget params
- Replace `.html()` with `.text()` in jPaginator demo page
- Validate redirect URIs against same-origin before assigning `window.location.href` in resource detail views
- Escape SQL interpolations in Cypress test helpers
- Add path traversal guards (`path.resolve` + base-dir assertion) in Cypress task handlers

Fixes: [MON-200903](https://centreon.atlassian.net/browse/MON-200903)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

- Verify Timeline widget still loads and displays data correctly on custom views
- Verify jPaginator demo page still renders page numbers
- Verify widget parameter trigger dropdowns still populate correctly
- Navigate to Resources Status > click a resource > Details tab > verify group chip configuration links still work
- Navigate to Resources Status > click a resource > Notifications tab > verify contact configuration links still work
- Run Cypress E2E tests to confirm test helpers still function

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-200903]: https://centreon.atlassian.net/browse/MON-200903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ