### PR TITLE
feat(logging): align authentication events with OWASP security log split

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,3 +66,6 @@ dependencies/**                         @centreon/owners-pipelines
 .gitleaksignore               @centreon/owners-security
 .githooks/pre-commit          @centreon/owners-security
 **/secu-*.yml                 @centreon/owners-security
+
+# PHP documentation: overrides the global *.md rule above (must stay last to win)
+**/doc/php/                             @centreon/owners-php

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -19,6 +19,8 @@ This document describes the platform pipeline that captures logs emitted by the 
 8. [Processor scope](#8-processor-scope)
 9. [Routing and output file](#9-routing-and-output-file)
 10. [Masking sensitive fields with `#[Sensitive]`](#10-masking-sensitive-fields-with-sensitive)
+11. [Legacy bridge — `Adaptation\Log\Logger`](#11-legacy-bridge--adaptationloglogger)
+12. [Writing authentication events](#12-writing-authentication-events)
 
 ---
 
@@ -469,7 +471,7 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 | `token` | MON-151077 → dedicated file `prod.token.log`. |
 | `password`, `plugin-pack-manager`, `upgrade` | MON-151077 → dedicated files. Not Monolog channels strictly speaking today (written directly by legacy `CentreonLog` code), but listed in anticipation of a future migration to Monolog. |
 
-> **Backward compatibility — `login.log` is intentionally kept.** Authentication events now flow to the `authentication` channel (`prod.access.log`). To avoid breaking external consumers that parse the historical `/var/log/centreon/login.log` — most notably **fail2ban** jails matching the `Authentication failed for …` line with the client IP — `CentreonUserLog::insertLog()` still mirrors every `TYPE_LOGIN` event to `login.log` in the original pipe-delimited format (`date|uid|page|option|message`). This duplicate write is **transitional**: it is kept on purpose for client compatibility and will be removed in a future release once consumers have migrated to the Monolog access log (cleanup tracked in a dedicated ticket). `login.log` remains covered by `logrotate/centreon`.
+> **Backward compatibility — `login.log` is intentionally kept.** Authentication events now flow to the `authentication` channel (`prod.access.log`). To avoid breaking external consumers that parse the historical `/var/log/centreon/login.log` — most notably **fail2ban** jails matching the `Authentication failed for …` line with the client IP — login events are still mirrored to `login.log` in the original pipe-delimited format (`date|uid|page|option|message`) by **two** writers: `LoggerAuthentication::mirrorToLegacyLoginLog()` for events emitted on the new-kernel path (the OpenID/SAML/WebSSO logins routed through the `Login` use case, and the legacy local/LDAP success/failure now routed through the facade), and `CentreonUserLog::insertLog()` for `TYPE_LOGIN` events still flowing through the legacy code path (e.g. `LoginLogger`). The facade writer is try/catch protected so a mirror failure can never break a login; the legacy `CentreonUserLog` writer is not. This duplicate write is **transitional**: it is kept on purpose for client compatibility and will be removed in a future release once consumers have migrated to the Monolog access log (cleanup tracked in a dedicated ticket). `login.log` remains covered by `logrotate/centreon`.
 
 | Property | Effect |
 |----------|--------|
@@ -497,6 +499,33 @@ In production, the `prod.*.log` files are rotated by **logrotate** (config `cent
 Default retention: `weekly` × `rotate 52` (1 year), with `compress` + `delaycompress` + `copytruncate`.
 
 In development (`when@dev` in `monolog.yaml`), the handlers use `rotating_file` directly (daily `Y-m-d` suffix, `max_files: 14` retention) — no need for logrotate.
+
+### `prod.web.log` is a two-format file
+
+`prod.web.log` aggregates records from **two writers** sharing the same file, and they don't share the same line shape — by construction, not by choice:
+
+1. **Monolog** (the application framework, `LoggingMiddleware` + processors + every DI-resolved `LoggerInterface`) writes with the `LineFormatter`:
+
+   ```
+   [2026-05-20T14:30:00+02:00] app.INFO: Dispatching command.bus App\…\Foo {"dispatch_id":"…"} {"uid":"…"}
+   ```
+
+   - RFC3339 timestamp, `channel.LEVEL` prefix, JSON `context` + JSON `extra`.
+
+2. **PHP-FPM** native `error_log` (`packaging/src/php-fpm.{rpm,deb}.conf`, `php_admin_value[error_log] = /var/log/centreon/prod.web.log`) writes whatever PHP cannot route through Monolog — parse errors, fatal pre-boot errors, OOM, `trigger_error(..., E_USER_ERROR)`:
+
+   ```
+   [20-May-2026 14:26:47 Europe/Paris] PHP Fatal error:  forced PHP test error in /tmp/foo.php on line 2
+   ```
+
+   - Legacy date format (`d-M-Y H:i:s T`), `PHP <Type> error:` prefix, no JSON.
+
+The two formats **cannot be unified at the source**: PHP-FPM does not expose any `error_log_format` directive (the format is hardcoded in the PHP engine, `main/main.c`). What the framework can catch, however, is caught: `framework.php_errors.log: true` routes every runtime PHP `Warning` / `Notice` / `Deprecation` / `ErrorException` through Monolog on the `php` channel, so they land in `prod.web.log` **at the Monolog format**. Only the native pre-Monolog failures (parse error, fatal pre-boot, OOM) keep the PHP-FPM format.
+
+Practical consequence for downstream consumers (log shippers, fail2ban filters, manual `tail`): match the line by **its first character pattern**, not by date:
+
+- `^\[\d{4}-\d{2}-\d{2}T` → Monolog record (RFC3339)
+- `^\[\d{2}-[A-Z][a-z]{2}-\d{4}` → PHP-FPM native error
 
 ---
 
@@ -552,3 +581,309 @@ PHP's built-in [`#[\SensitiveParameter]`](https://www.php.net/manual/en/class.se
 - **Mechanism** — it only redacts a value in **exception stack traces** (handled by the PHP engine); it does not mask log payloads. The scanner reflects *properties*, so it would not even see a `#[\SensitiveParameter]` placed on a promoted parameter.
 
 A property-level attribute is therefore the right tool for reflection-based **payload** masking. A future enhancement could make `SensitivityScanner` *additionally* honour `#[\SensitiveParameter]` on promoted constructor parameters (gaining stack-trace redaction for free) while keeping `#[Sensitive]` for plain properties.
+
+---
+
+## 11. Legacy bridge — `Adaptation\Log\Logger`
+
+The platform pipeline described above runs under `App\Shared\Infrastructure\Symfony\Kernel`. Legacy entry points (procedural `www/` code, classes wired through `App\Kernel`) cannot autowire Monolog services directly; they go through a thin façade so every record still lands on the MON-151077 layout.
+
+```mermaid
+flowchart LR
+    Legacy["Legacy code (www/, CentreonLog, CentreonUserLog)"] --> Facade["Adaptation\\Log\\Logger::create(LogChannelEnum)"]
+    Facade --> Adapter["Adaptation\\Log\\Adapter\\MonologAdapter"]
+    Adapter --> Stream["StreamHandler → /var/log/centreon/&lt;env&gt;.&lt;slug&gt;.log"]
+    Stream --> Fmt["LineFormatter (RFC3339)"]
+
+    classDef src fill:#f5f5f5,stroke:#9e9e9e,color:#212121
+    classDef proc fill:#e0e0e0,stroke:#616161,color:#212121
+    classDef out fill:#bdbdbd,stroke:#424242,stroke-width:2px,color:#000
+    class Legacy src
+    class Facade,Adapter proc
+    class Stream,Fmt out
+```
+
+### `LogChannelEnum`
+
+`Adaptation\Log\Enum\LogChannelEnum` enumerates the Monolog channels the legacy code is allowed to write to. The case value is the **channel name** (matches `config.new/packages/monolog.yaml`); `getLogFileSlug()` returns the **file-name slug** appended to `<env>.<slug>.log`.
+
+| Case | Channel | File slug | Production file |
+|---|---|---|---|
+| `AUTHENTICATION` | `authentication` | `access` | `prod.access.log` |
+| `PASSWORD` | `password` | `password` | `prod.password.log` |
+| `PLUGIN_PACK_MANAGER` | `plugin-pack-manager` | `plugin-pack-manager` | `prod.plugin-pack-manager.log` |
+| `TOKEN` | `token` | `token` | `prod.token.log` |
+| `UPGRADE` | `upgrade` | `upgrade` | `prod.upgrade.log` |
+| `WEB` | `web` | `web` | `prod.web.log` |
+
+Only `AUTHENTICATION` carries a different slug — login/ldap/openid/saml records all converge in the shared `access.log` file (cf. MON-151077).
+
+### `Adaptation\Log\Logger`
+
+```php
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+
+Logger::create(LogChannelEnum::WEB)->error(
+    'Could not generate the host configuration',
+    ['host_id' => 42, 'exception' => $e],
+);
+```
+
+`Logger::create()` returns a PSR-3 `LoggerInterface`. Internally it instantiates a `MonologAdapter` carrying a single `StreamHandler` configured with `LineFormatter` + `RFC3339`. Rotation is **not** wired at this layer — production hosts delegate to `logrotate` (cf. `logrotate/centreon`).
+
+If `MonologAdapter::create()` cannot build the handler (e.g. permission error on the log directory), `Logger::create()` falls back to a `NullLogger` and writes the failure reason to `error_log()` — log emission must never break a request.
+
+#### Processors attached by `MonologAdapter`
+
+To mirror the platform pipeline as closely as possible without booting the Symfony container, `MonologAdapter::pushPlatformProcessors()` attaches three processors to every channel logger it creates:
+
+| Processor | Source | Adds |
+|---|---|---|
+| `Monolog\Processor\UidProcessor` | Monolog vendor | `extra.uid` — 7-char hex id, **shared across every channel logger built in the current process** via a `private static` cache. Enables cross-file correlation (`grep "uid\":\"…\"" /var/log/centreon/*.log`) just like the new-kernel pipeline. |
+| `Monolog\Processor\WebProcessor` | Monolog vendor | `extra.url`, `extra.ip`, `extra.http_method`, `extra.server`, `extra.referrer` — sourced from `$_SERVER` directly (the Symfony bridge variant is bypassed because its data is populated by a kernel-request listener that does not run from legacy code paths). |
+| `App\Shared\Infrastructure\Logging\ExceptionFormatterProcessor` | platform | Unwraps `context.exception` through `ExceptionFormatter::format()`, producing the same nested-exception layout used on `prod.web.log` (cf. §5). |
+
+`RouteProcessor` and `TokenProcessor` are **not** wired here: they depend on the Symfony `RequestStack` / `TokenStorage` services and would be empty in the legacy stack. Records emitted via `Adaptation\Log\Logger` therefore do **not** carry `extra.controller`, `extra.route` or `extra.token`. Call sites that need those fields should write through the new-kernel pipeline (the catch-all `app` / `request` channels and every dedicated channel) where the full processor stack is wired globally by `config.new/services/shared.php`.
+
+#### Format alignment — no more `{custom, exception, default}` wrap
+
+Before MON-151077, both `CentreonLog::log()` and `Centreon\Domain\Log\LoggerTrait::executeLog()` reshaped the `context` array before handing it to Monolog:
+
+- `CentreonLog::buildContext()` pre-formatted the `Throwable` with `ExceptionLogFormatter` (legacy) and added `context.request_infos`.
+- `LoggerTrait::normalizeContext()` rewrapped everything as `{custom, exception, default: {request_infos}}` — and **moved** the `Throwable` out of `context.exception` so `ExceptionFormatterProcessor` never saw it.
+
+Both helpers are gone. The legacy façades now hand the caller-supplied `$context` directly to the underlying logger, only normalizing one thing: a `?Throwable $exception` argument is moved into `$context['exception']` so the platform processor can unwrap the chain on the way out.
+
+Concrete consequences:
+
+- Exceptions logged via `CentreonLog::create()->error(TYPE_*, 'msg', $ctx, $throwable)` end up with the **same** structured shape as the new-kernel records (handled by `App\Shared\Infrastructure\Logging\ExceptionFormatter`).
+- The HTTP context (`url`, `ip`, `http_method`, `server`, `referrer`) lives under `extra`, not `context.request_infos` — that is where the rest of the platform reads it.
+- `Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger::log()` still pre-formats through `ExceptionLogFormatter` (legacy) for the `BusinessLogicException` `from_exception` / `traces` fields its callers rely on. Its records therefore keep the legacy `context.exception` shape — that is a property of `ExceptionLogger` callers, not of the underlying logger.
+
+### Domain-specific facades
+
+Three siblings of `Adaptation\Log\Logger` expose a **constrained, semantic API** instead of the raw PSR-3 surface:
+
+| Facade | Channel | File | Methods |
+|---|---|---|---|
+| `Adaptation\Log\LoggerPassword` | `password` | `prod.password.log` | `success`, `warning` |
+| `Adaptation\Log\LoggerToken` | `token` | `prod.token.log` | `success`, `warning` |
+| `Adaptation\Log\LoggerAuthentication` | `authentication` | `prod.access.log` | `loginSuccess`, `loginFailure`, `logout`, `tokenRefreshSuccess`, `tokenRefreshFailure`, `unauthorized`, `forbidden` |
+
+They exist for two reasons:
+
+1. **Downstream consumers expect a stable JSON schema** — fail2ban filters (auth), SIEM correlation (password, auth, token). Hard-coding the schema in the helper guarantees every caller emits the same shape (`event`, `status`, `user_id`, `provider`, `ip_address`, …).
+2. **OWASP-aligned semantics** — distinguishing a security event (`WARNING` for an attempted-but-refused login) from a technical crash (`ERROR` for an unhandled exception) is a domain concern; the helper enforces the right Monolog level for each method.
+
+For channels that carry **free-form messages with arbitrary context** (`web`, `upgrade`, `plugin-pack-manager`), call sites use `Adaptation\Log\Logger::create(LogChannelEnum::*)` directly — wrapping them in a helper adds no value over the PSR-3 facade.
+
+Decision rule for adding a new `Logger<Channel>` class: when the channel either feeds an automated consumer that requires a stable schema, **or** carries a well-defined lifecycle (`loginSuccess` / `loginFailure` / `logout` / …) that benefits from semantic method names. Otherwise, route through `Adaptation\Log\Logger::create(LogChannelEnum::*)` directly.
+
+### `CentreonLog` and `CentreonUserLog` façades
+
+Both classes (`www/class/centreonLog.class.php`) keep their public surface but reroute every write through `Adaptation\Log\Logger`. The legacy `TYPE_*` identifiers map onto channels as follows:
+
+| Legacy constant | Channel | Output file |
+|---|---|---|
+| `TYPE_LOGIN`, `TYPE_LDAP` | `AUTHENTICATION` | `prod.access.log` |
+| `TYPE_SQL`, `TYPE_BUSINESS_LOG` | `WEB` | `prod.web.log` |
+| `TYPE_UPGRADE` | `UPGRADE` | `prod.upgrade.log` |
+| `TYPE_PLUGIN_PACK_MANAGER` | `PLUGIN_PACK_MANAGER` | `prod.plugin-pack-manager.log` |
+
+`CentreonLog::pushLogFileHandler()` and `setPathLogFile()` are kept as deprecated no-ops for backward compatibility with extension modules — file routing is now driven exclusively by `LogChannelEnum`.
+
+Both classes are tagged `@deprecated`. The DI/Application code that still autowires them keeps working, but **new code should call `Adaptation\Log\Logger` directly** with an explicit `LogChannelEnum`.
+
+### `Centreon\Domain\Log\LoggerTrait`
+
+`LoggerTrait` (~389 callers) keeps providing the PSR-3 helper shape used by Domain services that autowire a `LoggerInterface` via `#[Required]`. The pre-MON-151077 `ContactForDebug` gate is gone — `canBeLogged()` now only checks that a logger has been injected. The trait carries a descriptive note but no formal `@deprecated` tag, because `Symfony\Component\ErrorHandler\DebugClassLoader` would otherwise cascade the deprecation onto every class still using the trait during the transition.
+
+### Symfony-side configuration
+
+`config/packages/monolog.yaml` (legacy kernel) is a single-line `imports:` pointing at `config.new/packages/monolog.yaml`. There is one source of truth for channels, handlers and processors — adding or renaming a channel for the platform pipeline automatically reaches the legacy kernel too.
+
+Both kernels resolve `kernel.logs_dir` to `/var/log/centreon` (`App\Kernel::getLogDir()` and `App\Shared\Infrastructure\Symfony\Kernel::getLogDir()`), so the path templates in `monolog.yaml` produce identical filenames regardless of which kernel boots a request.
+
+---
+
+## 12. Writing authentication events
+
+Authentication is the only flow where the platform splits two destinations on purpose, following the [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html) and [ASVS V7](https://owasp.org/www-project-application-security-verification-standard/) recommendations:
+
+- **Application Security Events** → `prod.access.log` (channel `authentication`) — login success/failure, logout, token refresh, unauthorized, forbidden. Consumed by SOC / SIEM / fail2ban.
+- **Application Error Logs** → `prod.web.log` (channel `web`) — exceptions, protocol diagnostics, dependency errors.
+
+Every auth provider routes through this split. The new kernel uses Symfony DI (`#[Autowire(service: 'monolog.logger.authentication')]`), the legacy side uses the `LoggerAuthentication` facade.
+
+### Facade API
+
+```php
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\LoggerAuthentication;
+
+LoggerAuthentication::create()->loginSuccess($message, $userId, $provider);
+LoggerAuthentication::create()->loginFailure($message, $userId, $provider, $exception);
+LoggerAuthentication::create()->logout($message, $userId, $provider);
+LoggerAuthentication::create()->tokenRefreshSuccess($message, $userId, $provider);
+LoggerAuthentication::create()->tokenRefreshFailure($message, $userId, $provider, $exception);
+LoggerAuthentication::create()->unauthorized($message, $userId);
+LoggerAuthentication::create()->forbidden($message, $userId, $resource);
+```
+
+| Method | Monolog level | When to use |
+|---|---|---|
+| `loginSuccess($message, $userId, $provider)` | `INFO` | Credentials accepted, session opened. |
+| `loginFailure($message, $userId, $provider, $e)` | `WARNING` | Refused login: bad credentials, IP blacklisted, claim missing, IdP error. **WARNING, not ERROR** — this is an expected security event, not a crash. |
+| `logout($message, $userId, $provider)` | `INFO` | Session ended. |
+| `tokenRefreshSuccess($message, $userId, $provider)` | `INFO` | OIDC refresh token exchanged. |
+| `tokenRefreshFailure($message, $userId, $provider, $e)` | `WARNING` | Refresh refused or token endpoint error during refresh. |
+| `unauthorized($message, $userId)` | `WARNING` | Authenticated user not allowed to reach a resource (HTTP 401 outside of login). |
+| `forbidden($message, $userId, $resource)` | `WARNING` | Authenticated user denied on a specific resource (HTTP 403). |
+
+`$userId` is the Centreon `contact_id` (int). Pass `null` when the user is not yet resolved (early OpenID failure before the `userinfo` exchange, IP blacklist hit before authentication, …). `$provider` is an `AuthProviderEnum` case: `LOCAL`, `LDAP`, `OPENID`, `SAML`, `WEB_SSO`, `API_TOKEN`, `AUTOLOGIN`, `CLAPI`.
+
+### Context structure
+
+Every method emits the same JSON context shape:
+
+```json
+{
+  "event": "login.success" | "login.failure" | "logout" | "token.refresh.success" | "token.refresh.failure" | "unauthorized" | "forbidden",
+  "status": "success" | "failure",
+  "user_id": 42,
+  "ip_address": "10.0.0.42",
+  "provider": "openid",
+  "exception": { ... },
+  "resource": "host:42"
+}
+```
+
+- **Always present:** `event`, `status`, `user_id` (may be `null` before the user is resolved), and `ip_address` — which is the literal string `"unknown"` when `$_SERVER['REMOTE_ADDR']` is unset, notably for CLI / CLAPI events.
+- **Conditional:** `provider` is omitted for `unauthorized` / `forbidden` (these carry no provider); `exception` appears only on the failure methods when a `Throwable` is passed; `resource` appears only on `forbidden` when a resource is supplied.
+
+This shape is the contract — downstream filters and dashboards pin on `event`, `status`, `ip_address` and (where present) `provider`. Do not bypass the facade to add ad-hoc top-level keys.
+
+### Recommended pattern in a provider
+
+Inside the auth providers (`src/Core/Security/Authentication/...`), the rule is:
+
+- **Login failures** → `LoggerAuthentication::create()->loginFailure(...)` at the exact point the decision is taken (just before throwing the SSO exception), where the user is usually not yet resolved (so `user_id` is `null`).
+- **Login success** → emitted once by the `Login` use case after `findUserOrFail()` resolves the contact, so the event carries the real `user_id`. It is emitted only for the external providers (OpenID / SAML / WebSSO); local and LDAP success is already logged through the legacy `centreonAuth` path, which is excluded there to avoid a duplicate access-log entry.
+- **Technical diagnostics** → `Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info/error(...)` for the surrounding traces (request sent to IdP, JSON decode error, HTTP 5xx). These are not security events; they belong in `prod.web.log`.
+
+```php
+foreach ($conditions->getBlacklistClientAddresses() as $blackListedAddress) {
+    if (preg_match('/' . $blackListedAddress . '/', $clientIp)) {
+        // Security event — SOC needs to see this on prod.access.log.
+        LoggerAuthentication::create()->loginFailure(
+            'Client IP is blacklisted',
+            null,
+            AuthProviderEnum::OPENID
+        );
+
+        throw SSOAuthenticationException::blackListedClient();
+    }
+}
+
+try {
+    $response = $this->client->request('POST', $tokenEndpoint, ['body' => $data]);
+} catch (Exception $exception) {
+    // Security event — login refused, SOC needs to see it.
+    LoggerAuthentication::create()->loginFailure(
+        'Failed to retrieve access token from provider',
+        null,
+        AuthProviderEnum::OPENID,
+        $exception
+    );
+
+    // Technical trace — kept on prod.web.log for ops investigation.
+    Logger::create(LogChannelEnum::WEB)->error(
+        sprintf('[Error] Unable to get Token Access Information:, message: %s', $exception->getMessage())
+    );
+
+    throw SSOAuthenticationException::requestForConnectionTokenFail();
+}
+```
+
+### Other lifecycle events
+
+```php
+// Logout — emit when the session is closed (legacy logout button, OIDC end-session callback, SAML SLS).
+LoggerAuthentication::create()->logout(
+    sprintf("[%s] [%s] Logout for '%s'", $authType, $clientIp, $username),
+    (int) $contactId,
+    AuthProviderEnum::OPENID
+);
+
+// Token refresh — OIDC refresh_token exchanged successfully against the IdP.
+LoggerAuthentication::create()->tokenRefreshSuccess(
+    'OIDC refresh token exchanged successfully',
+    (int) $contactId,
+    AuthProviderEnum::OPENID
+);
+```
+
+### Authorization events
+
+```php
+// API endpoint reached without a token, or with an expired one.
+LoggerAuthentication::create()->unauthorized(
+    'Missing or invalid bearer token',
+    null
+);
+
+// Authenticated user denied on a specific resource by a voter or an ACL check.
+LoggerAuthentication::create()->forbidden(
+    'User cannot access host resource',
+    (int) $user->getId(),
+    'host:42'
+);
+```
+
+### Application layer (DDD)
+
+The DDD scope (`src/App/...`) calls `LoggerAuthentication` directly the same way as the legacy code — Application is allowed to depend on `Adaptation\Log\*` because that namespace is the platform-side wrapper, not a third-party I/O. If a particular use case wants strict DIP (Application depending on an abstraction, Infrastructure providing the adapter), follow the `UpgradeLoggerInterface` / `LoggerUpgradeAdapter` pattern described in [§11 of the upgrade flow doc] — define an `AuthenticationLoggerInterface` in `App\<Bounded>\Application\Logger\` and a `LoggerAuthenticationAdapter` in `App\<Bounded>\Infrastructure\Logger\` that delegates to the facade.
+
+### Sample output
+
+`prod.access.log`:
+
+```
+authentication.INFO: [local] [172.18.0.1] Authentication succeeded for 'admin'
+  {"event":"login.success","status":"success","user_id":1,"provider":"local","ip_address":"172.18.0.1"}
+
+authentication.WARNING: [local] [172.18.0.1] Authentication failed for 'admin' : invalid credentials
+  {"event":"login.failure","status":"failure","user_id":null,"provider":"local","ip_address":"172.18.0.1"}
+
+authentication.WARNING: No authorization code returned from external provider
+  {"event":"login.failure","status":"failure","user_id":null,"provider":"openid","ip_address":"10.0.0.42"}
+
+authentication.WARNING: Client IP is blacklisted
+  {"event":"login.failure","status":"failure","user_id":null,"provider":"web-sso","ip_address":"10.0.0.42"}
+```
+
+> The `[local]` success/failure lines above originate from the legacy `centreonAuth` path (`CentreonUserLog` on the `authentication` channel), **not** from `LoggerAuthentication::loginSuccess()`: the `Login` use case deliberately skips local/LDAP to avoid a duplicate entry (see [§12 above](#recommended-pattern-in-a-provider)). The `openid` / `web-sso` lines are the ones emitted through the facade.
+
+`prod.web.log` (same request, technical trace):
+
+```
+app.INFO: Start authenticating user... {"provider":"openid"}
+app.ERROR: No authorization code returned from external provider {"provider":"openid"}
+app.ERROR: An error occurred during authentication {"trace":"…SSOAuthenticationException…"}
+```
+
+### fail2ban compatibility
+
+The legacy local/LDAP messages keep their historical pattern (`[local] [<ip>] Authentication succeeded for '<alias>'` / `Authentication failed for '<alias>' : <reason>`); the facade does not rewrite the message — the caller passes it verbatim as the first argument and only enriches the context.
+
+But fail2ban jails are bound to a **file path** (`logpath = /var/log/centreon/login.log`), not to a message pattern: routing the events to `prod.access.log` alone would silently break existing jails. To avoid that, `LoggerAuthentication` also mirrors `loginSuccess` / `loginFailure` to the historical `login.log` in the original pipe-delimited format (`date|uid|page|option|message`), reproducing exactly what the legacy `centreonAuth` emitted through `CentreonUserLog::insertLog(TYPE_LOGIN)`. This duplicate write is transitional and will be removed in a future release once consumers read the Monolog access log instead. The same shim exists on the legacy path (`CentreonUserLog::insertLog`) for events still emitted through it (e.g. `LoginLogger`).
+
+### Best practices
+
+- **One decision point = one `loginSuccess` / `loginFailure` call.** No "summarising" loop log; emit the event where the throw / accept actually happens.
+- **`WARNING`, not `ERROR`, for refused logins.** A bad password is a security event, not a crash. ERROR is reserved for true technical failures.
+- **No PII, no secrets** in the message or the context. Mask tokens, redact passwords. The file is shipped to SOC pipelines.
+- **`$userId` is `null` early, populated once resolved.** Don't fabricate a fake id (e.g. `0`) — `null` is the signal that the user was not authenticated at this stage.
+- **Provider always set.** Use the `AuthProviderEnum` cases; do not pass a free-form string. The enum is the single source of truth of which providers exist.
+- **Don't duplicate on both channels.** A security event goes to `prod.access.log` via the facade. The technical trace (stack trace, ldap_error, HTTP body) belongs to `prod.web.log` via `Logger::create(LogChannelEnum::WEB)`.

--- a/centreon/src/Adaptation/Log/Enum/AuthProviderEnum.php
+++ b/centreon/src/Adaptation/Log/Enum/AuthProviderEnum.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Adaptation\Log\Enum;
+
+enum AuthProviderEnum: string
+{
+    case LOCAL = 'local';
+    case LDAP = 'ldap';
+    case OPENID = 'openid';
+    case SAML = 'saml';
+    case WEB_SSO = 'web-sso';
+    case API_TOKEN = 'api-token';
+    case AUTOLOGIN = 'autologin';
+    case CLAPI = 'clapi';
+}

--- a/centreon/src/Adaptation/Log/LoggerAuthentication.php
+++ b/centreon/src/Adaptation/Log/LoggerAuthentication.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Adaptation\Log;
+
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+final class LoggerAuthentication
+{
+    private static ?self $instance = null;
+
+    private function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public static function create(): self
+    {
+        if (! self::$instance instanceof self) {
+            self::$instance = new self(Logger::create(LogChannelEnum::AUTHENTICATION));
+        }
+
+        return self::$instance;
+    }
+
+    public function loginSuccess(string $message, int $userId, AuthProviderEnum $provider): void
+    {
+        $this->logger->log(
+            LogLevel::INFO,
+            $message,
+            $this->baseContext('login.success', 'success', $userId, $provider)
+        );
+
+        $this->mirrorToLegacyLoginLog($message, $userId);
+    }
+
+    public function loginFailure(
+        string $message,
+        ?int $userId,
+        AuthProviderEnum $provider,
+        ?\Throwable $exception = null,
+    ): void {
+        $this->logger->log(
+            LogLevel::WARNING,
+            $message,
+            $this->baseContext('login.failure', 'failure', $userId, $provider, $exception)
+        );
+
+        $this->mirrorToLegacyLoginLog($message, $userId);
+    }
+
+    public function logout(string $message, int $userId, AuthProviderEnum $provider): void
+    {
+        $this->logger->log(
+            LogLevel::INFO,
+            $message,
+            $this->baseContext('logout', 'success', $userId, $provider)
+        );
+    }
+
+    public function tokenRefreshSuccess(string $message, int $userId, AuthProviderEnum $provider): void
+    {
+        $this->logger->log(
+            LogLevel::INFO,
+            $message,
+            $this->baseContext('token.refresh.success', 'success', $userId, $provider)
+        );
+    }
+
+    public function tokenRefreshFailure(
+        string $message,
+        ?int $userId,
+        AuthProviderEnum $provider,
+        ?\Throwable $exception = null,
+    ): void {
+        $this->logger->log(
+            LogLevel::WARNING,
+            $message,
+            $this->baseContext('token.refresh.failure', 'failure', $userId, $provider, $exception)
+        );
+    }
+
+    public function unauthorized(string $message, ?int $userId = null): void
+    {
+        $this->logger->log(
+            LogLevel::WARNING,
+            $message,
+            $this->baseContext('unauthorized', 'failure', $userId, null)
+        );
+    }
+
+    public function forbidden(string $message, int $userId, ?string $resource = null): void
+    {
+        $context = $this->baseContext('forbidden', 'failure', $userId, null);
+        if ($resource !== null) {
+            $context['resource'] = $resource;
+        }
+        $this->logger->log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * Mirror a login event to the historical login.log file.
+     *
+     * Login success/failure events are routed to the Monolog "authentication" channel
+     * (prod.access.log). This duplicate write keeps the legacy pipe-delimited format and
+     * file path so external consumers that watch /var/log/centreon/login.log (fail2ban
+     * jails matching the "Authentication failed" line with the client IP, SIEM parsers)
+     * keep working unchanged. It reproduces exactly the lines the legacy centreonAuth used
+     * to emit through CentreonUserLog::insertLog(TYPE_LOGIN). It is transitional and will be
+     * removed in a future release once those consumers read the Monolog access log instead.
+     *
+     * Mirroring the security feed must never break the authentication flow: a write failure
+     * (unwritable directory, full disk) is reported to error_log() and swallowed rather than
+     * propagated, so logging a login can never turn a successful login into an error.
+     */
+    private function mirrorToLegacyLoginLog(string $message, ?int $userId): void
+    {
+        $logDir = defined('_CENTREON_LOG_') ? _CENTREON_LOG_ : '/var/log/centreon';
+        // Neutralize line breaks and the field delimiter so a crafted message (e.g. a
+        // login containing CRLF) cannot forge or split records in the pipe-delimited file,
+        // while keeping the historical backtick-strip / asterisk-escape behavior.
+        $sanitizedMessage = str_replace(
+            ["\r", "\n", '|', '`', '*'],
+            [' ', ' ', ' ', '', '\*'],
+            $message
+        );
+        $line = date('Y-m-d H:i:s') . '|' . ($userId ?? 0) . '|0|0|' . $sanitizedMessage;
+
+        try {
+            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND);
+            if ($written === false) {
+                error_log(sprintf('LoggerAuthentication: unable to mirror login event to %s/login.log', $logDir));
+            }
+        } catch (\Throwable $e) {
+            error_log(sprintf('LoggerAuthentication: unable to mirror login event to login.log: %s', $e->getMessage()));
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function baseContext(
+        string $event,
+        string $status,
+        ?int $userId,
+        ?AuthProviderEnum $provider,
+        ?\Throwable $exception = null,
+    ): array {
+        $context = [
+            'event' => $event,
+            'status' => $status,
+            'user_id' => $userId,
+            'ip_address' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+        ];
+        if ($provider instanceof AuthProviderEnum) {
+            $context['provider'] = $provider->value;
+        }
+        if ($exception instanceof \Throwable) {
+            $context['exception'] = $exception;
+        }
+
+        return $context;
+    }
+}

--- a/centreon/src/Adaptation/Log/LoggerAuthentication.php
+++ b/centreon/src/Adaptation/Log/LoggerAuthentication.php
@@ -149,7 +149,7 @@ final class LoggerAuthentication
         $line = date('Y-m-d H:i:s') . '|' . ($userId ?? 0) . '|0|0|' . $sanitizedMessage;
 
         try {
-            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND);
+            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
             if ($written === false) {
                 error_log(sprintf('LoggerAuthentication: unable to mirror login event to %s/login.log', $logDir));
             }

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
@@ -98,9 +98,10 @@ final class Login
                 throw LegacyAuthenticationException::notAllowedToReachWebApplication();
             }
 
-            // Record the SSO authentication success on the security access log. Local/LDAP
-            // logins are already logged by the legacy centreonAuth path, so they are excluded
-            // here to avoid a duplicate access-log entry. Provider names that are not part of
+            // Record the SSO authentication success on the security access log. Local logins
+            // (including LDAP, which authenticates through the local provider) are already
+            // logged by the legacy centreonAuth path, so the local provider is excluded here
+            // to avoid a duplicate access-log entry. Provider names that are not part of
             // AuthProviderEnum (e.g. a module-provided provider) are skipped rather than
             // breaking the login flow on a strict enum lookup.
             $authProvider = AuthProviderEnum::tryFrom($loginRequest->providerName);

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Application\UseCase\Login;
 
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\LoggerAuthentication;
 use Centreon\Domain\Authentication\Exception\AuthenticationException as LegacyAuthenticationException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
@@ -94,6 +96,25 @@ final class Login
             $user = $this->provider->findUserOrFail();
             if ($loginRequest->providerName === Provider::LOCAL && ! $user->isAllowedToReachWeb()) {
                 throw LegacyAuthenticationException::notAllowedToReachWebApplication();
+            }
+
+            // Record the SSO authentication success on the security access log. Local/LDAP
+            // logins are already logged by the legacy centreonAuth path, so they are excluded
+            // here to avoid a duplicate access-log entry. Provider names that are not part of
+            // AuthProviderEnum (e.g. a module-provided provider) are skipped rather than
+            // breaking the login flow on a strict enum lookup.
+            $authProvider = AuthProviderEnum::tryFrom($loginRequest->providerName);
+            if ($loginRequest->providerName !== Provider::LOCAL && $authProvider !== null) {
+                LoggerAuthentication::create()->loginSuccess(
+                    sprintf(
+                        "[%s] [%s] Authentication succeeded for '%s'",
+                        $loginRequest->providerName,
+                        $loginRequest->clientIp,
+                        $user->getAlias()
+                    ),
+                    $user->getId(),
+                    $authProvider
+                );
             }
 
             $this->updateACL($user);

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -23,11 +23,13 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Domain\Provider;
 
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+use Adaptation\Log\LoggerAuthentication;
 use Centreon;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Contact\Interfaces\ContactServiceInterface;
-use Centreon\Domain\Log\LoggerTrait;
-use CentreonLog;
 use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Contact\Domain\Model\ContactGroup;
@@ -62,7 +64,6 @@ use Throwable;
 
 class OpenIdProvider implements OpenIdProviderInterface
 {
-    use LoggerTrait;
     public const NAME = 'openid';
 
     /** @var Configuration */
@@ -178,7 +179,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
-        $this->info('Auto import starting...', [
+        Logger::create(LogChannelEnum::WEB)->info('Auto import starting...', [
             'user' => $this->username,
         ]);
         $this->validateAutoImportAttributesOrFail();
@@ -198,7 +199,7 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $user->setContactTemplate($customConfiguration->getContactTemplate());
         $this->userRepository->create($user);
-        $this->info('Auto import complete', [
+        Logger::create(LogChannelEnum::WEB)->info('Auto import complete', [
             'user_alias' => $this->username,
             'user_fullname' => $this->userInformations[$customConfiguration->getUserNameBindAttribute()],
             'user_email' => $this->userInformations[$customConfiguration->getEmailBindAttribute()],
@@ -254,11 +255,16 @@ class OpenIdProvider implements OpenIdProviderInterface
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
 
-        $this->info('Start authenticating user...', [
+        Logger::create(LogChannelEnum::WEB)->info('Start authenticating user...', [
             'provider' => $this->configuration->getName(),
         ]);
         if (empty($authorizationCode)) {
-            $this->error(
+            LoggerAuthentication::create()->loginFailure(
+                'No authorization code returned from external provider',
+                null,
+                AuthProviderEnum::OPENID
+            );
+            Logger::create(LogChannelEnum::WEB)->error(
                 'No authorization code returned from external provider',
                 [
                     'provider' => $this->configuration->getName(),
@@ -299,7 +305,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     public function getUser(): ?ContactInterface
     {
-        $this->info('Searching user : ' . $this->username);
+        Logger::create(LogChannelEnum::WEB)->info('Searching user : ' . $this->username);
 
         return $this->contactService->findByName($this->username)
             ?? $this->contactService->findByEmail($this->username);
@@ -307,6 +313,10 @@ class OpenIdProvider implements OpenIdProviderInterface
 
     /**
      * @inheritDoc
+     *
+     * @throws SSOAuthenticationException when the refresh token is missing or the IdP refuses the refresh request
+     * @throws \JsonException when the IdP response cannot be JSON-decoded
+     * @throws \DateMalformedIntervalStringException when the expires_in value is not a valid DateInterval payload
      */
     public function refreshToken(AuthenticationTokens $authenticationTokens): AuthenticationTokens
     {
@@ -316,7 +326,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         if ($authenticationTokens->getProviderRefreshToken() === null) {
             throw SSOAuthenticationException::noRefreshToken();
         }
-        $this->info(
+        Logger::create(LogChannelEnum::WEB)->info(
             'Refreshing token using refresh token',
             [
                 'refresh_token' => mb_substr($authenticationTokens->getProviderRefreshToken()->getToken(), -10),
@@ -383,6 +393,12 @@ class OpenIdProvider implements OpenIdProviderInterface
                 );
             }
         }
+
+        LoggerAuthentication::create()->tokenRefreshSuccess(
+            'OIDC refresh token exchanged successfully',
+            $authenticationTokens->getUserId(),
+            AuthProviderEnum::OPENID
+        );
 
         return new AuthenticationTokens(
             $authenticationTokens->getUserId(),
@@ -455,7 +471,7 @@ class OpenIdProvider implements OpenIdProviderInterface
 
             return json_decode($this->urlSafeTokenDecode($tokenParts[1]), true);
         } catch (Throwable $ex) {
-            $this->error(
+            Logger::create(LogChannelEnum::WEB)->error(
                 SSOAuthenticationException::unableToDecodeIdToken()->getMessage(),
                 ['trace' => $ex->getTraceAsString()]
             );
@@ -474,7 +490,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function sendRequestForConnectionTokenOrFail(string $authorizationCode, ?string $redirectUrl): void
     {
-        $this->info('Send request to external provider for connection token...');
+        Logger::create(LogChannelEnum::WEB)->info('Send request to external provider for connection token...');
 
         // Define parameters for the request
         $redirectUri = $redirectUrl !== null
@@ -566,7 +582,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function sendRequestForIntrospectionEndpoint(): array
     {
-        $this->info('Sending request for introspection token information');
+        Logger::create(LogChannelEnum::WEB)->info('Sending request for introspection token information');
 
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
@@ -619,7 +635,7 @@ class OpenIdProvider implements OpenIdProviderInterface
             );
         } catch (Exception $exception) {
             $this->logExceptionInLoginLogFile('Unable to get Introspection Information: %s, message: %s', $exception);
-            $this->error(
+            Logger::create(LogChannelEnum::WEB)->error(
                 sprintf(
                     '[Error] Unable to get Introspection Token Information:, message: %s',
                     $exception->getMessage()
@@ -675,7 +691,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function sendRequestForUserInformationEndpoint(): array
     {
-        $this->info('Sending Request for User Information...');
+        Logger::create(LogChannelEnum::WEB)->info('Sending Request for User Information...');
 
         $headers = [
             'Authorization' => 'Bearer ' . trim($this->providerToken->getToken()),
@@ -728,7 +744,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function verifyThatClientIsAllowedToConnectOrFail(string $clientIp): void
     {
-        $this->info('Check Client IP against blacklist/whitelist addresses');
+        Logger::create(LogChannelEnum::WEB)->info('Check Client IP against blacklist/whitelist addresses');
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
         $authenticationConditions = $customConfiguration->getAuthenticationConditions();
@@ -737,7 +753,11 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         foreach ($authenticationConditions->getBlacklistClientAddresses() as $blackListedAddress) {
             if ($blackListedAddress !== '' && preg_match('/' . $blackListedAddress . '/', $clientIp)) {
-                $this->error('IP Blacklisted', ['ip' => '...' . mb_substr($clientIp, -5)]);
+                LoggerAuthentication::create()->loginFailure(
+                    'Client IP is blacklisted',
+                    null,
+                    AuthProviderEnum::OPENID
+                );
 
                 throw SSOAuthenticationException::blackListedClient();
             }
@@ -748,7 +768,11 @@ class OpenIdProvider implements OpenIdProviderInterface
                 $trustedClientAddress !== ''
                 && preg_match('/' . $trustedClientAddress . '/', $clientIp)
             ) {
-                $this->error('IP not  Whitelisted', ['ip' => '...' . mb_substr($clientIp, -5)]);
+                LoggerAuthentication::create()->loginFailure(
+                    'Client IP is not whitelisted',
+                    null,
+                    AuthProviderEnum::OPENID
+                );
 
                 throw SSOAuthenticationException::notWhiteListedClient();
             }
@@ -830,11 +854,15 @@ class OpenIdProvider implements OpenIdProviderInterface
             $this->getUserInformationFromUserInfoEndpoint();
         }
         if (! array_key_exists($loginClaim, $this->userInformations)) {
-            CentreonLog::create()->error(
-                CentreonLog::TYPE_LOGIN,
-                '[Openid] Unable to get login from claim: ' . $loginClaim
+            LoggerAuthentication::create()->loginFailure(
+                'Configured login claim not found in user information',
+                null,
+                AuthProviderEnum::OPENID
             );
-            $this->error('Login Claim not found', ['login_claim' => $loginClaim]);
+            Logger::create(LogChannelEnum::WEB)->error(
+                '[Openid] Unable to get login from claim: ' . $loginClaim,
+                ['login_claim' => $loginClaim]
+            );
 
             throw SSOAuthenticationException::loginClaimNotFound($this->configuration->getName(), $loginClaim);
         }
@@ -910,13 +938,25 @@ class OpenIdProvider implements OpenIdProviderInterface
         } catch (Exception $exception) {
             $this->logExceptionInLoginLogFile('Unable to get Token Access Information: %s, message: %s', $exception);
             if (array_key_exists('refresh_token', $data)) {
-                $this->error(
+                LoggerAuthentication::create()->tokenRefreshFailure(
+                    'Failed to refresh access token from provider',
+                    null,
+                    AuthProviderEnum::OPENID,
+                    $exception
+                );
+                Logger::create(LogChannelEnum::WEB)->error(
                     sprintf('[Error] Unable to get Token Refresh Information:, message: %s', $exception->getMessage())
                 );
 
                 throw SSOAuthenticationException::requestForRefreshTokenFail();
             }
-            $this->error(
+            LoggerAuthentication::create()->loginFailure(
+                'Failed to retrieve access token from provider',
+                null,
+                AuthProviderEnum::OPENID,
+                $exception
+            );
+            Logger::create(LogChannelEnum::WEB)->error(
                 sprintf('[Error] Unable to get Token Access Information:, message: %s', $exception->getMessage())
             );
 
@@ -959,7 +999,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function logErrorFromExternalProvider(array $content): void
     {
-        $this->error(
+        Logger::create(LogChannelEnum::WEB)->error(
             'error from external provider :' . (array_key_exists('error_description', $content)
                 ? $content['error_description']
                 : 'No content in response')
@@ -974,7 +1014,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function logErrorForInvalidStatusCode(int $codeReceived, int $codeExpected): void
     {
-        $this->error(
+        Logger::create(LogChannelEnum::WEB)->error(
             sprintf(
                 'invalid status code return by external provider, [%d] returned, [%d] expected',
                 $codeReceived,
@@ -992,10 +1032,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     private function logErrorInLoginLogFile(string $message, array $content): void
     {
         if (array_key_exists('error_description', $content)) {
-            CentreonLog::create()->error(
-                CentreonLog::TYPE_LOGIN,
-                "[Openid] {$message} " . $content['error_description']
-            );
+            Logger::create(LogChannelEnum::WEB)->error("[Openid] {$message} " . $content['error_description']);
         }
     }
 
@@ -1022,11 +1059,7 @@ class OpenIdProvider implements OpenIdProviderInterface
         if (isset($content['provider_token'])) {
             $content['provider_token'] = mb_substr($content['provider_token'], -10);
         }
-        CentreonLog::create()->debug(
-            CentreonLog::TYPE_LOGIN,
-            "[Openid] {$message} " . json_encode($content, JSON_THROW_ON_ERROR)
-        );
-        $this->debug('Authentication information : ', $content);
+        Logger::create(LogChannelEnum::WEB)->debug("[Openid] {$message}", $content);
     }
 
     /**
@@ -1037,13 +1070,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function logAuthenticationInfo(string $message, ?array $content = null): void
     {
-        CentreonLog::create()->info(
-            CentreonLog::TYPE_LOGIN,
-            "[Openid] {$message}" . ($content !== null ? ' : ' . json_encode($content, JSON_THROW_ON_ERROR) : ''),
-            $content ?: []
-        );
-
-        $this->info("{$message} : ", $content ?: []);
+        Logger::create(LogChannelEnum::WEB)->info("[Openid] {$message}", $content ?? []);
     }
 
     /**
@@ -1054,15 +1081,13 @@ class OpenIdProvider implements OpenIdProviderInterface
      */
     private function logExceptionInLoginLogFile(string $message, Exception $exception): void
     {
-        CentreonLog::create()->error(
-            CentreonLog::TYPE_LOGIN,
+        Logger::create(LogChannelEnum::WEB)->error(
             sprintf(
                 "[Openid] {$message}",
                 $exception::class,
                 $exception->getMessage()
             ),
-            ['exception' => $exception],
-            $exception
+            ['exception' => $exception]
         );
     }
 

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/AclUpdater.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/AclUpdater.php
@@ -23,8 +23,9 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Infrastructure\Provider;
 
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Core\Contact\Application\Repository\WriteContactGroupRepositoryInterface;
 use Core\Contact\Domain\Model\ContactGroup;
@@ -38,8 +39,6 @@ use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 
 class AclUpdater implements AclUpdaterInterface
 {
-    use LoggerTrait;
-
     /** @var ProviderAuthenticationInterface */
     private ProviderAuthenticationInterface $provider;
 
@@ -58,6 +57,8 @@ class AclUpdater implements AclUpdaterInterface
     /**
      * @param ProviderAuthenticationInterface $provider
      * @param ContactInterface $user
+     *
+     * @throws ProviderException when the provider does not support ACL updates from claims (must be OpenId or SAML)
      */
     public function updateForProviderAndUser(ProviderAuthenticationInterface $provider, ContactInterface $user): void
     {
@@ -95,7 +96,7 @@ class AclUpdater implements AclUpdaterInterface
     private function updateAccessGroupsForUser(ContactInterface $user, array $userAccessGroups): void
     {
         try {
-            $this->info('Updating User Access Groups', [
+            Logger::create(LogChannelEnum::WEB)->info('Updating User Access Groups', [
                 'user_id' => $user->getId(),
                 'access_groups' => $userAccessGroups,
             ]);
@@ -105,7 +106,7 @@ class AclUpdater implements AclUpdaterInterface
             $this->dataStorageEngine->commitTransaction();
         } catch (\Exception $ex) {
             $this->dataStorageEngine->rollbackTransaction();
-            $this->error('Error during ACL update', [
+            Logger::create(LogChannelEnum::WEB)->error('Error during ACL update', [
                 'user_id' => $user->getId(),
                 'access_groups' => $userAccessGroups,
                 'trace' => $ex->getTraceAsString(),
@@ -123,11 +124,12 @@ class AclUpdater implements AclUpdaterInterface
     {
         $contactGroup = null;
         try {
-            $this->info('Updating user contact group', [
+            Logger::create(LogChannelEnum::WEB)->info('Updating user contact group', [
                 'user_id' => $user->getId(),
-                'contact_group_id' => [
-                    array_map(fn ($contactGroup) => $contactGroup->getId(), $contactGroups),
-                ],
+                'contact_group_id' => array_map(
+                    static fn (ContactGroup $group): int => $group->getId(),
+                    $contactGroups
+                ),
             ]);
             $this->dataStorageEngine->startTransaction();
             $this->contactGroupRepository->deleteContactGroupsForUser($user);
@@ -137,7 +139,7 @@ class AclUpdater implements AclUpdaterInterface
             $this->dataStorageEngine->commitTransaction();
         } catch (\Exception $ex) {
             $this->dataStorageEngine->rollbackTransaction();
-            $this->error('Error during contact group update', [
+            Logger::create(LogChannelEnum::WEB)->error('Error during contact group update', [
                 'user_id' => $user->getId(),
                 'contact_group_id' => $contactGroup?->getId(),
                 'trace' => $ex->getTraceAsString(),

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
@@ -23,8 +23,9 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Infrastructure\Provider;
 
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Infrastructure\Service\Exception\NotFoundException;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
@@ -49,8 +50,6 @@ use Throwable;
 
 class OpenId implements ProviderAuthenticationInterface
 {
-    use LoggerTrait;
-
     /** @var string */
     private string $username;
 
@@ -90,17 +89,17 @@ class OpenId implements ProviderAuthenticationInterface
     {
         $user = $this->getAuthenticatedUser();
         if ($user === null) {
-            $this->info('User not found');
+            Logger::create(LogChannelEnum::WEB)->info('User not found');
             if (! $this->isAutoImportEnabled()) {
                 throw new NotFoundException('User could not be created');
             }
-            $this->info('Start auto import');
+            Logger::create(LogChannelEnum::WEB)->info('Start auto import');
             $this->provider->createUser();
             $user = $this->getAuthenticatedUser();
             if ($user === null) {
                 throw new NotFoundException('User not found');
             }
-            $this->info('User imported: ' . $user->getName());
+            Logger::create(LogChannelEnum::WEB)->info('User imported: ' . $user->getName());
         }
 
         return $user;
@@ -130,10 +129,10 @@ class OpenId implements ProviderAuthenticationInterface
     {
         $user = $this->provider->getUser();
         if ($this->isAutoImportEnabled() && $user === null) {
-            $this->info('Start auto import');
+            Logger::create(LogChannelEnum::WEB)->info('Start auto import');
             $this->provider->createUser();
             $user = $this->findUserOrFail();
-            $this->info('User imported: ' . $user->getName());
+            Logger::create(LogChannelEnum::WEB)->info('User imported: ' . $user->getName());
         }
     }
 
@@ -145,10 +144,10 @@ class OpenId implements ProviderAuthenticationInterface
     {
         $user = $this->provider->getUser();
         if ($this->isAutoImportEnabled() === true && $user === null) {
-            $this->info('Start auto import');
+            Logger::create(LogChannelEnum::WEB)->info('Start auto import');
             $this->provider->createUser();
             if ($user = $this->provider->getUser()) {
-                $this->info('User imported: ' . $user->getName());
+                Logger::create(LogChannelEnum::WEB)->info('User imported: ' . $user->getName());
             }
         }
     }
@@ -247,7 +246,7 @@ class OpenId implements ProviderAuthenticationInterface
         foreach ($customConfiguration->getACLConditions()->getRelations() as $authorizationRule) {
             $claimValue = $authorizationRule->getClaimValue();
             if (! in_array($claimValue, $this->provider->getAclConditionsMatches(), true)) {
-                $this->info(
+                Logger::create(LogChannelEnum::WEB)->info(
                     'Configured claim value not found in user claims',
                     ['claim_value' => $claimValue]
                 );

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -23,11 +23,14 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Infrastructure\Provider;
 
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+use Adaptation\Log\LoggerAuthentication;
 use Assert\AssertionFailedException;
 use Centreon;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
-use Centreon\Domain\Log\LoggerTrait;
 use CentreonSession;
 use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
 use Core\Common\Domain\Exception\RepositoryException;
@@ -68,8 +71,6 @@ use Throwable;
 
 class SAML implements ProviderAuthenticationInterface
 {
-    use LoggerTrait;
-
     /** @var Configuration */
     private Configuration $configuration;
 
@@ -116,6 +117,12 @@ class SAML implements ProviderAuthenticationInterface
         $errors = $auth->getErrors();
         if (! empty($errors)) {
             $ex = ProcessAuthenticationResponseException::create();
+            LoggerAuthentication::create()->loginFailure(
+                'Failed to process SAML authentication response',
+                null,
+                AuthProviderEnum::SAML,
+                $ex
+            );
             $this->loginLogger->error(Provider::SAML, $ex->getMessage(), ['context' => (string) json_encode($errors), 'error' => $this->auth->getLastErrorReason()]);
 
             throw $ex;
@@ -123,6 +130,12 @@ class SAML implements ProviderAuthenticationInterface
 
         if (! $auth->isAuthenticated()) {
             $ex = UserNotAuthenticatedException::create();
+            LoggerAuthentication::create()->loginFailure(
+                'User not authenticated by SAML provider',
+                null,
+                AuthProviderEnum::SAML,
+                $ex
+            );
             $this->loginLogger->error(Provider::SAML, $ex->getMessage());
 
             throw $ex;
@@ -133,7 +146,13 @@ class SAML implements ProviderAuthenticationInterface
         $errors = $settings->validateMetadata($metadata);
         if (! empty($errors)) {
             $ex = InvalidMetadataException::create();
-            $this->info($ex->getMessage(), ['errors' => $errors]);
+            LoggerAuthentication::create()->loginFailure(
+                'Invalid SAML metadata',
+                null,
+                AuthProviderEnum::SAML,
+                $ex
+            );
+            Logger::create(LogChannelEnum::WEB)->info($ex->getMessage(), ['errors' => $errors]);
 
             throw $ex;
         }
@@ -142,7 +161,7 @@ class SAML implements ProviderAuthenticationInterface
             Provider::SAML,
             'User information: ' . json_encode($auth->getAttributes())
         );
-        $this->info('User information: ', $auth->getAttributes());
+        Logger::create(LogChannelEnum::WEB)->info('User information: ', $auth->getAttributes());
 
         $attrs = $auth->getAttribute($customConfiguration->getUserIdAttribute());
         if (! is_array($attrs) || ! is_string($attrs[0] ?? null)) {
@@ -186,7 +205,7 @@ class SAML implements ProviderAuthenticationInterface
      */
     public function getUser(): ?ContactInterface
     {
-        $this->info('Searching user : ' . $this->username);
+        Logger::create(LogChannelEnum::WEB)->info('Searching user : ' . $this->username);
 
         return $this->contactRepository->findByName($this->username)
             ?? $this->contactRepository->findByEmail($this->username);
@@ -219,11 +238,11 @@ class SAML implements ProviderAuthenticationInterface
     {
         $user = $this->getUser();
         if ($this->isAutoImportEnabled() && $user === null) {
-            $this->info('Start auto import');
+            Logger::create(LogChannelEnum::WEB)->info('Start auto import');
             $this->loginLogger->info($this->configuration->getType(), 'start auto import');
             $this->createUser();
             $user = $this->findUserOrFail();
-            $this->info('User imported: ' . $user->getName());
+            Logger::create(LogChannelEnum::WEB)->info('User imported: ' . $user->getName());
             $this->loginLogger->info(
                 $this->configuration->getType(),
                 'user imported',
@@ -240,10 +259,10 @@ class SAML implements ProviderAuthenticationInterface
     {
         $user = $this->getAuthenticatedUser();
         if ($this->isAutoImportEnabled() === true && $user === null) {
-            $this->info('Start auto import');
+            Logger::create(LogChannelEnum::WEB)->info('Start auto import');
             $this->createUser();
             if ($user = $this->getAuthenticatedUser()) {
-                $this->info('User imported: ' . $user->getName());
+                Logger::create(LogChannelEnum::WEB)->info('User imported: ' . $user->getName());
             }
         }
     }
@@ -343,7 +362,7 @@ class SAML implements ProviderAuthenticationInterface
         foreach ($customConfiguration->getACLConditions()->getRelations() as $authorizationRule) {
             $claimValue = $authorizationRule->getClaimValue();
             if (! in_array($claimValue, $claims, true)) {
-                $this->info(
+                Logger::create(LogChannelEnum::WEB)->info(
                     'Configured claim value not found in user claims',
                     ['claim_value' => $claimValue]
                 );
@@ -503,7 +522,7 @@ class SAML implements ProviderAuthenticationInterface
      */
     public function handleCallbackLogoutResponse(): void
     {
-        $this->info('SAML SLS invoked');
+        Logger::create(LogChannelEnum::WEB)->info('SAML SLS invoked');
 
         try {
             $auth = $this->authFactory->create($this->formatter->format($this->configuration->getCustomConfiguration()));
@@ -576,7 +595,7 @@ class SAML implements ProviderAuthenticationInterface
     {
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->configuration->getCustomConfiguration();
-        $this->info('Auto import starting...', ['user' => $this->username]);
+        Logger::create(LogChannelEnum::WEB)->info('Auto import starting...', ['user' => $this->username]);
         $this->loginLogger->info(
             $this->configuration->getType(),
             'auto import starting...',
@@ -600,7 +619,7 @@ class SAML implements ProviderAuthenticationInterface
         }
         $user->setContactTemplate($customConfiguration->getContactTemplate());
         $this->userRepository->create($user);
-        $this->info('Auto import complete', [
+        Logger::create(LogChannelEnum::WEB)->info('Auto import complete', [
             'user_alias' => $alias,
             'user_fullname' => $fullname,
             'user_email' => $email,

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
@@ -23,6 +23,10 @@ declare(strict_types=1);
 
 namespace Core\Security\Authentication\Infrastructure\Provider;
 
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+use Adaptation\Log\LoggerAuthentication;
 use Centreon;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
@@ -41,8 +45,6 @@ use Security\Domain\Authentication\Interfaces\WebSSOProviderInterface as LegacyW
 
 class WebSSO implements ProviderAuthenticationInterface
 {
-    use Centreon\Domain\Log\LoggerTrait;
-
     private ?ContactInterface $authenticatedUser = null;
 
     /**
@@ -167,7 +169,7 @@ class WebSSO implements ProviderAuthenticationInterface
      */
     public function authenticateOrFail(LoginRequest $request): void
     {
-        $this->info('Authenticate the user');
+        Logger::create(LogChannelEnum::WEB)->info('Authenticate the user');
         $this->ipIsAllowToConnect($request->clientIp ?? '');
         $this->validateLoginAttributeOrFail();
     }
@@ -181,7 +183,7 @@ class WebSSO implements ProviderAuthenticationInterface
     public function findUserOrFail(): ContactInterface
     {
         $alias = $this->extractUsernameFromLoginClaimOrFail();
-        $this->info('searching for user', ['user' => $alias]);
+        Logger::create(LogChannelEnum::WEB)->info('searching for user', ['user' => $alias]);
         $user = $this->contactRepository->findByName($alias);
         if ($user === null) {
             throw SSOAuthenticationException::aliasNotFound($alias);
@@ -202,11 +204,15 @@ class WebSSO implements ProviderAuthenticationInterface
      */
     public function ipIsAllowToConnect(string $ipAddress): void
     {
-        $this->info('Check Client IP from blacklist/whitelist addresses');
+        Logger::create(LogChannelEnum::WEB)->info('Check Client IP from blacklist/whitelist addresses');
         /** @var CustomConfiguration $customConfiguration */
         $customConfiguration = $this->getConfiguration()->getCustomConfiguration();
         if (in_array($ipAddress, $customConfiguration->getBlackListClientAddresses(), true)) {
-            $this->error('IP Blacklisted', ['ip' => '...' . mb_substr($ipAddress, -5)]);
+            LoggerAuthentication::create()->loginFailure(
+                'Client IP is blacklisted',
+                null,
+                AuthProviderEnum::WEB_SSO
+            );
 
             throw SSOAuthenticationException::blackListedClient();
         }
@@ -214,7 +220,11 @@ class WebSSO implements ProviderAuthenticationInterface
             ! empty($customConfiguration->getTrustedClientAddresses())
             && ! in_array($ipAddress, $customConfiguration->getTrustedClientAddresses(), true)
         ) {
-            $this->error('IP not Whitelisted', ['ip' => '...' . mb_substr($ipAddress, -5)]);
+            LoggerAuthentication::create()->loginFailure(
+                'Client IP is not whitelisted',
+                null,
+                AuthProviderEnum::WEB_SSO
+            );
 
             throw SSOAuthenticationException::notWhiteListedClient();
         }
@@ -233,11 +243,13 @@ class WebSSO implements ProviderAuthenticationInterface
             return;
         }
 
-        $this->info('Validating login header attribute');
+        Logger::create(LogChannelEnum::WEB)->info('Validating login header attribute');
         if (! array_key_exists($customConfiguration->getLoginHeaderAttribute() ?? '', $_SERVER)) {
-            $this->error('login header attribute not found in server environment', [
-                'login_header_attribute' => $customConfiguration->getLoginHeaderAttribute(),
-            ]);
+            LoggerAuthentication::create()->loginFailure(
+                'Login header attribute missing in server environment',
+                null,
+                AuthProviderEnum::WEB_SSO
+            );
 
             throw SSOAuthenticationException::missingRemoteLoginAttribute();
         }
@@ -252,7 +264,7 @@ class WebSSO implements ProviderAuthenticationInterface
      */
     public function extractUsernameFromLoginClaimOrFail(): string
     {
-        $this->info('Retrieving username from login claim');
+        Logger::create(LogChannelEnum::WEB)->info('Retrieving username from login claim');
 
         $this->validateLoginAttributeOrFail();
 
@@ -268,10 +280,11 @@ class WebSSO implements ProviderAuthenticationInterface
                 $_SERVER[$customConfiguration->getLoginHeaderAttribute()]
             );
             if (empty($userAlias)) {
-                $this->error('Regex does not match anything', [
-                    'regex' => $customConfiguration->getPatternMatchingLogin(),
-                    'subject' => $_SERVER[$customConfiguration->getLoginHeaderAttribute()],
-                ]);
+                LoggerAuthentication::create()->loginFailure(
+                    'Unable to extract username from login header',
+                    null,
+                    AuthProviderEnum::WEB_SSO
+                );
 
                 throw SSOAuthenticationException::unableToRetrieveUsernameFromLoginClaim();
             }
@@ -290,6 +303,8 @@ class WebSSO implements ProviderAuthenticationInterface
 
     /**
      * Update user in data storage.
+     *
+     * @throws \Exception always — the feature is not supported by the WebSSO provider
      */
     public function updateUser(): void
     {

--- a/centreon/tests/php/Adaptation/Log/LoggerAuthenticationTest.php
+++ b/centreon/tests/php/Adaptation/Log/LoggerAuthenticationTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\LoggerAuthentication;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+beforeEach(function (): void {
+    $_SERVER['APP_ENV'] = 'test';
+});
+
+afterEach(function (): void {
+    foreach (['login.log', 'test.access.log'] as $name) {
+        $file = _CENTREON_LOG_ . $name;
+        if (file_exists($file)) {
+            @unlink($file);
+        }
+    }
+});
+
+function loggerAuthLoginLogPath(): string
+{
+    return _CENTREON_LOG_ . 'login.log';
+}
+
+/**
+ * Build a facade backed by a recording logger so the Monolog emission (level, message and
+ * context shape) can be asserted without touching the real authentication channel file.
+ * The constructor is private and the facade is a singleton, so the spy is wired through
+ * reflection — this keeps the production API free of any test-only seam.
+ *
+ * @return array{0: LoggerAuthentication, 1: object{records: list<array{level: string, message: string, context: array<string, mixed>}>}}
+ */
+function loggerAuthWithSpy(): array
+{
+    $spy = new class () extends AbstractLogger {
+        /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+        }
+    };
+
+    $reflection = new ReflectionClass(LoggerAuthentication::class);
+    /** @var LoggerAuthentication $facade */
+    $facade = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('logger')->setValue($facade, $spy);
+
+    return [$facade, $spy];
+}
+
+it('emits a login failure as a WARNING carrying the event, status, provider and null user id', function (): void {
+    [$facade, $spy] = loggerAuthWithSpy();
+
+    $facade->loginFailure('bad credentials', null, AuthProviderEnum::LOCAL);
+
+    expect($spy->records)->toHaveCount(1);
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::WARNING)
+        ->and($record['message'])->toBe('bad credentials')
+        ->and($record['context']['event'])->toBe('login.failure')
+        ->and($record['context']['status'])->toBe('failure')
+        ->and($record['context']['provider'])->toBe('local')
+        ->and($record['context']['user_id'])->toBeNull()
+        ->and($record['context'])->toHaveKey('ip_address')
+        ->and($record['context'])->not->toHaveKey('exception');
+});
+
+it('attaches the throwable to the context when a login failure carries an exception', function (): void {
+    [$facade, $spy] = loggerAuthWithSpy();
+    $exception = new RuntimeException('IdP unreachable');
+
+    $facade->loginFailure('token exchange failed', 7, AuthProviderEnum::OPENID, $exception);
+
+    $record = $spy->records[0];
+    expect($record['context']['user_id'])->toBe(7)
+        ->and($record['context']['provider'])->toBe('openid')
+        ->and($record['context']['exception'])->toBe($exception);
+});
+
+it('emits a login success as an INFO with the resolved user id', function (): void {
+    [$facade, $spy] = loggerAuthWithSpy();
+
+    $facade->loginSuccess('welcome', 42, AuthProviderEnum::SAML);
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::INFO)
+        ->and($record['context']['event'])->toBe('login.success')
+        ->and($record['context']['status'])->toBe('success')
+        ->and($record['context']['user_id'])->toBe(42)
+        ->and($record['context']['provider'])->toBe('saml');
+});
+
+it('emits token refresh success and failure on the expected levels and events', function (): void {
+    [$facade, $spy] = loggerAuthWithSpy();
+    $exception = new RuntimeException('refresh refused');
+
+    $facade->tokenRefreshSuccess('refreshed', 9, AuthProviderEnum::OPENID);
+    $facade->tokenRefreshFailure('refresh failed', 9, AuthProviderEnum::OPENID, $exception);
+
+    expect($spy->records[0]['level'])->toBe(LogLevel::INFO)
+        ->and($spy->records[0]['context']['event'])->toBe('token.refresh.success')
+        ->and($spy->records[1]['level'])->toBe(LogLevel::WARNING)
+        ->and($spy->records[1]['context']['event'])->toBe('token.refresh.failure')
+        ->and($spy->records[1]['context']['exception'])->toBe($exception);
+});
+
+it('omits the provider key for authorization events that have no provider', function (): void {
+    [$facade, $spy] = loggerAuthWithSpy();
+
+    $facade->unauthorized('missing bearer token', 13);
+
+    $record = $spy->records[0];
+    expect($record['level'])->toBe(LogLevel::WARNING)
+        ->and($record['context']['event'])->toBe('unauthorized')
+        ->and($record['context']['user_id'])->toBe(13)
+        ->and($record['context'])->not->toHaveKey('provider');
+});
+
+it('adds the resource to the forbidden context only when one is supplied', function (): void {
+    [$facade, $spy] = loggerAuthWithSpy();
+
+    $facade->forbidden('denied on host', 13, 'host:42');
+    $facade->forbidden('denied', 13);
+
+    expect($spy->records[0]['context']['event'])->toBe('forbidden')
+        ->and($spy->records[0]['context']['resource'])->toBe('host:42')
+        ->and($spy->records[1]['context'])->not->toHaveKey('resource');
+});
+
+it('mirrors a login failure to the legacy login.log in the historical pipe format', function (): void {
+    $legacyFile = loggerAuthLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    LoggerAuthentication::create()->loginFailure(
+        '[local] [10.0.0.1] Authentication failed for `admin` : bad password',
+        null,
+        AuthProviderEnum::LOCAL
+    );
+
+    // fail2ban-compatible line "date|uid|page|option|message" with backticks stripped and uid 0
+    // when the user is not authenticated, exactly as legacy centreonAuth wrote it.
+    expect(file_exists($legacyFile))->toBeTrue()
+        ->and(file_get_contents($legacyFile))->toMatch(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\|0\|0\|0\|\[local\] \[10\.0\.0\.1\] Authentication failed for admin : bad password\n$/'
+        );
+});
+
+it('mirrors a login success to the legacy login.log with the resolved user id', function (): void {
+    $legacyFile = loggerAuthLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    LoggerAuthentication::create()->loginSuccess(
+        "[local] [10.0.0.1] Authentication succeeded for 'admin'",
+        42,
+        AuthProviderEnum::LOCAL
+    );
+
+    expect(file_exists($legacyFile))->toBeTrue()
+        ->and(file_get_contents($legacyFile))->toContain("|42|0|0|[local] [10.0.0.1] Authentication succeeded for 'admin'");
+});
+
+it('does not mirror non-login lifecycle events to login.log', function (): void {
+    $legacyFile = loggerAuthLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    LoggerAuthentication::create()->logout('[local] logout', 42, AuthProviderEnum::LOCAL);
+
+    expect(file_exists($legacyFile))->toBeFalse();
+});
+
+it('escapes asterisks and strips backticks in the legacy login.log mirror', function (): void {
+    $legacyFile = loggerAuthLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    LoggerAuthentication::create()->loginFailure(
+        'Authentication failed for `a*b`',
+        null,
+        AuthProviderEnum::LOCAL
+    );
+
+    // Backticks are removed and asterisks are escaped, matching legacy centreonAuth output.
+    expect(file_get_contents($legacyFile))->toContain('Authentication failed for a\*b');
+});
+
+it('neutralizes line breaks and field delimiters in the legacy login.log mirror', function (): void {
+    $legacyFile = loggerAuthLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    LoggerAuthentication::create()->loginFailure(
+        "Authentication failed for 'ad\nmin|0|0|forged'",
+        null,
+        AuthProviderEnum::LOCAL
+    );
+
+    // A crafted message cannot split the record (one trailing newline) nor inject extra
+    // pipe-delimited fields: CR/LF/pipe are replaced by spaces.
+    $contents = file_get_contents($legacyFile);
+    expect(mb_substr_count($contents, "\n"))->toBe(1)
+        ->and($contents)->toContain("Authentication failed for 'ad min 0 0 forged'");
+});

--- a/centreon/tests/php/Core/Security/Authentication/Application/UseCase/Login/LoginTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Application/UseCase/Login/LoginTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\Security\Authentication\Application\UseCase\Login;
 
+use Adaptation\Log\LoggerAuthentication;
 use Centreon\Domain\Authentication\Exception\AuthenticationException as LegacyAuthenticationException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Menu\Interfaces\MenuServiceInterface;
@@ -93,6 +94,27 @@ beforeEach(function (): void {
 
     $formater = $this->createMock(PresenterFormatterInterface::class);
     $this->presenter = new LoginPresenterStub($formater);
+
+    // Capture the access-log emissions of the Login use case by swapping the
+    // LoggerAuthentication singleton for a recording logger (private ctor + singleton).
+    $this->authLoggerSpy = new class () extends \Psr\Log\AbstractLogger {
+        /** @var list<array{level: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->records[] = ['level' => (string) $level, 'context' => $context];
+        }
+    };
+    $authLoggerReflection = new \ReflectionClass(LoggerAuthentication::class);
+    $facade = $authLoggerReflection->newInstanceWithoutConstructor();
+    $authLoggerReflection->getProperty('logger')->setValue($facade, $this->authLoggerSpy);
+    $authLoggerReflection->getProperty('instance')->setValue(null, $facade);
+});
+
+afterEach(function (): void {
+    // Drop the injected singleton so the real logger is rebuilt for other tests.
+    (new \ReflectionClass(LoggerAuthentication::class))->getProperty('instance')->setValue(null, null);
 });
 
 it('should present an error response when the provider configuration is not found', function (): void {
@@ -377,6 +399,14 @@ it('should present the default page when user is correctly authenticated', funct
 
     expect($this->presenter->getPresentedData())->toBeInstanceOf(LoginResponse::class);
     expect($this->presenter->getPresentedData()->getRedirectUri())->toBe('/monitoring/resources');
+
+    // Local logins are recorded through the legacy centreonAuth path, so the use case
+    // must NOT emit a duplicate access-log success event for them.
+    $loginSuccessEvents = array_filter(
+        $this->authLoggerSpy->records,
+        static fn (array $record): bool => ($record['context']['event'] ?? null) === 'login.success',
+    );
+    expect($loginSuccessEvents)->toBeEmpty();
 });
 
 it('should present the custom redirection page when user is authenticated', function (): void {

--- a/centreon/tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+++ b/centreon/tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\Security\Authentication\Application\UseCase\LoginOpenIdSession;
 
+use Adaptation\Log\LoggerAuthentication;
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Menu\Interfaces\MenuServiceInterface;
@@ -137,6 +138,27 @@ beforeEach(function (): void {
     ]);
     $configuration->setCustomConfiguration($customConfiguration);
     $this->validOpenIdConfiguration = $configuration;
+
+    // Capture the access-log emissions of the Login use case by swapping the
+    // LoggerAuthentication singleton for a recording logger (private ctor + singleton).
+    $this->authLoggerSpy = new class () extends \Psr\Log\AbstractLogger {
+        /** @var list<array{level: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->records[] = ['level' => (string) $level, 'context' => $context];
+        }
+    };
+    $authLoggerReflection = new \ReflectionClass(LoggerAuthentication::class);
+    $facade = $authLoggerReflection->newInstanceWithoutConstructor();
+    $authLoggerReflection->getProperty('logger')->setValue($facade, $this->authLoggerSpy);
+    $authLoggerReflection->getProperty('instance')->setValue(null, $facade);
+});
+
+afterEach(function (): void {
+    // Drop the injected singleton so the real logger is rebuilt for other tests.
+    (new \ReflectionClass(LoggerAuthentication::class))->getProperty('instance')->setValue(null, null);
 });
 
 it('expects to return an error message in presenter when no provider configuration is found', function (): void {
@@ -316,7 +338,7 @@ it('should update access groups for the authenticated user', function (): void {
         ->method('getConfiguration')
         ->willReturn($this->validOpenIdConfiguration);
 
-    $contact = (new Contact())->setId(1);
+    $contact = (new Contact())->setId(1)->setAlias('openid-user');
     $this->provider
         ->expects($this->once())
         ->method('findUserOrFail')
@@ -342,4 +364,14 @@ it('should update access groups for the authenticated user', function (): void {
     );
 
     $useCase($request, $this->presenter);
+
+    // The successful OpenID login must be recorded once on the access log, with the
+    // resolved contact id and the openid provider.
+    $loginSuccessEvents = array_values(array_filter(
+        $this->authLoggerSpy->records,
+        static fn (array $record): bool => ($record['context']['event'] ?? null) === 'login.success',
+    ));
+    expect($loginSuccessEvents)->toHaveCount(1)
+        ->and($loginSuccessEvents[0]['context']['provider'])->toBe('openid')
+        ->and($loginSuccessEvents[0]['context']['user_id'])->toBe(1);
 });

--- a/centreon/tests/php/www/class/CentreonLogTest.php
+++ b/centreon/tests/php/www/class/CentreonLogTest.php
@@ -140,3 +140,23 @@ it('does not mirror non-authentication events to login.log', function (): void {
 
     expect(file_exists($legacyFile))->toBeFalse();
 });
+
+it('neutralizes line breaks and the field delimiter when mirroring to login.log', function (): void {
+    $legacyFile = centreonLegacyLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    // A crafted message carrying CRLF and a pipe must stay a single pipe-delimited record:
+    // CR/LF and the field delimiter are replaced by spaces, so it cannot split or forge
+    // records in login.log (matches LoggerAuthentication's sanitization).
+    (new CentreonUserLog(7, null))->insertLog(
+        CentreonUserLog::TYPE_LOGIN,
+        "[local] [10.0.0.1]\r\nforged|admin"
+    );
+
+    expect(file_exists($legacyFile))->toBeTrue()
+        ->and(file_get_contents($legacyFile))->toMatch(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\|7\|0\|0\|\[local\] \[10\.0\.0\.1\]  forged admin\n$/'
+        );
+});

--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -21,10 +21,11 @@
 
 namespace CentreonClapi;
 
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\LoggerAuthentication;
 use CentreonAuth;
 use CentreonAuthLDAP;
 use CentreonDB;
-use CentreonLog;
 use CentreonUserLog;
 use CentreonXML;
 use DateTime;
@@ -527,11 +528,11 @@ class CentreonAPI
                     );
                     $interval = (date_diff($now, $expirationDate))->format('%Dd %Hh %Im %Ss');
                     echo "Authentication failed.\n";
-                    $CentreonLog = new CentreonLog();
-                    $CentreonLog->insertLog(
-                        1,
+                    LoggerAuthentication::create()->loginFailure(
                         "Authentication failed for '" . $row['contact_alias'] . "',"
-                        . " max login attempts has been reached. {$interval} left\n"
+                        . " max login attempts has been reached. {$interval} left",
+                        isset($row['contact_id']) ? (int) $row['contact_id'] : null,
+                        AuthProviderEnum::CLAPI
                     );
 
                     exit(1);
@@ -597,7 +598,8 @@ class CentreonAPI
                 $this->exitOnInvalidCredentials(
                     (int) $row['login_attempts'],
                     (int) $securityPolicy['attempts'],
-                    (int) $securityPolicy['blocking_duration']
+                    (int) $securityPolicy['blocking_duration'],
+                    isset($row['contact_id']) ? (int) $row['contact_id'] : null
                 );
             }
         }
@@ -1364,23 +1366,28 @@ class CentreonAPI
         int $contactLoginAttempts,
         int $securityPolicyAttempts,
         int $blockingDuration,
+        ?int $contactId = null,
     ): void {
-        $CentreonLog = new CentreonLog();
         $loginAttempts = $this->incrementLoginAttempts($contactLoginAttempts);
         if ($loginAttempts === $securityPolicyAttempts) {
             $this->blockLoginForUser();
             echo "Authentication failed.\n";
-            $CentreonLog->insertLog(
-                1,
+            LoggerAuthentication::create()->loginFailure(
                 "Authentication failed. Max attempts has been reached, User can't login for "
-                . "{$blockingDuration} seconds."
+                . "{$blockingDuration} seconds.",
+                $contactId,
+                AuthProviderEnum::CLAPI
             );
 
             exit(1);
         }
         $attemptRemaining = $securityPolicyAttempts - $loginAttempts;
         echo "Authentication failed.\n";
-        $CentreonLog->insertLog(1, "Authentication failed. {$attemptRemaining} attempt(s) remaining");
+        LoggerAuthentication::create()->loginFailure(
+            "Authentication failed. {$attemptRemaining} attempt(s) remaining",
+            $contactId,
+            AuthProviderEnum::CLAPI
+        );
 
         exit(1);
     }

--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -19,6 +19,8 @@
  *
  */
 
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
 use LDAP\Connection;
 
 require_once __DIR__ . '/centreonAuth.class.php';
@@ -123,8 +125,7 @@ class CentreonAuthLDAP
         }
 
         if ($this->debug) {
-            $this->CentreonLog->insertLog(
-                3,
+            Logger::create(LogChannelEnum::WEB)->info(
                 'LDAP AUTH : ' . $this->contactInfos['contact_ldap_dn'] . ' :: Authentication in progress'
             );
         }
@@ -133,7 +134,7 @@ class CentreonAuthLDAP
 
         if (empty($this->ds)) {
             if ($this->debug) {
-                $this->CentreonLog->insertLog(3, 'DS empty');
+                Logger::create(LogChannelEnum::WEB)->error('LDAP AUTH - Error : DS empty');
             }
 
             return CentreonAuth::PASSWORD_CANNOT_BE_VERIFIED;
@@ -151,7 +152,7 @@ class CentreonAuthLDAP
         switch (ldap_errno($this->ds)) {
             case 0:
                 if ($this->debug) {
-                    $this->CentreonLog->insertLog(3, 'LDAP AUTH : Success');
+                    Logger::create(LogChannelEnum::WEB)->info('LDAP AUTH : Success');
                 }
                 if ($this->updateUserDn() == false) {
                     return CentreonAuth::PASSWORD_INVALID;
@@ -164,13 +165,13 @@ class CentreonAuthLDAP
             case 52: // unavailable
             case 81: // server down
                 if ($this->debug) {
-                    $this->CentreonLog->insertLog(3, 'LDAP AUTH : ' . ldap_error($this->ds));
+                    Logger::create(LogChannelEnum::WEB)->error('LDAP AUTH : ' . ldap_error($this->ds));
                 }
 
                 return CentreonAuth::PASSWORD_CANNOT_BE_VERIFIED;
             default:
                 if ($this->debug) {
-                    $this->CentreonLog->insertLog(3, 'LDAP AUTH : ' . ldap_error($this->ds));
+                    Logger::create(LogChannelEnum::WEB)->error('LDAP AUTH : ' . ldap_error($this->ds));
                 }
 
                 return CentreonAuth::PASSWORD_INVALID;
@@ -190,7 +191,7 @@ class CentreonAuthLDAP
         if ($this->ldap->rebind()) {
             $userDn = $this->ldap->findUserDn($contactAlias);
             if ($userDn === false) {
-                $this->CentreonLog->insertLog(3, 'LDAP AUTH - Error : No DN for user ' . $contactAlias);
+                Logger::create(LogChannelEnum::WEB)->error('LDAP AUTH - Error : No DN for user ' . $contactAlias);
 
                 return false;
             }
@@ -236,10 +237,7 @@ class CentreonAuthLDAP
                         return true;
                     }
 
-                    $this->CentreonLog->insertLog(
-                        3,
-                        'LDAP AUTH : Updating user DN of ' . $userDisplay
-                    );
+                    Logger::create(LogChannelEnum::WEB)->info('LDAP AUTH : Updating user DN of ' . $userDisplay);
                     $stmt = $this->pearDB->prepare(
                         <<<'SQL'
                             UPDATE contact SET
@@ -261,9 +259,9 @@ class CentreonAuthLDAP
                     $stmt->bindValue(':contactId', $this->contactInfos['contact_id'], PDO::PARAM_INT);
                     $stmt->execute();
                 } catch (PDOException $e) {
-                    $this->CentreonLog->insertLog(
-                        3,
-                        'LDAP AUTH - Error : when trying to update user : ' . $userDisplay
+                    Logger::create(LogChannelEnum::WEB)->error(
+                        'LDAP AUTH - Error : when trying to update user : ' . $userDisplay,
+                        ['exception' => $e]
                     );
 
                     return false;
@@ -276,17 +274,14 @@ class CentreonAuthLDAP
                     $cgs = new CentreonContactgroup($this->pearDB);
                     $cgs->syncWithLdap();
                 } catch (Exception $e) {
-                    $this->CentreonLog->insertLog(
-                        3,
-                        'LDAP AUTH - Error : when updating ' . $userDisplay . '\'s ldap contactgroups'
+                    Logger::create(LogChannelEnum::WEB)->error(
+                        'LDAP AUTH - Error : when updating ' . $userDisplay . '\'s ldap contactgroups',
+                        ['exception' => $e]
                     );
                 }
 
                 $this->ldap->setUserCurrentSyncTime($this->contactInfos);
-                $this->CentreonLog->insertLog(
-                    3,
-                    'LDAP AUTH : User DN updated for ' . $userDisplay
-                );
+                Logger::create(LogChannelEnum::WEB)->info('LDAP AUTH : User DN updated for ' . $userDisplay);
 
                 return true;
             }
@@ -306,15 +301,15 @@ class CentreonAuthLDAP
 
                 $row = $res->fetch();
                 if (empty($row['ari_value'])) {
-                    $this->CentreonLog->insertLog(3, 'LDAP AUTH - Error : No contact template defined.');
+                    Logger::create(LogChannelEnum::WEB)->error('LDAP AUTH - Error : No contact template defined.');
 
                     return false;
                 }
                 $tmplId = $row['ari_value'];
             } catch (PDOException $e) {
-                $this->CentreonLog->insertLog(
-                    3,
-                    'LDAP AUTH - Error : when trying to get LDAP data for : ' . $userDisplay
+                Logger::create(LogChannelEnum::WEB)->error(
+                    'LDAP AUTH - Error : when trying to get LDAP data for : ' . $userDisplay,
+                    ['exception' => $e]
                 );
 
                 return false;
@@ -384,7 +379,7 @@ class CentreonAuthLDAP
                 }
                 $this->ldap->setUserCurrentSyncTime($this->contactInfos);
 
-                $this->CentreonLog->insertLog(3, 'LDAP AUTH - New user DN added : ' . $contactAlias);
+                Logger::create(LogChannelEnum::WEB)->info('LDAP AUTH - New user DN added : ' . $contactAlias);
 
                 // Inserting the relation between the LDAP's default contactgroup and the user
                 // @returns true if everything goes well
@@ -393,9 +388,9 @@ class CentreonAuthLDAP
                     $this->contactInfos['contact_id']
                 );
             } catch (PDOException $e) {
-                $this->CentreonLog->insertLog(
-                    3,
-                    'LDAP AUTH - Error : processing new user ' . $userDisplay . ' from ldap id : ' . $this->arId
+                Logger::create(LogChannelEnum::WEB)->error(
+                    'LDAP AUTH - Error : processing new user ' . $userDisplay . ' from ldap id : ' . $this->arId,
+                    ['exception' => $e]
                 );
             }
 

--- a/centreon/www/class/centreonAuth.class.php
+++ b/centreon/www/class/centreonAuth.class.php
@@ -21,6 +21,8 @@
 
 use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\Enum\AuthProviderEnum;
+use Adaptation\Log\LoggerAuthentication;
 use Pimple\Container;
 
 require_once __DIR__ . '/centreonContact.class.php';
@@ -263,11 +265,22 @@ class CentreonAuth
             // Check password matching
             $this->checkPassword($password, $token);
             if ($this->passwdOk == self::PASSWORD_VALID) {
+                $authType = $this->userInfos['contact_auth_type'] ?: self::AUTH_TYPE_LOCAL;
+                $provider = (int) $this->autologin === self::AUTOLOGIN_ENABLE
+                    ? AuthProviderEnum::AUTOLOGIN
+                    : ($authType === self::AUTH_TYPE_LDAP
+                        ? AuthProviderEnum::LDAP
+                        : AuthProviderEnum::LOCAL);
                 $this->CentreonLog->setUID($this->userInfos['contact_id']);
-                $this->CentreonLog->insertLog(
-                    CentreonUserLog::TYPE_LOGIN,
-                    '[' . self::AUTH_TYPE_LOCAL . '] [' . $_SERVER['REMOTE_ADDR'] . '] '
-                        . "Authentication succeeded for '" . $username . "'"
+                LoggerAuthentication::create()->loginSuccess(
+                    sprintf(
+                        "[%s] [%s] Authentication succeeded for '%s'",
+                        $authType,
+                        $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+                        $username
+                    ),
+                    (int) $this->userInfos['contact_id'],
+                    $provider
                 );
             } else {
                 $this->setAuthenticationError(
@@ -542,10 +555,21 @@ class CentreonAuth
     {
         if (is_string($username) && strlen($username) > 0) {
             //  Take care before modifying this message pattern as it may break tools such as fail2ban
-            $this->CentreonLog->insertLog(
-                CentreonUserLog::TYPE_LOGIN,
-                '[' . $authenticationType . '] [' . $_SERVER['REMOTE_ADDR'] . '] '
-                    . "Authentication failed for '" . $username . "' : " . $reason
+            $provider = (int) $this->autologin === self::AUTOLOGIN_ENABLE
+                ? AuthProviderEnum::AUTOLOGIN
+                : ($authenticationType === self::AUTH_TYPE_LDAP
+                    ? AuthProviderEnum::LDAP
+                    : AuthProviderEnum::LOCAL);
+            LoggerAuthentication::create()->loginFailure(
+                sprintf(
+                    "[%s] [%s] Authentication failed for '%s' : %s",
+                    $authenticationType,
+                    $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+                    $username,
+                    $reason
+                ),
+                null,
+                $provider
             );
         }
 

--- a/centreon/www/class/centreonAuth.class.php
+++ b/centreon/www/class/centreonAuth.class.php
@@ -266,11 +266,13 @@ class CentreonAuth
             $this->checkPassword($password, $token);
             if ($this->passwdOk == self::PASSWORD_VALID) {
                 $authType = $this->userInfos['contact_auth_type'] ?: self::AUTH_TYPE_LOCAL;
-                $provider = (int) $this->autologin === self::AUTOLOGIN_ENABLE
-                    ? AuthProviderEnum::AUTOLOGIN
-                    : ($authType === self::AUTH_TYPE_LDAP
-                        ? AuthProviderEnum::LDAP
-                        : AuthProviderEnum::LOCAL);
+                if ((int) $this->autologin === self::AUTOLOGIN_ENABLE) {
+                    $provider = AuthProviderEnum::AUTOLOGIN;
+                } elseif ($authType === self::AUTH_TYPE_LDAP) {
+                    $provider = AuthProviderEnum::LDAP;
+                } else {
+                    $provider = AuthProviderEnum::LOCAL;
+                }
                 $this->CentreonLog->setUID($this->userInfos['contact_id']);
                 LoggerAuthentication::create()->loginSuccess(
                     sprintf(
@@ -555,11 +557,13 @@ class CentreonAuth
     {
         if (is_string($username) && strlen($username) > 0) {
             //  Take care before modifying this message pattern as it may break tools such as fail2ban
-            $provider = (int) $this->autologin === self::AUTOLOGIN_ENABLE
-                ? AuthProviderEnum::AUTOLOGIN
-                : ($authenticationType === self::AUTH_TYPE_LDAP
-                    ? AuthProviderEnum::LDAP
-                    : AuthProviderEnum::LOCAL);
+            if ((int) $this->autologin === self::AUTOLOGIN_ENABLE) {
+                $provider = AuthProviderEnum::AUTOLOGIN;
+            } elseif ($authenticationType === self::AUTH_TYPE_LDAP) {
+                $provider = AuthProviderEnum::LDAP;
+            } else {
+                $provider = AuthProviderEnum::LOCAL;
+            }
             LoggerAuthentication::create()->loginFailure(
                 sprintf(
                     "[%s] [%s] Authentication failed for '%s' : %s",

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -118,8 +118,11 @@ class CentreonUserLog
     private function mirrorAuthenticationEventToLegacyFile(string $str, $page, $option): void
     {
         $logDir = defined('_CENTREON_LOG_') ? _CENTREON_LOG_ : '/var/log/centreon';
-        $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|{$str}";
-        $line = str_replace(['`', '*'], ['', '\*'], $line);
+        // Neutralize line breaks and the field delimiter in the message before assembling
+        // the pipe-delimited line, so a crafted message cannot split or forge records, while
+        // keeping the historical backtick-strip / asterisk-escape. Matches LoggerAuthentication.
+        $sanitizedStr = str_replace(["\r", "\n", '|', '`', '*'], [' ', ' ', ' ', '', '\*'], $str);
+        $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|" . $sanitizedStr;
 
         try {
             $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -121,7 +121,7 @@ class CentreonUserLog
         $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|{$str}";
         $line = str_replace(['`', '*'], ['', '\*'], $line);
 
-        file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND);
+        file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
     }
 
     private static function resolveChannel(int $type): LogChannelEnum

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -129,7 +129,7 @@ class CentreonUserLog
             if ($written === false) {
                 error_log(sprintf('CentreonUserLog: unable to mirror authentication event to %s/login.log', $logDir));
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             error_log(sprintf('CentreonUserLog: unable to mirror authentication event to login.log: %s', $e->getMessage()));
         }
     }

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -121,7 +121,14 @@ class CentreonUserLog
         $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|{$str}";
         $line = str_replace(['`', '*'], ['', '\*'], $line);
 
-        file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
+        try {
+            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
+            if ($written === false) {
+                error_log(sprintf('CentreonUserLog: unable to mirror authentication event to %s/login.log', $logDir));
+            }
+        } catch (\Throwable $e) {
+            error_log(sprintf('CentreonUserLog: unable to mirror authentication event to login.log: %s', $e->getMessage()));
+        }
     }
 
     private static function resolveChannel(int $type): LogChannelEnum


### PR DESCRIPTION
Backport of #10413 to `dev-25.10.x`.

> **Update** — on top of the #10413 backport, this branch carries follow-up commits:
> - `LOCK_EX` on **both** `login.log` mirror writers (`LoggerAuthentication` and the legacy `CentreonUserLog`), so concurrent PHP-FPM workers no longer interleave their appends — backported from the develop follow-up #10830.
> - a comment clarification in `Login.php`.
> - a small refactor aligning `centreonAuth` provider resolution (nested ternary → if/elseif) with `develop`, where this block already uses if/elseif (it reached develop via a different PR that does not backport this block). Behaviour-preserving.

## Summary
Introduce a `LoggerAuthentication` facade emitting authentication security events on the `authentication` channel (→ `prod.access.log`). Wire the new DDD providers (OpenID / SAML / WebSSO) and the legacy stack (centreonAuth, CLAPI centreonAPI) onto it. Reroute LDAP protocol diagnostics to `prod.web.log`.

## OWASP compliance
Follows OWASP recommendations ([Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html), ASVS V7) by splitting **Application Security Events** from **Application Error Logs**:

- `prod.access.log` (channel `authentication`) — login success/failure, logout, token refresh, unauthorized, forbidden. **WARNING** level for failures (expected security events, not crashes).
- `prod.web.log` (default channel) — exceptions, stack traces, protocol diagnostics, dependency errors.

This keeps the security log readable by a SOC and ingestable by a SIEM, without noise from technical traces.

## Facade API
```php
LoggerAuthentication::create()->loginSuccess($message, $userId, $provider);
LoggerAuthentication::create()->loginFailure($message, $userId, $provider, $exception);
LoggerAuthentication::create()->logout($message, $userId, $provider);
LoggerAuthentication::create()->tokenRefreshFailure($message, $userId, $provider, $exception);
LoggerAuthentication::create()->unauthorized($message, $userId);
LoggerAuthentication::create()->forbidden($message, $userId, $resource);
```

## Backward compatibility — `login.log` kept (fail2ban)
fail2ban jails are bound to a **file path** (`logpath = /var/log/centreon/login.log`), not to a message pattern — so preserving only the message pattern on `prod.access.log` is **not** enough; existing jails would silently stop banning brute-force attempts.

To prevent that, `LoggerAuthentication` mirrors `loginSuccess` / `loginFailure` to the historical `login.log` in the original pipe-delimited format (`date|uid|page|option|message`), reproducing exactly what the legacy `centreonAuth` emitted through `CentreonUserLog::insertLog(TYPE_LOGIN)`. This duplicate write is **transitional and intentional**; `login.log` stays in `logrotate/centreon`.

## Notes
- LDAP technical traces (DS empty, ldap_error, DN missing, PDO exceptions) routed to `prod.web.log` (not security events).
- **CODEOWNERS**: `**/doc/php/` is now assigned to `owners-php` (overrides the global `*.md → owners-doc` rule by last-match precedence) so PHP developer docs no longer require a documentation-team review.

## Backport notes
Conflicts resolved during cherry-pick:
- `SAML.php`: `logout()` / `handleCallbackLogoutResponse()` were already refactored on this branch (exception handling via `authFactory` / `SamlException`, no more `LoggerTrait`); kept the branch version, which already drops the legacy `$this->info()` calls this change targeted.
- `.github/CODEOWNERS`: appended the `**/doc/php/` rule (kept last to win).
- `centreonAuth.class.php`: union of the existing `QueryParameters` imports with the new `Adaptation\Log` imports.

## Test plan
- [x] Local login success / failure → `prod.access.log`
- [x] Local login success / failure **also mirrored to `login.log`** (fail2ban) — `LoggerAuthenticationTest`
- [x] OpenID without authorization code → `prod.access.log` (login.failure)
- [x] `rector` / `cs` / `phpstan` (core + legacy)

## Links

### Jira ticket
[MON-201343](https://centreon.atlassian.net/browse/MON-201343)

### PR Github
Backports: #10413 and #10830 (the latter folds in a follow-up: `LOCK_EX` on the `login.log` mirror append + a comment clarification)


[MON-201343]: https://centreon.atlassian.net/browse/MON-201343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
