### PR TITLE
feat(logging): mask sensitive data in record extra and the legacy MonologAdapter

### DIFF
--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -161,6 +161,25 @@ services:
         arguments:
             $dateFormat: !php/const DateTimeInterface::RFC3339
 
+    # #[Sensitive] payload masking. The App\Shared namespace is not glob-loaded
+    # here, so these services are declared by hand; autoconfigure: false stops
+    # Symfony from also deriving the monolog.processor tag from #[AsMonologProcessor]
+    # and double-registering the processor.
+    #
+    # Declared FIRST on purpose: the MonologBundle pushes tagged processors in
+    # definition order and Monolog's pushProcessor is LIFO, so the first-declared
+    # one runs LAST — after WebProcessor & co. have filled `extra` (the request
+    # URL lives in `extra.url`). The bundle ignores the tag `priority` for
+    # processors, so ordering is controlled by declaration position here.
+    App\Shared\Infrastructure\Logging\PayloadSanitizer:
+        autoconfigure: false
+
+    App\Shared\Infrastructure\Logging\SanitizingProcessor:
+        autoconfigure: false
+        arguments:
+            $sanitizer: '@App\Shared\Infrastructure\Logging\PayloadSanitizer'
+        tags: ['monolog.processor']
+
     # Global Monolog processor: turns any \Throwable found in a record's
     # context.exception into a structured, bounded array (flat cause chain).
     # Registered explicitly because src/App/Shared is not autoloaded as
@@ -198,16 +217,3 @@ services:
         autoconfigure: false
         tags:
             - { name: kernel.reset, method: reset }
-
-    # #[Sensitive] payload masking. The App\Shared namespace is not glob-loaded
-    # here, so these services are declared by hand; autoconfigure: false stops
-    # Symfony from also deriving the monolog.processor tag from #[AsMonologProcessor]
-    # and double-registering the processor.
-    App\Shared\Infrastructure\Logging\PayloadSanitizer:
-        autoconfigure: false
-
-    App\Shared\Infrastructure\Logging\SanitizingProcessor:
-        autoconfigure: false
-        arguments:
-            $sanitizer: '@App\Shared\Infrastructure\Logging\PayloadSanitizer'
-        tags: ['monolog.processor']

--- a/centreon/src/Adaptation/Log/Adapter/MonologAdapter.php
+++ b/centreon/src/Adaptation/Log/Adapter/MonologAdapter.php
@@ -27,6 +27,8 @@ use Adaptation\Log\Enum\LogChannelEnum;
 use Adaptation\Log\Exception\LoggerException;
 use Adaptation\Log\Logger;
 use App\Shared\Infrastructure\Logging\ExceptionFormatterProcessor;
+use App\Shared\Infrastructure\Logging\PayloadSanitizer;
+use App\Shared\Infrastructure\Logging\SanitizingProcessor;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
@@ -154,6 +156,10 @@ final class MonologAdapter implements LoggerInterface
 
     private function pushPlatformProcessors(): void
     {
+        // pushProcessor is LIFO: the first one pushed runs LAST. The sanitiser
+        // must run after WebProcessor (which fills `extra.url`, query string
+        // included), so it is pushed first to redact as the final step.
+        $this->logger->pushProcessor(new SanitizingProcessor(new PayloadSanitizer()));
         $this->logger->pushProcessor(new ExceptionFormatterProcessor());
         $this->logger->pushProcessor(new WebProcessor());
         $this->logger->pushProcessor(self::$uidProcessor ??= new UidProcessor());

--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -26,16 +26,22 @@ namespace App\Shared\Infrastructure\Logging;
 use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
 
 /**
- * Stateless walker that masks the values of `#[Sensitive]`-annotated
- * properties inside an arbitrary payload (an ad-hoc logger context,
- * anything Monolog forwards to a handler).
+ * Stateless walker that masks sensitive values inside an arbitrary
+ * payload (a Command/Query, an ad-hoc logger context, a Monolog
+ * record's `context` / `extra` — anything forwarded to a handler).
  *
  * Typed payloads are masked **attribute-driven**: a property without
  * `#[Sensitive]` is logged in clear, the owning class declares its
  * sensitivity explicitly. As an extra net, raw array keys are
  * additionally matched against {@see SensitiveKeywordDenylist} so that
  * an ad-hoc `$logger->error('m', ['token' => $x])` — which carries no
- * class to reflect — is still caught.
+ * class to reflect — is still caught. Independently, in any string value
+ * holding a URL **query string**, the `&`-separated parameters whose name
+ * matches that same denylist are redacted in place (e.g. `…?page=2&token=***`).
+ * This covers the common case of a secret logged in a request URL
+ * (`extra.url`); it is best-effort and scoped to the query component —
+ * secrets in the path, the fragment, or nested inside another parameter's
+ * value are out of scope.
  *
  * Object values are rendered defensively to avoid leaking private
  * properties; `\Throwable` instances are returned as-is so that
@@ -48,15 +54,35 @@ final readonly class PayloadSanitizer
 
     /**
      * @param class-string|null $contextClass class whose `#[Sensitive]`
-     *                                        attributes annotate the
-     *                                        array keys at the current
-     *                                        depth, or `null` when the
-     *                                        type at this level is
+     *                                        attributes annotate the array
+     *                                        keys, or `null` when the type is
      *                                        scalar / array / unknown
+     * @param bool $maskKeywordKeys whether array keys matching the shared
+     *                              keyword denylist are masked. `true` for
+     *                              ad-hoc / context payloads; `false` for a
+     *                              Monolog `extra` bag, whose keys are set by
+     *                              platform processors (e.g. `token` => an
+     *                              audit descriptor of the authenticated user
+     *                              — authenticated flag, roles, identifier —
+     *                              not a credential) and must stay readable;
+     *                              there only URL query secrets are redacted.
      *
      * @throws \ReflectionException when SensitivityScanner cannot reflect the context class
      */
-    public function sanitize(mixed $data, int $depth = 0, ?string $contextClass = null): mixed
+    public function sanitize(mixed $data, ?string $contextClass = null, bool $maskKeywordKeys = true): mixed
+    {
+        return $this->walk($data, 0, $contextClass, $maskKeywordKeys);
+    }
+
+    /**
+     * Recursive masking walk; `$depth` bounds the recursion. Internal —
+     * callers use {@see self::sanitize()}.
+     *
+     * @param class-string|null $contextClass
+     *
+     * @throws \ReflectionException
+     */
+    private function walk(mixed $data, int $depth, ?string $contextClass, bool $maskKeywordKeys): mixed
     {
         if ($depth >= self::MAX_DEPTH) {
             return '{…}';
@@ -86,7 +112,7 @@ final readonly class PayloadSanitizer
                 }
 
                 if (\is_string($key)
-                    && (\in_array($key, $sensitive, true) || SensitiveKeywordDenylist::matches($key))
+                    && (\in_array($key, $sensitive, true) || ($maskKeywordKeys && SensitiveKeywordDenylist::matches($key)))
                 ) {
                     $result[$key] = '***';
 
@@ -106,7 +132,7 @@ final readonly class PayloadSanitizer
                     continue;
                 }
 
-                $result[$key] = $this->sanitize($value, $depth + 1, $childContext);
+                $result[$key] = $this->walk($value, $depth + 1, $childContext, $maskKeywordKeys);
             }
 
             return $result;
@@ -116,11 +142,58 @@ final readonly class PayloadSanitizer
             return $this->sanitizeObject($data);
         }
 
-        if (\is_string($data) && \mb_strlen($data) > self::MAX_VALUE_LENGTH) {
-            return mb_substr($data, 0, self::MAX_VALUE_LENGTH) . '…[truncated]';
+        if (\is_string($data)) {
+            return $this->capLength($this->maskSensitiveUrlQueryParameters($data));
         }
 
         return $data;
+    }
+
+    /**
+     * Redacts, in place, the values of `&`-separated query parameters whose
+     * name matches the shared keyword denylist inside a URL-like string; the
+     * path and non-sensitive parameters are preserved. Scoped to the query
+     * component only — the path, the fragment, alternate (`;`) separators, and
+     * secrets nested inside a parameter's value are NOT inspected. No-op for
+     * strings without a query part, so it is safe to run on every string value.
+     */
+    private function maskSensitiveUrlQueryParameters(string $value): string
+    {
+        $queryStart = mb_strpos($value, '?');
+        if ($queryStart === false) {
+            return $value;
+        }
+
+        $query = mb_substr($value, $queryStart + 1);
+        if ($query === '') {
+            return $value;
+        }
+
+        $masked = false;
+        $pairs = explode('&', $query);
+        foreach ($pairs as $index => $pair) {
+            $separator = mb_strpos($pair, '=');
+            if ($separator === false) {
+                continue;
+            }
+
+            $name = mb_substr($pair, 0, $separator);
+            if (SensitiveKeywordDenylist::matches(rawurldecode($name))) {
+                $pairs[$index] = $name . '=***';
+                $masked = true;
+            }
+        }
+
+        return $masked
+            ? mb_substr($value, 0, $queryStart + 1) . implode('&', $pairs)
+            : $value;
+    }
+
+    private function capLength(string $value): string
+    {
+        return \mb_strlen($value) > self::MAX_VALUE_LENGTH
+            ? mb_substr($value, 0, self::MAX_VALUE_LENGTH) . '…[truncated]'
+            : $value;
     }
 
     /**
@@ -153,11 +226,7 @@ final readonly class PayloadSanitizer
         }
 
         if ($data instanceof \Stringable) {
-            $string = (string) $data;
-
-            return \mb_strlen($string) > self::MAX_VALUE_LENGTH
-                ? mb_substr($string, 0, self::MAX_VALUE_LENGTH) . '…[truncated]'
-                : $string;
+            return $this->capLength($this->maskSensitiveUrlQueryParameters((string) $data));
         }
 
         return '{' . $data::class . '}';

--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -27,8 +27,8 @@ use App\Shared\Infrastructure\Logging\Attribute\SensitivityScanner;
 
 /**
  * Stateless walker that masks sensitive values inside an arbitrary
- * payload (a Command/Query, an ad-hoc logger context, a Monolog
- * record's `context` / `extra` — anything forwarded to a handler).
+ * payload (an ad-hoc logger context, a Monolog record's `context` /
+ * `extra` — anything forwarded to a handler).
  *
  * Typed payloads are masked **attribute-driven**: a property without
  * `#[Sensitive]` is logged in clear, the owning class declares its

--- a/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
@@ -23,17 +23,22 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Logging;
 
-use Monolog\Attribute\AsMonologProcessor;
 use Monolog\LogRecord;
 
 /**
- * Global Monolog processor that masks `#[Sensitive]` entries in every
- * record's `context` through {@see PayloadSanitizer}, including the
- * ad-hoc `$logger->error('msg', $context)` calls. `\Throwable` values
- * are returned as-is so that {@see ExceptionFormatterProcessor} can
- * structure them downstream.
+ * Monolog processor that masks sensitive data in every record through
+ * {@see PayloadSanitizer}: `#[Sensitive]` / keyword entries in `context`
+ * (the ad-hoc `$logger->error('msg', $context)` paths that bypass the
+ * bus middleware) and secrets carried in URL query strings under `extra`
+ * (notably `extra.url`, set by the WebProcessor).
+ *
+ * It must run after the context-enriching processors that populate
+ * `extra`. Registration order — not the tag `priority`, which the
+ * MonologBundle ignores for processors — guarantees this; see
+ * config/services.yaml. `\Throwable` values under
+ * `context.exception` are left as-is so that
+ * {@see ExceptionFormatterProcessor} can structure them downstream.
  */
-#[AsMonologProcessor]
 final readonly class SanitizingProcessor
 {
     public function __construct(private PayloadSanitizer $sanitizer)
@@ -45,9 +50,18 @@ final readonly class SanitizingProcessor
      */
     public function __invoke(LogRecord $record): LogRecord
     {
-        /** @var array<string, mixed> $sanitized */
-        $sanitized = $this->sanitizer->sanitize($record->context);
+        /** @var array<string, mixed> $context */
+        $context = $this->sanitizer->sanitize($record->context);
 
-        return $record->with(context: $sanitized);
+        // `extra` is filled by platform processors (WebProcessor puts the
+        // request URI — query string included — in `extra.url`). Its keys are
+        // not user-controlled, so keyword-key masking stays off to keep audit
+        // fields readable (e.g. `extra.token` is TokenProcessor's audit
+        // descriptor of the authenticated user, not a credential); only
+        // sensitive URL query-string parameters are redacted.
+        /** @var array<string, mixed> $extra */
+        $extra = $this->sanitizer->sanitize($record->extra, maskKeywordKeys: false);
+
+        return $record->with(context: $context, extra: $extra);
     }
 }

--- a/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SanitizingProcessor.php
@@ -28,9 +28,9 @@ use Monolog\LogRecord;
 /**
  * Monolog processor that masks sensitive data in every record through
  * {@see PayloadSanitizer}: `#[Sensitive]` / keyword entries in `context`
- * (the ad-hoc `$logger->error('msg', $context)` paths that bypass the
- * bus middleware) and secrets carried in URL query strings under `extra`
- * (notably `extra.url`, set by the WebProcessor).
+ * (the ad-hoc `$logger->error('msg', $context)` calls) and secrets carried
+ * in URL query strings under `extra` (notably `extra.url`, set by the
+ * WebProcessor).
  *
  * It must run after the context-enriching processors that populate
  * `extra`. Registration order — not the tag `priority`, which the

--- a/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/SensitiveKeywordDenylist.php
@@ -35,7 +35,11 @@ namespace App\Shared\Infrastructure\Logging;
  */
 final class SensitiveKeywordDenylist
 {
-    public const KEYWORDS = ['password', 'token', 'secret', 'api_key', 'authorization', 'credential', 'private_key'];
+    public const KEYWORDS = [
+        'password', 'passwd', 'pwd', 'token', 'secret', 'api_key', 'apikey', 'api-key',
+        'access_key', 'authorization', 'bearer', 'credential', 'private_key', 'signature',
+        'session_id', 'sessionid',
+    ];
 
     /**
      * Memoises the sensitive-or-not verdict per key to skip the keyword

--- a/centreon/tests/php/Adaptation/Log/Adapter/MonologAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Log/Adapter/MonologAdapterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Adaptation\Log\Adapter;
+
+use Adaptation\Log\Adapter\MonologAdapter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use App\Shared\Infrastructure\Logging\SanitizingProcessor;
+use Monolog\Logger;
+use Monolog\Processor\WebProcessor;
+use PHPUnit\Framework\TestCase;
+
+final class MonologAdapterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // create() builds a StreamHandler under _CENTREON_LOG_; the stream is
+        // opened lazily (only on write), so a temp dir is enough and merely
+        // constructing the logger writes no file.
+        if (! defined('_CENTREON_LOG_')) {
+            define('_CENTREON_LOG_', sys_get_temp_dir() . '/');
+        }
+    }
+
+    public function testSanitizingProcessorRunsLastAfterWebProcessor(): void
+    {
+        // The redaction processor must run AFTER WebProcessor fills `extra.url`.
+        // Monolog applies processors in array order, so the sanitiser has to be
+        // the LAST element — it is pushed first and pushProcessor is LIFO.
+        $adapter = MonologAdapter::create(LogChannelEnum::WEB);
+
+        $logger = (new \ReflectionProperty($adapter, 'logger'))->getValue($adapter);
+        self::assertInstanceOf(Logger::class, $logger);
+
+        $order = array_map(
+            static fn (object $processor): string => $processor::class,
+            $logger->getProcessors(),
+        );
+
+        self::assertContains(WebProcessor::class, $order);
+        self::assertSame(SanitizingProcessor::class, $order[array_key_last($order)]);
+        self::assertGreaterThan(
+            array_search(WebProcessor::class, $order, true),
+            array_search(SanitizingProcessor::class, $order, true),
+        );
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
@@ -65,7 +65,6 @@ final class PayloadSanitizerTest extends TestCase
     {
         $sanitised = $this->sanitizer->sanitize(
             ['passcode' => '482031', 'ssoTicket' => 'st-abc', 'userId' => 7],
-            0,
             SecretsCommand::class,
         );
 
@@ -76,7 +75,6 @@ final class PayloadSanitizerTest extends TestCase
     {
         $sanitised = $this->sanitizer->sanitize(
             ['inner' => ['passcode' => '482031', 'label' => 'two-factor']],
-            0,
             NestedPayloadCommand::class,
         );
 
@@ -87,7 +85,6 @@ final class PayloadSanitizerTest extends TestCase
     {
         $sanitised = $this->sanitizer->sanitize(
             ['apiToken' => 'tok-123', 'login' => 'admin'],
-            0,
             MethodSecretCommand::class,
         );
 
@@ -101,7 +98,6 @@ final class PayloadSanitizerTest extends TestCase
                 'card' => ['number' => 'card-number-test', 'holder' => 'admin'],
                 'label' => 'default card',
             ],
-            0,
             CardHolderCommand::class,
         );
 
@@ -155,5 +151,134 @@ final class PayloadSanitizerTest extends TestCase
 
         \assert(\is_array($sanitised));
         self::assertSame('red', $sanitised['status']);
+    }
+
+    public function testMasksSensitiveQueryParametersInUrlStrings(): void
+    {
+        // The request URL (e.g. WebProcessor's `extra.url`) is a plain string,
+        // not a key/value pair, so a secret passed as a query parameter is not
+        // caught by key masking. Parameters whose name matches the denylist are
+        // redacted in place; the path and the other parameters are preserved.
+        $sanitised = $this->sanitizer->sanitize([
+            'url' => '/centreon/api/latest/login?useralias=admin&token=ABC123&autologin=1',
+        ]);
+
+        self::assertSame(
+            ['url' => '/centreon/api/latest/login?useralias=admin&token=***&autologin=1'],
+            $sanitised,
+        );
+    }
+
+    public function testLeavesUrlStringsWithoutSensitiveQueryParametersUntouched(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(['url' => '/monitoring/resources?page=2&limit=30']);
+
+        self::assertSame(['url' => '/monitoring/resources?page=2&limit=30'], $sanitised);
+    }
+
+    public function testStillRedactsUrlSecretsWhenKeywordKeyMaskingIsDisabled(): void
+    {
+        // `extra` is sanitised with keyword-key masking OFF (its keys are set by
+        // platform processors and must stay readable): `token` keeps its audit
+        // payload, but a secret inside a URL query is still redacted.
+        $sanitised = $this->sanitizer->sanitize(
+            [
+                'token' => ['username' => 'admin', 'role' => 'ROLE_ADMIN'],
+                'url' => '/login?token=ABC123',
+            ],
+            maskKeywordKeys: false,
+        );
+
+        self::assertSame(
+            [
+                'token' => ['username' => 'admin', 'role' => 'ROLE_ADMIN'],
+                'url' => '/login?token=***',
+            ],
+            $sanitised,
+        );
+    }
+
+    public function testPropagatesKeywordKeyMaskingFlagThroughRecursion(): void
+    {
+        // With keyword-key masking off, a denylisted key stays in clear at any
+        // depth — the flag must survive the recursive descent, not just the top
+        // level. URL-query masking still applies regardless of the flag.
+        $sanitised = $this->sanitizer->sanitize(
+            ['outer' => ['token' => 'raw', 'url' => '/x?secret=s']],
+            maskKeywordKeys: false,
+        );
+
+        self::assertSame(
+            ['outer' => ['token' => 'raw', 'url' => '/x?secret=***']],
+            $sanitised,
+        );
+    }
+
+    public function testMasksSensitiveUrlQueryParametersInStringableValues(): void
+    {
+        $url = new class () implements \Stringable {
+            public function __toString(): string
+            {
+                return '/login?useralias=admin&token=ABC123';
+            }
+        };
+
+        $sanitised = $this->sanitizer->sanitize(['ref' => $url]);
+
+        self::assertSame(['ref' => '/login?useralias=admin&token=***'], $sanitised);
+    }
+
+    public function testLeavesQueryEdgeCasesUntouched(): void
+    {
+        // Empty query and a parameter with no `=` are no-ops.
+        self::assertSame(['u' => '/x?'], $this->sanitizer->sanitize(['u' => '/x?']));
+        self::assertSame(['u' => '/x?token'], $this->sanitizer->sanitize(['u' => '/x?token']));
+    }
+
+    public function testMatchesQueryParameterNamesCaseInsensitivelyAndUrlDecoded(): void
+    {
+        // The parameter name is lowercased and percent-decoded before matching,
+        // so `Token` and `to%6Ben` are both recognised; only the value is replaced.
+        self::assertSame(['u' => '/x?Token=***'], $this->sanitizer->sanitize(['u' => '/x?Token=ABC']));
+        self::assertSame(['u' => '/x?to%6Ben=***'], $this->sanitizer->sanitize(['u' => '/x?to%6Ben=ABC']));
+    }
+
+    public function testDoesNotMaskSecretsOutsideTheQueryComponent(): void
+    {
+        // Documented scope limits (best-effort, query component only): a secret in
+        // the PATH, or nested inside another parameter's VALUE after a second `?`,
+        // is NOT masked. Pinned so widening the parser stays a conscious choice.
+        self::assertSame(
+            ['u' => '/reset/TOKEN-ABC/confirm'],
+            $this->sanitizer->sanitize(['u' => '/reset/TOKEN-ABC/confirm']),
+        );
+        self::assertSame(
+            ['u' => '/cb?next=/r?token=ABC&page=2'],
+            $this->sanitizer->sanitize(['u' => '/cb?next=/r?token=ABC&page=2']),
+        );
+    }
+
+    public function testMasksTheAdditionalKeywordAliases(): void
+    {
+        $sanitised = $this->sanitizer->sanitize([
+            'apikey' => 'a',
+            'pwd' => 'b',
+            'signature' => 'c',
+            'session_id' => 'd',
+            'access_key' => 'e',
+            'login' => 'admin',
+        ]);
+
+        self::assertSame(
+            [
+                'apikey' => '***',
+                'pwd' => '***',
+                'signature' => '***',
+                'session_id' => '***',
+                'access_key' => '***',
+                'login' => 'admin',
+            ],
+            $sanitised,
+        );
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/SanitizingProcessorTest.php
@@ -77,10 +77,37 @@ final class SanitizingProcessorTest extends TestCase
         self::assertSame($record->level, $processed->level);
     }
 
+    public function testMasksUrlQuerySecretsInExtraWhileKeepingAuditFields(): void
+    {
+        // WebProcessor records the request URI in `extra.url`; a secret passed
+        // as a query parameter must be redacted. The other `extra` fields set
+        // by platform processors (e.g. `token` => TokenProcessor's audit
+        // descriptor of the authenticated user, not a credential) are not user
+        // input and stay readable for auditing.
+        $record = $this->makeRecord(
+            context: [],
+            extra: [
+                'url' => '/centreon/api/latest/login?useralias=admin&token=leaked',
+                'token' => ['authenticated' => true, 'user_identifier' => 'admin'],
+                'ip' => '203.0.113.7',
+            ],
+        );
+
+        $processed = ($this->processor)($record);
+
+        self::assertSame(
+            '/centreon/api/latest/login?useralias=admin&token=***',
+            $processed->extra['url'],
+        );
+        self::assertSame(['authenticated' => true, 'user_identifier' => 'admin'], $processed->extra['token']);
+        self::assertSame('203.0.113.7', $processed->extra['ip']);
+    }
+
     /**
      * @param array<string, mixed> $context
+     * @param array<string, mixed> $extra
      */
-    private function makeRecord(array $context): LogRecord
+    private function makeRecord(array $context, array $extra = []): LogRecord
     {
         return new LogRecord(
             datetime: new \DateTimeImmutable(),
@@ -88,6 +115,7 @@ final class SanitizingProcessorTest extends TestCase
             level: Level::Error,
             message: 'a message',
             context: $context,
+            extra: $extra,
         );
     }
 }


### PR DESCRIPTION
## Description

Extends the `#[Sensitive]` payload masking so it also covers a Monolog record's `extra` bag and the legacy `MonologAdapter`.

`SanitizingProcessor` previously masked only `context`. Two gaps are closed:

- **`extra` is now sanitised.** `WebProcessor` stores the request URI (query string included) in `extra.url`; sensitive query parameters are now redacted. `extra` is masked with keyword-key masking **off**: its keys are set by platform processors (`WebProcessor`, `TokenProcessor`, …), not by callers, so they stay readable for auditing (e.g. `extra.token` is `TokenProcessor`'s audit descriptor of the authenticated user — authenticated flag, roles, identifier — not a credential). Only sensitive values inside URL query strings are redacted there (best-effort, query component only).
- **`MonologAdapter` now runs the `SanitizingProcessor`** (it previously pushed only `ExceptionFormatterProcessor` + `WebProcessor` + `UidProcessor`), so logs emitted through the legacy adapter are masked too.

### Processor ordering

The sanitizer must run **after** `WebProcessor` (which fills `extra.url`). The MonologBundle ignores the `priority` tag for processors and Monolog applies them LIFO, so ordering is controlled by registration position: the sanitizer is registered **first** so it executes last — pushed first by `MonologAdapter`, and (on this branch) declared first among the `monolog.processor`-tagged services in `config/services.yaml`.

## Backport notes (24.10 specifics)

`dev-24.10.x` wires Monolog through YAML, not the new-kernel PHP config of `develop` / `25.10`, so the original PR was adapted:

- There is **no** `config.new/services/monolog.php` / `shared.php` on this branch; the processors live in `config/services.yaml`. The "monolog config consolidation" part of the original PR is therefore N/A. Instead, the `SanitizingProcessor` / `PayloadSanitizer` service declarations were **moved to the top** of the tagged-processor block so the LIFO push order makes the sanitizer run last (after `WebProcessor`).
- There is **no** `LoggingMiddleware` (command/query bus) on this branch, so that file is not part of the backport.
- `doc/php/logging.md` has a different, older structure here and does not document the `#[Sensitive]` masking layer, so it is left unchanged (the original PR's doc edits target sections that do not exist on this branch).

## Changes

- `PayloadSanitizer`: URL-query-aware masking (params whose name matches `SensitiveKeywordDenylist`, redacted in place); a `maskKeywordKeys` flag; public `sanitize()` split from a private recursive `walk()` so callers don't thread the internal `$depth`.
- `SanitizingProcessor`: sanitises `context` (full) and `extra` (URL-query only).
- `SensitiveKeywordDenylist`: added secret-name aliases (`apikey`, `api-key`, `passwd`, `pwd`, `access_key`, `bearer`, `signature`, `session_id`, `sessionid`).
- `MonologAdapter`: wires the sanitizer (pushed first → runs last).
- `config/services.yaml`: declares the sanitizer first so it runs last in the global processor chain.

## Tests

- `PayloadSanitizerTest`: URL query masking, the `maskKeywordKeys` flag through recursion, the `Stringable` path, query edge cases, case-insensitive / percent-decoded param names, the new aliases, and pinned out-of-scope limitations (secret in path / nested value).
- `SanitizingProcessorTest`: `extra.url` query secret redacted while audit fields (`extra.token`, `extra.ip`) stay intact.
- `MonologAdapterTest`: asserts the sanitizer runs last (after `WebProcessor`).
- All three suites green locally (18 + 4 + 1).

## Verification

Backport via cherry-pick of the `dev-25.10.x` commit, with manual resolution of the structural divergence described above (config in YAML, no bus middleware, divergent doc). `config/services.yaml` and `config/packages/monolog.yaml` parse cleanly; the three logging unit suites run green.

## Links

### Jira ticket

[MON-201885](https://centreon.atlassian.net/browse/MON-201885)

### PR Github

Backports: #10810


[MON-201885]: https://centreon.atlassian.net/browse/MON-201885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ