### PR TITLE
fix(web): use prepared statements and allowlists in legacy classes

### DIFF
--- a/centreon/src/Centreon/Domain/Repository/TaskRepository.php
+++ b/centreon/src/Centreon/Domain/Repository/TaskRepository.php
@@ -118,8 +118,10 @@ class TaskRepository extends ServiceEntityRepository
      */
     public function updateStatus($status, $taskId)
     {
-        $sql = "UPDATE task SET status = '{$status}' WHERE id = {$taskId}";
+        $sql = 'UPDATE task SET status = :status WHERE id = :id';
         $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':status', $status, PDO::PARAM_STR);
+        $stmt->bindValue(':id', (int) $taskId, PDO::PARAM_INT);
 
         return $stmt->execute();
     }

--- a/centreon/www/class/centreonCriticality.class.php
+++ b/centreon/www/class/centreonCriticality.class.php
@@ -302,20 +302,32 @@ class CentreonCriticality
         $limit = null,
     ) {
         $sql = 'SELECT sc_id, sc_name, level, icon_id, sc_description
-                FROM service_categories 
+                FROM service_categories
                 WHERE level IS NOT NULL ';
+        $bindParams = [];
         if (! is_null($searchString) && $searchString != '') {
-            $sql .= " AND sc_name LIKE '%" . $this->db->escape($searchString) . "%' ";
+            $sql .= ' AND sc_name LIKE :searchString ';
+            $bindParams[':searchString'] = '%' . $searchString . '%';
         }
         if (! is_null($orderBy) && ! is_null($sort)) {
+            // ORDER BY column and direction cannot be bound as parameters, so they
+            // are validated against explicit allowlists.
+            $allowedOrderBy = ['sc_id', 'sc_name', 'level', 'icon_id', 'sc_description'];
+            $allowedSort = ['ASC', 'DESC'];
+            $orderBy = in_array($orderBy, $allowedOrderBy, true) ? $orderBy : 'level';
+            $sort = in_array(strtoupper((string) $sort), $allowedSort, true) ? strtoupper((string) $sort) : 'ASC';
             $sql .= " ORDER BY {$orderBy} {$sort} ";
         }
         if (! is_null($offset) && ! is_null($limit)) {
-            $sql .= " LIMIT {$offset},{$limit}";
+            $sql .= ' LIMIT ' . (int) $offset . ',' . (int) $limit;
         }
-        $res = $this->db->query($sql);
+        $res = $this->db->prepare($sql);
+        foreach ($bindParams as $param => $value) {
+            $res->bindValue($param, $value, PDO::PARAM_STR);
+        }
+        $res->execute();
         $elements = [];
-        while ($row = $res->fetchRow()) {
+        while ($row = $res->fetch()) {
             $elements[$row['sc_id']] = [];
             $elements[$row['sc_id']]['sc_name'] = $row['sc_name'];
             $elements[$row['sc_id']]['level'] = $row['level'];
@@ -345,17 +357,21 @@ class CentreonCriticality
 
         $request = "SELECT service_id, service_template_model_stm_id FROM service
             WHERE service_register = '0' AND service_activate = '1'
-                AND service_id = {$service_id} ORDER BY service_template_model_stm_id ASC";
-        $RES = $pearDB->query($request);
+                AND service_id = :serviceId ORDER BY service_template_model_stm_id ASC";
+        $RES = $pearDB->prepare($request);
+        $RES->bindValue(':serviceId', (int) $service_id, PDO::PARAM_INT);
+        $RES->execute();
         if (isset($RES) && $RES->rowCount()) {
-            while ($data = $RES->fetchRow()) {
-                $request2 = "select sr.* FROM service_categories_relation sr, service_categories sc
+            while ($data = $RES->fetch()) {
+                $request2 = 'select sr.* FROM service_categories_relation sr, service_categories sc
                     WHERE sr.sc_id = sc.sc_id
-                        AND sr.service_service_id = '" . $data['service_id'] . "'
-                        AND sc.level IS NOT NULL";
-                $RES2 = $pearDB->query($request2);
+                        AND sr.service_service_id = :serviceServiceId
+                        AND sc.level IS NOT NULL';
+                $RES2 = $pearDB->prepare($request2);
+                $RES2->bindValue(':serviceServiceId', (int) $data['service_id'], PDO::PARAM_INT);
+                $RES2->execute();
                 if ($RES2->rowCount() != 0) {
-                    $criticity = $RES2->fetchRow();
+                    $criticity = $RES2->fetch();
                     if ($criticity['sc_id'] && isset($criticity['sc_id'])) {
                         return $criticity['sc_id'];
                     }

--- a/centreon/www/class/centreonFeature.class.php
+++ b/centreon/www/class/centreonFeature.class.php
@@ -142,12 +142,22 @@ class CentreonFeature
         }
         foreach ($features as $name => $versions) {
             foreach ($versions as $version => $value) {
-                $query = 'DELETE FROM contact_feature WHERE contact_id = ' . $userId . ' AND feature = "'
-                    . $this->db->escape($name) . '" AND feature_version = "' . $this->db->escape($version) . '"';
-                $this->db->query($query);
-                $query = 'INSERT INTO contact_feature VALUES (' . $userId . ', "' . $this->db->escape($name) . '", "'
-                    . $this->db->escape($version) . '", ' . (int) $value . ')';
-                $this->db->query($query);
+                $deleteQuery = 'DELETE FROM contact_feature
+                    WHERE contact_id = :userId AND feature = :name AND feature_version = :version';
+                $deleteStmt = $this->db->prepare($deleteQuery);
+                $deleteStmt->bindValue(':userId', (int) $userId, PDO::PARAM_INT);
+                $deleteStmt->bindValue(':name', $name, PDO::PARAM_STR);
+                $deleteStmt->bindValue(':version', $version, PDO::PARAM_STR);
+                $deleteStmt->execute();
+
+                $insertQuery = 'INSERT INTO contact_feature (contact_id, feature, feature_version, feature_enabled)
+                    VALUES (:userId, :name, :version, :value)';
+                $insertStmt = $this->db->prepare($insertQuery);
+                $insertStmt->bindValue(':userId', (int) $userId, PDO::PARAM_INT);
+                $insertStmt->bindValue(':name', $name, PDO::PARAM_STR);
+                $insertStmt->bindValue(':version', $version, PDO::PARAM_STR);
+                $insertStmt->bindValue(':value', (int) $value, PDO::PARAM_INT);
+                $insertStmt->execute();
             }
         }
     }

--- a/centreon/www/class/centreonGraphStatus.class.php
+++ b/centreon/www/class/centreonGraphStatus.class.php
@@ -214,9 +214,11 @@ class CentreonGraphStatus
      */
     public static function getIndexId($hostId, $serviceId, $dbc)
     {
-        $query = 'SELECT id, 1 AS REALTIME FROM index_data WHERE host_id = ' . $hostId . ' AND service_id = '
-            . $serviceId;
-        $res = $dbc->query($query);
+        $query = 'SELECT id, 1 AS REALTIME FROM index_data WHERE host_id = :hostId AND service_id = :serviceId';
+        $res = $dbc->prepare($query);
+        $res->bindValue(':hostId', (int) $hostId, PDO::PARAM_INT);
+        $res->bindValue(':serviceId', (int) $serviceId, PDO::PARAM_INT);
+        $res->execute();
         $row = $res->fetch();
 
         if ($row == false) {

--- a/centreon/www/class/centreonIssue.class.php
+++ b/centreon/www/class/centreonIssue.class.php
@@ -65,7 +65,7 @@ class CentreonIssue
 					AND s.service_id = i.service_id
 					AND s.host_id = h.host_id
 					AND i.issue_id = iip.child_id
-					AND iip.parent_id = ' . $this->dbb->escape($issueId) . '
+					AND iip.parent_id = ' . (int) $issueId . '
 
 					UNION
 
@@ -81,7 +81,7 @@ class CentreonIssue
 					WHERE h2.host_id = i2.host_id
 					AND i2.service_id IS NULL
 					AND i2.issue_id = iip2.child_id
-					AND iip2.parent_id = ' . $this->dbb->escape($issueId) . '
+					AND iip2.parent_id = ' . (int) $issueId . '
         		  ) tb ';
         $res = $this->dbb->query($query);
         $childTab = [];
@@ -106,7 +106,7 @@ class CentreonIssue
     {
         $query = 'SELECT parent_id
             FROM issues_issues_parents
-            WHERE parent_id = ' . $this->dbb->escape($issueId) . ' LIMIT 1';
+            WHERE parent_id = ' . (int) $issueId . ' LIMIT 1';
         $res = $this->dbb->query($query);
 
         return (bool) ($res->rowCount());

--- a/centreon/www/class/centreonIssue.class.php
+++ b/centreon/www/class/centreonIssue.class.php
@@ -65,7 +65,7 @@ class CentreonIssue
 					AND s.service_id = i.service_id
 					AND s.host_id = h.host_id
 					AND i.issue_id = iip.child_id
-					AND iip.parent_id = ' . (int) $issueId . '
+					AND iip.parent_id = :issueIdService
 
 					UNION
 
@@ -81,11 +81,14 @@ class CentreonIssue
 					WHERE h2.host_id = i2.host_id
 					AND i2.service_id IS NULL
 					AND i2.issue_id = iip2.child_id
-					AND iip2.parent_id = ' . (int) $issueId . '
+					AND iip2.parent_id = :issueIdHost
         		  ) tb ';
-        $res = $this->dbb->query($query);
+        $res = $this->dbb->prepare($query);
+        $res->bindValue(':issueIdService', (int) $issueId, PDO::PARAM_INT);
+        $res->bindValue(':issueIdHost', (int) $issueId, PDO::PARAM_INT);
+        $res->execute();
         $childTab = [];
-        while ($row = $res->fetchRow()) {
+        while ($row = $res->fetch()) {
             foreach ($row as $key => $val) {
                 $childTab[$row['issue_id']][$key] = $val;
             }
@@ -106,8 +109,10 @@ class CentreonIssue
     {
         $query = 'SELECT parent_id
             FROM issues_issues_parents
-            WHERE parent_id = ' . (int) $issueId . ' LIMIT 1';
-        $res = $this->dbb->query($query);
+            WHERE parent_id = :issueId LIMIT 1';
+        $res = $this->dbb->prepare($query);
+        $res->bindValue(':issueId', (int) $issueId, PDO::PARAM_INT);
+        $res->execute();
 
         return (bool) ($res->rowCount());
     }

--- a/centreon/www/class/centreonMedia.class.php
+++ b/centreon/www/class/centreonMedia.class.php
@@ -190,13 +190,16 @@ class CentreonMedia
             . 'FROM view_img_dir dir, view_img_dir_relation rel, view_img img '
             . 'WHERE dir.dir_id = rel.dir_dir_parent_id '
             . 'AND rel.img_img_id = img.img_id '
-            . "AND img.img_path = '" . $imagename . "' "
-            . "AND dir.dir_name = '" . $dirname . "' "
+            . 'AND img.img_path = :imagename '
+            . 'AND dir.dir_name = :dirname '
             . 'LIMIT 1';
-        $RES = $this->db->query($query);
+        $RES = $this->db->prepare($query);
+        $RES->bindValue(':imagename', $imagename, PDO::PARAM_STR);
+        $RES->bindValue(':dirname', $dirname, PDO::PARAM_STR);
+        $RES->execute();
         $img_id = null;
         if ($RES->rowCount()) {
-            $row = $RES->fetchRow();
+            $row = $RES->fetch();
             $img_id = $row['img_id'];
         }
 

--- a/centreon/www/class/centreonNotification.class.php
+++ b/centreon/www/class/centreonNotification.class.php
@@ -115,7 +115,7 @@ class CentreonNotification
         $sql = 'SELECT cg_id, cg_name
         		FROM contactgroup cg, contactgroup_contact_relation ccr
         		WHERE cg.cg_id = ccr.contactgroup_cg_id
-        		AND ccr.contact_contact_id = ' . $contactId;
+        		AND ccr.contact_contact_id = ' . (int) $contactId;
         $res = $this->db->query($sql);
         $tab = [];
         while ($row = $res->fetchRow()) {
@@ -189,7 +189,7 @@ class CentreonNotification
      */
     protected function isNotificationEnabled($contactId)
     {
-        $sql = 'SELECT contact_enable_notifications FROM contact WHERE contact_id = ' . $contactId;
+        $sql = 'SELECT contact_enable_notifications FROM contact WHERE contact_id = ' . (int) $contactId;
         $res = $this->db->query($sql);
         if ($res->rowCount()) {
             $row = $res->fetchRow();
@@ -211,7 +211,7 @@ class CentreonNotification
      */
     protected function getHostEscalations($escalations)
     {
-        $escalations = implode(',', array_keys($escalations));
+        $escalations = implode(',', array_map('intval', array_keys($escalations)));
         $sql = 'SELECT h.host_id, h.host_name
         		FROM escalation_host_relation ehr, host h
         		WHERE h.host_id = ehr.host_host_id
@@ -241,7 +241,7 @@ class CentreonNotification
      */
     protected function getServiceEscalations($escalations)
     {
-        $escalationsList = implode('', array_keys($escalations));
+        $escalationsList = implode('', array_map('intval', array_keys($escalations)));
         $sql = 'SELECT h.host_id, h.host_name, s.service_id, s.service_description
         		FROM escalation_service_relation esr, host h, service s
         		WHERE h.host_id = esr.host_host_id
@@ -284,7 +284,7 @@ class CentreonNotification
         $sql = 'SELECT ecr.escalation_esc_id, e.esc_name
         		FROM escalation_contactgroup_relation ecr, escalation e
         		WHERE e.esc_id = ecr.escalation_esc_id
-        		AND ecr.contactgroup_cg_id IN (' . implode(',', array_keys($contactgroups)) . ')';
+        		AND ecr.contactgroup_cg_id IN (' . implode(',', array_map('intval', array_keys($contactgroups))) . ')';
         $res = $this->db->query($sql);
         $escTab = [];
         while ($row = $res->fetchRow()) {
@@ -313,13 +313,13 @@ class CentreonNotification
     {
         $sql = 'SELECT host_id, host_name, host_register, 1 as notif_type
         		FROM contact_host_relation chr, host h
-        		WHERE chr.contact_id = ' . $contactId . '
+        		WHERE chr.contact_id = ' . (int) $contactId . '
         		AND chr.host_host_id = h.host_id ';
         if (count($contactgroups)) {
             $sql .= ' UNION
         			  SELECT host_id, host_name, host_register, 2 as notif_type
         			  FROM contactgroup_host_relation chr, host h
-        			  WHERE chr.contactgroup_cg_id IN (' . implode(',', array_keys($contactgroups)) . ')
+        			  WHERE chr.contactgroup_cg_id IN (' . implode(',', array_map('intval', array_keys($contactgroups))) . ')
         			  AND chr.host_host_id = h.host_id ';
         }
         $res = $this->db->query($sql);
@@ -338,7 +338,7 @@ class CentreonNotification
         if ($this->notifiedHosts !== []) {
             $sql2 = 'SELECT host_id, host_name
                 FROM host
-                WHERE host_id NOT IN (' . implode(',', array_keys($this->notifiedHosts)) . ") AND host_register = '1'";
+                WHERE host_id NOT IN (' . implode(',', array_map('intval', array_keys($this->notifiedHosts))) . ") AND host_register = '1'";
         } else {
             $sql2 = "SELECT host_id, host_name FROM host WHERE host_register = '1'";
         }
@@ -409,13 +409,13 @@ class CentreonNotification
         		FROM contact_service_relation csr, service s
         		LEFT JOIN host_service_relation hsr ON hsr.service_service_id = s.service_id
         		LEFT JOIN host h ON h.host_id = hsr.host_host_id
-        		WHERE csr.contact_id = ' . $contactId . "
+        		WHERE csr.contact_id = ' . (int) $contactId . "
                 AND csr.service_service_id = s.service_id
                 AND s.service_use_only_contacts_from_host != '1'
         		UNION
                 SELECT h.host_id, h.host_name, s.service_id, s.service_description, s.service_register, 1 as notif_type
         		FROM contact_service_relation csr, service s, host h, host_service_relation hsr, hostgroup_relation hgr
-        		WHERE csr.contact_id = " . $contactId . "
+        		WHERE csr.contact_id = " . (int) $contactId . "
         		AND csr.service_service_id = s.service_id
         		AND s.service_id = hsr.service_service_id
         		AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id
@@ -423,7 +423,7 @@ class CentreonNotification
                 AND s.service_use_only_contacts_from_host != '1'";
 
         if (count($contactGroups)) {
-            $contactGroups = implode(',', array_keys($contactGroups));
+            $contactGroups = implode(',', array_map('intval', array_keys($contactGroups)));
             $sql .= ' UNION
         			  SELECT h.host_id, h.host_name, s.service_id, s.service_description, s.service_register,
                       2 as notif_type
@@ -470,7 +470,7 @@ class CentreonNotification
                 . 'FROM service s, host h, host_service_relation hsr '
                 . 'WHERE hsr.service_service_id = s.service_id '
                 . 'AND hsr.host_host_id = h.host_id '
-                . 'AND h.host_id IN (' . implode(',', array_keys($this->notifiedHosts)) . ')';
+                . 'AND h.host_id IN (' . implode(',', array_map('intval', array_keys($this->notifiedHosts))) . ')';
             $res = $this->db->query($sql);
             while ($row = $res->fetchRow()) {
                 $svcTab[$row['host_id']][$row['service_id']] = [];
@@ -487,7 +487,7 @@ class CentreonNotification
             }
             $sql2 = 'SELECT service_id, service_description
             		 FROM service
-            		 WHERE service_id NOT IN (' . implode(',', $tab) . ") AND service_register = '1'";
+            		 WHERE service_id NOT IN (' . implode(',', array_map('intval', $tab)) . ") AND service_register = '1'";
         } else {
             $sql2 = "SELECT service_id, service_description
             		 FROM service

--- a/centreon/www/class/centreonNotification.class.php
+++ b/centreon/www/class/centreonNotification.class.php
@@ -241,7 +241,7 @@ class CentreonNotification
      */
     protected function getServiceEscalations($escalations)
     {
-        $escalationsList = implode('', array_map('intval', array_keys($escalations)));
+        $escalationsList = implode(',', array_map('intval', array_keys($escalations)));
         $sql = 'SELECT h.host_id, h.host_name, s.service_id, s.service_description
         		FROM escalation_service_relation esr, host h, service s
         		WHERE h.host_id = esr.host_host_id

--- a/centreon/www/class/centreonResources.class.php
+++ b/centreon/www/class/centreonResources.class.php
@@ -74,11 +74,13 @@ class CentreonResources
      */
     public static function getResourceByName($db, $name)
     {
-        $queryResources = "SELECT * FROM cfg_resource WHERE resource_name = '{$name}'";
-        $resultQueryResources = $db->query($queryResources);
+        $queryResources = 'SELECT * FROM cfg_resource WHERE resource_name = :name';
+        $resultQueryResources = $db->prepare($queryResources);
+        $resultQueryResources->bindValue(':name', $name, PDO::PARAM_STR);
+        $resultQueryResources->execute();
 
         $finalResource = [];
-        while ($resultResources = $resultQueryResources->fetchRow()) {
+        while ($resultResources = $resultQueryResources->fetch()) {
             $finalResource = $resultResources;
         }
 

--- a/centreon/www/class/centreonTopology.class.php
+++ b/centreon/www/class/centreonTopology.class.php
@@ -47,6 +47,13 @@ class CentreonTopology
      */
     public function getTopology($key, $value)
     {
+        // The column name fragment cannot be bound as a parameter, so $key is
+        // validated against an allowlist of permitted topology columns.
+        $allowedKeys = ['page', 'id', 'name', 'parent'];
+        if (! in_array($key, $allowedKeys, true)) {
+            throw new Exception(sprintf('Invalid topology column: %s', $key));
+        }
+
         $queryTopologyPage = 'SELECT * FROM topology WHERE topology_' . $key . ' = :keyTopo';
         $stmt = $this->db->prepare($queryTopologyPage);
         $stmt->bindParam(':keyTopo', $value);

--- a/centreon/www/class/centreonWidget.class.php
+++ b/centreon/www/class/centreonWidget.class.php
@@ -510,18 +510,15 @@ class CentreonWidget
             if ($str != '') {
                 $str .= ',';
             }
-            $str .= '(:viewId, :widgetId' . $widgetId . ')';
-            $queryValues['widgetId' . $widgetId] = (int) $widgetId;
+            $str .= '(?, ?)';
+            $queryValues[] = (int) $viewId;
+            $queryValues[] = (int) $widgetId;
         }
 
         if ($str != '') {
             $query = 'INSERT INTO widget_views (custom_view_id, widget_id) VALUES ' . $str;
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
-            foreach ($queryValues as $widgetId) {
-                $stmt->bindValue(':widgetId' . $widgetId, $widgetId, PDO::PARAM_INT);
-            }
-            $dbResult = $stmt->execute();
+            $dbResult = $stmt->execute($queryValues);
             if (! $dbResult) {
                 throw new Exception('An error occured');
             }

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -243,9 +243,9 @@ $tM = $centreon->optGen['AjaxTimeReloadMonitoring'] * 1000;
         jQuery(function () {
             <?php
         $res = null;
-$query = "SELECT DISTINCT PathName_js, init FROM topology_JS WHERE id_page = '"
-    . $p . "' AND (o = '" . $o . "' OR o IS NULL)";
-$DBRESULT = $pearDB->query($query);
+$query = 'SELECT DISTINCT PathName_js, init FROM topology_JS WHERE id_page = ? AND (o = ? OR o IS NULL)';
+$DBRESULT = $pearDB->prepare($query);
+$DBRESULT->execute([$p, $o]);
 while ($topology_js = $DBRESULT->fetch()) {
     if ($topology_js['init'] == 'initM') {
         if ($o != 'hd' && $o != 'svcd') {
@@ -254,7 +254,7 @@ while ($topology_js = $DBRESULT->fetch()) {
                 $obis .= '_pb';
             }
             if (isset($_GET['acknowledge'])) {
-                $obis .= '_ack_' . $_GET['acknowledge'];
+                $obis .= '_ack_' . htmlspecialchars($_GET['acknowledge'], ENT_QUOTES, 'UTF-8');
             }
             echo "\tsetTimeout('initM({$tM}, \"{$obis}\")', 0);";
         }


### PR DESCRIPTION
## Description

Refs MON-200904.

Hardens SQL handling and output rendering across assorted legacy classes that previously built statements via string concatenation.

### Changes
- Migrate concatenated queries to prepared statements with bound parameters (`prepare()` / `bindValue()` / `execute()`).
- Cast integer identifiers to `int` where binding is not practical (e.g. `IN (...)` lists built from internal id arrays via `array_map('intval', ...)`).
- Validate non-bindable identifiers (`ORDER BY` columns / sort direction, dynamic column-name fragments) against explicit allowlists.
- Escape dynamic value rendered into an inline `<script>` block with `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')`.

### Files
- `www/include/core/header/htmlHeader.php`
- `src/Centreon/Domain/Repository/TaskRepository.php`
- `www/class/centreonCriticality.class.php`
- `www/class/centreonMedia.class.php`
- `www/class/centreonResources.class.php`
- `www/class/centreonWidget.class.php`
- `www/class/centreonFeature.class.php`
- `www/class/centreonGraphStatus.class.php`
- `www/class/centreonIssue.class.php`
- `www/class/centreonNotification.class.php`
- `www/class/centreonTopology.class.php`

### Tests / validation
- `php -l` clean on all modified files.
- No dedicated unit tests exist for these legacy classes.

