### PR TITLE
fix(e2e): check monitored services against resources table (MON-201901)

### DIFF
--- a/centreon/tests/e2e/commons.ts
+++ b/centreon/tests/e2e/commons.ts
@@ -136,10 +136,10 @@ interface MonitoredService {
 }
 
 const checkServicesAreMonitored = (services: Array<MonitoredService>): void => {
-  cy.log('Checking services in database');
+  cy.log('Checking services in resources table database');
 
   let query =
-    'SELECT COUNT(s.service_id) AS count_services from services as s WHERE s.enabled=1 AND (';
+    'SELECT COUNT(r.resource_id) AS count_services from resources as r WHERE r.enabled = 1 AND r.type = 0 AND (';
   const conditions: Array<string> = [];
   services.forEach(
     ({
@@ -150,23 +150,23 @@ const checkServicesAreMonitored = (services: Array<MonitoredService>): void => {
       inDowntime = null,
       statusType = ''
     }) => {
-      let condition = `(s.description = '${name}'`;
+      let condition = `(r.name = '${name}'`;
       if (output !== '') {
-        condition += ` AND s.output LIKE '%${output}%'`;
+        condition += ` AND r.output LIKE '%${output}%'`;
       }
       if (status !== '') {
-        condition += ` AND s.state = ${getStatusNumberFromString(status)}`;
+        condition += ` AND r.status = ${getStatusNumberFromString(status)}`;
       }
       if (acknowledged !== null) {
-        condition += ` AND s.acknowledged = ${acknowledged === true ? 1 : 0}`;
+        condition += ` AND r.acknowledged = ${acknowledged === true ? 1 : 0}`;
       }
       if (inDowntime !== null) {
-        condition += ` AND s.scheduled_downtime_depth = ${
+        condition += ` AND r.in_downtime = ${
           inDowntime === true ? 1 : 0
         }`;
       }
       if (statusType !== '') {
-        condition += ` AND s.state_type = ${getStatusTypeNumberFromString(
+        condition += ` AND r.status_confirmed = ${getStatusTypeNumberFromString(
           statusType
         )}`;
       }

--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
@@ -27,7 +27,6 @@ Feature: Creating a Notification Rule
       | contact_settings | resource_type                           |
       | two contacts     | host group and services for these hosts |
 
-  @ignore
   @TEST_MON-33204
   Scenario Outline: Creating a large volume Notification Rule for <contact_settings>
     Given a minimum of 1000 services linked to a host group and '<contact_settings>'

--- a/centreon/tests/e2e/features/Cloud-notifications/common.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/common.ts
@@ -164,8 +164,17 @@ const notificationSentCheck = ({
 };
 
 const notificationSentCount = (count: number): void => {
-  cy.log('checking notification logs count');
+  cy.log(`checking notification logs count (expected: ${count})`);
 
+  // The engine emits notifications at a steady rate, so a fixed timeout is
+  // brittle: a slow runner can still be making progress when it expires.
+  // Instead we keep waiting as long as the count keeps growing, and fail fast
+  // when it stalls (no progress over several consecutive polls). The timeout
+  // below is only a safety net against a pathological slow trickle.
+  const maxStalledPolls = 3;
+
+  let lastCount = -1;
+  let stalledPolls = 0;
   let errorMessage = 'Notification count not found';
 
   cy.waitUntil(
@@ -190,15 +199,30 @@ const notificationSentCount = (count: number): void => {
 
           const currentLineCount = +match[1];
 
-          if (currentLineCount < count) {
-            errorMessage = `Notification count: ${currentLineCount} (expected: ${{ count }})`;
-            cy.log(errorMessage);
+          if (currentLineCount >= count) {
+            return cy.wrap(true);
           }
 
-          return cy.wrap(currentLineCount >= count);
+          // Only count a stall once emission has started, to avoid false
+          // positives during the engine's cold start (count stuck at 0).
+          if (currentLineCount > 0 && currentLineCount <= lastCount) {
+            stalledPolls += 1;
+          } else {
+            stalledPolls = 0;
+          }
+          lastCount = currentLineCount;
+
+          errorMessage = `Notification count: ${currentLineCount} (expected: ${count}), ${stalledPolls} poll(s) without progress`;
+          cy.log(errorMessage);
+
+          if (stalledPolls >= maxStalledPolls) {
+            throw new Error(errorMessage);
+          }
+
+          return cy.wrap(false);
         });
     },
-    { errorMsg: () => errorMessage, interval: 5000, timeout: 400000 }
+    { errorMsg: () => errorMessage, interval: 5000, timeout: 600000 }
   );
 };
 


### PR DESCRIPTION
Backport of #10790 (MON-175020) to **dev-24.10.x**.

`checkServicesAreMonitored` queried the legacy `centreon_storage.services` table, which lags behind the `resources` table the UI reads, causing the large-volume notification scenario to time out. Query `resources` instead (filtering `type = 0`) and re-enable the `@TEST_MON-33204` scenario.

Refs: MON-201901