### PR TITLE
feat(logging): mask sensitive data in record extra and the legacy MonologAdapter

### DIFF
--- a/centreon/config.new/services/monolog.php
+++ b/centreon/config.new/services/monolog.php
@@ -22,6 +22,8 @@
 declare(strict_types=1);
 
 use Adaptation\Log\Adapter\MonologAdapterResetter;
+use App\Shared\Infrastructure\Logging\PayloadSanitizer;
+use App\Shared\Infrastructure\Logging\SanitizingProcessor;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Processor\UidProcessor;
 use Symfony\Bridge\Monolog\Processor\RouteProcessor;
@@ -33,6 +35,16 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+
+    // Redaction processor. Registered FIRST on purpose: the MonologBundle
+    // pushes processors in definition order and Monolog's pushProcessor is
+    // LIFO, so the first-registered one runs LAST — after WebProcessor & co.
+    // have filled `extra` (the request URL lives in `extra.url`). The bundle
+    // ignores the tag `priority` for processors, so ordering is controlled by
+    // registration position here.
+    $services->set('monolog.processor.sanitizing', SanitizingProcessor::class)
+        ->arg('$sanitizer', service(PayloadSanitizer::class))
+        ->tag('monolog.processor');
 
     // No channel tag: applies to every logger.
     $services->set('monolog.processor.uid', UidProcessor::class)

--- a/centreon/config.new/services/monolog.php
+++ b/centreon/config.new/services/monolog.php
@@ -46,25 +46,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->arg('$sanitizer', service(PayloadSanitizer::class))
         ->tag('monolog.processor');
 
-    // No channel tag: applies to every logger.
+    // Platform processors, registered globally (no channel tag): every logger —
+    // catch-all and dedicated — carries the same enriched record shape.
     $services->set('monolog.processor.uid', UidProcessor::class)
         ->tag('monolog.processor');
 
     $services->set('monolog.processor.web', WebProcessor::class)
-        ->tag('monolog.processor', ['channel' => 'bus'])
-        ->tag('monolog.processor', ['channel' => 'request'])
-        ->tag('monolog.processor', ['channel' => 'app']);
+        ->tag('monolog.processor');
 
     $services->set('monolog.processor.route', RouteProcessor::class)
-        ->tag('monolog.processor', ['channel' => 'bus'])
-        ->tag('monolog.processor', ['channel' => 'request'])
-        ->tag('monolog.processor', ['channel' => 'app']);
+        ->tag('monolog.processor');
 
     $services->set('monolog.processor.token', TokenProcessor::class)
         ->arg('$tokenStorage', service('security.token_storage'))
-        ->tag('monolog.processor', ['channel' => 'bus'])
-        ->tag('monolog.processor', ['channel' => 'request'])
-        ->tag('monolog.processor', ['channel' => 'app']);
+        ->tag('monolog.processor');
 
     // Set the line timestamp to RFC3339 at service level: handler-level
     // date_format would instead configure the rotating_file filename suffix.

--- a/centreon/config.new/services/shared.php
+++ b/centreon/config.new/services/shared.php
@@ -37,8 +37,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire()
         ->autoconfigure();
 
+    // SanitizingProcessor is registered explicitly in monolog.php so its
+    // execution order can be controlled; keep it out of the autoload tagging
+    // to avoid a duplicate `monolog.processor` registration.
     $services->load('App\\Shared\\', __DIR__ . '/../../src/App/Shared')
-        ->exclude([__DIR__ . '/../../src/App/Shared/Infrastructure/Symfony/Kernel.php']);
+        ->exclude([
+            __DIR__ . '/../../src/App/Shared/Infrastructure/Symfony/Kernel.php',
+            __DIR__ . '/../../src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php',
+        ]);
 
     // UidProcessor stamps every record on every channel with one id per
     // process — single `grep <uid>` across all log files.

--- a/centreon/config.new/services/shared.php
+++ b/centreon/config.new/services/shared.php
@@ -21,14 +21,7 @@
 
 declare(strict_types=1);
 
-use Monolog\Formatter\LineFormatter;
-use Monolog\Processor\UidProcessor;
-use Symfony\Bridge\Monolog\Processor\RouteProcessor;
-use Symfony\Bridge\Monolog\Processor\TokenProcessor;
-use Symfony\Bridge\Monolog\Processor\WebProcessor;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -45,27 +38,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/../../src/App/Shared/Infrastructure/Symfony/Kernel.php',
             __DIR__ . '/../../src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php',
         ]);
-
-    // UidProcessor stamps every record on every channel with one id per
-    // process — single `grep <uid>` across all log files.
-    $services->set('monolog.processor.uid', UidProcessor::class)
-        ->tag('monolog.processor');
-
-    // Request/security context globally — every log file (catch-all and
-    // dedicated) gets the HTTP shape when a request is in scope; CLI
-    // workers see empty values, never problematic noise.
-    $services->set('monolog.processor.web', WebProcessor::class)
-        ->tag('monolog.processor');
-
-    $services->set('monolog.processor.route', RouteProcessor::class)
-        ->tag('monolog.processor');
-
-    $services->set('monolog.processor.token', TokenProcessor::class)
-        ->arg('$tokenStorage', service('security.token_storage'))
-        ->tag('monolog.processor');
-
-    // RFC3339 timestamp at service level. NOT at handler level on
-    // rotating_file, where `date_format:` configures the FILENAME suffix.
-    $services->set('monolog.formatter.line', LineFormatter::class)
-        ->arg('$dateFormat', DateTimeInterface::RFC3339);
 };

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -1,9 +1,6 @@
-# Logging pipeline — Messenger bus, Monolog and MON-151077
+# Logging pipeline — Messenger bus and Monolog
 
-This document describes the platform pipeline that captures logs emitted by the Symfony Messenger buses (`command.bus`, `query.bus`), enriches each record with HTTP / security context and routes it to `prod.web.log`. References: [MON-199096] (platform-side middleware migration), [MON-151077] (file layout, channel exclusions, RFC3339 format).
-
-[MON-199096]: https://centreon.atlassian.net/browse/MON-199096
-[MON-151077]: https://centreon.atlassian.net/browse/MON-151077
+This document describes the platform pipeline that captures logs emitted by the Symfony Messenger buses (`command.bus`, `query.bus`), enriches each record with HTTP / security context and routes it to `prod.web.log`.
 
 ---
 
@@ -174,7 +171,7 @@ The middleware emits a record on the Monolog `app` channel (Symfony default) for
   - `tokenize_input` (bool flag) → masked (contains `token`)
   - `credential_check_id` (reference id) → masked (contains `credential`)
 
-  This *"over-mask rather than under-mask"* default is intentional: we'd rather lose a bit of debug info than miss a real secret carried by an unlisted variant (e.g. `passwords_v2`, `customer_token_id`). For the opposite cases — a real secret carrying an unlisted name, or keyword noise on a given Command — the explicit, type-safe complement is the `#[Sensitive]` attribute (implemented under [MON-199097](https://centreon.atlassian.net/browse/MON-199097), see [§10](#10-masking-sensitive-fields-with-sensitive)). It is preferred over broadening the keyword list or switching to exact match, which would open the door to forgotten variants.
+  This *"over-mask rather than under-mask"* default is intentional: we'd rather lose a bit of debug info than miss a real secret carried by an unlisted variant (e.g. `passwords_v2`, `customer_token_id`). For the opposite cases — a real secret carrying an unlisted name, or keyword noise on a given Command — the explicit, type-safe complement is the `#[Sensitive]` attribute (see [§10](#10-masking-sensitive-fields-with-sensitive)). It is preferred over broadening the keyword list or switching to exact match, which would open the door to forgotten variants.
 - **`exception`**: produced by `ExceptionFormatter::format()` (see [§5](#5-exceptionformatter-and-exceptionformatterprocessor)).
 
 ---
@@ -276,7 +273,7 @@ prod.token.log
 […] token.INFO Token refreshed for user 42                          {"uid":"89796c2",…}
 ```
 
-An operator runs `grep "uid\":\"89796c2\"" /var/log/centreon/*.log` and gets the full chronology of the request, **including what landed in the MON-151077 dedicated files**.
+An operator runs `grep "uid\":\"89796c2\"" /var/log/centreon/*.log` and gets the full chronology of the request, **including what landed in the dedicated files**.
 
 ---
 
@@ -462,15 +459,15 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 
 **Why not `date_format:` at the handler level on `rotating_file`?** On a `rotating_file` handler, the Symfony Monolog Bundle's `date_format:` key is passed to the **`RotatingFileHandler` constructor** where it configures the **filename** date suffix (`Y-m-d` by default). Setting RFC3339 there throws `InvalidArgumentException` at boot. For other types (`stream`, `console`…) the key applies to the formatter — but we choose the single-service approach to stay DRY.
 
-**Exclusive filter (MON-151077 alignment).** Rather than a whitelist `[request, app]`, we use a blacklist of channels that have their own file or that are noise. Everything else — `request`, `app` (Symfony default), `main`, `security`, `http_client`, etc. — lands in `prod.web.log`.
+**Exclusive filter.** Rather than a whitelist `[request, app]`, we use a blacklist of channels that have their own file or that are noise. Everything else — `request`, `app` (Symfony default), `main`, `security`, `http_client`, etc. — lands in `prod.web.log`.
 
 | Excluded channel | Reason |
 |------------------|--------|
 | `event`, `doctrine`, `console` | Internal Symfony / DBAL noise — not desired in `prod.web.log`. |
-| `deprecation` | MON-151077 → dedicated file `prod.deprecations.log`. |
-| `authentication` | MON-151077 → merged into `prod.access.log` on the centreon-web side (see the backward-compatibility note below for `login.log`). |
-| `token` | MON-151077 → dedicated file `prod.token.log`. |
-| `password`, `plugin-pack-manager`, `upgrade` | MON-151077 → dedicated files. Not Monolog channels strictly speaking today (written directly by legacy `CentreonLog` code), but listed in anticipation of a future migration to Monolog. |
+| `deprecation` | dedicated file `prod.deprecations.log`. |
+| `authentication` | merged into `prod.access.log` on the centreon-web side (see the backward-compatibility note below for `login.log`). |
+| `token` | dedicated file `prod.token.log`. |
+| `password`, `plugin-pack-manager`, `upgrade` | dedicated files. Not Monolog channels strictly speaking today (written directly by legacy `CentreonLog` code), but listed in anticipation of a future migration to Monolog. |
 
 > **Backward compatibility — `login.log` is intentionally kept.** Authentication events now flow to the `authentication` channel (`prod.access.log`). To avoid breaking external consumers that parse the historical `/var/log/centreon/login.log` — most notably **fail2ban** jails matching the `Authentication failed for …` line with the client IP — login events are still mirrored to `login.log` in the original pipe-delimited format (`date|uid|page|option|message`) by **two** writers: `LoggerAuthentication::mirrorToLegacyLoginLog()` for events emitted on the new-kernel path (the OpenID/SAML/WebSSO logins routed through the `Login` use case, and the legacy local/LDAP success/failure now routed through the facade), and `CentreonUserLog::insertLog()` for `TYPE_LOGIN` events still flowing through the legacy code path (e.g. `LoginLogger`). The facade writer is try/catch protected so a mirror failure can never break a login; the legacy `CentreonUserLog` writer is not. This duplicate write is **transitional**: it is kept on purpose for client compatibility and will be removed in a future release once consumers have migrated to the Monolog access log (cleanup tracked in a dedicated ticket). `login.log` remains covered by `logrotate/centreon`.
 
@@ -479,15 +476,15 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 | `type: fingers_crossed` + `action_level: error` | On success, `INFO`/`DEBUG` records are buffered in RAM and discarded at the end of the request — zero disk I/O. On the first `ERROR`, the entire buffer plus the triggering record are flushed to the nested handler. |
 | `excluded_http_codes: [404, 405]` | The `HttpCodeActivationStrategy` wraps the activation: if the current request returns a 404 or 405, an `ERROR` does not trigger the flush. Prevents bot scans (`/wp-admin`, `/.env`, `/phpinfo`…) from flooding `prod.web.log`. Aligned with the default Symfony recipe. |
 | `stop_buffering: true` | After the triggering flush, the handler stops buffering — the rest of the request writes directly. |
-| `buffer_size: 50` | Memory cap of the buffer. Beyond that, the `FingersCrossedHandler` **drops the oldest records**. 50 is the MON-151077 target value. |
+| `buffer_size: 50` | Memory cap of the buffer. Beyond that, the `FingersCrossedHandler` **drops the oldest records**. 50 is the chosen target value. |
 | `bubble: false` | **The record stops after our handler.** Consequence: HTTP exceptions caught by Symfony's `ErrorListener` (`request` channel) **no longer** bubble up to the host's `main` handler (`var/log/{env}.log`). They live only in `var/log/{env}.web.log`. |
 | `priority: 255` | Our handler is executed first in the channel's Monolog stack — combined with `bubble: false`, this guarantees effective isolation. |
 | `path: ...{env}.web.log` | In prod, a fixed `prod.web.log` file (rotation is delegated to `logrotate` on production hosts, cf. `logrotate/centreon`). In dev, the handler is `rotating_file` with a daily suffix. |
-| `formatter: monolog.formatter.line` | Standard Symfony Monolog Bundle service, redefined in `monolog.php` with `dateFormat: RFC3339`. Timestamp format mandated by MON-151077 (e.g. `2025-09-08T15:38:41+02:00`). |
+| `formatter: monolog.formatter.line` | Standard Symfony Monolog Bundle service, redefined in `monolog.php` with `dateFormat: RFC3339`. Timestamp format standardised across the platform (e.g. `2025-09-08T15:38:41+02:00`). |
 
 ### File rotation
 
-In production, the `prod.*.log` files are rotated by **logrotate** (config `centreon/logrotate/centreon`, deployed to `/etc/logrotate.d/centreon`). The MON-151077 files listed:
+In production, the `prod.*.log` files are rotated by **logrotate** (config `centreon/logrotate/centreon`, deployed to `/etc/logrotate.d/centreon`). The files listed:
 
 - `prod.web.log` (catch-all)
 - `prod.deprecations.log`
@@ -589,7 +586,7 @@ A property-level attribute is therefore the right tool for reflection-based **pa
 
 ## 11. Legacy bridge — `Adaptation\Log\Logger`
 
-The platform pipeline described above runs under `App\Shared\Infrastructure\Symfony\Kernel`. Legacy entry points (procedural `www/` code, classes wired through `App\Kernel`) cannot autowire Monolog services directly; they go through a thin façade so every record still lands on the MON-151077 layout.
+The platform pipeline described above runs under `App\Shared\Infrastructure\Symfony\Kernel`. Legacy entry points (procedural `www/` code, classes wired through `App\Kernel`) cannot autowire Monolog services directly; they go through a thin façade so every record still lands on the same platform layout.
 
 ```mermaid
 flowchart LR
@@ -619,7 +616,7 @@ flowchart LR
 | `UPGRADE` | `upgrade` | `upgrade` | `prod.upgrade.log` |
 | `WEB` | `web` | `web` | `prod.web.log` |
 
-Only `AUTHENTICATION` carries a different slug — login/ldap/openid/saml records all converge in the shared `access.log` file (cf. MON-151077).
+Only `AUTHENTICATION` carries a different slug — login/ldap/openid/saml records all converge in the shared `access.log` file.
 
 ### `Adaptation\Log\Logger`
 
@@ -651,7 +648,7 @@ To mirror the platform pipeline as closely as possible without booting the Symfo
 
 #### Format alignment — no more `{custom, exception, default}` wrap
 
-Before MON-151077, both `CentreonLog::log()` and `Centreon\Domain\Log\LoggerTrait::executeLog()` reshaped the `context` array before handing it to Monolog:
+Before the legacy-logging migration, both `CentreonLog::log()` and `Centreon\Domain\Log\LoggerTrait::executeLog()` reshaped the `context` array before handing it to Monolog:
 
 - `CentreonLog::buildContext()` pre-formatted the `Throwable` with `ExceptionLogFormatter` (legacy) and added `context.request_infos`.
 - `LoggerTrait::normalizeContext()` rewrapped everything as `{custom, exception, default: {request_infos}}` — and **moved** the `Throwable` out of `context.exception` so `ExceptionFormatterProcessor` never saw it.
@@ -701,7 +698,7 @@ Both classes are tagged `@deprecated`. The DI/Application code that still autowi
 
 ### `Centreon\Domain\Log\LoggerTrait`
 
-`LoggerTrait` (~389 callers) keeps providing the PSR-3 helper shape used by Domain services that autowire a `LoggerInterface` via `#[Required]`. The pre-MON-151077 `ContactForDebug` gate is gone — `canBeLogged()` now only checks that a logger has been injected. The trait carries a descriptive note but no formal `@deprecated` tag, because `Symfony\Component\ErrorHandler\DebugClassLoader` would otherwise cascade the deprecation onto every class still using the trait during the transition.
+`LoggerTrait` (~389 callers) keeps providing the PSR-3 helper shape used by Domain services that autowire a `LoggerInterface` via `#[Required]`. The former `ContactForDebug` gate is gone — `canBeLogged()` now only checks that a logger has been injected. The trait carries a descriptive note but no formal `@deprecated` tag, because `Symfony\Component\ErrorHandler\DebugClassLoader` would otherwise cascade the deprecation onto every class still using the trait during the transition.
 
 ### Symfony-side configuration
 

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -568,11 +568,13 @@ When such an object flows through the logging pipeline, the annotated values are
 | --- | --- |
 | `…\Domain\Logging\Attribute\Sensitive` | the marker placed on properties, accessor methods, and classes |
 | `…\Infrastructure\Logging\Attribute\SensitivityScanner` | reflects a class, collects its `#[Sensitive]` properties and accessor keys, honours class-level sensitive types, and **recurses into nested class-typed properties**, so a secret nested in a sub-object is found too |
-| `…\Infrastructure\Logging\PayloadSanitizer` | stateless walker that masks the `#[Sensitive]` values of a payload given its owning class (`contextClass`), falls back to the keyword denylist for raw array keys, and truncates string values at `MAX_VALUE_LENGTH` (1024) |
+| `…\Infrastructure\Logging\PayloadSanitizer` | stateless walker that masks the `#[Sensitive]` values of a payload given its owning class (`contextClass`), falls back to the keyword denylist for raw array keys, **redacts secrets carried in a URL query string** (parameters whose name matches the denylist, e.g. in `extra.url`), and truncates string values at `MAX_VALUE_LENGTH` (1024) |
 | `…\Infrastructure\Logging\SensitiveKeywordDenylist` | single source of truth for the keyword net (`password`, `token`, …) shared by `LogPayloadNormalizer` and `PayloadSanitizer`, so both nets mask the same field names |
-| `…\Infrastructure\Logging\SanitizingProcessor` | Monolog processor that applies the sanitizer to every record |
+| `…\Infrastructure\Logging\SanitizingProcessor` | Monolog processor that applies the sanitizer to every record's `context` (full masking) and `extra` (URL-query masking only — see below). Registered to run **last**, after the processors that fill `extra` |
 
 The owning class is the **context** the sanitizer needs in order to know which keys are sensitive. On the command/query bus, `LoggingMiddleware` provides the dispatched message class, so `#[Sensitive]` on a Command / Query / DTO is honoured automatically. A **raw array** (`['secret' => $x]`) carries no class context, so the attribute layer cannot reflect it — but as the cross-channel net, `PayloadSanitizer` still applies the shared keyword denylist to its keys, so a `['password' => $x]` is masked everywhere it is logged. To get the explicit, type-safe attribute masking outside the bus, pass a typed object rather than a raw array.
+
+`extra` is sanitised too, but with keyword-key masking **off**: its keys are produced by platform processors (`WebProcessor`, `TokenProcessor`, …), not by callers, and must stay readable for auditing (e.g. `extra.token` carries the authenticated user). Only secrets inside URL query strings are redacted there, closing the leak of a token passed in a request URL (`extra.url`). Because Monolog applies processors in reverse registration order and the MonologBundle **ignores the tag `priority`** for processors, the sanitizer is registered first (in `config.new/services/monolog.php`, and pushed first by `MonologAdapter`) so that it executes last — after `WebProcessor` has populated `extra`.
 
 ### Why not the native `#[\SensitiveParameter]`?
 

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -56,7 +56,7 @@ flowchart LR
     class File out
 ```
 
-Every component lives under `App\Shared\Infrastructure\…` and is wired declaratively in `config.new/packages/messenger.yaml` (middleware) and `config.new/services/shared.php` (processors + formatter).
+Every component lives under `App\Shared\Infrastructure\…` and is wired declaratively in `config.new/packages/messenger.yaml` (middleware) and `config.new/services/monolog.php` (processors + formatter).
 
 ---
 
@@ -236,7 +236,7 @@ Being global, it guarantees a **uniform exception shape** on every channel (catc
 
 ## 6. HTTP / security processors (Web, Route, Token)
 
-`Symfony\Bridge\Monolog\Processor\WebProcessor`, `RouteProcessor` and `TokenProcessor` are registered in `config.new/services/shared.php` and tagged `monolog.processor` **globally** — same scope as `ExceptionFormatterProcessor` and `UidProcessor`, so every channel carries the same enriched shape.
+`Symfony\Bridge\Monolog\Processor\WebProcessor`, `RouteProcessor` and `TokenProcessor` are registered in `config.new/services/monolog.php` and tagged `monolog.processor` **globally** — same scope as `ExceptionFormatterProcessor` and `UidProcessor`, so every channel carries the same enriched shape.
 
 | Processor | Adds to `extra` |
 |-----------|-----------------|
@@ -249,7 +249,7 @@ Being global, it guarantees a **uniform exception shape** on every channel (catc
 
 ### `UidProcessor` — cross-channel correlation
 
-`Monolog\Processor\UidProcessor` is registered in `config.new/services/shared.php` **with no channel tag** — it therefore applies to **every logger** (request, app, deprecation, authentication, token, password, upgrade, plugin-pack-manager). It generates **a single 7-character hex id per process** and stamps it under `extra.uid` on every record:
+`Monolog\Processor\UidProcessor` is registered in `config.new/services/monolog.php` **with no channel tag** — it therefore applies to **every logger** (request, app, deprecation, authentication, token, password, upgrade, plugin-pack-manager). It generates **a single 7-character hex id per process** and stamps it under `extra.uid` on every record:
 
 ```php
 $services->set('monolog.processor.uid', UidProcessor::class)
@@ -451,7 +451,7 @@ when@dev:
                 # ... (same path, formatter, date_format)
 ```
 
-**RFC3339 driven at the service level.** `config.new/services/shared.php` overrides the `monolog.formatter.line` service with `dateFormat: RFC3339`:
+**RFC3339 driven at the service level.** `config.new/services/monolog.php` overrides the `monolog.formatter.line` service with `dateFormat: RFC3339`:
 
 ```php
 $services->set('monolog.formatter.line', LineFormatter::class)
@@ -483,7 +483,7 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 | `bubble: false` | **The record stops after our handler.** Consequence: HTTP exceptions caught by Symfony's `ErrorListener` (`request` channel) **no longer** bubble up to the host's `main` handler (`var/log/{env}.log`). They live only in `var/log/{env}.web.log`. |
 | `priority: 255` | Our handler is executed first in the channel's Monolog stack — combined with `bubble: false`, this guarantees effective isolation. |
 | `path: ...{env}.web.log` | In prod, a fixed `prod.web.log` file (rotation is delegated to `logrotate` on production hosts, cf. `logrotate/centreon`). In dev, the handler is `rotating_file` with a daily suffix. |
-| `formatter: monolog.formatter.line` | Standard Symfony Monolog Bundle service, redefined in `shared.php` with `dateFormat: RFC3339`. Timestamp format mandated by MON-151077 (e.g. `2025-09-08T15:38:41+02:00`). |
+| `formatter: monolog.formatter.line` | Standard Symfony Monolog Bundle service, redefined in `monolog.php` with `dateFormat: RFC3339`. Timestamp format mandated by MON-151077 (e.g. `2025-09-08T15:38:41+02:00`). |
 
 ### File rotation
 
@@ -574,7 +574,7 @@ When such an object flows through the logging pipeline, the annotated values are
 
 The owning class is the **context** the sanitizer needs in order to know which keys are sensitive. On the command/query bus, `LoggingMiddleware` provides the dispatched message class, so `#[Sensitive]` on a Command / Query / DTO is honoured automatically. A **raw array** (`['secret' => $x]`) carries no class context, so the attribute layer cannot reflect it — but as the cross-channel net, `PayloadSanitizer` still applies the shared keyword denylist to its keys, so a `['password' => $x]` is masked everywhere it is logged. To get the explicit, type-safe attribute masking outside the bus, pass a typed object rather than a raw array.
 
-`extra` is sanitised too, but with keyword-key masking **off**: its keys are produced by platform processors (`WebProcessor`, `TokenProcessor`, …), not by callers, and must stay readable for auditing (e.g. `extra.token` carries the authenticated user). Only secrets inside URL query strings are redacted there, closing the leak of a token passed in a request URL (`extra.url`). Because Monolog applies processors in reverse registration order and the MonologBundle **ignores the tag `priority`** for processors, the sanitizer is registered first (in `config.new/services/monolog.php`, and pushed first by `MonologAdapter`) so that it executes last — after `WebProcessor` has populated `extra`.
+`extra` is sanitised too, but with keyword-key masking **off**: its keys are produced by platform processors (`WebProcessor`, `TokenProcessor`, …), not by callers, and must stay readable for auditing (e.g. `extra.token` is `TokenProcessor`'s audit descriptor of the authenticated user — authenticated flag, roles, identifier — not a credential). There, only the sensitive query-string parameters of URL-like values are redacted (best-effort, query component only), covering a token passed in a request URL (`extra.url`). Because Monolog applies processors in reverse registration order and the MonologBundle **ignores the tag `priority`** for processors, the sanitizer is registered first (in `config.new/services/monolog.php`, and pushed first by `MonologAdapter`) so that it executes last — after `WebProcessor` has populated `extra`.
 
 ### Why not the native `#[\SensitiveParameter]`?
 
@@ -647,7 +647,7 @@ To mirror the platform pipeline as closely as possible without booting the Symfo
 | `Monolog\Processor\WebProcessor` | Monolog vendor | `extra.url`, `extra.ip`, `extra.http_method`, `extra.server`, `extra.referrer` — sourced from `$_SERVER` directly (the Symfony bridge variant is bypassed because its data is populated by a kernel-request listener that does not run from legacy code paths). |
 | `App\Shared\Infrastructure\Logging\ExceptionFormatterProcessor` | platform | Unwraps `context.exception` through `ExceptionFormatter::format()`, producing the same nested-exception layout used on `prod.web.log` (cf. §5). |
 
-`RouteProcessor` and `TokenProcessor` are **not** wired here: they depend on the Symfony `RequestStack` / `TokenStorage` services and would be empty in the legacy stack. Records emitted via `Adaptation\Log\Logger` therefore do **not** carry `extra.controller`, `extra.route` or `extra.token`. Call sites that need those fields should write through the new-kernel pipeline (the catch-all `app` / `request` channels and every dedicated channel) where the full processor stack is wired globally by `config.new/services/shared.php`.
+`RouteProcessor` and `TokenProcessor` are **not** wired here: they depend on the Symfony `RequestStack` / `TokenStorage` services and would be empty in the legacy stack. Records emitted via `Adaptation\Log\Logger` therefore do **not** carry `extra.controller`, `extra.route` or `extra.token`. Call sites that need those fields should write through the new-kernel pipeline (the catch-all `app` / `request` channels and every dedicated channel) where the full processor stack is wired globally by `config.new/services/monolog.php`.
 
 #### Format alignment — no more `{custom, exception, default}` wrap
 

--- a/centreon/src/Adaptation/Log/Adapter/MonologAdapter.php
+++ b/centreon/src/Adaptation/Log/Adapter/MonologAdapter.php
@@ -27,6 +27,8 @@ use Adaptation\Log\Enum\LogChannelEnum;
 use Adaptation\Log\Exception\LoggerException;
 use Adaptation\Log\Logger;
 use App\Shared\Infrastructure\Logging\ExceptionFormatterProcessor;
+use App\Shared\Infrastructure\Logging\PayloadSanitizer;
+use App\Shared\Infrastructure\Logging\SanitizingProcessor;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
@@ -154,6 +156,10 @@ final class MonologAdapter implements LoggerInterface
 
     private function pushPlatformProcessors(): void
     {
+        // pushProcessor is LIFO: the first one pushed runs LAST. The sanitiser
+        // must run after WebProcessor (which fills `extra.url`, query string
+        // included), so it is pushed first to redact as the final step.
+        $this->logger->pushProcessor(new SanitizingProcessor(new PayloadSanitizer()));
         $this->logger->pushProcessor(new ExceptionFormatterProcessor());
         $this->logger->pushProcessor(new WebProcessor());
         $this->logger->pushProcessor(self::$uidProcessor ??= new UidProcessor());

--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -26,16 +26,19 @@ namespace App\Shared\Infrastructure\Logging;
 use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
 
 /**
- * Stateless walker that masks the values of `#[Sensitive]`-annotated
- * properties inside an arbitrary payload (a Command/Query, an ad-hoc
- * logger context, anything Monolog forwards to a handler).
+ * Stateless walker that masks sensitive values inside an arbitrary
+ * payload (a Command/Query, an ad-hoc logger context, a Monolog
+ * record's `context` / `extra` — anything forwarded to a handler).
  *
  * Typed payloads are masked **attribute-driven**: a property without
  * `#[Sensitive]` is logged in clear, the owning class declares its
  * sensitivity explicitly. As the cross-channel net, raw array keys are
  * additionally matched against {@see SensitiveKeywordDenylist} so that
  * an ad-hoc `$logger->error('m', ['token' => $x])` — which carries no
- * class to reflect — is still caught.
+ * class to reflect — is still caught. Independently, any string value
+ * holding a URL query has the parameters whose name matches that same
+ * denylist redacted in place (e.g. `…?login=x&token=***`), so a secret
+ * carried in a logged URL — notably `extra.url` — does not leak.
  *
  * Object values are rendered defensively to avoid leaking private
  * properties; `\Throwable` instances are returned as-is so that
@@ -53,10 +56,18 @@ final readonly class PayloadSanitizer
      *                                        depth, or `null` when the
      *                                        type at this level is
      *                                        scalar / array / unknown
+     * @param bool $maskKeywordKeys whether array keys matching the shared
+     *                              keyword denylist are masked. `true` for
+     *                              ad-hoc / context payloads; `false` for a
+     *                              Monolog `extra` bag, whose keys are set
+     *                              by platform processors (e.g. `token` =>
+     *                              the authenticated user) and must stay
+     *                              readable — there only URL query secrets
+     *                              are redacted.
      *
      * @throws \ReflectionException when SensitivityScanner cannot reflect the context class
      */
-    public function sanitize(mixed $data, int $depth = 0, ?string $contextClass = null): mixed
+    public function sanitize(mixed $data, int $depth = 0, ?string $contextClass = null, bool $maskKeywordKeys = true): mixed
     {
         if ($depth >= self::MAX_DEPTH) {
             return '{…}';
@@ -86,7 +97,7 @@ final readonly class PayloadSanitizer
                 }
 
                 if (\is_string($key)
-                    && (\in_array($key, $sensitive, true) || SensitiveKeywordDenylist::matches($key))
+                    && (\in_array($key, $sensitive, true) || ($maskKeywordKeys && SensitiveKeywordDenylist::matches($key)))
                 ) {
                     $result[$key] = '***';
 
@@ -106,7 +117,7 @@ final readonly class PayloadSanitizer
                     continue;
                 }
 
-                $result[$key] = $this->sanitize($value, $depth + 1, $childContext);
+                $result[$key] = $this->sanitize($value, $depth + 1, $childContext, $maskKeywordKeys);
             }
 
             return $result;
@@ -116,11 +127,56 @@ final readonly class PayloadSanitizer
             return $this->sanitizeObject($data);
         }
 
-        if (\is_string($data) && \mb_strlen($data) > self::MAX_VALUE_LENGTH) {
-            return mb_substr($data, 0, self::MAX_VALUE_LENGTH) . '…[truncated]';
+        if (\is_string($data)) {
+            return $this->capLength($this->maskSensitiveUrlQueryParameters($data));
         }
 
         return $data;
+    }
+
+    /**
+     * Redacts the values of query parameters whose name matches the shared
+     * keyword denylist inside a URL-like string, in place — the path and
+     * non-sensitive parameters are preserved. No-op for strings without a
+     * query part, so it is safe to run on every string value.
+     */
+    private function maskSensitiveUrlQueryParameters(string $value): string
+    {
+        $queryStart = mb_strpos($value, '?');
+        if ($queryStart === false) {
+            return $value;
+        }
+
+        $query = mb_substr($value, $queryStart + 1);
+        if ($query === '') {
+            return $value;
+        }
+
+        $masked = false;
+        $pairs = explode('&', $query);
+        foreach ($pairs as $index => $pair) {
+            $separator = mb_strpos($pair, '=');
+            if ($separator === false) {
+                continue;
+            }
+
+            $name = mb_substr($pair, 0, $separator);
+            if (SensitiveKeywordDenylist::matches(rawurldecode($name))) {
+                $pairs[$index] = $name . '=***';
+                $masked = true;
+            }
+        }
+
+        return $masked
+            ? mb_substr($value, 0, $queryStart + 1) . implode('&', $pairs)
+            : $value;
+    }
+
+    private function capLength(string $value): string
+    {
+        return \mb_strlen($value) > self::MAX_VALUE_LENGTH
+            ? mb_substr($value, 0, self::MAX_VALUE_LENGTH) . '…[truncated]'
+            : $value;
     }
 
     /**
@@ -153,11 +209,7 @@ final readonly class PayloadSanitizer
         }
 
         if ($data instanceof \Stringable) {
-            $string = (string) $data;
-
-            return \mb_strlen($string) > self::MAX_VALUE_LENGTH
-                ? mb_substr($string, 0, self::MAX_VALUE_LENGTH) . '…[truncated]'
-                : $string;
+            return $this->capLength($this->maskSensitiveUrlQueryParameters((string) $data));
         }
 
         return '{' . $data::class . '}';

--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -35,10 +35,13 @@ use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
  * sensitivity explicitly. As the cross-channel net, raw array keys are
  * additionally matched against {@see SensitiveKeywordDenylist} so that
  * an ad-hoc `$logger->error('m', ['token' => $x])` — which carries no
- * class to reflect — is still caught. Independently, any string value
- * holding a URL query has the parameters whose name matches that same
- * denylist redacted in place (e.g. `…?login=x&token=***`), so a secret
- * carried in a logged URL — notably `extra.url` — does not leak.
+ * class to reflect — is still caught. Independently, in any string value
+ * holding a URL **query string**, the `&`-separated parameters whose name
+ * matches that same denylist are redacted in place (e.g. `…?page=2&token=***`).
+ * This covers the common case of a secret logged in a request URL
+ * (`extra.url`); it is best-effort and scoped to the query component —
+ * secrets in the path, the fragment, or nested inside another parameter's
+ * value are out of scope.
  *
  * Object values are rendered defensively to avoid leaking private
  * properties; `\Throwable` instances are returned as-is so that
@@ -51,23 +54,35 @@ final readonly class PayloadSanitizer
 
     /**
      * @param class-string|null $contextClass class whose `#[Sensitive]`
-     *                                        attributes annotate the
-     *                                        array keys at the current
-     *                                        depth, or `null` when the
-     *                                        type at this level is
+     *                                        attributes annotate the array
+     *                                        keys, or `null` when the type is
      *                                        scalar / array / unknown
      * @param bool $maskKeywordKeys whether array keys matching the shared
      *                              keyword denylist are masked. `true` for
      *                              ad-hoc / context payloads; `false` for a
-     *                              Monolog `extra` bag, whose keys are set
-     *                              by platform processors (e.g. `token` =>
-     *                              the authenticated user) and must stay
-     *                              readable — there only URL query secrets
-     *                              are redacted.
+     *                              Monolog `extra` bag, whose keys are set by
+     *                              platform processors (e.g. `token` => an
+     *                              audit descriptor of the authenticated user
+     *                              — authenticated flag, roles, identifier —
+     *                              not a credential) and must stay readable;
+     *                              there only URL query secrets are redacted.
      *
      * @throws \ReflectionException when SensitivityScanner cannot reflect the context class
      */
-    public function sanitize(mixed $data, int $depth = 0, ?string $contextClass = null, bool $maskKeywordKeys = true): mixed
+    public function sanitize(mixed $data, ?string $contextClass = null, bool $maskKeywordKeys = true): mixed
+    {
+        return $this->walk($data, 0, $contextClass, $maskKeywordKeys);
+    }
+
+    /**
+     * Recursive masking walk; `$depth` bounds the recursion. Internal —
+     * callers use {@see self::sanitize()}.
+     *
+     * @param class-string|null $contextClass
+     *
+     * @throws \ReflectionException
+     */
+    private function walk(mixed $data, int $depth, ?string $contextClass, bool $maskKeywordKeys): mixed
     {
         if ($depth >= self::MAX_DEPTH) {
             return '{…}';
@@ -117,7 +132,7 @@ final readonly class PayloadSanitizer
                     continue;
                 }
 
-                $result[$key] = $this->sanitize($value, $depth + 1, $childContext, $maskKeywordKeys);
+                $result[$key] = $this->walk($value, $depth + 1, $childContext, $maskKeywordKeys);
             }
 
             return $result;
@@ -135,10 +150,12 @@ final readonly class PayloadSanitizer
     }
 
     /**
-     * Redacts the values of query parameters whose name matches the shared
-     * keyword denylist inside a URL-like string, in place — the path and
-     * non-sensitive parameters are preserved. No-op for strings without a
-     * query part, so it is safe to run on every string value.
+     * Redacts, in place, the values of `&`-separated query parameters whose
+     * name matches the shared keyword denylist inside a URL-like string; the
+     * path and non-sensitive parameters are preserved. Scoped to the query
+     * component only — the path, the fragment, alternate (`;`) separators, and
+     * secrets nested inside a parameter's value are NOT inspected. No-op for
+     * strings without a query part, so it is safe to run on every string value.
      */
     private function maskSensitiveUrlQueryParameters(string $value): string
     {

--- a/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
@@ -56,8 +56,9 @@ final readonly class SanitizingProcessor
         // `extra` is filled by platform processors (WebProcessor puts the
         // request URI — query string included — in `extra.url`). Its keys are
         // not user-controlled, so keyword-key masking stays off to keep audit
-        // fields readable (e.g. `extra.token` = the authenticated user added
-        // by TokenProcessor); only secrets inside URL query strings are redacted.
+        // fields readable (e.g. `extra.token` is TokenProcessor's audit
+        // descriptor of the authenticated user, not a credential); only
+        // sensitive URL query-string parameters are redacted.
         /** @var array<string, mixed> $extra */
         $extra = $this->sanitizer->sanitize($record->extra, maskKeywordKeys: false);
 

--- a/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
@@ -23,17 +23,22 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Logging;
 
-use Monolog\Attribute\AsMonologProcessor;
 use Monolog\LogRecord;
 
 /**
- * Monolog processor that masks `#[Sensitive]` entries in every
- * record's `context` through {@see PayloadSanitizer}. Covers the
- * ad-hoc `$logger->error('msg', $context)` paths that bypass the
- * bus middleware. `\Throwable` values are returned as-is so that
+ * Monolog processor that masks sensitive data in every record through
+ * {@see PayloadSanitizer}: `#[Sensitive]` / keyword entries in `context`
+ * (the ad-hoc `$logger->error('msg', $context)` paths that bypass the
+ * bus middleware) and secrets carried in URL query strings under `extra`
+ * (notably `extra.url`, set by the WebProcessor).
+ *
+ * It must run after the context-enriching processors that populate
+ * `extra`. Registration order — not the tag `priority`, which the
+ * MonologBundle ignores for processors — guarantees this; see
+ * config.new/services/monolog.php. `\Throwable` values under
+ * `context.exception` are left as-is so that
  * {@see ExceptionFormatterProcessor} can structure them downstream.
  */
-#[AsMonologProcessor]
 final readonly class SanitizingProcessor
 {
     public function __construct(private PayloadSanitizer $sanitizer)
@@ -45,9 +50,17 @@ final readonly class SanitizingProcessor
      */
     public function __invoke(LogRecord $record): LogRecord
     {
-        /** @var array<string, mixed> $sanitized */
-        $sanitized = $this->sanitizer->sanitize($record->context);
+        /** @var array<string, mixed> $context */
+        $context = $this->sanitizer->sanitize($record->context);
 
-        return $record->with(context: $sanitized);
+        // `extra` is filled by platform processors (WebProcessor puts the
+        // request URI — query string included — in `extra.url`). Its keys are
+        // not user-controlled, so keyword-key masking stays off to keep audit
+        // fields readable (e.g. `extra.token` = the authenticated user added
+        // by TokenProcessor); only secrets inside URL query strings are redacted.
+        /** @var array<string, mixed> $extra */
+        $extra = $this->sanitizer->sanitize($record->extra, maskKeywordKeys: false);
+
+        return $record->with(context: $context, extra: $extra);
     }
 }

--- a/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
@@ -37,7 +37,11 @@ namespace App\Shared\Infrastructure\Logging;
  */
 final class SensitiveKeywordDenylist
 {
-    public const KEYWORDS = ['password', 'token', 'secret', 'api_key', 'authorization', 'credential', 'private_key'];
+    public const KEYWORDS = [
+        'password', 'passwd', 'pwd', 'token', 'secret', 'api_key', 'apikey', 'api-key',
+        'access_key', 'authorization', 'bearer', 'credential', 'private_key', 'signature',
+        'session_id', 'sessionid',
+    ];
 
     /**
      * Memoises the sensitive-or-not verdict per key to skip the keyword

--- a/centreon/src/App/Shared/Infrastructure/Messenger/LoggingMiddleware.php
+++ b/centreon/src/App/Shared/Infrastructure/Messenger/LoggingMiddleware.php
@@ -160,6 +160,6 @@ final readonly class LoggingMiddleware implements MiddlewareInterface
         }
 
         /** @var array<string, mixed> */
-        return $this->sanitizer->sanitize($payload, 0, $message::class);
+        return $this->sanitizer->sanitize($payload, $message::class);
     }
 }

--- a/centreon/tests/php/Adaptation/Log/Adapter/MonologAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Log/Adapter/MonologAdapterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Adaptation\Log\Adapter;
+
+use Adaptation\Log\Adapter\MonologAdapter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use App\Shared\Infrastructure\Logging\SanitizingProcessor;
+use Monolog\Logger;
+use Monolog\Processor\WebProcessor;
+use PHPUnit\Framework\TestCase;
+
+final class MonologAdapterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // create() builds a StreamHandler under _CENTREON_LOG_; the stream is
+        // opened lazily (only on write), so a temp dir is enough and merely
+        // constructing the logger writes no file.
+        if (! defined('_CENTREON_LOG_')) {
+            define('_CENTREON_LOG_', sys_get_temp_dir() . '/');
+        }
+    }
+
+    public function testSanitizingProcessorRunsLastAfterWebProcessor(): void
+    {
+        // The redaction processor must run AFTER WebProcessor fills `extra.url`.
+        // Monolog applies processors in array order, so the sanitiser has to be
+        // the LAST element — it is pushed first and pushProcessor is LIFO.
+        $adapter = MonologAdapter::create(LogChannelEnum::WEB);
+
+        $logger = (new \ReflectionProperty($adapter, 'logger'))->getValue($adapter);
+        self::assertInstanceOf(Logger::class, $logger);
+
+        $order = array_map(
+            static fn (object $processor): string => $processor::class,
+            $logger->getProcessors(),
+        );
+
+        self::assertContains(WebProcessor::class, $order);
+        self::assertSame(SanitizingProcessor::class, $order[array_key_last($order)]);
+        self::assertGreaterThan(
+            array_search(WebProcessor::class, $order, true),
+            array_search(SanitizingProcessor::class, $order, true),
+        );
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
@@ -156,4 +156,51 @@ final class PayloadSanitizerTest extends TestCase
         \assert(\is_array($sanitised));
         self::assertSame('red', $sanitised['status']);
     }
+
+    public function testMasksSensitiveQueryParametersInUrlStrings(): void
+    {
+        // The request URL (e.g. WebProcessor's `extra.url`) is a plain string,
+        // not a key/value pair, so a secret passed as a query parameter is not
+        // caught by key masking. Parameters whose name matches the denylist are
+        // redacted in place; the path and the other parameters are preserved.
+        $sanitised = $this->sanitizer->sanitize([
+            'url' => '/centreon/api/latest/login?useralias=admin&token=ABC123&autologin=1',
+        ]);
+
+        self::assertSame(
+            ['url' => '/centreon/api/latest/login?useralias=admin&token=***&autologin=1'],
+            $sanitised,
+        );
+    }
+
+    public function testLeavesUrlStringsWithoutSensitiveQueryParametersUntouched(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(['url' => '/monitoring/resources?page=2&limit=30']);
+
+        self::assertSame(['url' => '/monitoring/resources?page=2&limit=30'], $sanitised);
+    }
+
+    public function testStillRedactsUrlSecretsWhenKeywordKeyMaskingIsDisabled(): void
+    {
+        // `extra` is sanitised with keyword-key masking OFF (its keys are set by
+        // platform processors and must stay readable): `token` keeps its audit
+        // payload, but a secret inside a URL query is still redacted.
+        $sanitised = $this->sanitizer->sanitize(
+            [
+                'token' => ['username' => 'admin', 'role' => 'ROLE_ADMIN'],
+                'url' => '/login?token=ABC123',
+            ],
+            0,
+            null,
+            false,
+        );
+
+        self::assertSame(
+            [
+                'token' => ['username' => 'admin', 'role' => 'ROLE_ADMIN'],
+                'url' => '/login?token=***',
+            ],
+            $sanitised,
+        );
+    }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
@@ -65,7 +65,6 @@ final class PayloadSanitizerTest extends TestCase
     {
         $sanitised = $this->sanitizer->sanitize(
             ['passcode' => '482031', 'ssoTicket' => 'st-abc', 'userId' => 7],
-            0,
             SecretsCommand::class,
         );
 
@@ -76,7 +75,6 @@ final class PayloadSanitizerTest extends TestCase
     {
         $sanitised = $this->sanitizer->sanitize(
             ['inner' => ['passcode' => '482031', 'label' => 'two-factor']],
-            0,
             NestedPayloadCommand::class,
         );
 
@@ -87,7 +85,6 @@ final class PayloadSanitizerTest extends TestCase
     {
         $sanitised = $this->sanitizer->sanitize(
             ['apiToken' => 'tok-123', 'login' => 'admin'],
-            0,
             MethodSecretCommand::class,
         );
 
@@ -101,7 +98,6 @@ final class PayloadSanitizerTest extends TestCase
                 'card' => ['number' => 'card-number-test', 'holder' => 'admin'],
                 'label' => 'default card',
             ],
-            0,
             CardHolderCommand::class,
         );
 
@@ -190,15 +186,97 @@ final class PayloadSanitizerTest extends TestCase
                 'token' => ['username' => 'admin', 'role' => 'ROLE_ADMIN'],
                 'url' => '/login?token=ABC123',
             ],
-            0,
-            null,
-            false,
+            maskKeywordKeys: false,
         );
 
         self::assertSame(
             [
                 'token' => ['username' => 'admin', 'role' => 'ROLE_ADMIN'],
                 'url' => '/login?token=***',
+            ],
+            $sanitised,
+        );
+    }
+
+    public function testPropagatesKeywordKeyMaskingFlagThroughRecursion(): void
+    {
+        // With keyword-key masking off, a denylisted key stays in clear at any
+        // depth — the flag must survive the recursive descent, not just the top
+        // level. URL-query masking still applies regardless of the flag.
+        $sanitised = $this->sanitizer->sanitize(
+            ['outer' => ['token' => 'raw', 'url' => '/x?secret=s']],
+            maskKeywordKeys: false,
+        );
+
+        self::assertSame(
+            ['outer' => ['token' => 'raw', 'url' => '/x?secret=***']],
+            $sanitised,
+        );
+    }
+
+    public function testMasksSensitiveUrlQueryParametersInStringableValues(): void
+    {
+        $url = new class () implements \Stringable {
+            public function __toString(): string
+            {
+                return '/login?useralias=admin&token=ABC123';
+            }
+        };
+
+        $sanitised = $this->sanitizer->sanitize(['ref' => $url]);
+
+        self::assertSame(['ref' => '/login?useralias=admin&token=***'], $sanitised);
+    }
+
+    public function testLeavesQueryEdgeCasesUntouched(): void
+    {
+        // Empty query and a parameter with no `=` are no-ops.
+        self::assertSame(['u' => '/x?'], $this->sanitizer->sanitize(['u' => '/x?']));
+        self::assertSame(['u' => '/x?token'], $this->sanitizer->sanitize(['u' => '/x?token']));
+    }
+
+    public function testMatchesQueryParameterNamesCaseInsensitivelyAndUrlDecoded(): void
+    {
+        // The parameter name is lowercased and percent-decoded before matching,
+        // so `Token` and `to%6Ben` are both recognised; only the value is replaced.
+        self::assertSame(['u' => '/x?Token=***'], $this->sanitizer->sanitize(['u' => '/x?Token=ABC']));
+        self::assertSame(['u' => '/x?to%6Ben=***'], $this->sanitizer->sanitize(['u' => '/x?to%6Ben=ABC']));
+    }
+
+    public function testDoesNotMaskSecretsOutsideTheQueryComponent(): void
+    {
+        // Documented scope limits (best-effort, query component only): a secret in
+        // the PATH, or nested inside another parameter's VALUE after a second `?`,
+        // is NOT masked. Pinned so widening the parser stays a conscious choice.
+        self::assertSame(
+            ['u' => '/reset/TOKEN-ABC/confirm'],
+            $this->sanitizer->sanitize(['u' => '/reset/TOKEN-ABC/confirm']),
+        );
+        self::assertSame(
+            ['u' => '/cb?next=/r?token=ABC&page=2'],
+            $this->sanitizer->sanitize(['u' => '/cb?next=/r?token=ABC&page=2']),
+        );
+    }
+
+    public function testMasksTheAdditionalKeywordAliases(): void
+    {
+        $sanitised = $this->sanitizer->sanitize([
+            'apikey' => 'a',
+            'pwd' => 'b',
+            'signature' => 'c',
+            'session_id' => 'd',
+            'access_key' => 'e',
+            'login' => 'admin',
+        ]);
+
+        self::assertSame(
+            [
+                'apikey' => '***',
+                'pwd' => '***',
+                'signature' => '***',
+                'session_id' => '***',
+                'access_key' => '***',
+                'login' => 'admin',
             ],
             $sanitised,
         );

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
@@ -77,10 +77,36 @@ final class SanitizingProcessorTest extends TestCase
         self::assertSame($record->level, $processed->level);
     }
 
+    public function testMasksUrlQuerySecretsInExtraWhileKeepingAuditFields(): void
+    {
+        // WebProcessor records the request URI in `extra.url`; a secret passed
+        // as a query parameter must be redacted. The other `extra` fields set
+        // by platform processors (e.g. `token` => the authenticated user) are
+        // not user input and stay readable for auditing.
+        $record = $this->makeRecord(
+            context: [],
+            extra: [
+                'url' => '/centreon/api/latest/login?useralias=admin&token=leaked',
+                'token' => ['username' => 'admin'],
+                'ip' => '203.0.113.7',
+            ],
+        );
+
+        $processed = ($this->processor)($record);
+
+        self::assertSame(
+            '/centreon/api/latest/login?useralias=admin&token=***',
+            $processed->extra['url'],
+        );
+        self::assertSame(['username' => 'admin'], $processed->extra['token']);
+        self::assertSame('203.0.113.7', $processed->extra['ip']);
+    }
+
     /**
      * @param array<string, mixed> $context
+     * @param array<string, mixed> $extra
      */
-    private function makeRecord(array $context): LogRecord
+    private function makeRecord(array $context, array $extra = []): LogRecord
     {
         return new LogRecord(
             datetime: new \DateTimeImmutable(),
@@ -88,6 +114,7 @@ final class SanitizingProcessorTest extends TestCase
             level: Level::Error,
             message: 'a message',
             context: $context,
+            extra: $extra,
         );
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
@@ -81,13 +81,14 @@ final class SanitizingProcessorTest extends TestCase
     {
         // WebProcessor records the request URI in `extra.url`; a secret passed
         // as a query parameter must be redacted. The other `extra` fields set
-        // by platform processors (e.g. `token` => the authenticated user) are
-        // not user input and stay readable for auditing.
+        // by platform processors (e.g. `token` => TokenProcessor's audit
+        // descriptor of the authenticated user, not a credential) are not user
+        // input and stay readable for auditing.
         $record = $this->makeRecord(
             context: [],
             extra: [
                 'url' => '/centreon/api/latest/login?useralias=admin&token=leaked',
-                'token' => ['username' => 'admin'],
+                'token' => ['authenticated' => true, 'user_identifier' => 'admin'],
                 'ip' => '203.0.113.7',
             ],
         );
@@ -98,7 +99,7 @@ final class SanitizingProcessorTest extends TestCase
             '/centreon/api/latest/login?useralias=admin&token=***',
             $processed->extra['url'],
         );
-        self::assertSame(['username' => 'admin'], $processed->extra['token']);
+        self::assertSame(['authenticated' => true, 'user_identifier' => 'admin'], $processed->extra['token']);
         self::assertSame('203.0.113.7', $processed->extra['ip']);
     }
 


### PR DESCRIPTION
## Description

Extends the `#[Sensitive]` payload masking so it also covers a Monolog record's `extra` bag and the legacy `MonologAdapter`, and consolidates the new-kernel monolog service config.

`SanitizingProcessor` previously masked only `context`. Two gaps are closed:

- **`extra` is now sanitised.** `WebProcessor` stores the request URI (query string included) in `extra.url`; sensitive query parameters are now redacted — on the new-kernel pipeline too. `extra` is masked with keyword-key masking **off**: its keys are set by platform processors (`WebProcessor`, `TokenProcessor`, …), not by callers, so they stay readable for auditing (e.g. `extra.token` is `TokenProcessor`'s audit descriptor of the authenticated user — authenticated flag, roles, identifier — not a credential). Only sensitive values inside URL query strings are redacted there (best-effort, query component only).
- **`MonologAdapter` now runs the `SanitizingProcessor`** (it previously pushed only `ExceptionFormatterProcessor` + `WebProcessor` + `UidProcessor`), so logs emitted through the legacy adapter are masked too.

### Processor ordering

The sanitizer must run **after** `WebProcessor` (which fills `extra.url`). The MonologBundle ignores the `priority` tag for processors and Monolog applies them LIFO, so ordering is controlled by registration position: the sanitizer is registered **first** (in `config.new/services/monolog.php`, and pushed first by `MonologAdapter`) so it executes last.

### Monolog config consolidation

The new-kernel monolog processors were defined in **both** `shared.php` (global) and `monolog.php` (channel-scoped) — a duplication where `shared.php` silently won by load order, leaving `monolog.php`'s channel scoping dead and broken (it referenced the non-existent `bus`/`request` channels). This PR makes `monolog.php` the single home (global processors + formatter + resetter + sanitizer) and reduces `shared.php` to the `App\Shared\` autoloader, matching its siblings. Runtime is unchanged.

## Changes

- `PayloadSanitizer`: URL-query-aware masking (params whose name matches `SensitiveKeywordDenylist`, redacted in place); a `maskKeywordKeys` flag; public `sanitize()` split from a private recursive `walk()` so callers don't thread the internal `$depth`.
- `SanitizingProcessor`: sanitises `context` (full) and `extra` (URL-query only); registered explicitly (attribute removed) to control order.
- `SensitiveKeywordDenylist`: added secret-name aliases (`apikey`, `api-key`, `passwd`, `pwd`, `access_key`, `bearer`, `signature`, `session_id`, `sessionid`).
- `config.new/services/{monolog,shared}.php`: consolidation (single home + pure autoloader).
- `MonologAdapter`: wires the sanitizer (pushed first → runs last).
- `doc/php/logging.md`: documents the `extra`/URL coverage and ordering, scoped honestly (query component only).

## Tests

- `PayloadSanitizerTest`: URL query masking, the `maskKeywordKeys` flag through recursion, the `Stringable` path, query edge cases, case-insensitive / percent-decoded param names, the new aliases, and pinned out-of-scope limitations (secret in path / nested value).
- `SanitizingProcessorTest`: `extra.url` query secret redacted while audit fields (`extra.token`, `extra.ip`) stay intact.
- `MonologAdapterTest`: asserts the sanitizer runs last (after `WebProcessor`).
- All green; `rector:diff` + `cs:diff` clean.

## Verification

Both pipelines verified in a docker environment: the new-kernel container (boot + `getProcessors()` order → sanitizer last on every channel) and the legacy `MonologAdapter` (real log → `extra.url` `token=***`, `context` masked, audit fields preserved).

Fixes: [MON-201784](https://centreon.atlassian.net/browse/MON-201784)


[MON-201784]: https://centreon.atlassian.net/browse/MON-201784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ