### PR TITLE
fix(resources): allow realtime severity level up to 127

### DIFF
--- a/centreon/src/Core/Severity/RealTime/Domain/Model/Severity.php
+++ b/centreon/src/Core/Severity/RealTime/Domain/Model/Severity.php
@@ -29,6 +29,8 @@ use Core\Domain\RealTime\Model\Icon;
 class Severity
 {
     public const MAX_NAME_LENGTH = 255;
+    public const MIN_LEVEL = 0;
+    public const MAX_LEVEL = 127;
     public const SERVICE_SEVERITY_TYPE_ID = 0;
     public const HOST_SEVERITY_TYPE_ID = 1;
     public const TYPES_AS_STRING = [
@@ -54,8 +56,8 @@ class Severity
     ) {
         Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'Severity::name');
         Assertion::notEmpty($name, 'Severity::name');
-        Assertion::min($level, 0, 'Severity::level');
-        Assertion::max($level, 100, 'Severity::level');
+        Assertion::min($level, self::MIN_LEVEL, 'Severity::level');
+        Assertion::max($level, self::MAX_LEVEL, 'Severity::level');
         Assertion::inArray(
             $type,
             [self::HOST_SEVERITY_TYPE_ID, self::SERVICE_SEVERITY_TYPE_ID],

--- a/centreon/tests/php/Core/Severity/RealTime/Domain/Model/SeverityTest.php
+++ b/centreon/tests/php/Core/Severity/RealTime/Domain/Model/SeverityTest.php
@@ -53,13 +53,24 @@ it('should throw an exception when severity name is too long', function (): void
     )->getMessage()
 );
 
-it('should throw an exception when severity level is lower than 0', function (): void {
-    new Severity(1, 'name', -1, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
-})->throws(\Assert\InvalidArgumentException::class, AssertionException::min(-1, 0, 'Severity::level')->getMessage());
+it('should throw an exception when severity level is lower than the minimum', function (): void {
+    new Severity(1, 'name', Severity::MIN_LEVEL - 1, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
+})->throws(
+    \Assert\InvalidArgumentException::class,
+    AssertionException::min(Severity::MIN_LEVEL - 1, Severity::MIN_LEVEL, 'Severity::level')->getMessage()
+);
 
-it('should throw an exception when severity level is greater than 100', function (): void {
-    new Severity(1, 'name', 200, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
-})->throws(\Assert\InvalidArgumentException::class, AssertionException::max(200, 100, 'Severity::level')->getMessage());
+it('should throw an exception when severity level is greater than the maximum', function (): void {
+    new Severity(1, 'name', Severity::MAX_LEVEL + 1, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
+})->throws(
+    \Assert\InvalidArgumentException::class,
+    AssertionException::max(Severity::MAX_LEVEL + 1, Severity::MAX_LEVEL, 'Severity::level')->getMessage()
+);
+
+it('should accept a severity level up to the maximum allowed by configuration', function (): void {
+    $severity = new Severity(1, 'name', Severity::MAX_LEVEL, Severity::HOST_SEVERITY_TYPE_ID, $this->icon);
+    expect($severity->getLevel())->toBe(Severity::MAX_LEVEL);
+});
 
 it('should throw an exception when severity type is not handled', function (): void {
     new Severity(1, 'name', 60, 2, $this->icon);


### PR DESCRIPTION
## Description

Ref: [MON-201020](https://centreon.atlassian.net/browse/MON-201020)

Setting a host/service category severity level above 100 (the documented range is 1–127) caused the **resources status page** to fail with a red error popup.

### Root cause

The realtime `Severity` domain model (`Core\Severity\RealTime\Domain\Model\Severity`) hard-capped `level` at **100**, whereas:

- the configuration model allows up to **127** (`HostSeverity::MAX_LEVEL_NUMBER = 127`),
- the database column is a signed `TINYINT` (`-128`–`127`),
- the documentation states the valid range is **1–127**.

When a resource carried a severity level in the 101–127 range, building the realtime `Severity` object threw:

```
[Severity::level] The value "127" was expected to be at most 100
```

This `AssertionException` bubbled up through `DbReadResourceRepository::findResourcesByAccessGroupIds()` / `findParentResourcesById()` and broke the whole resources listing.

### Fix

- Raise the realtime severity level upper bound from `100` to `127` so it matches the configuration model, the DB column and the documentation.
- Replace the magic numbers with named `MIN_LEVEL` / `MAX_LEVEL` constants.

### Tests

- Updated the min/max assertion unit tests to use the new constants.
- Added a regression test asserting a level of `127` is accepted.
- `vendor/bin/pest` on `SeverityTest` → 6 passed.

[MON-201020]: https://centreon.atlassian.net/browse/MON-201020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ