### PR TITLE
feat(logging): mask only #[Sensitive]-annotated payload fields

### DIFF
--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -198,3 +198,16 @@ services:
         autoconfigure: false
         tags:
             - { name: kernel.reset, method: reset }
+
+    # MON-199097 backport: #[Sensitive] payload masking. On develop these are
+    # autoconfigured via the App\Shared service loader (config.new); declared
+    # explicitly here since dev-24.10.x has no such loader. SanitizingProcessor
+    # is global (masks #[Sensitive] entries in every record's context).
+    App\Shared\Infrastructure\Logging\PayloadSanitizer:
+        autoconfigure: false
+
+    App\Shared\Infrastructure\Logging\SanitizingProcessor:
+        autoconfigure: false
+        arguments:
+            $sanitizer: '@App\Shared\Infrastructure\Logging\PayloadSanitizer'
+        tags: ['monolog.processor']

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -199,9 +199,10 @@ services:
         tags:
             - { name: kernel.reset, method: reset }
 
-    # #[Sensitive] payload masking, declared explicitly (no attribute-based
-    # service autoconfiguration on this serie). SanitizingProcessor is a global
-    # Monolog processor: it masks #[Sensitive] entries in every record's context.
+    # #[Sensitive] payload masking. The App\Shared namespace is not glob-loaded
+    # here, so these services are declared by hand; autoconfigure: false stops
+    # Symfony from also deriving the monolog.processor tag from #[AsMonologProcessor]
+    # and double-registering the processor.
     App\Shared\Infrastructure\Logging\PayloadSanitizer:
         autoconfigure: false
 

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -199,10 +199,9 @@ services:
         tags:
             - { name: kernel.reset, method: reset }
 
-    # MON-199097 backport: #[Sensitive] payload masking. On develop these are
-    # autoconfigured via the App\Shared service loader (config.new); declared
-    # explicitly here since dev-24.10.x has no such loader. SanitizingProcessor
-    # is global (masks #[Sensitive] entries in every record's context).
+    # #[Sensitive] payload masking, declared explicitly (no attribute-based
+    # service autoconfiguration on this serie). SanitizingProcessor is a global
+    # Monolog processor: it masks #[Sensitive] entries in every record's context.
     App\Shared\Infrastructure\Logging\PayloadSanitizer:
         autoconfigure: false
 

--- a/centreon/src/Adaptation/Database/Connection/Model/ConnectionConfig.php
+++ b/centreon/src/Adaptation/Database/Connection/Model/ConnectionConfig.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Adaptation\Database\Connection\Model;
 
 use Adaptation\Database\Connection\Enum\ConnectionDriverEnum;
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 
 /**
  * Class
@@ -42,6 +43,7 @@ final readonly class ConnectionConfig
     public function __construct(
         private string $host,
         private string $user,
+        #[Sensitive]
         private string $password,
         private string $databaseNameConfiguration,
         private string $databaseNameRealTime,

--- a/centreon/src/App/Shared/Domain/Logging/Attribute/Sensitive.php
+++ b/centreon/src/App/Shared/Domain/Logging/Attribute/Sensitive.php
@@ -21,30 +21,19 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace App\Shared\Domain\Logging\Attribute;
 
-use App\Shared\Domain\Logging\Attribute\Sensitive;
-
-class LogoutRequest
+/**
+ * Marks a value that must be masked (`***`) when the containing object
+ * flows through the logging pipeline. Allowed on:
+ *
+ *  - a **property** — its value is masked;
+ *  - a **method** (typically a getter) — the accessor key it exposes is
+ *    masked (`getX`/`isX`/`hasX` → `x`, otherwise the raw method name);
+ *  - a **class** — every value typed as that class is masked wholesale,
+ *    so the sanitiser never descends into it.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
+final readonly class Sensitive
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
-    }
 }

--- a/centreon/src/App/Shared/Infrastructure/Logging/Attribute/SensitivityScanner.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/Attribute/SensitivityScanner.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Logging\Attribute;
+
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
+/**
+ * Scans the `#[Sensitive]` markers and nested class types of a class.
+ * `#[Sensitive]` is honoured on three targets:
+ *
+ *  - **property** — the property value is masked;
+ *  - **method** — the accessor key it exposes (`getX`/`isX`/`hasX` →
+ *    `x`, otherwise the raw method name) is masked, matching how the
+ *    Symfony normalizer derives keys from getters;
+ *  - **class** — every value typed as that class is masked wholesale
+ *    (`classSensitive`), so the sanitiser never descends into it.
+ *
+ * Result cached per class to share the {@see \ReflectionClass} walk
+ * across every record produced by the same payload.
+ */
+final class SensitivityScanner
+{
+    /**
+     * @var array<class-string, array{
+     *     sensitive: list<string>,
+     *     subClasses: array<string, class-string>,
+     *     classSensitive: bool
+     * }>
+     */
+    private static array $cache = [];
+
+    /**
+     * @param class-string $class
+     *
+     * @throws \ReflectionException when the class does not exist or cannot be reflected
+     *
+     * @return array{
+     *     sensitive: list<string>,
+     *     subClasses: array<string, class-string>,
+     *     classSensitive: bool
+     * }
+     */
+    public static function scan(string $class): array
+    {
+        if (isset(self::$cache[$class])) {
+            return self::$cache[$class];
+        }
+
+        $sensitive = [];
+        $subClasses = [];
+
+        $reflection = new \ReflectionClass($class);
+        $classSensitive = $reflection->getAttributes(Sensitive::class) !== [];
+
+        foreach ($reflection->getProperties() as $property) {
+            $name = $property->getName();
+
+            if ($property->getAttributes(Sensitive::class) !== []) {
+                $sensitive[] = $name;
+            }
+
+            $type = $property->getType();
+            if ($type instanceof \ReflectionNamedType && ! $type->isBuiltin()) {
+                /** @var class-string $typeName */
+                $typeName = $type->getName();
+                $subClasses[$name] = $typeName;
+            }
+        }
+
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->getAttributes(Sensitive::class) === []) {
+                continue;
+            }
+
+            $key = self::accessorKey($method->getName());
+            if (! \in_array($key, $sensitive, true)) {
+                $sensitive[] = $key;
+            }
+        }
+
+        return self::$cache[$class] = [
+            'sensitive' => $sensitive,
+            'subClasses' => $subClasses,
+            'classSensitive' => $classSensitive,
+        ];
+    }
+
+    /**
+     * Reset the cache. Reserved for tests — production callers must
+     * never invoke this, the scan is otherwise stable for the lifetime
+     * of a process.
+     *
+     * @internal
+     */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
+     * Derives the payload key a method exposes, mirroring the Symfony
+     * normalizer: `getPasscode` → `passcode`, `isActive` → `active`,
+     * `hasToken` → `token`; any other method keeps its own name.
+     */
+    private static function accessorKey(string $method): string
+    {
+        foreach (['get', 'is', 'has'] as $prefix) {
+            if (\str_starts_with($method, $prefix) && \mb_strlen($method) > \mb_strlen($prefix)) {
+                return \lcfirst(\mb_substr($method, \mb_strlen($prefix)));
+            }
+        }
+
+        return $method;
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -27,12 +27,12 @@ use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
 
 /**
  * Stateless walker that masks the values of `#[Sensitive]`-annotated
- * properties inside an arbitrary payload (a Command/Query, an ad-hoc
- * logger context, anything Monolog forwards to a handler).
+ * properties inside an arbitrary payload (an ad-hoc logger context,
+ * anything Monolog forwards to a handler).
  *
  * Typed payloads are masked **attribute-driven**: a property without
  * `#[Sensitive]` is logged in clear, the owning class declares its
- * sensitivity explicitly. As the cross-channel net, raw array keys are
+ * sensitivity explicitly. As an extra net, raw array keys are
  * additionally matched against {@see SensitiveKeywordDenylist} so that
  * an ad-hoc `$logger->error('m', ['token' => $x])` — which carries no
  * class to reflect — is still caught.

--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Logging;
+
+use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
+
+/**
+ * Stateless walker that masks the values of `#[Sensitive]`-annotated
+ * properties inside an arbitrary payload (a Command/Query, an ad-hoc
+ * logger context, anything Monolog forwards to a handler).
+ *
+ * Typed payloads are masked **attribute-driven**: a property without
+ * `#[Sensitive]` is logged in clear, the owning class declares its
+ * sensitivity explicitly. As the cross-channel net, raw array keys are
+ * additionally matched against {@see SensitiveKeywordDenylist} so that
+ * an ad-hoc `$logger->error('m', ['token' => $x])` — which carries no
+ * class to reflect — is still caught.
+ *
+ * Object values are rendered defensively to avoid leaking private
+ * properties; `\Throwable` instances are returned as-is so that
+ * `ExceptionFormatterProcessor` can format them downstream.
+ */
+final readonly class PayloadSanitizer
+{
+    public const MAX_DEPTH = 3;
+    public const MAX_VALUE_LENGTH = 1024;
+
+    /**
+     * @param class-string|null $contextClass class whose `#[Sensitive]`
+     *                                        attributes annotate the
+     *                                        array keys at the current
+     *                                        depth, or `null` when the
+     *                                        type at this level is
+     *                                        scalar / array / unknown
+     *
+     * @throws \ReflectionException when SensitivityScanner cannot reflect the context class
+     */
+    public function sanitize(mixed $data, int $depth = 0, ?string $contextClass = null): mixed
+    {
+        if ($depth >= self::MAX_DEPTH) {
+            return '{…}';
+        }
+
+        if (\is_array($data)) {
+            $sensitive = [];
+            $subClasses = [];
+            if ($contextClass !== null && class_exists($contextClass)) {
+                $scan = SensitivityScanner::scan($contextClass);
+                $sensitive = $scan['sensitive'];
+                $subClasses = $scan['subClasses'];
+            }
+
+            $result = [];
+            foreach ($data as $key => $value) {
+                // `context.exception` carries one of two legitimate shapes: a raw
+                // Throwable (handed to ExceptionFormatterProcessor downstream) or an
+                // already-structured exception array (ExceptionFormatter::format),
+                // whose nested chain is deeper than MAX_DEPTH and must not be
+                // truncated. Leave both intact; any other type under this key falls
+                // through to the normal masking walk.
+                if ($key === 'exception' && ($value instanceof \Throwable || \is_array($value))) {
+                    $result[$key] = $value;
+
+                    continue;
+                }
+
+                if (\is_string($key)
+                    && (\in_array($key, $sensitive, true) || SensitiveKeywordDenylist::matches($key))
+                ) {
+                    $result[$key] = '***';
+
+                    continue;
+                }
+
+                $childContext = (\is_string($key) ? ($subClasses[$key] ?? null) : null);
+
+                // A `#[Sensitive]` class masks every value typed as it,
+                // so the whole sub-payload is redacted without descending.
+                if ($childContext !== null
+                    && class_exists($childContext)
+                    && SensitivityScanner::scan($childContext)['classSensitive']
+                ) {
+                    $result[$key] = '***';
+
+                    continue;
+                }
+
+                $result[$key] = $this->sanitize($value, $depth + 1, $childContext);
+            }
+
+            return $result;
+        }
+
+        if (\is_object($data)) {
+            return $this->sanitizeObject($data);
+        }
+
+        if (\is_string($data) && \mb_strlen($data) > self::MAX_VALUE_LENGTH) {
+            return mb_substr($data, 0, self::MAX_VALUE_LENGTH) . '…[truncated]';
+        }
+
+        return $data;
+    }
+
+    /**
+     * Defense-in-depth for objects normalisation would otherwise pass
+     * through as-is (DateTime without a dedicated normalizer, Enum, VO
+     * without a custom normalizer). Without this branch, a nested
+     * object could carry an unmasked sensitive property all the way
+     * down to the Monolog LineFormatter.
+     *
+     * `\Throwable` instances are returned as-is — they are the
+     * dedicated input of {@see ExceptionFormatterProcessor} and must
+     * survive the sanitisation walk.
+     */
+    private function sanitizeObject(object $data): mixed
+    {
+        if ($data instanceof \Throwable) {
+            return $data;
+        }
+
+        if ($data instanceof \BackedEnum) {
+            return $data->value;
+        }
+
+        if ($data instanceof \UnitEnum) {
+            return $data->name;
+        }
+
+        if ($data instanceof \DateTimeInterface) {
+            return $data->format(\DateTimeInterface::ATOM);
+        }
+
+        if ($data instanceof \Stringable) {
+            $string = (string) $data;
+
+            return \mb_strlen($string) > self::MAX_VALUE_LENGTH
+                ? mb_substr($string, 0, self::MAX_VALUE_LENGTH) . '…[truncated]'
+                : $string;
+        }
+
+        return '{' . $data::class . '}';
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
@@ -27,11 +27,11 @@ use Monolog\Attribute\AsMonologProcessor;
 use Monolog\LogRecord;
 
 /**
- * Monolog processor that masks `#[Sensitive]` entries in every
- * record's `context` through {@see PayloadSanitizer}. Covers the
- * ad-hoc `$logger->error('msg', $context)` paths that bypass the
- * bus middleware. `\Throwable` values are returned as-is so that
- * {@see ExceptionFormatterProcessor} can structure them downstream.
+ * Global Monolog processor that masks `#[Sensitive]` entries in every
+ * record's `context` through {@see PayloadSanitizer}, including the
+ * ad-hoc `$logger->error('msg', $context)` calls. `\Throwable` values
+ * are returned as-is so that {@see ExceptionFormatterProcessor} can
+ * structure them downstream.
  */
 #[AsMonologProcessor]
 final readonly class SanitizingProcessor

--- a/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Logging;
+
+use Monolog\Attribute\AsMonologProcessor;
+use Monolog\LogRecord;
+
+/**
+ * Monolog processor that masks `#[Sensitive]` entries in every
+ * record's `context` through {@see PayloadSanitizer}. Covers the
+ * ad-hoc `$logger->error('msg', $context)` paths that bypass the
+ * bus middleware. `\Throwable` values are returned as-is so that
+ * {@see ExceptionFormatterProcessor} can structure them downstream.
+ */
+#[AsMonologProcessor]
+final readonly class SanitizingProcessor
+{
+    public function __construct(private PayloadSanitizer $sanitizer)
+    {
+    }
+
+    /**
+     * @throws \ReflectionException propagated from PayloadSanitizer when a context class cannot be reflected
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        /** @var array<string, mixed> $sanitized */
+        $sanitized = $this->sanitizer->sanitize($record->context);
+
+        return $record->with(context: $sanitized);
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Logging;
+
+/**
+ * Single source of truth for the keyword-based masking net shared by
+ * {@see LogPayloadNormalizer} (bus messages) and {@see PayloadSanitizer}
+ * (ad-hoc logger contexts). Keeping one list guarantees both nets mask
+ * the same field names instead of drifting apart.
+ *
+ * Matched via str_contains on the lowercased key — intentionally
+ * permissive: any field name that *contains* one of these tokens is
+ * masked (e.g. `oauth_authorization_url`, `password_changed_at`,
+ * `customer_token_id`). Over-masking is preferred to under-masking so a
+ * variant we did not anticipate can't leak a real secret.
+ */
+final class SensitiveKeywordDenylist
+{
+    public const KEYWORDS = ['password', 'token', 'secret', 'api_key', 'authorization', 'credential', 'private_key'];
+
+    /**
+     * Memoises the sensitive-or-not verdict per key to skip the keyword
+     * scan on repeated fields.
+     *
+     * @var array<string, bool>
+     */
+    private static array $cache = [];
+
+    public static function matches(string $key): bool
+    {
+        if (isset(self::$cache[$key])) {
+            return self::$cache[$key];
+        }
+
+        $lower = mb_strtolower($key);
+
+        foreach (self::KEYWORDS as $keyword) {
+            if (str_contains($lower, $keyword)) {
+                return self::$cache[$key] = true;
+            }
+        }
+
+        return self::$cache[$key] = false;
+    }
+
+    /**
+     * Reset the cache. Reserved for tests — production callers must never
+     * invoke this, the verdict is otherwise stable for the process.
+     *
+     * @internal
+     */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
@@ -24,10 +24,8 @@ declare(strict_types=1);
 namespace App\Shared\Infrastructure\Logging;
 
 /**
- * Single source of truth for the keyword-based masking net shared by
- * {@see LogPayloadNormalizer} (bus messages) and {@see PayloadSanitizer}
- * (ad-hoc logger contexts). Keeping one list guarantees both nets mask
- * the same field names instead of drifting apart.
+ * Single source of truth for the keyword-based masking net used by
+ * {@see PayloadSanitizer} (ad-hoc logger contexts).
  *
  * Matched via str_contains on the lowercased key — intentionally
  * permissive: any field name that *contains* one of these tokens is

--- a/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApiRequest.php
+++ b/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApiRequest.php
@@ -23,12 +23,15 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Authentication\UseCase;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 class AuthenticateApiRequest
 {
     /** @var string */
     private $login;
 
     /** @var string */
+    #[Sensitive]
     private $password;
 
     /**

--- a/centreon/src/Centreon/Domain/Contact/Contact.php
+++ b/centreon/src/Centreon/Domain/Contact/Contact.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Contact;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Menu\Model\Page;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -156,9 +157,11 @@ class Contact implements UserInterface, ContactInterface
     private $isAllowedToReachWeb;
 
     /** @var string|null Authentication Token */
+    #[Sensitive]
     private $token;
 
     /** @var string|null Encoded password */
+    #[Sensitive]
     private $encodedPassword;
 
     /** @var bool Indicates if this user has access to the configuration section of API */

--- a/centreon/src/Centreon/Domain/Gorgone/ActionLog.php
+++ b/centreon/src/Centreon/Domain/Gorgone/ActionLog.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Gorgone;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 /**
  * This class is designed to represent a action log received by the Gorgone server.
  *
@@ -42,6 +44,7 @@ class ActionLog
     private $id;
 
     /** @var string Token of the response */
+    #[Sensitive]
     private $token;
 
     /**

--- a/centreon/src/Centreon/Domain/Gorgone/Command/AbstractCommand.php
+++ b/centreon/src/Centreon/Domain/Gorgone/Command/AbstractCommand.php
@@ -23,11 +23,13 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Gorgone\Command;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Gorgone\Interfaces\CommandInterface;
 
 abstract class AbstractCommand
 {
     /** @var string token of the command assigned by the Gorgone server */
+    #[Sensitive]
     private $token;
 
     /** @var int Poller id */

--- a/centreon/src/Centreon/Domain/Gorgone/Response.php
+++ b/centreon/src/Centreon/Domain/Gorgone/Response.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Gorgone;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Gorgone\Interfaces\CommandInterface;
 use Centreon\Domain\Gorgone\Interfaces\ResponseInterface;
 use Centreon\Domain\Gorgone\Interfaces\ResponseRepositoryInterface;
@@ -48,6 +49,7 @@ class Response implements ResponseInterface
      * @var string|null token assigned by the Gorgone server to this response which must be equal to the
      *                  associated command
      */
+    #[Sensitive]
     private $token;
 
     /** @var ActionLog[] action logs based on the command sent to the Gorgone server */

--- a/centreon/src/Centreon/Domain/Proxy/Proxy.php
+++ b/centreon/src/Centreon/Domain/Proxy/Proxy.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Proxy;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 /**
  * This class is designed to represent a proxy configuration.
  *
@@ -57,6 +59,7 @@ class Proxy
     private $user;
 
     /** @var string|null */
+    #[Sensitive]
     private $password;
 
     /** @var string Proxy connection protocol (default: Proxy::PROTOCOL_HTTP) */

--- a/centreon/src/Centreon/Domain/Security/AuthenticationToken.php
+++ b/centreon/src/Centreon/Domain/Security/AuthenticationToken.php
@@ -23,9 +23,12 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Security;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 class AuthenticationToken
 {
     /** @var string Authentication token */
+    #[Sensitive]
     private $token;
 
     /** @var \DateTime Generation date of the authentication token */

--- a/centreon/src/Core/Proxy/Domain/Model/Proxy.php
+++ b/centreon/src/Core/Proxy/Domain/Model/Proxy.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Proxy\Domain\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 
@@ -42,6 +43,7 @@ class Proxy implements \Stringable
         private string $url,
         readonly private ?int $port = null,
         private ?string $login = null,
+        #[Sensitive]
         private ?string $password = null,
     ) {
         $this->url = trim($this->url);

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/LoginRequest.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/LoginRequest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\UseCase\Login;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 
 final class LoginRequest
@@ -41,6 +42,7 @@ final class LoginRequest
         public string $providerName,
         public ?string $clientIp = null,
         public ?string $username = null,
+        #[Sensitive]
         public ?string $password = null,
         public ?string $code = null,
         public ?string $refererQueryParameters = null,

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/ThirdPartyLoginForm.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/ThirdPartyLoginForm.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\UseCase\Login;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
@@ -44,6 +45,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 final class ThirdPartyLoginForm
 {
+    #[Sensitive]
     private string $token = '';
 
     private ?bool $isActive = null;

--- a/centreon/src/Core/Security/Authentication/Domain/Model/AuthenticationTokens.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Model/AuthenticationTokens.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Domain\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 class AuthenticationTokens
 {
     /**
@@ -35,6 +37,7 @@ class AuthenticationTokens
     public function __construct(
         private int $userId,
         private int $configurationProviderId,
+        #[Sensitive]
         private string $sessionToken,
         private NewProviderToken|ProviderToken $providerToken,
         private NewProviderToken|ProviderToken|null $providerRefreshToken,

--- a/centreon/src/Core/Security/Authentication/Domain/Model/NewProviderToken.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Model/NewProviderToken.php
@@ -23,9 +23,11 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Domain\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use DateTime;
 use DateTimeImmutable;
 
+#[Sensitive]
 class NewProviderToken
 {
     /**

--- a/centreon/src/Core/Security/Authentication/Domain/Model/ProviderToken.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Model/ProviderToken.php
@@ -23,12 +23,14 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Domain\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use DateTimeImmutable;
 
 class ProviderToken extends NewProviderToken
 {
     public function __construct(
         private int $id,
+        #[Sensitive]
         private string $token,
         private DateTimeImmutable $creationDate,
         private ?DateTimeImmutable $expirationDate = null,

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Application\OpenId\UseCase\FindOpenIdConfiguration;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Core\Contact\Domain\Model\ContactTemplate;
 use Core\Security\ProviderConfiguration\Domain\Model\ACLConditions;
 use Core\Security\ProviderConfiguration\Domain\Model\AuthenticationConditions;
@@ -108,6 +109,7 @@ final class FindOpenIdConfigurationResponse
     public ?string $clientId = null;
 
     /** @var string|null */
+    #[Sensitive]
     public ?string $clientSecret = null;
 
     /** @var string|null */

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationRequest.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationRequest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Application\OpenId\UseCase\UpdateOpenIdConfiguration;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 /**
  * @phpstan-type _RoleMapping array{
  *  is_enabled: bool,
@@ -122,6 +124,7 @@ final class UpdateOpenIdConfigurationRequest
     public ?string $clientId = null;
 
     /** @var string|null */
+    #[Sensitive]
     public ?string $clientSecret = null;
 
     /** @var string|null */

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfiguration.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Domain\OpenId\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Core\Contact\Domain\Model\ContactGroup;
 use Core\Contact\Domain\Model\ContactTemplate;
 use Core\Security\ProviderConfiguration\Domain\CustomConfigurationInterface;
@@ -66,6 +67,7 @@ class CustomConfiguration implements CustomConfigurationInterface, OpenIdCustomC
     private ?string $clientId = null;
 
     /** @var string|null */
+    #[Sensitive]
     private ?string $clientSecret = null;
 
     /** @var string|null */

--- a/centreon/src/Core/Security/Token/Application/UseCase/GetToken/GetTokenResponse.php
+++ b/centreon/src/Core/Security/Token/Application/UseCase/GetToken/GetTokenResponse.php
@@ -23,13 +23,16 @@ declare(strict_types=1);
 
 namespace Core\Security\Token\Application\UseCase\GetToken;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Core\Application\Common\UseCase\StandardResponseInterface;
 use Core\Security\Token\Domain\Model\Token;
 
 final class GetTokenResponse implements StandardResponseInterface
 {
     public function __construct(
+        #[Sensitive]
         public Token $token,
+        #[Sensitive]
         public string $tokenString,
     ) {
     }

--- a/centreon/src/Core/Security/Token/Domain/Model/NewApiToken.php
+++ b/centreon/src/Core/Security/Token/Domain/Model/NewApiToken.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Token\Domain\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Common\Domain\TrimmedString;
@@ -30,6 +31,7 @@ use Security\Encryption;
 
 final class NewApiToken extends NewToken
 {
+    #[Sensitive]
     private string $token;
 
     /**

--- a/centreon/src/Core/Security/User/Domain/Model/User.php
+++ b/centreon/src/Core/Security/User/Domain/Model/User.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Security\User\Domain\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 class User
 {
     /**
@@ -37,6 +39,7 @@ class User
         private int $id,
         private string $alias,
         private array $oldPasswords,
+        #[Sensitive]
         private UserPassword $password,
         private ?int $loginAttempts,
         private ?\DateTimeImmutable $blockingTime,

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\Security\Vault\Domain\Model;
 
 use App\Shared\Domain\Assert\Assert as CentreonAssert;
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Security\Interfaces\EncryptionInterface;
 
@@ -77,6 +78,7 @@ class VaultConfiguration
         private string $rootPath,
         private string $encryptedRoleId,
         private string $encryptedSecretId,
+        #[Sensitive]
         private string $salt,
     ) {
         $this->setName($name);

--- a/centreon/src/Security/Domain/Authentication/Model/AuthenticationTokens.php
+++ b/centreon/src/Security/Domain/Authentication/Model/AuthenticationTokens.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Security\Domain\Authentication\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
 use Centreon\Domain\Common\Assertion\Assertion;
 
 class AuthenticationTokens
@@ -30,6 +31,7 @@ class AuthenticationTokens
     private const SESSION_TOKEN_MIN_LENGTH = 1;
 
     /** @var string */
+    #[Sensitive]
     private $sessionToken;
 
     /** @var ProviderToken */

--- a/centreon/src/Security/Domain/Authentication/Model/ProviderToken.php
+++ b/centreon/src/Security/Domain/Authentication/Model/ProviderToken.php
@@ -23,12 +23,15 @@ declare(strict_types=1);
 
 namespace Security\Domain\Authentication\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 class ProviderToken
 {
     /** @var int|null */
     private $id;
 
     /** @var string */
+    #[Sensitive]
     private $token;
 
     /** @var \DateTime */

--- a/centreon/src/Security/Domain/Authentication/Model/Session.php
+++ b/centreon/src/Security/Domain/Authentication/Model/Session.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Security\Domain\Authentication\Model;
 
+use App\Shared\Domain\Logging\Attribute\Sensitive;
+
 class Session
 {
     /**
@@ -31,6 +33,7 @@ class Session
      * @param string|null $clientIp
      */
     public function __construct(
+        #[Sensitive]
         private string $token,
         private int $contactId,
         private ?string $clientIp,

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/CardHolderCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/CardHolderCommand.php
@@ -21,30 +21,17 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
-use App\Shared\Domain\Logging\Attribute\Sensitive;
-
-class LogoutRequest
+/**
+ * Carries a {@see SensitiveValueObject} typed property to pin that a
+ * `#[Sensitive]` class is masked wholesale through recursion.
+ */
+final readonly class CardHolderCommand
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
+    public function __construct(
+        public SensitiveValueObject $card,
+        public string $label,
+    ) {
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/MethodSecretCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/MethodSecretCommand.php
@@ -21,30 +21,26 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
-class LogoutRequest
+/**
+ * Pins the TARGET_METHOD path: a `#[Sensitive]` getter masks the
+ * accessor key it exposes (`getApiToken` → `apiToken`), exactly like an
+ * annotated property would.
+ */
+final readonly class MethodSecretCommand
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
+    public function __construct(
+        private string $apiToken,
+        public string $login,
+    ) {
     }
 
-    /**
-     * @return string
-     */
-    public function getToken(): string
+    #[Sensitive]
+    public function getApiToken(): string
     {
-        return $this->token;
+        return $this->apiToken;
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/NestedInnerPayload.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/NestedInnerPayload.php
@@ -21,30 +21,21 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
-class LogoutRequest
+/**
+ * Nested value object carried by {@see NestedPayloadCommand} — pins
+ * that recursive sanitisation honours `#[Sensitive]` declared on a
+ * sub-class typed property, not only on the top-level Command itself.
+ */
+final readonly class NestedInnerPayload
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
+    public function __construct(
+        #[Sensitive]
+        public string $passcode,
+        public string $label,
+    ) {
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/NestedPayloadCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/NestedPayloadCommand.php
@@ -21,30 +21,12 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
-use App\Shared\Domain\Logging\Attribute\Sensitive;
-
-class LogoutRequest
+final readonly class NestedPayloadCommand
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
+    public function __construct(
+        public NestedInnerPayload $inner,
+    ) {
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/PlainCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/PlainCommand.php
@@ -21,30 +21,13 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
-use App\Shared\Domain\Logging\Attribute\Sensitive;
-
-class LogoutRequest
+final readonly class PlainCommand
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
+    public function __construct(
+        public string $login,
+        public int $userId,
+    ) {
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/SecretsCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/SecretsCommand.php
@@ -21,30 +21,23 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
-class LogoutRequest
+/**
+ * Covers the MON-199097 under-mask cases: `passcode`, `ssoTicket` are
+ * real secrets but don't match any keyword of the shared
+ * `SensitiveKeywordDenylist` — `#[Sensitive]` lifts the gap.
+ */
+final readonly class SecretsCommand
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
+    public function __construct(
+        #[Sensitive]
+        public string $passcode,
+        #[Sensitive]
+        public string $ssoTicket,
+        public int $userId,
+    ) {
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/SecretsCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/SecretsCommand.php
@@ -26,7 +26,7 @@ namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
 /**
- * Covers the MON-199097 under-mask cases: `passcode`, `ssoTicket` are
+ * Covers the under-mask cases: `passcode`, `ssoTicket` are
  * real secrets but don't match any keyword of the shared
  * `SensitiveKeywordDenylist` — `#[Sensitive]` lifts the gap.
  */

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/SensitiveValueObject.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/SensitiveValueObject.php
@@ -21,30 +21,21 @@
 
 declare(strict_types=1);
 
-namespace Centreon\Domain\Authentication\UseCase;
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
 
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
-class LogoutRequest
+/**
+ * Pins the TARGET_CLASS path: the whole value object is sensitive, so
+ * any property typed as it must be masked wholesale by the sanitiser
+ * without descending into its own properties.
+ */
+#[Sensitive]
+final readonly class SensitiveValueObject
 {
-    /**
-     * Authentication Token
-     *
-     * @var string
-     */
-    #[Sensitive]
-    private $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken(): string
-    {
-        return $this->token;
+    public function __construct(
+        public string $number,
+        public string $holder,
+    ) {
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/SensitivityScannerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/SensitivityScannerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute;
+
+use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\MethodSecretCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\NestedInnerPayload;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\NestedPayloadCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\PlainCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\SecretsCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\SensitiveValueObject;
+
+final class SensitivityScannerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SensitivityScanner::reset();
+    }
+
+    public function testReturnsEmptySensitiveListForClassWithoutAnnotations(): void
+    {
+        $scan = SensitivityScanner::scan(PlainCommand::class);
+
+        self::assertSame([], $scan['sensitive']);
+    }
+
+    public function testCollectsSensitivePropertyNames(): void
+    {
+        $scan = SensitivityScanner::scan(SecretsCommand::class);
+
+        self::assertSame(['passcode', 'ssoTicket'], $scan['sensitive']);
+    }
+
+    public function testCollectsAccessorKeyFromSensitiveMethod(): void
+    {
+        $scan = SensitivityScanner::scan(MethodSecretCommand::class);
+
+        // `#[Sensitive] getApiToken()` masks the `apiToken` key the
+        // normalizer derives from the getter.
+        self::assertSame(['apiToken'], $scan['sensitive']);
+    }
+
+    public function testFlagsClassAnnotatedAsSensitive(): void
+    {
+        $scan = SensitivityScanner::scan(SensitiveValueObject::class);
+
+        self::assertTrue($scan['classSensitive']);
+    }
+
+    public function testDoesNotFlagPlainClassAsSensitive(): void
+    {
+        $scan = SensitivityScanner::scan(PlainCommand::class);
+
+        self::assertFalse($scan['classSensitive']);
+    }
+
+    public function testResolvesNonBuiltinPropertyTypesForRecursiveSanitisation(): void
+    {
+        $scan = SensitivityScanner::scan(NestedPayloadCommand::class);
+
+        self::assertSame(['inner' => NestedInnerPayload::class], $scan['subClasses']);
+    }
+
+    public function testCachesScanResultBetweenCalls(): void
+    {
+        // Same class scanned twice — second call must return the same
+        // array (the cache is the contract, otherwise every dispatch of
+        // the same Command class re-walks its ReflectionClass).
+        $first = SensitivityScanner::scan(SecretsCommand::class);
+        $second = SensitivityScanner::scan(SecretsCommand::class);
+
+        self::assertSame($first, $second);
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Double/BackedColour.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Double/BackedColour.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Logging\Double;
+
+enum BackedColour: string
+{
+    case Red = 'red';
+    case Blue = 'blue';
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Logging;
+
+use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
+use App\Shared\Infrastructure\Logging\PayloadSanitizer;
+use App\Shared\Infrastructure\Logging\SensitiveKeywordDenylist;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\CardHolderCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\MethodSecretCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\NestedPayloadCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\SecretsCommand;
+
+final class PayloadSanitizerTest extends TestCase
+{
+    private PayloadSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        SensitivityScanner::reset();
+        SensitiveKeywordDenylist::reset();
+        $this->sanitizer = new PayloadSanitizer();
+    }
+
+    public function testMasksKeywordKeysOfRawArraysWithoutAContextClass(): void
+    {
+        // No contextClass: there is no class to scan for #[Sensitive].
+        // As the cross-channel net, the sanitiser still masks raw array
+        // keys that match the shared keyword denylist, so an ad-hoc
+        // `$logger->error('m', ['password' => ...])` cannot leak.
+        $sanitised = $this->sanitizer->sanitize([
+            'login' => 'admin',
+            'password' => 'secret123',
+            'api_key' => 'abc',
+        ]);
+
+        self::assertSame(
+            ['login' => 'admin', 'password' => '***', 'api_key' => '***'],
+            $sanitised,
+        );
+    }
+
+    public function testMasksOnlyTheAnnotatedPropertiesOfTheContextClass(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(
+            ['passcode' => '482031', 'ssoTicket' => 'st-abc', 'userId' => 7],
+            0,
+            SecretsCommand::class,
+        );
+
+        self::assertSame(['passcode' => '***', 'ssoTicket' => '***', 'userId' => 7], $sanitised);
+    }
+
+    public function testRecursesIntoTypedSubObjectsToHonourNestedAnnotations(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(
+            ['inner' => ['passcode' => '482031', 'label' => 'two-factor']],
+            0,
+            NestedPayloadCommand::class,
+        );
+
+        self::assertSame(['inner' => ['passcode' => '***', 'label' => 'two-factor']], $sanitised);
+    }
+
+    public function testMasksTheAccessorKeyExposedByASensitiveMethod(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(
+            ['apiToken' => 'tok-123', 'login' => 'admin'],
+            0,
+            MethodSecretCommand::class,
+        );
+
+        self::assertSame(['apiToken' => '***', 'login' => 'admin'], $sanitised);
+    }
+
+    public function testMasksWholeValueTypedAsASensitiveClass(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(
+            [
+                'card' => ['number' => 'card-number-test', 'holder' => 'admin'],
+                'label' => 'default card',
+            ],
+            0,
+            CardHolderCommand::class,
+        );
+
+        // The `card` property is typed as a `#[Sensitive]` class: the
+        // whole sub-payload is masked, never descended into.
+        self::assertSame(['card' => '***', 'label' => 'default card'], $sanitised);
+    }
+
+    public function testReturnsThrowableUntouchedSoExceptionFormatterCanStructureIt(): void
+    {
+        // Pin the contract relied on by ExceptionFormatterProcessor:
+        // a raw Throwable in the context survives sanitisation as-is,
+        // otherwise the downstream processor would see a placeholder
+        // string and could not unwrap the chain.
+        $exception = new \RuntimeException('boom');
+
+        $sanitised = $this->sanitizer->sanitize(['exception' => $exception, 'context_id' => 7]);
+
+        \assert(\is_array($sanitised));
+        self::assertSame($exception, $sanitised['exception']);
+        self::assertSame(7, $sanitised['context_id']);
+    }
+
+    public function testTruncatesStringsLongerThanCap(): void
+    {
+        $longString = str_repeat('a', 2000);
+
+        $sanitised = $this->sanitizer->sanitize(['note' => $longString]);
+
+        \assert(\is_array($sanitised));
+        self::assertSame(str_repeat('a', 1024) . '…[truncated]', $sanitised['note']);
+    }
+
+    public function testCapsRecursionDepth(): void
+    {
+        // 4 levels deep: the cap is 3, so the innermost array must be
+        // collapsed to the `{…}` marker.
+        $nested = ['l1' => ['l2' => ['l3' => ['l4' => 'reached']]]];
+
+        $sanitised = $this->sanitizer->sanitize($nested);
+
+        \assert(\is_array($sanitised));
+        \assert(\is_array($sanitised['l1']));
+        \assert(\is_array($sanitised['l1']['l2']));
+        self::assertSame('{…}', $sanitised['l1']['l2']['l3']);
+    }
+
+    public function testRendersBackedEnumByValue(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(['status' => Double\BackedColour::Red]);
+
+        \assert(\is_array($sanitised));
+        self::assertSame('red', $sanitised['status']);
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Logging;
+
+use App\Shared\Infrastructure\Logging\PayloadSanitizer;
+use App\Shared\Infrastructure\Logging\SanitizingProcessor;
+use Monolog\Level;
+use Monolog\LogRecord;
+use PHPUnit\Framework\TestCase;
+
+final class SanitizingProcessorTest extends TestCase
+{
+    private SanitizingProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->processor = new SanitizingProcessor(new PayloadSanitizer());
+    }
+
+    public function testMasksKeywordKeysOfAdHocContextWhenNoClassContextIsAvailable(): void
+    {
+        // The cross-channel safety net catches ad-hoc raw arrays too: an
+        // `$logger->error('msg', ['password' => $raw])` carries no class
+        // context, so there is no `#[Sensitive]` to reflect — the shared
+        // keyword denylist masks the matching keys instead. Keys that
+        // match nothing (`login`) stay in clear.
+        $record = $this->makeRecord(['login' => 'admin', 'password' => 'secret123']);
+
+        $processed = ($this->processor)($record);
+
+        self::assertSame(['login' => 'admin', 'password' => '***'], $processed->context);
+    }
+
+    public function testKeepsThrowableInstancesUntouchedForDownstreamFormatter(): void
+    {
+        // ExceptionFormatterProcessor relies on `context.exception`
+        // being a real Throwable — the sanitiser must not turn it into
+        // a placeholder string. Pin that contract here.
+        $exception = new \RuntimeException('boom');
+        $record = $this->makeRecord(['exception' => $exception, 'context_id' => 7]);
+
+        $processed = ($this->processor)($record);
+
+        self::assertSame($exception, $processed->context['exception']);
+        self::assertSame(7, $processed->context['context_id']);
+    }
+
+    public function testPreservesNonContextRecordFields(): void
+    {
+        $record = $this->makeRecord(['note' => 'a payload']);
+
+        $processed = ($this->processor)($record);
+
+        self::assertSame($record->channel, $processed->channel);
+        self::assertSame($record->message, $processed->message);
+        self::assertSame($record->level, $processed->level);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function makeRecord(array $context): LogRecord
+    {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'app',
+            level: Level::Error,
+            message: 'a message',
+            context: $context,
+        );
+    }
+}


### PR DESCRIPTION
Backport of [MON-199097](https://centreon.atlassian.net/browse/MON-199097) to `dev-24.10.x` — Jira: [MON-201783](https://centreon.atlassian.net/browse/MON-201783).

Cherry-pick of the merged develop PR #10409 (`feat(logging): mask only #[Sensitive]-annotated payload fields`).

> **Rebased onto `dev-24.10.x`**: the MON-151077 prerequisite (#10806) has merged, so this PR now targets `dev-24.10.x` directly and carries only the MON-199097 delta (the redundant prerequisite commits have been dropped).

## Scope on dev-24.10.x (no new kernel)

Backported: the `#[Sensitive]` attribute (`App\Shared\Domain\Logging\Attribute\Sensitive`) + `SensitivityScanner` / `PayloadSanitizer` / `SanitizingProcessor` / `SensitiveKeywordDenylist`, and the `#[Sensitive]` annotations on the domain models that carry secrets (Contact, Proxy, AuthenticationToken, ProviderToken, User, Session, VaultConfiguration, OpenId CustomConfiguration, ConnectionConfig, Gorgone…). The `SanitizingProcessor` is registered as a **global** monolog processor in `config/services.yaml` (on develop it is autoconfigured via the `App\Shared` loader, absent here) so it masks `#[Sensitive]` context entries on every channel.

## Not included / adapted
- `LoggingMiddleware` / `LogPayloadNormalizer` changes — those classes don't exist on `dev-24.10.x` (no Symfony Messenger / new kernel).
- `App\Security\Domain\Aggregate\Token.php`, the Messenger test doubles, `LoggingMiddleware(Integration)Test` — not present on this branch.
- `doc/php/logging.md` kept as the dev-24.10.x trimmed version.

> Conflicts (incl. false rename-pairings from git, resolved by keeping the unrelated HEAD files intact) were handled manually — worth a careful review. CI validates `backend-lint` / `backend-unit-test`.


[MON-199097]: https://centreon.atlassian.net/browse/MON-199097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-201783]: https://centreon.atlassian.net/browse/MON-201783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
