### PR TITLE
fix(docker): use www-data for web service in debian based OS

### DIFF
--- a/.github/docker/centreon-awie/trixie/entrypoint.sh
+++ b/.github/docker/centreon-awie/trixie/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-su apache -s /bin/bash -c "/tmp/install-centreon-module.php -b /usr/share/centreon/bootstrap.php -m centreon-awie"
+su www-data -s /bin/bash -c "/tmp/install-centreon-module.php -b /usr/share/centreon/bootstrap.php -m centreon-awie"


### PR DESCRIPTION
## Description

* fix trixie entrypoint
* use www-data for debian base distribs, and use for web service

**Fixes** #MON-201896

