### PR TITLE
feat(logging): structured logging for the upgrade flow

### DIFF
--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -19,6 +19,7 @@ This document describes the platform pipeline that captures logs emitted by the 
 8. [Processor scope](#8-processor-scope)
 9. [Routing and output file](#9-routing-and-output-file)
 10. [Masking sensitive fields with `#[Sensitive]`](#10-masking-sensitive-fields-with-sensitive)
+11. [Writing upgrade scripts (`Update-*.php`)](#11-writing-upgrade-scripts-update-php)
 
 ---
 
@@ -552,3 +553,69 @@ PHP's built-in [`#[\SensitiveParameter]`](https://www.php.net/manual/en/class.se
 - **Mechanism** — it only redacts a value in **exception stack traces** (handled by the PHP engine); it does not mask log payloads. The scanner reflects *properties*, so it would not even see a `#[\SensitiveParameter]` placed on a promoted parameter.
 
 A property-level attribute is therefore the right tool for reflection-based **payload** masking. A future enhancement could make `SensitivityScanner` *additionally* honour `#[\SensitiveParameter]` on promoted constructor parameters (gaining stack-trace redaction for free) while keeping `#[Sensitive]` for plain properties.
+
+---
+
+## 11. Writing upgrade scripts (`Update-*.php`)
+
+Each upgrade ships under `www/install/php/Update-<version>.php` (DB DDL/DML + business migration). It runs either through the DDD command — `UpdateCommandHandler` brackets each step with its `runStep()` helper and emits the logs, while `DbalUpdateRepository` only performs the operations — or through the legacy web wizard (`process_step4/5` + `DbWriteUpdateRepository`, which logs inline via `executeStep()`). Either way the `php_script` step is bracketed (start / completed / failure). **Inside the script itself, trace each meaningful action through `LoggerUpgrade` so operators get a play-by-play view in `prod.upgrade.log`.**
+
+The legacy web upgrade splits the flow across two steps: `process_step4.php` runs the version updates (`runUpdate`), `process_step5.php` runs the post-update (`runPostUpdate`) under a `post_update` step — grep both when tracking a step name.
+
+### Facade API
+
+```php
+use Adaptation\Log\LoggerUpgrade;
+
+LoggerUpgrade::create()->info($version, "Adding column X to table Y");
+LoggerUpgrade::create()->error($version, "Schema check failed", $exception);
+
+LoggerUpgrade::create()->stepFailure($message, $version, $stepName, $exception);
+LoggerUpgrade::create()->step($version, $stepName, $message);
+```
+
+| Method | Monolog level | When to use |
+|---|---|---|
+| `start($from, $to)` | `INFO` | Begin of the global upgrade flow (emitted by `UpdateCommandHandler` / `process_step4.php`, **not** by individual scripts). |
+| `success($from, $to, $durationMs)` | `INFO` | End of the global upgrade flow, with measured duration. |
+| `failure($message, $from, $to, $e)` | `ERROR` | Global upgrade aborted (catch-all in the handler). |
+| `step($version, $stepName, $message)` | `INFO` | Sub-step **start** / progress (`monitoring_sql`, `php_script`, …). `status: running`. Emitted by the repositories; rarely needed inside an upgrade script. |
+| `stepCompleted($version, $stepName, $durationMs, $message)` | `INFO` | Sub-step **completion**. `status: completed`, carries `duration_ms` in the context (not just the message), so completed steps are queryable without parsing text. |
+| `stepFailure($message, $version, $stepName, $e)` | `ERROR` | A bracketed step threw. Primarily emitted by the repositories / handler; also used inside an upgrade script's catch block with the `php_script` step name (or `php_script_rollback` when the rollback itself fails). |
+| **`info($version, $message)`** | `INFO` | **Trace a meaningful action** (entering a function, finished an `ALTER TABLE`, skipped because already migrated, …). This is the workhorse inside upgrade scripts. |
+| **`error($version, $message, $e)`** | `ERROR` | Free-form error inside a script that you choose not to re-throw (rare — usually you re-throw and let the surrounding `try/catch` call `stepFailure`). |
+
+### Recommended pattern
+
+Copy `www/install/php/Update-next.php.tpl` — it is the canonical skeleton and is kept in sync with the flow. Its shape:
+
+- **Wrap each business action in its own callable** and set `$errorMessage` to a human description **before** running it, so the catch-all `stepFailure` reports which action failed.
+- **Trace intent and outcome** with `info($version, …)`; log skip branches too — they prove the script is safely re-entrant.
+- **Run DML inside a transaction** guarded by `isTransactionActive()`, and log "Rolling back…" only inside the `if` that actually rolls back.
+- **On failure, call `stepFailure(...)`** with the `php_script` step name (`php_script_rollback` if the rollback itself fails), then **re-throw**: the global flow (`UpdateCommandHandler` / `process_step4.php`) catches it and writes the final `failure`. A silent return breaks that chain.
+
+### Sample output (`prod.upgrade.log`)
+
+```
+upgrade.INFO: Upgrade started from 25.10.0 to 25.11.0
+  {"event":"upgrade.start","status":"started","from_version":"25.10.0","to_version":"25.11.0"}
+upgrade.INFO: Starting step 'php_script'
+  {"event":"upgrade.step","status":"running","version":"25.11.0","step":"php_script"}
+upgrade.INFO: Adding vmware_updated field into nagios_server table
+  {"event":"upgrade.info","status":"info","version":"25.11.0"}
+upgrade.INFO: Step 'php_script' completed in 124ms
+  {"event":"upgrade.step_completed","status":"completed","version":"25.11.0","step":"php_script","duration_ms":124}
+upgrade.INFO: Upgrade from 25.10.0 to 25.11.0 completed successfully
+  {"event":"upgrade.success","status":"success","from_version":"25.10.0","to_version":"25.11.0","duration_ms":4242}
+```
+
+On failure, the failing action writes `upgrade.step_failure` (ERROR) and the global flow writes a final `upgrade.failure` carrying the from→to versions and the wrapped exception.
+
+### Best practices
+
+- **One business action = one `info` line** before it runs (intent) and one after (outcome). Skip branches deserve their own line so operators can read the log top-to-bottom without re-deriving control flow.
+- **Carry `$version` on every call** — the field is what lets SIEM/Grafana partition the file per release.
+- **No PII, no secrets** in the message or the context. The file is shipped to operators / SOC pipelines; the same redaction rules as `prod.access.log` apply.
+- **Don't duplicate the surrounding `step` log** — the repository already brackets the script with `step` / `stepFailure`. Inside the script, use `info` / `error` (free-form) and let `stepFailure` be raised by the outer `try/catch`.
+- **Idempotent actions still log** — even "skipped because already migrated" is signal: it confirms the migration was applied on a previous run and the script is safely re-entrant.
+- **Re-throw on failure**. Returning silently after logging masks the failure from the surrounding `UpdateCommandHandler` / `process_step4` which then misses the final `upgrade.failure` record.

--- a/centreon/src/Adaptation/Log/LoggerUpgrade.php
+++ b/centreon/src/Adaptation/Log/LoggerUpgrade.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Adaptation\Log;
+
+use Adaptation\Log\Enum\LogChannelEnum;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+final class LoggerUpgrade
+{
+    private static ?self $instance = null;
+
+    private function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public static function create(): self
+    {
+        if (! self::$instance instanceof self) {
+            self::$instance = new self(Logger::create(LogChannelEnum::UPGRADE));
+        }
+
+        return self::$instance;
+    }
+
+    public function start(string $fromVersion, string $toVersion): void
+    {
+        $this->write(
+            LogLevel::INFO,
+            "Upgrade started from {$fromVersion} to {$toVersion}",
+            $this->lifecycleContext('upgrade.start', 'started', $fromVersion, $toVersion)
+        );
+    }
+
+    public function success(string $fromVersion, string $toVersion, int $durationMs): void
+    {
+        $context = $this->lifecycleContext('upgrade.success', 'success', $fromVersion, $toVersion);
+        $context['duration_ms'] = $durationMs;
+        $this->write(LogLevel::INFO, "Upgrade from {$fromVersion} to {$toVersion} completed successfully", $context);
+    }
+
+    public function failure(
+        string $message,
+        ?string $fromVersion,
+        ?string $toVersion,
+        ?\Throwable $exception = null,
+    ): void {
+        $this->write(
+            LogLevel::ERROR,
+            $message,
+            $this->lifecycleContext('upgrade.failure', 'failure', $fromVersion, $toVersion, $exception)
+        );
+    }
+
+    public function info(string $version, string $message): void
+    {
+        $this->write(LogLevel::INFO, $message, $this->versionContext('upgrade.info', 'info', $version));
+    }
+
+    public function error(string $version, string $message, ?\Throwable $exception = null): void
+    {
+        $this->write(LogLevel::ERROR, $message, $this->versionContext('upgrade.error', 'error', $version, $exception));
+    }
+
+    public function step(string $version, string $stepName, string $message): void
+    {
+        $context = $this->versionContext('upgrade.step', 'running', $version);
+        $context['step'] = $stepName;
+        $this->write(LogLevel::INFO, $message, $context);
+    }
+
+    public function stepCompleted(string $version, string $stepName, int $durationMs, string $message): void
+    {
+        $context = $this->versionContext('upgrade.step_completed', 'completed', $version);
+        $context['step'] = $stepName;
+        $context['duration_ms'] = $durationMs;
+        $this->write(LogLevel::INFO, $message, $context);
+    }
+
+    public function stepFailure(
+        string $message,
+        string $version,
+        string $stepName,
+        ?\Throwable $exception = null,
+    ): void {
+        $context = $this->versionContext('upgrade.step_failure', 'failure', $version, $exception);
+        $context['step'] = $stepName;
+        $this->write(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * Writes the record through the underlying logger, swallowing any failure.
+     *
+     * Logging must never break the upgrade: a failure while emitting a log line
+     * (success or failure path alike) must not bubble up and abort — or worse,
+     * make a successful upgrade look failed.
+     *
+     * @param array<string,mixed> $context
+     */
+    private function write(string $level, string $message, array $context): void
+    {
+        try {
+            $this->logger->log($level, $message, $context);
+        } catch (\Throwable $exception) {
+            // The primary sink is unavailable; keep the upgrade event in error_log rather than
+            // losing it — including the original throwable, which is often the line that matters.
+            $original = $context['exception'] ?? null;
+            error_log(sprintf(
+                'LoggerUpgrade: failed to write the upgrade log [%s] "%s"%s: %s',
+                $level,
+                $message,
+                $original instanceof \Throwable ? sprintf(' (%s: %s)', $original::class, $original->getMessage()) : '',
+                $exception->getMessage(),
+            ));
+        }
+    }
+
+    /**
+     * Context for the global upgrade lifecycle (start / success / failure), which spans two versions.
+     *
+     * @return array<string,mixed>
+     */
+    private function lifecycleContext(
+        string $event,
+        string $status,
+        ?string $fromVersion,
+        ?string $toVersion,
+        ?\Throwable $exception = null,
+    ): array {
+        $context = [
+            'event' => $event,
+            'status' => $status,
+            'from_version' => $fromVersion,
+            'to_version' => $toVersion,
+        ];
+        if ($exception instanceof \Throwable) {
+            $context['exception'] = $exception;
+        }
+
+        return $context;
+    }
+
+    /**
+     * Context for per-version events (step / info / error), which carry a single `version`
+     * rather than a from/to pair.
+     *
+     * @return array<string,mixed>
+     */
+    private function versionContext(
+        string $event,
+        string $status,
+        string $version,
+        ?\Throwable $exception = null,
+    ): array {
+        $context = [
+            'event' => $event,
+            'status' => $status,
+            'version' => $version,
+        ];
+        if ($exception instanceof \Throwable) {
+            $context['exception'] = $exception;
+        }
+
+        return $context;
+    }
+}

--- a/centreon/src/App/Upgrade/Application/Command/UpdateCommandHandler.php
+++ b/centreon/src/App/Upgrade/Application/Command/UpdateCommandHandler.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Application\Command;
 
+use Adaptation\Log\LoggerUpgrade;
 use App\Shared\Application\Command\AsCommandHandler;
 use App\Upgrade\Application\CacheClearer;
 use App\Upgrade\Application\DbmsVersionValidator;
@@ -48,35 +49,77 @@ final readonly class UpdateCommandHandler
     ) {
     }
 
+    /**
+     * @throws \RuntimeException when another update is already in progress or the current version cannot be read
+     * @throws \Throwable any failure thrown by validation, the repositories or the cache clearer (re-thrown after the lock is released and the failure is logged)
+     */
     public function __invoke(UpdateCommand $command): void
     {
-        $this->dbmsVersionValidator->validateOrFail();
-        if (! $this->updateLocker->lock()) {
-            throw new \RuntimeException('An update is already in progress');
-        }
+        $startedAt = microtime(true);
+        $currentVersion = null;
+        $targetVersion = null;
+
         try {
-            $currentVersion = $this->updateRepository->findCurrentVersion();
+            $this->dbmsVersionValidator->validateOrFail();
 
-            if ($currentVersion === null) {
-                throw new \RuntimeException('Cannot retrieve the current platform version');
+            if (! $this->updateLocker->lock()) {
+                throw new \RuntimeException('An update is already in progress');
             }
 
-            $availableUpdates = $this->updateScriptFinder->findOrderedAvailableUpdates($currentVersion);
+            try {
+                $currentVersion = $this->updateRepository->findCurrentVersion();
+                if ($currentVersion === null || trim($currentVersion) === '') {
+                    throw new \RuntimeException('Cannot retrieve the current platform version');
+                }
 
-            foreach ($availableUpdates as $version) {
-                $this->updateRepository->runUpdate($version);
+                $availableUpdates = $this->updateScriptFinder->findOrderedAvailableUpdates($currentVersion);
+                $targetVersion = $availableUpdates === [] ? $currentVersion : end($availableUpdates);
+
+                LoggerUpgrade::create()->start($currentVersion, $targetVersion);
+
+                // The handler owns step sequencing and logging; the repository only runs each operation.
+                foreach ($availableUpdates as $version) {
+                    $this->runStep($version, 'monitoring_sql', fn () => $this->updateRepository->runMonitoringSql($version));
+                    $this->runStep($version, 'php_script', fn () => $this->updateRepository->runScript($version));
+                    $this->runStep($version, 'configuration_sql', fn () => $this->updateRepository->runConfigurationSql($version));
+                    $this->runStep($version, 'php_post_script', fn () => $this->updateRepository->runPostScript($version));
+                    $this->runStep($version, 'update_version_information', fn () => $this->updateRepository->updateVersionInformation($version));
+                }
+
+                if ($this->updateRepository->installDirectoryExists()) {
+                    $this->runStep($currentVersion, 'backup_install_directory', fn () => $this->updateRepository->backupInstallDirectory($currentVersion));
+                    $this->runStep($currentVersion, 'remove_install_directory', fn () => $this->updateRepository->removeInstallDirectory());
+                }
+
+                $this->runStep($currentVersion, 'modules_update', fn () => $this->moduleRepository->updateAll());
+                $this->runStep($currentVersion, 'widgets_update', fn () => $this->widgetRepository->updateAll());
+                $this->runStep($currentVersion, 'engine_context', fn () => $this->engineContextWriter->writeIfMissing());
+                $this->runStep($currentVersion, 'cache_clear', fn () => $this->cacheClearer->clear());
+
+                $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
+                LoggerUpgrade::create()->success($currentVersion, $targetVersion, $durationMs);
+            } finally {
+                $this->updateLocker->unlock();
             }
+        } catch (\Throwable $exception) {
+            LoggerUpgrade::create()->failure($exception->getMessage(), $currentVersion, $targetVersion, $exception);
 
-            // Must always run whether there are updates or not.
-            $this->updateRepository->runPostUpdate($currentVersion);
-
-            $this->moduleRepository->updateAll();
-            $this->widgetRepository->updateAll();
-
-            $this->engineContextWriter->writeIfMissing();
-            $this->cacheClearer->clear();
-        } finally {
-            $this->updateLocker->unlock();
+            throw $exception;
         }
+    }
+
+    private function runStep(string $version, string $step, callable $action): void
+    {
+        LoggerUpgrade::create()->step($version, $step, "Starting step '{$step}'");
+        $startedAt = microtime(true);
+        try {
+            $action();
+        } catch (\Throwable $exception) {
+            LoggerUpgrade::create()->stepFailure($exception->getMessage(), $version, $step, $exception);
+
+            throw $exception;
+        }
+        $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
+        LoggerUpgrade::create()->stepCompleted($version, $step, $durationMs, "Step '{$step}' completed in {$durationMs}ms");
     }
 }

--- a/centreon/src/App/Upgrade/Domain/Repository/UpdateRepository.php
+++ b/centreon/src/App/Upgrade/Domain/Repository/UpdateRepository.php
@@ -23,6 +23,10 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Domain\Repository;
 
+/**
+ * Individual upgrade operations. Sequencing and per-step logging are owned by the caller
+ * (UpdateCommandHandler), which brackets each operation; this repository only runs them.
+ */
 interface UpdateRepository
 {
     /**
@@ -31,12 +35,42 @@ interface UpdateRepository
     public function findCurrentVersion(): ?string;
 
     /**
-     * Run all update scripts (SQL + PHP) for the given version and record it in DB.
+     * Run the monitoring (centstorage) SQL update file for the given version, if present.
      */
-    public function runUpdate(string $version): void;
+    public function runMonitoringSql(string $version): void;
 
     /**
-     * Run post-update actions: backup and remove the install directory.
+     * Run the PHP update script for the given version, if present.
      */
-    public function runPostUpdate(string $currentVersion): void;
+    public function runScript(string $version): void;
+
+    /**
+     * Run the configuration (centreon) SQL update file for the given version, if present.
+     */
+    public function runConfigurationSql(string $version): void;
+
+    /**
+     * Run the PHP post-update script for the given version, if present.
+     */
+    public function runPostScript(string $version): void;
+
+    /**
+     * Record the given version as the current installed version.
+     */
+    public function updateVersionInformation(string $version): void;
+
+    /**
+     * Whether the install directory still exists (post-update is skipped otherwise).
+     */
+    public function installDirectoryExists(): bool;
+
+    /**
+     * Back up the install directory before it is removed.
+     */
+    public function backupInstallDirectory(string $currentVersion): void;
+
+    /**
+     * Remove the install directory.
+     */
+    public function removeInstallDirectory(): void;
 }

--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
@@ -27,10 +27,13 @@ use Adaptation\Database\Connection\Adapter\Dbal\DbalConnectionAdapter;
 use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Domain\Repository\UpdateRepository;
 use Doctrine\DBAL\Connection;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * Runs the individual upgrade operations. Step sequencing and logging are owned by the
+ * caller (UpdateCommandHandler): this repository only performs each operation.
+ */
 final readonly class DbalUpdateRepository implements UpdateRepository
 {
     public function __construct(
@@ -44,7 +47,6 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         #[Autowire(param: 'upgrade.install_dir')]
         private string $installDir,
         private Filesystem $filesystem,
-        private LoggerInterface $logger,
     ) {
     }
 
@@ -57,47 +59,7 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         return is_scalar($result) ? (string) $result : null;
     }
 
-    public function runUpdate(string $version): void
-    {
-        $this->logger->info('Running update', ['version' => $version]);
-        $this->runMonitoringSql($version);
-        $this->runScript($version);
-        $this->runConfigurationSql($version);
-        $this->runPostScript($version);
-        $this->updateVersionInformation($version);
-    }
-
-    public function runPostUpdate(string $currentVersion): void
-    {
-        if (! $this->filesystem->exists($this->installDir)) {
-            return;
-        }
-
-        $installsDir = $this->libDir . '/installs';
-        if (! is_dir($installsDir) || ! is_writable($installsDir)) {
-            throw new \RuntimeException(
-                'The installs backup directory does not exist or is not writable. '
-                . 'Please create it with write permissions for the web server user.'
-            );
-        }
-
-        $backupDirectory = $installsDir . '/install-' . $currentVersion . '-' . date('Ymd_His');
-
-        $this->logger->info('Backing up installation directory', [
-            'source' => $this->installDir,
-            'destination' => $backupDirectory,
-        ]);
-
-        $this->filesystem->mirror($this->installDir, $backupDirectory);
-
-        $this->logger->info('Removing installation directory', [
-            'installation_directory' => $this->installDir,
-        ]);
-
-        $this->filesystem->remove($this->installDir);
-    }
-
-    private function runMonitoringSql(string $version): void
+    public function runMonitoringSql(string $version): void
     {
         $filePath = $this->installDir . '/sql/centstorage/Update-CSTG-' . $version . '.sql';
 
@@ -106,7 +68,7 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         }
     }
 
-    private function runScript(string $version): void
+    public function runScript(string $version): void
     {
         // $pearDB and $pearDBO are exposed as local variables to the included update script.
         // Scripts expect ConnectionInterface (Adaptation), not raw PDO.
@@ -119,7 +81,7 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         }
     }
 
-    private function runConfigurationSql(string $version): void
+    public function runConfigurationSql(string $version): void
     {
         $filePath = $this->installDir . '/sql/centreon/Update-DB-' . $version . '.sql';
 
@@ -128,7 +90,7 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         }
     }
 
-    private function runPostScript(string $version): void
+    public function runPostScript(string $version): void
     {
         // $pearDB and $pearDBO are exposed as local variables to the included post-update script.
         // Scripts expect ConnectionInterface (Adaptation), not raw PDO.
@@ -141,12 +103,36 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         }
     }
 
-    private function updateVersionInformation(string $version): void
+    public function updateVersionInformation(string $version): void
     {
         $this->configConnection->executeStatement(
             "UPDATE `informations` SET `value` = :version WHERE `key` = 'version'",
             ['version' => $version]
         );
+    }
+
+    public function installDirectoryExists(): bool
+    {
+        return $this->filesystem->exists($this->installDir);
+    }
+
+    public function backupInstallDirectory(string $currentVersion): void
+    {
+        $installsDir = $this->libDir . '/installs';
+        if (! is_dir($installsDir) || ! is_writable($installsDir)) {
+            throw new \RuntimeException(
+                'The installs backup directory does not exist or is not writable. '
+                . 'Please create it with write permissions for the web server user.'
+            );
+        }
+
+        $backupDirectory = $installsDir . '/install-' . $currentVersion . '-' . date('Ymd_His');
+        $this->filesystem->mirror($this->installDir, $backupDirectory);
+    }
+
+    public function removeInstallDirectory(): void
+    {
+        $this->filesystem->remove($this->installDir);
     }
 
     private function runSqlFile(Connection $connection, string $filePath): void
@@ -178,13 +164,7 @@ final readonly class DbalUpdateRepository implements UpdateRepository
                 if (! empty(trim($query)) && preg_match('/;\s*$/', $query)) {
                     $executedCount++;
                     if ($executedCount > $alreadyExecutedCount) {
-                        try {
-                            $connection->executeStatement($query);
-                        } catch (\Throwable $ex) {
-                            $this->logger->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
-
-                            throw $ex;
-                        }
+                        $connection->executeStatement($query);
                         $this->writeExecutedQueriesCount($tmpFile, $executedCount);
                     }
                     $query = '';
@@ -209,10 +189,13 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     private function writeExecutedQueriesCount(string $tmpFile, int $count): void
     {
-        if (! file_exists($tmpFile) || is_writable($tmpFile)) {
-            file_put_contents($tmpFile, $count);
-        } else {
-            $this->logger->warning('Cannot write in temporary file', ['path' => $tmpFile]);
+        if (file_exists($tmpFile) && ! is_writable($tmpFile)) {
+            throw new \RuntimeException(sprintf('Cannot write in temporary file: %s', $tmpFile));
+        }
+        // A failed write (missing parent dir on a fresh run, full disk, partial write) must not
+        // be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
+        if (file_put_contents($tmpFile, $count) === false) {
+            throw new \RuntimeException(sprintf('Cannot write in temporary file: %s', $tmpFile));
         }
     }
 }

--- a/centreon/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
+++ b/centreon/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Platform\Infrastructure\Repository;
 
-use Centreon\Domain\Log\LoggerTrait;
+use Adaptation\Log\LoggerUpgrade;
 use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
@@ -33,8 +33,6 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpdateRepositoryInterface
 {
-    use LoggerTrait;
-
     /**
      * @param string $libDir
      * @param string $installDir
@@ -54,18 +52,22 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
 
     /**
      * @inheritDoc
+     *
+     * @throws \Throwable any failure raised by a sub-step (SQL execution, included PHP script, version update) re-thrown after the matching upgrade.step_failure event is logged
      */
     public function runUpdate(string $version): void
     {
-        $this->runMonitoringSql($version);
-        $this->runScript($version);
-        $this->runConfigurationSql($version);
-        $this->runPostScript($version);
-        $this->updateVersionInformation($version);
+        $this->executeStep($version, 'monitoring_sql', fn () => $this->runMonitoringSql($version));
+        $this->executeStep($version, 'php_script', fn () => $this->runScript($version));
+        $this->executeStep($version, 'configuration_sql', fn () => $this->runConfigurationSql($version));
+        $this->executeStep($version, 'php_post_script', fn () => $this->runPostScript($version));
+        $this->executeStep($version, 'update_version_information', fn () => $this->updateVersionInformation($version));
     }
 
     /**
      * @inheritDoc
+     *
+     * @throws \Symfony\Component\Filesystem\Exception\IOException when the install directory cannot be mirrored or removed
      */
     public function runPostUpdate(string $currentVersion): void
     {
@@ -74,24 +76,52 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
         }
 
         $this->backupInstallDirectory($currentVersion);
-        $this->removeInstallDirectory();
+        $this->removeInstallDirectory($currentVersion);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    private function executeStep(string $version, string $stepName, callable $callable): void
+    {
+        LoggerUpgrade::create()->step($version, $stepName, "Starting step '{$stepName}'");
+        $startedAt = microtime(true);
+        try {
+            $callable();
+        } catch (\Throwable $exception) {
+            LoggerUpgrade::create()->stepFailure(
+                "Step '{$stepName}' failed: {$exception->getMessage()}",
+                $version,
+                $stepName,
+                $exception
+            );
+
+            throw $exception;
+        }
+        $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
+        LoggerUpgrade::create()->stepCompleted(
+            $version,
+            $stepName,
+            $durationMs,
+            "Step '{$stepName}' completed in {$durationMs}ms"
+        );
     }
 
     /**
      * Backup installation directory.
      *
      * @param string $currentVersion
+     *
+     * @throws \Symfony\Component\Filesystem\Exception\IOException when the install directory cannot be mirrored to the backup location
      */
     private function backupInstallDirectory(string $currentVersion): void
     {
         $backupDirectory = $this->libDir . '/installs/install-' . $currentVersion . '-' . date('Ymd_His');
 
-        $this->info(
-            'Backing up installation directory',
-            [
-                'source' => $this->installDir,
-                'destination' => $backupDirectory,
-            ],
+        LoggerUpgrade::create()->step(
+            $currentVersion,
+            'backup_install_directory',
+            "Backing up installation directory from {$this->installDir} to {$backupDirectory}"
         );
 
         $this->filesystem->mirror(
@@ -102,14 +132,17 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
 
     /**
      * Remove installation directory.
+     *
+     * @param string $currentVersion
+     *
+     * @throws \Symfony\Component\Filesystem\Exception\IOException when the install directory cannot be removed
      */
-    private function removeInstallDirectory(): void
+    private function removeInstallDirectory(string $currentVersion): void
     {
-        $this->info(
-            'Removing installation directory',
-            [
-                'installation_directory' => $this->installDir,
-            ],
+        LoggerUpgrade::create()->step(
+            $currentVersion,
+            'remove_install_directory',
+            "Removing installation directory at {$this->installDir}"
         );
 
         $this->filesystem->remove($this->installDir);
@@ -119,6 +152,8 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * Run sql queries on monitoring database.
      *
      * @param string $version
+     *
+     * @throws RepositoryException when a SQL statement fails or the progress file cannot be written
      */
     private function runMonitoringSql(string $version): void
     {
@@ -133,6 +168,8 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * Run php upgrade script.
      *
      * @param string $version
+     *
+     * @throws \Throwable any failure raised by the included Update-<version>.php script
      */
     private function runScript(string $version): void
     {
@@ -149,6 +186,8 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * Run sql queries on configuration database.
      *
      * @param string $version
+     *
+     * @throws RepositoryException when a SQL statement fails or the progress file cannot be written
      */
     private function runConfigurationSql(string $version): void
     {
@@ -163,6 +202,8 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * Run php post upgrade script.
      *
      * @param string $version
+     *
+     * @throws \Throwable any failure raised by the included Update-<version>.post.php script
      */
     private function runPostScript(string $version): void
     {
@@ -179,6 +220,8 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * Update version information.
      *
      * @param string $version
+     *
+     * @throws \PDOException when the version update statement fails
      */
     private function updateVersionInformation(string $version): void
     {
@@ -195,6 +238,8 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * Run sql file and use temporary file to store last executed line.
      *
      * @param string $filePath
+     *
+     * @throws RepositoryException when a SQL statement fails or the temporary progress file cannot be written
      */
     private function runSqlFile(string $filePath): void
     {
@@ -222,23 +267,12 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
                         if ($this->isSqlCompleteQuery($query)) {
                             $executedQueriesCount++;
                             if ($executedQueriesCount > $alreadyExecutedQueriesCount) {
-                                try {
-                                    $this->executeQuery($query);
-                                } catch (RepositoryException $ex) {
-                                    $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
-
-                                    throw $ex;
-                                }
-
+                                $this->executeQuery($query);
                                 $this->writeExecutedQueriesCountInTemporaryFile($tmpFile, $executedQueriesCount);
                             }
                             $query = '';
                         }
                     }
-                } catch (\Throwable $ex) {
-                    $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
-
-                    throw $ex;
                 } finally {
                     fclose($fileStream);
                 }
@@ -271,14 +305,18 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      *
      * @param string $tmpFile
      * @param int $count
+     *
+     * @throws RepositoryException when the temporary file exists but is not writable
      */
     private function writeExecutedQueriesCountInTemporaryFile(string $tmpFile, int $count): void
     {
-        if (! file_exists($tmpFile) || is_writable($tmpFile)) {
-            $this->info('Writing in temporary file : ' . $tmpFile);
-            file_put_contents($tmpFile, $count);
-        } else {
-            $this->warning('Cannot write in temporary file : ' . $tmpFile);
+        if (file_exists($tmpFile) && ! is_writable($tmpFile)) {
+            throw new RepositoryException(sprintf('Cannot write in temporary file: %s', $tmpFile));
+        }
+        // A failed write (missing parent dir on a fresh run, full disk, partial write) must not
+        // be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
+        if (file_put_contents($tmpFile, $count) === false) {
+            throw new RepositoryException(sprintf('Cannot write in temporary file: %s', $tmpFile));
         }
     }
 
@@ -311,15 +349,13 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      *
      * @param string $query
      *
-     * @throws \Exception
+     * @throws RepositoryException when the underlying query fails
      */
     private function executeQuery(string $query): void
     {
         try {
             $this->db->query($query);
         } catch (\Exception $ex) {
-            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
-
             throw new RepositoryException('Cannot execute query: ' . $query, 0, $ex);
         }
     }

--- a/centreon/tests/php/Adaptation/Log/LoggerUpgradeTest.php
+++ b/centreon/tests/php/Adaptation/Log/LoggerUpgradeTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+use Adaptation\Log\LoggerUpgrade;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+/**
+ * Build a facade backed by a recording logger so the Monolog emission (level, message and
+ * context shape) can be asserted without touching the real upgrade channel file. The
+ * constructor is private and the facade is a singleton, so the spy is wired through
+ * reflection — this keeps the production API free of any test-only seam.
+ *
+ * @return array{0: LoggerUpgrade, 1: object{records: list<array{level: string, message: string, context: array<string, mixed>}>}}
+ */
+function loggerUpgradeWithSpy(): array
+{
+    $spy = new class () extends AbstractLogger {
+        /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+        }
+    };
+
+    $reflection = new ReflectionClass(LoggerUpgrade::class);
+    /** @var LoggerUpgrade $facade */
+    $facade = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('logger')->setValue($facade, $spy);
+
+    return [$facade, $spy];
+}
+
+it('emits the start of the upgrade as an INFO carrying the from/to lifecycle context', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+
+    $facade->start('25.10.0', '25.11.0');
+
+    expect($spy->records)->toHaveCount(1);
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::INFO)
+        ->and($record['message'])->toBe('Upgrade started from 25.10.0 to 25.11.0')
+        ->and($record['context']['event'])->toBe('upgrade.start')
+        ->and($record['context']['status'])->toBe('started')
+        ->and($record['context']['from_version'])->toBe('25.10.0')
+        ->and($record['context']['to_version'])->toBe('25.11.0')
+        ->and($record['context'])->not->toHaveKey('exception');
+});
+
+it('emits the success with the measured duration', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+
+    $facade->success('25.10.0', '25.11.0', 4242);
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::INFO)
+        ->and($record['context']['event'])->toBe('upgrade.success')
+        ->and($record['context']['status'])->toBe('success')
+        ->and($record['context']['duration_ms'])->toBe(4242);
+});
+
+it('emits a failure as an ERROR and attaches the throwable, with nullable versions', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+    $exception = new RuntimeException('boom');
+
+    $facade->failure('upgrade aborted', null, null, $exception);
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::ERROR)
+        ->and($record['message'])->toBe('upgrade aborted')
+        ->and($record['context']['event'])->toBe('upgrade.failure')
+        ->and($record['context']['status'])->toBe('failure')
+        ->and($record['context']['from_version'])->toBeNull()
+        ->and($record['context']['to_version'])->toBeNull()
+        ->and($record['context']['exception'])->toBe($exception);
+});
+
+it('emits a step start as a running upgrade.step carrying the step name', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+
+    $facade->step('25.11.0', 'php_script', "Starting step 'php_script'");
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::INFO)
+        ->and($record['context']['event'])->toBe('upgrade.step')
+        ->and($record['context']['status'])->toBe('running')
+        ->and($record['context']['version'])->toBe('25.11.0')
+        ->and($record['context']['step'])->toBe('php_script');
+});
+
+it('emits a step completion as a completed event carrying duration and step name', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+
+    $facade->stepCompleted('25.11.0', 'php_script', 124, "Step 'php_script' completed in 124ms");
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::INFO)
+        ->and($record['context']['event'])->toBe('upgrade.step_completed')
+        ->and($record['context']['status'])->toBe('completed')
+        ->and($record['context']['step'])->toBe('php_script')
+        ->and($record['context']['duration_ms'])->toBe(124);
+});
+
+it('emits a step failure as an ERROR with the step name and the throwable', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+    $exception = new RuntimeException('SQL failed');
+
+    $facade->stepFailure('step failed', '25.11.0', 'configuration_sql', $exception);
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::ERROR)
+        ->and($record['context']['event'])->toBe('upgrade.step_failure')
+        ->and($record['context']['status'])->toBe('failure')
+        ->and($record['context']['step'])->toBe('configuration_sql')
+        ->and($record['context']['exception'])->toBe($exception);
+});
+
+it('emits free-form info and error events on the per-version context', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+    $exception = new RuntimeException('check failed');
+
+    $facade->info('25.11.0', 'Adding column X');
+    $facade->error('25.11.0', 'Schema check failed', $exception);
+
+    expect($spy->records[0]['level'])->toBe(LogLevel::INFO)
+        ->and($spy->records[0]['context']['event'])->toBe('upgrade.info')
+        ->and($spy->records[0]['context']['version'])->toBe('25.11.0')
+        ->and($spy->records[1]['level'])->toBe(LogLevel::ERROR)
+        ->and($spy->records[1]['context']['event'])->toBe('upgrade.error')
+        ->and($spy->records[1]['context']['exception'])->toBe($exception);
+});
+
+it('never lets a logging failure abort the upgrade', function (): void {
+    $throwingLogger = new class () extends AbstractLogger {
+        public int $attempts = 0;
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            $this->attempts++;
+
+            throw new RuntimeException('log sink is down');
+        }
+    };
+
+    $reflection = new ReflectionClass(LoggerUpgrade::class);
+    /** @var LoggerUpgrade $facade */
+    $facade = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('logger')->setValue($facade, $throwingLogger);
+
+    // The call must return normally: write() swallows the throwable (falling back to
+    // error_log) so a broken log sink can never abort — or falsely fail — an upgrade.
+    $facade->success('25.10.0', '25.11.0', 10);
+
+    // The underlying logger was invoked and threw, yet the facade call completed.
+    expect($throwingLogger->attempts)->toBe(1);
+});

--- a/centreon/tests/php/App/Upgrade/Application/Command/UpdateCommandHandlerTest.php
+++ b/centreon/tests/php/App/Upgrade/Application/Command/UpdateCommandHandlerTest.php
@@ -96,6 +96,7 @@ final class UpdateCommandHandlerTest extends TestCase
 
         ($this->handler)(new UpdateCommand());
 
+        // Each available update is run in order, then the post-update runs.
         self::assertSame(['24.10.1', '24.10.2'], $this->updateRepository->updatesRun);
         self::assertTrue($this->updateRepository->postUpdateCalled);
         self::assertTrue($this->locker->unlockCalled);
@@ -114,6 +115,18 @@ final class UpdateCommandHandlerTest extends TestCase
     public function testThrowsWhenCurrentVersionCannotBeRetrieved(): void
     {
         $this->updateRepository->currentVersion = null;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/current platform version/');
+
+        ($this->handler)(new UpdateCommand());
+    }
+
+    public function testThrowsWhenCurrentVersionIsBlank(): void
+    {
+        // A blank version from the DB must be treated like a missing one, so the upgrade
+        // fails with a clear message instead of running steps against an unknown version.
+        $this->updateRepository->currentVersion = '   ';
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/current platform version/');
@@ -145,7 +158,7 @@ final class UpdateCommandHandlerTest extends TestCase
                 $this->currentVersion = $version;
             }
 
-            public function runUpdate(string $version): void
+            public function runMonitoringSql(string $version): void
             {
                 throw new \RuntimeException('SQL error during update');
             }
@@ -162,13 +175,44 @@ final class UpdateCommandHandlerTest extends TestCase
             $this->cacheClearer,
         );
 
-        $this->expectException(\RuntimeException::class);
-
         try {
             $handler(new UpdateCommand());
-        } finally {
-            self::assertTrue($this->locker->unlockCalled, 'Lock must be released even after a failure');
+            self::fail('Expected the update failure to propagate as a RuntimeException');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('SQL error during update', $exception->getMessage());
         }
+
+        // The lock must be released even though the update failed.
+        self::assertTrue($this->locker->unlockCalled, 'Lock must be released even after a failure');
+
+        // A failed upgrade must never run the post-update.
+        self::assertFalse($failingRepository->postUpdateCalled);
+    }
+
+    public function testLockIsReleasedWhenAWrappedStepFails(): void
+    {
+        // A failure inside one of the handler-owned steps (here cache_clear) must still
+        // propagate and release the lock.
+        $this->cacheClearer->method('clear')->willThrowException(new \RuntimeException('cache clear failed'));
+
+        try {
+            ($this->handler)(new UpdateCommand());
+            self::fail('Expected the cache clear failure to propagate');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('cache clear failed', $exception->getMessage());
+        }
+
+        self::assertTrue($this->locker->unlockCalled, 'Lock must be released even when a wrapped step fails');
+    }
+
+    public function testPostUpdateBacksUpBeforeRemovingTheInstallDir(): void
+    {
+        $this->scriptFinder->availableUpdates = [];
+
+        ($this->handler)(new UpdateCommand());
+
+        // The handler must back up the install directory before removing it.
+        self::assertSame(['backup', 'remove'], $this->updateRepository->calls);
     }
 
     public function testEngineContextAndCacheAreCalledOnSuccess(): void

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepositoryTest.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepositoryTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Upgrade\Infrastructure\Dbal;
+
+use Adaptation\Database\Connection\Model\ConnectionConfig;
+use App\Upgrade\Infrastructure\Dbal\DbalUpdateRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class DbalUpdateRepositoryTest extends TestCase
+{
+    private const VERSION = '24.10.1';
+
+    private Connection&MockObject $configConnection;
+
+    private Connection&MockObject $realtimeConnection;
+
+    private ConnectionConfig $connectionConfig;
+
+    private Filesystem $realFilesystem;
+
+    private string $baseDir;
+
+    private string $installDir;
+
+    private string $libDir;
+
+    protected function setUp(): void
+    {
+        $this->configConnection = $this->createMock(Connection::class);
+        $this->realtimeConnection = $this->createMock(Connection::class);
+        $this->connectionConfig = new ConnectionConfig(
+            'localhost',
+            'centreon',
+            'password',
+            'centreon',
+            'centreon_storage',
+        );
+        $this->realFilesystem = new Filesystem();
+
+        $this->baseDir = sys_get_temp_dir() . '/centreon-update-test-' . uniqid();
+        $this->installDir = $this->baseDir . '/install';
+        $this->libDir = $this->baseDir . '/lib';
+        $this->realFilesystem->mkdir([$this->installDir, $this->libDir]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->realFilesystem->remove($this->baseDir);
+    }
+
+    public function testUpdateVersionInformationRunsTheVersionUpdate(): void
+    {
+        $executed = [];
+        $this->configConnection
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql) use (&$executed): int {
+                $executed[] = $sql;
+
+                return 1;
+            });
+
+        $this->repository()->updateVersionInformation(self::VERSION);
+
+        self::assertStringContainsString('UPDATE `informations`', implode(' | ', $executed));
+    }
+
+    public function testRunConfigurationSqlResumesFromProgressCountAndSkipsAlreadyExecutedStatements(): void
+    {
+        // A configuration SQL file with two statements, the first already applied on a previous run.
+        $this->createConfigurationSqlFile("-- a comment\nSELECT 1;\nSELECT 2;\n");
+        file_put_contents($this->progressFile(), '1');
+
+        $executed = [];
+        $this->configConnection
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql) use (&$executed): int {
+                $executed[] = $sql;
+
+                return 1;
+            });
+
+        $this->repository()->runConfigurationSql(self::VERSION);
+
+        // The already-applied first statement is skipped; only the second one runs.
+        $statementsRun = implode(' | ', $executed);
+        self::assertStringContainsString('SELECT 2', $statementsRun);
+        self::assertStringNotContainsString('SELECT 1', $statementsRun);
+
+        // The progress file is advanced to the new count.
+        self::assertSame('2', file_get_contents($this->progressFile()));
+    }
+
+    public function testRunConfigurationSqlFailsWhenProgressFileIsNotWritable(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            self::markTestSkipped('Permission bits are bypassed when running as root.');
+        }
+
+        $this->createConfigurationSqlFile("SELECT 1;\n");
+        // The progress file exists but is read-only: writing the new count must fail loudly.
+        $progressFile = $this->progressFile();
+        file_put_contents($progressFile, '0');
+        chmod($progressFile, 0o444);
+
+        $this->configConnection->method('executeStatement')->willReturn(1);
+
+        try {
+            $this->repository()->runConfigurationSql(self::VERSION);
+            self::fail('Expected the non-writable progress file to abort the step');
+        } catch (\RuntimeException $exception) {
+            self::assertMatchesRegularExpression('/temporary file/', $exception->getMessage());
+        } finally {
+            chmod($progressFile, 0o644);
+        }
+    }
+
+    public function testInstallDirectoryExistsReflectsTheFilesystem(): void
+    {
+        self::assertTrue($this->repository()->installDirectoryExists());
+
+        $this->realFilesystem->remove($this->installDir);
+
+        self::assertFalse($this->repository()->installDirectoryExists());
+    }
+
+    public function testBackupInstallDirectoryThrowsWhenBackupDirectoryIsMissing(): void
+    {
+        // installDir exists (created in setUp) but libDir/installs does not.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/backup directory/');
+
+        $this->repository()->backupInstallDirectory(self::VERSION);
+    }
+
+    public function testBackupInstallDirectoryCopiesTheInstallContents(): void
+    {
+        $this->realFilesystem->mkdir($this->libDir . '/installs');
+        file_put_contents($this->installDir . '/marker.txt', 'data');
+
+        $this->repository()->backupInstallDirectory(self::VERSION);
+
+        // A timestamped backup copy holding the install contents now exists under installs/.
+        $backups = glob($this->libDir . '/installs/install-' . self::VERSION . '-*') ?: [];
+        self::assertCount(1, $backups);
+        self::assertFileExists($backups[0] . '/marker.txt');
+        // The install directory itself is left untouched by the backup step.
+        self::assertDirectoryExists($this->installDir);
+    }
+
+    public function testRemoveInstallDirectoryDeletesIt(): void
+    {
+        $this->repository()->removeInstallDirectory();
+
+        self::assertDirectoryDoesNotExist($this->installDir);
+    }
+
+    public function testBackupInstallDirectoryPropagatesFilesystemFailures(): void
+    {
+        $this->realFilesystem->mkdir($this->libDir . '/installs');
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('mirror')->willThrowException(new IOException('Cannot mirror the install directory'));
+
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessage('Cannot mirror the install directory');
+
+        $this->repository($filesystem)->backupInstallDirectory(self::VERSION);
+    }
+
+    private function repository(?Filesystem $filesystem = null): DbalUpdateRepository
+    {
+        return new DbalUpdateRepository(
+            $this->configConnection,
+            $this->realtimeConnection,
+            $this->connectionConfig,
+            $this->libDir,
+            $this->installDir,
+            $filesystem ?? $this->realFilesystem,
+        );
+    }
+
+    private function createConfigurationSqlFile(string $contents): void
+    {
+        $sqlDir = $this->installDir . '/sql/centreon';
+        $this->realFilesystem->mkdir([$sqlDir, $this->installDir . '/tmp']);
+        file_put_contents($sqlDir . '/Update-DB-' . self::VERSION . '.sql', $contents);
+    }
+
+    private function progressFile(): string
+    {
+        return $this->installDir . '/tmp/Update-DB-' . self::VERSION . '.sql';
+    }
+}

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Double/FakeUpdateRepository.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Double/FakeUpdateRepository.php
@@ -31,21 +31,53 @@ class FakeUpdateRepository implements UpdateRepository
 
     public bool $postUpdateCalled = false;
 
-    /** @var string[] */
+    public bool $installDirectoryPresent = true;
+
+    /** @var string[] versions whose version row was recorded */
     public array $updatesRun = [];
+
+    /** @var list<string> ordered post-update calls (backup / remove) */
+    public array $calls = [];
 
     public function findCurrentVersion(): ?string
     {
         return $this->currentVersion;
     }
 
-    public function runUpdate(string $version): void
+    public function runMonitoringSql(string $version): void
+    {
+    }
+
+    public function runScript(string $version): void
+    {
+    }
+
+    public function runConfigurationSql(string $version): void
+    {
+    }
+
+    public function runPostScript(string $version): void
+    {
+    }
+
+    public function updateVersionInformation(string $version): void
     {
         $this->updatesRun[] = $version;
     }
 
-    public function runPostUpdate(string $currentVersion): void
+    public function installDirectoryExists(): bool
     {
+        return $this->installDirectoryPresent;
+    }
+
+    public function backupInstallDirectory(string $currentVersion): void
+    {
+        $this->calls[] = 'backup';
+    }
+
+    public function removeInstallDirectory(): void
+    {
+        $this->calls[] = 'remove';
         $this->postUpdateCalled = true;
     }
 }

--- a/centreon/tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php
+++ b/centreon/tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Platform\Infrastructure\Repository;
+
+use Adaptation\Log\LoggerUpgrade;
+use Centreon\Domain\Repository\RepositoryException;
+use Core\Platform\Infrastructure\Repository\DbWriteUpdateRepository;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+beforeEach(function (): void {
+    // Install a recording logger as the LoggerUpgrade singleton so the upgrade events emitted by
+    // executeStep() can be asserted without writing to the real upgrade channel. The facade is a
+    // singleton with a private constructor, so the spy is wired through reflection.
+    $this->spy = new class () extends AbstractLogger {
+        /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+        }
+    };
+
+    $reflection = new \ReflectionClass(LoggerUpgrade::class);
+    $facade = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('logger')->setValue($facade, $this->spy);
+    $reflection->getProperty('instance')->setValue(null, $facade);
+
+    // The methods under test use no instance state, so the constructor (DB, Pimple, Filesystem) is skipped.
+    $this->repository = (new \ReflectionClass(DbWriteUpdateRepository::class))->newInstanceWithoutConstructor();
+});
+
+afterEach(function (): void {
+    // Drop the spy-backed singleton so it cannot leak into other test files sharing the process.
+    (new \ReflectionClass(LoggerUpgrade::class))->getProperty('instance')->setValue(null, null);
+});
+
+it('brackets a successful step with a running start and a completed event', function (): void {
+    $ran = false;
+    (new \ReflectionClass($this->repository))->getMethod('executeStep')->invoke(
+        $this->repository,
+        '24.10.1',
+        'php_script',
+        function () use (&$ran): void {
+            $ran = true;
+        }
+    );
+
+    expect($ran)->toBeTrue()
+        ->and($this->spy->records)->toHaveCount(2);
+
+    [$start, $completed] = $this->spy->records;
+    expect($start['level'])->toBe(LogLevel::INFO)
+        ->and($start['context']['event'])->toBe('upgrade.step')
+        ->and($start['context']['status'])->toBe('running')
+        ->and($start['context']['version'])->toBe('24.10.1')
+        ->and($start['context']['step'])->toBe('php_script')
+        ->and($completed['level'])->toBe(LogLevel::INFO)
+        ->and($completed['context']['event'])->toBe('upgrade.step_completed')
+        ->and($completed['context']['status'])->toBe('completed')
+        ->and($completed['context']['step'])->toBe('php_script')
+        ->and($completed['context']['duration_ms'])->toBeInt();
+});
+
+it('logs a step failure and re-throws the original exception when the step throws', function (): void {
+    $failure = new \RuntimeException('boom');
+
+    try {
+        (new \ReflectionClass($this->repository))->getMethod('executeStep')->invoke(
+            $this->repository,
+            '24.10.1',
+            'configuration_sql',
+            function () use ($failure): void {
+                throw $failure;
+            }
+        );
+        // executeStep must surface the failure, never swallow it.
+        $this->fail('Expected executeStep to re-throw the step failure');
+    } catch (\RuntimeException $caught) {
+        expect($caught)->toBe($failure);
+    }
+
+    // The start event is still emitted, then a step_failure carrying the throwable; no completed event.
+    expect($this->spy->records)->toHaveCount(2);
+    [$start, $stepFailure] = $this->spy->records;
+    expect($start['context']['event'])->toBe('upgrade.step')
+        ->and($stepFailure['level'])->toBe(LogLevel::ERROR)
+        ->and($stepFailure['context']['event'])->toBe('upgrade.step_failure')
+        ->and($stepFailure['context']['status'])->toBe('failure')
+        ->and($stepFailure['context']['step'])->toBe('configuration_sql')
+        ->and($stepFailure['context']['exception'])->toBe($failure);
+});
+
+it('writes the executed-queries count to the temporary resume file', function (): void {
+    $tmpFile = sys_get_temp_dir() . '/centreon-upgrade-cursor-' . uniqid() . '.tmp';
+
+    try {
+        (new \ReflectionClass($this->repository))
+            ->getMethod('writeExecutedQueriesCountInTemporaryFile')
+            ->invoke($this->repository, $tmpFile, 7);
+
+        expect(file_get_contents($tmpFile))->toBe('7');
+    } finally {
+        @unlink($tmpFile);
+    }
+});
+
+it('throws when the temporary resume file exists but is not writable', function (): void {
+    if (function_exists('posix_getuid') && posix_getuid() === 0) {
+        $this->markTestSkipped('Permission bits are bypassed when running as root.');
+    }
+
+    $tmpFile = sys_get_temp_dir() . '/centreon-upgrade-cursor-' . uniqid() . '.tmp';
+    file_put_contents($tmpFile, '0');
+    chmod($tmpFile, 0o444);
+
+    try {
+        (new \ReflectionClass($this->repository))
+            ->getMethod('writeExecutedQueriesCountInTemporaryFile')
+            ->invoke($this->repository, $tmpFile, 3);
+        $this->fail('Expected a non-writable resume file to abort the step');
+    } catch (RepositoryException $exception) {
+        expect($exception->getMessage())->toContain('temporary file');
+    } finally {
+        chmod($tmpFile, 0o644);
+        @unlink($tmpFile);
+    }
+});

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -23,6 +23,7 @@ use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ConnectionInterface;
 use Adaptation\Database\Connection\Exception\ConnectionException;
 use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\LoggerUpgrade;
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
@@ -40,26 +41,17 @@ $errorMessage = '';
 /** -------------------------------------- Resources performance indexes -------------------------------------- */
 $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $version): void {
     $errorMessage = 'Unable to add performance indexes to resources table';
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Adding performance indexes to centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Adding performance indexes to centreon_storage.resources');
 
     // Add is_module virtual column (pre-computes the NOT LIKE filter used to exclude internal Module/BAM resources)
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Adding is_module virtual column to centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Adding is_module virtual column to centreon_storage.resources');
     $hasIsModule = $pearDBO->columnExists(
         $pearDBO->getConnectionConfig()->getDatabaseNameRealTime(),
         'resources',
         'is_module'
     );
     if ($hasIsModule) {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Column is_module already exists on resources, skipping",
-        );
+        LoggerUpgrade::create()->info($version, 'Column is_module already exists on resources, skipping');
     } else {
         $pearDBO->executeStatement(
             <<<'SQL'
@@ -69,10 +61,7 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
                 ) VIRTUAL COMMENT 'computed flag: 1 if internal Module/BAM resource to exclude from listings'
                 SQL
         );
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Successfully added is_module virtual column to resources",
-        );
+        LoggerUpgrade::create()->info($version, 'Successfully added is_module virtual column to resources');
     }
 
     // Add/recreate sort index to allow MariaDB to satisfy the default
@@ -83,10 +72,7 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
     // On MariaDB 10.5–10.7 they are silently treated as ascending; the optimizer can still use
     // the index via a backward scan for DESC ORDER BY, so the index remains beneficial but slightly
     // less efficient than on 10.8+.
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Adding resources_enabled_status_sort_idx index to centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Adding resources_enabled_status_sort_idx index to centreon_storage.resources');
     $dbRealTime = $pearDBO->getConnectionConfig()->getDatabaseNameRealTime();
     $hasStatusSortIdxWithResourceId = $pearDBO->fetchOne(
         <<<'SQL'
@@ -99,10 +85,7 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
         QueryParameters::create([QueryParameter::string('db_name', $dbRealTime)])
     );
     if ($hasStatusSortIdxWithResourceId) {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Index resources_enabled_status_sort_idx already up to date, skipping",
-        );
+        LoggerUpgrade::create()->info($version, 'Index resources_enabled_status_sort_idx already up to date, skipping');
     } else {
         $hasStatusSortIdx = $pearDBO->fetchOne(
             <<<'SQL'
@@ -114,19 +97,13 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
             QueryParameters::create([QueryParameter::string('db_name', $dbRealTime)])
         );
         if ($hasStatusSortIdx) {
-            CentreonLog::create()->info(
-                logTypeId: CentreonLog::TYPE_UPGRADE,
-                message: "UPGRADE - {$version}: Dropping outdated resources_enabled_status_sort_idx index (missing resource_id column)",
-            );
+            LoggerUpgrade::create()->info($version, 'Dropping outdated resources_enabled_status_sort_idx index (missing resource_id column)');
             $pearDBO->executeStatement(
                 <<<'SQL'
                     ALTER TABLE `resources` DROP INDEX `resources_enabled_status_sort_idx`
                     SQL
             );
-            CentreonLog::create()->info(
-                logTypeId: CentreonLog::TYPE_UPGRADE,
-                message: "UPGRADE - {$version}: Successfully dropped outdated resources_enabled_status_sort_idx index",
-            );
+            LoggerUpgrade::create()->info($version, 'Successfully dropped outdated resources_enabled_status_sort_idx index');
         }
         $pearDBO->executeStatement(
             <<<'SQL'
@@ -134,18 +111,12 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
                 ADD INDEX `resources_enabled_status_sort_idx` (`enabled`, `status_ordered` DESC, `last_status_change` DESC, `resource_id` DESC)
                 SQL
         );
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Successfully added resources_enabled_status_sort_idx index to resources",
-        );
+        LoggerUpgrade::create()->info($version, 'Successfully added resources_enabled_status_sort_idx index to resources');
     }
 
     // resources_enabled_type_ismodule_idx is a left-prefix of resources_name_search_idx
     // (enabled, type, is_module, poller_id, name) so it is redundant — drop it if present.
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Checking for redundant resources_enabled_type_ismodule_idx index on centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Checking for redundant resources_enabled_type_ismodule_idx index on centreon_storage.resources');
     $hasIsModuleIdx = $pearDBO->fetchOne(
         <<<'SQL'
             SELECT 1 FROM information_schema.STATISTICS
@@ -156,31 +127,19 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
         QueryParameters::create([QueryParameter::string('db_name', $dbRealTime)])
     );
     if ($hasIsModuleIdx) {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Dropping redundant resources_enabled_type_ismodule_idx index (covered by resources_name_search_idx)",
-        );
+        LoggerUpgrade::create()->info($version, 'Dropping redundant resources_enabled_type_ismodule_idx index (covered by resources_name_search_idx)');
         $pearDBO->executeStatement(
             <<<'SQL'
                 ALTER TABLE `resources` DROP INDEX `resources_enabled_type_ismodule_idx`
                 SQL
         );
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Successfully dropped resources_enabled_type_ismodule_idx index",
-        );
+        LoggerUpgrade::create()->info($version, 'Successfully dropped resources_enabled_type_ismodule_idx index');
     } else {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Index resources_enabled_type_ismodule_idx not present, skipping",
-        );
+        LoggerUpgrade::create()->info($version, 'Index resources_enabled_type_ismodule_idx not present, skipping');
     }
 
     // Add covering index for status/state filter COUNT queries (status-first for tight seek on status IN (...))
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Adding resources_status_filter_idx index to centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Adding resources_status_filter_idx index to centreon_storage.resources');
     $hasStatusFilterIdx = $pearDBO->fetchOne(
         <<<'SQL'
             SELECT 1 FROM information_schema.STATISTICS
@@ -191,10 +150,7 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
         QueryParameters::create([QueryParameter::string('db_name', $dbRealTime)])
     );
     if ($hasStatusFilterIdx) {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Index resources_status_filter_idx already exists on resources, skipping",
-        );
+        LoggerUpgrade::create()->info($version, 'Index resources_status_filter_idx already exists on resources, skipping');
     } else {
         $pearDBO->executeStatement(
             <<<'SQL'
@@ -202,17 +158,11 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
                 ADD INDEX `resources_status_filter_idx` (`enabled`, `status`, `type`, `is_module`, `acknowledged`, `in_downtime`, `status_confirmed`, `poller_id`)
                 SQL
         );
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Successfully added resources_status_filter_idx index to resources",
-        );
+        LoggerUpgrade::create()->info($version, 'Successfully added resources_status_filter_idx index to resources');
     }
 
     // Add covering index for name search queries (includes name column to avoid row reads for REGEXP/LIKE)
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Adding resources_name_search_idx index to centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Adding resources_name_search_idx index to centreon_storage.resources');
     $hasNameSearchIdx = $pearDBO->fetchOne(
         <<<'SQL'
             SELECT 1 FROM information_schema.STATISTICS
@@ -223,10 +173,7 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
         QueryParameters::create([QueryParameter::string('db_name', $dbRealTime)])
     );
     if ($hasNameSearchIdx) {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Index resources_name_search_idx already exists on resources, skipping",
-        );
+        LoggerUpgrade::create()->info($version, 'Index resources_name_search_idx already exists on resources, skipping');
     } else {
         $pearDBO->executeStatement(
             <<<'SQL'
@@ -234,18 +181,12 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
                 ADD INDEX `resources_name_search_idx` (`enabled`, `type`, `is_module`, `poller_id`, `name`)
                 SQL
         );
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Successfully added resources_name_search_idx index to resources",
-        );
+        LoggerUpgrade::create()->info($version, 'Successfully added resources_name_search_idx index to resources');
     }
 
     // Add index for severity filter queries: allows direct seeks on severity_id instead of a full scan.
     // Used by the non-correlated IN subquery rewrite in DbReadResourceRepository::addSeveritySubRequest().
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Adding resources_severity_filter_idx index to centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Adding resources_severity_filter_idx index to centreon_storage.resources');
     $hasSeverityFilterIdx = $pearDBO->fetchOne(
         <<<'SQL'
             SELECT 1 FROM information_schema.STATISTICS
@@ -256,10 +197,7 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
         QueryParameters::create([QueryParameter::string('db_name', $dbRealTime)])
     );
     if ($hasSeverityFilterIdx) {
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Index resources_severity_filter_idx already exists on resources, skipping",
-        );
+        LoggerUpgrade::create()->info($version, 'Index resources_severity_filter_idx already exists on resources, skipping');
     } else {
         $pearDBO->executeStatement(
             <<<'SQL'
@@ -267,19 +205,15 @@ $addResourcesPerformanceIndexes = function () use ($pearDBO, &$errorMessage, $ve
                 ADD INDEX `resources_severity_filter_idx` (`severity_id`, `enabled`, `is_module`, `type`)
                 SQL
         );
-        CentreonLog::create()->info(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Successfully added resources_severity_filter_idx index to resources",
-        );
+        LoggerUpgrade::create()->info($version, 'Successfully added resources_severity_filter_idx index to resources');
     }
 
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: Successfully completed performance indexes setup on centreon_storage.resources",
-    );
+    LoggerUpgrade::create()->info($version, 'Successfully completed performance indexes setup on centreon_storage.resources');
 };
 
 try {
+    LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
+
     $addResourcesPerformanceIndexes();
     // DDL statements for real time database
     // TODO add your function calls to update the real time database structure here
@@ -296,22 +230,27 @@ try {
 
     $pearDB->commitTransaction();
 
+    LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
+
 } catch (Throwable $throwable) {
-    CentreonLog::create()->error(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: " . $errorMessage,
-        exception: $throwable
+    LoggerUpgrade::create()->stepFailure(
+        "UPGRADE - {$version}: {$errorMessage}",
+        $version,
+        'php_script',
+        $throwable
     );
 
     try {
         if ($pearDB->isTransactionActive()) {
+            LoggerUpgrade::create()->info($version, "Rolling back transaction after error: {$errorMessage}");
             $pearDB->rollBackTransaction();
         }
     } catch (ConnectionException $rollbackException) {
-        CentreonLog::create()->error(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
-            exception: $rollbackException
+        LoggerUpgrade::create()->stepFailure(
+            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
+            $version,
+            'php_script_rollback',
+            $rollbackException
         );
 
         throw new RuntimeException(

--- a/centreon/www/install/php/Update-next.php.tpl
+++ b/centreon/www/install/php/Update-next.php.tpl
@@ -21,6 +21,7 @@
 
 use Adaptation\Database\Connection\ConnectionInterface;
 use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Log\LoggerUpgrade;
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
@@ -36,6 +37,8 @@ $errorMessage = '';
 // TODO add your functions here
 
 try {
+    LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
+
     // DDL statements for real time database
     // TODO add your function calls to update the real time database structure here
 
@@ -51,22 +54,27 @@ try {
 
     $pearDB->commitTransaction();
 
+    LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
+
 } catch (Throwable $throwable) {
-    CentreonLog::create()->error(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: " . $errorMessage,
-        exception: $throwable
+    LoggerUpgrade::create()->stepFailure(
+        "UPGRADE - {$version}: {$errorMessage}",
+        $version,
+        'php_script',
+        $throwable
     );
 
     try {
         if ($pearDB->isTransactionActive()) {
+            LoggerUpgrade::create()->info($version, "Rolling back transaction after error: {$errorMessage}");
             $pearDB->rollBackTransaction();
         }
     } catch (ConnectionException $rollbackException) {
-        CentreonLog::create()->error(
-            logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
-            exception: $rollbackException
+        LoggerUpgrade::create()->stepFailure(
+            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
+            $version,
+            'php_script_rollback',
+            $rollbackException
         );
 
         throw new RuntimeException(

--- a/centreon/www/install/step_upgrade/process/process_step4.php
+++ b/centreon/www/install/step_upgrade/process/process_step4.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/../../../../bootstrap.php';
 require_once __DIR__ . '/../../../class/centreonDB.class.php';
 require_once __DIR__ . '/../../steps/functions.php';
 
+use Adaptation\Log\LoggerUpgrade;
 use Core\Platform\Application\Repository\ReadUpdateRepositoryInterface;
 use Core\Platform\Application\Repository\UpdateLockerRepositoryInterface;
 use Core\Platform\Application\Repository\WriteUpdateRepositoryInterface;
@@ -37,6 +38,9 @@ $kernel = App\Kernel::createForWeb();
 $updateLockerRepository = $kernel->getContainer()->get(UpdateLockerRepositoryInterface::class);
 $updateWriteRepository = $kernel->getContainer()->get(WriteUpdateRepositoryInterface::class);
 
+$startedAt = microtime(true);
+LoggerUpgrade::create()->start($current, $next);
+
 try {
     if (! $updateLockerRepository->lock()) {
         throw new RuntimeException('Update already in progress.');
@@ -45,7 +49,11 @@ try {
     $updateWriteRepository->runUpdate($next);
 
     $updateLockerRepository->unlock();
+
+    $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
+    LoggerUpgrade::create()->success($current, $next, $durationMs);
 } catch (Throwable $e) {
+    LoggerUpgrade::create()->failure($e->getMessage(), $current, $next, $e);
     exitUpgradeProcess(1, $current, $next, $e->getMessage());
 }
 

--- a/centreon/www/install/step_upgrade/process/process_step5.php
+++ b/centreon/www/install/step_upgrade/process/process_step5.php
@@ -23,6 +23,7 @@ session_start();
 require_once __DIR__ . '/../../../../bootstrap.php';
 require_once '../../steps/functions.php';
 
+use Adaptation\Log\LoggerUpgrade;
 use Core\Platform\Application\Repository\WriteUpdateRepositoryInterface;
 
 $kernel = App\Kernel::createForWeb();
@@ -44,6 +45,10 @@ if ($parameters) {
     $db->query($query);
 }
 
+$currentVersion = $_SESSION['CURRENT_VERSION'] ?? 'unknown';
+$startedAt = microtime(true);
+LoggerUpgrade::create()->step($currentVersion, 'post_update', 'Post-update phase started');
+
 try {
     if (! isset($_SESSION['CURRENT_VERSION']) || ! preg_match('/^\d+\.\d+\.\d+/', $_SESSION['CURRENT_VERSION'])) {
         throw new Exception('Cannot get current version');
@@ -58,7 +63,21 @@ try {
     }
 
     $updateWriteRepository->runPostUpdate($_SESSION['CURRENT_VERSION']);
+
+    $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
+    LoggerUpgrade::create()->stepCompleted(
+        $currentVersion,
+        'post_update',
+        $durationMs,
+        "Post-update phase completed in {$durationMs}ms"
+    );
 } catch (Throwable $e) {
+    LoggerUpgrade::create()->stepFailure(
+        "Post-update phase failed: {$e->getMessage()}",
+        $currentVersion,
+        'post_update',
+        $e
+    );
     exitUpgradeProcess(
         1,
         $current,


### PR DESCRIPTION
## Description

Backport to `dev-25.10.x` of the structured upgrade logging introduced on `develop` (#10416).

Introduces a `LoggerUpgrade` facade on the `upgrade` Monolog channel (`prod.upgrade.log`) and wires it through both upgrade flows:

- **DDD** — `UpdateCommandHandler` brackets each step (`start` / `stepCompleted` / `stepFailure` / `success` / `failure`); `DbalUpdateRepository` performs the operations.
- **Legacy** — `process_step4` / `process_step5` and `DbWriteUpdateRepository` (one `executeStep` per sub-step + backup/remove install dir) trace each step.

The `Update-next.php.tpl` template is updated so future upgrade scripts use the facade out of the box.

## Backport notes (25.10 specifics)

The original PR was adapted to the 25.10.x state:

- **`centreonAuth.class.php` is not part of this backport.** The original PR only restyled (ternary → `if/elseif`) the `LoggerAuthentication` / `AuthProviderEnum` login-logging block, which does not exist on `dev-25.10.x` (no `LoggerAuthentication`). It is unrelated to the upgrade flow.
- **`Update-next.php` carries a different migration on this branch** (`$addResourcesPerformanceIndexes`). Its `CentreonLog::TYPE_UPGRADE` logging was converted to `LoggerUpgrade`, consistently with the feature and the updated template.
- **`doc/php/logging.md` has fewer sections here.** Only the "Writing upgrade scripts" section is added, renumbered to **§11** (the develop §11 "Legacy bridge" / §12 "Writing authentication events" do not exist on this branch).

Infrastructure verified on this branch: `LogChannelEnum::UPGRADE` and the `upgrade` channel are configured, so `LoggerUpgrade` routes to `prod.upgrade.log`.

## Tests

- `LoggerUpgradeTest`, `DbalUpdateRepositoryTest`, `UpdateCommandHandlerTest` cherry-picked from the source commit.
- Added `DbWriteUpdateRepositoryTest` covering the legacy path's new behavior (`executeStep` step bracketing + re-throw, `writeExecutedQueriesCountInTemporaryFile` writable / non-writable) — 4 cases green under PHP 8.2.
- `php -l` clean on every touched file; `rector` clean.

## Verification

Cherry-pick of the `develop` commit `e6688b1e` with manual resolution of the three conflicts (doc structure, `centreonAuth`, `Update-next.php`) as described above. All files coming from `develop` are byte-identical to `develop`.

## Links

### Jira ticket

[MON-201535](https://centreon.atlassian.net/browse/MON-201535)

### PR Github

Backports: #10416


[MON-201535]: https://centreon.atlassian.net/browse/MON-201535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
