### PR TITLE
fix(logging): lock login.log mirror append against concurrent writes

### DIFF
--- a/centreon/src/Adaptation/Log/LoggerAuthentication.php
+++ b/centreon/src/Adaptation/Log/LoggerAuthentication.php
@@ -149,7 +149,7 @@ final class LoggerAuthentication
         $line = date('Y-m-d H:i:s') . '|' . ($userId ?? 0) . '|0|0|' . $sanitizedMessage;
 
         try {
-            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND);
+            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
             if ($written === false) {
                 error_log(sprintf('LoggerAuthentication: unable to mirror login event to %s/login.log', $logDir));
             }

--- a/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
+++ b/centreon/src/Core/Security/Authentication/Application/UseCase/Login/Login.php
@@ -98,9 +98,10 @@ final class Login
                 throw LegacyAuthenticationException::notAllowedToReachWebApplication();
             }
 
-            // Record the SSO authentication success on the security access log. Local/LDAP
-            // logins are already logged by the legacy centreonAuth path, so they are excluded
-            // here to avoid a duplicate access-log entry. Provider names that are not part of
+            // Record the SSO authentication success on the security access log. Local logins
+            // (including LDAP, which authenticates through the local provider) are already
+            // logged by the legacy centreonAuth path, so the local provider is excluded here
+            // to avoid a duplicate access-log entry. Provider names that are not part of
             // AuthProviderEnum (e.g. a module-provided provider) are skipped rather than
             // breaking the login flow on a strict enum lookup.
             $authProvider = AuthProviderEnum::tryFrom($loginRequest->providerName);

--- a/centreon/tests/php/www/class/CentreonLogTest.php
+++ b/centreon/tests/php/www/class/CentreonLogTest.php
@@ -142,3 +142,23 @@ it('does not mirror non-authentication events to login.log', function (): void {
 
     expect(file_exists($legacyFile))->toBeFalse();
 });
+
+it('neutralizes line breaks and the field delimiter when mirroring to login.log', function (): void {
+    $legacyFile = centreonLegacyLoginLogPath();
+    if (file_exists($legacyFile)) {
+        unlink($legacyFile);
+    }
+
+    // A crafted message carrying CRLF and a pipe must stay a single pipe-delimited record:
+    // CR/LF and the field delimiter are replaced by spaces, so it cannot split or forge
+    // records in login.log (matches LoggerAuthentication's sanitization).
+    (new CentreonUserLog(7, null))->insertLog(
+        CentreonUserLog::TYPE_LOGIN,
+        "[local] [10.0.0.1]\r\nforged|admin"
+    );
+
+    expect(file_exists($legacyFile))->toBeTrue()
+        ->and(file_get_contents($legacyFile))->toMatch(
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\|7\|0\|0\|\[local\] \[10\.0\.0\.1\]  forged admin\n$/'
+        );
+});

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -118,8 +118,11 @@ class CentreonUserLog
     private function mirrorAuthenticationEventToLegacyFile(string $str, $page, $option): void
     {
         $logDir = defined('_CENTREON_LOG_') ? _CENTREON_LOG_ : '/var/log/centreon';
-        $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|{$str}";
-        $line = str_replace(['`', '*'], ['', '\*'], $line);
+        // Neutralize line breaks and the field delimiter in the message before assembling
+        // the pipe-delimited line, so a crafted message cannot split or forge records, while
+        // keeping the historical backtick-strip / asterisk-escape. Matches LoggerAuthentication.
+        $sanitizedStr = str_replace(["\r", "\n", '|', '`', '*'], [' ', ' ', ' ', '', '\*'], $str);
+        $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|" . $sanitizedStr;
 
         try {
             $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -121,7 +121,7 @@ class CentreonUserLog
         $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|{$str}";
         $line = str_replace(['`', '*'], ['', '\*'], $line);
 
-        file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND);
+        file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
     }
 
     private static function resolveChannel(int $type): LogChannelEnum

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -129,7 +129,7 @@ class CentreonUserLog
             if ($written === false) {
                 error_log(sprintf('CentreonUserLog: unable to mirror authentication event to %s/login.log', $logDir));
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             error_log(sprintf('CentreonUserLog: unable to mirror authentication event to login.log: %s', $e->getMessage()));
         }
     }

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -121,7 +121,14 @@ class CentreonUserLog
         $line = date('Y-m-d H:i:s') . '|' . $this->uid . "|{$page}|{$option}|{$str}";
         $line = str_replace(['`', '*'], ['', '\*'], $line);
 
-        file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
+        try {
+            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
+            if ($written === false) {
+                error_log(sprintf('CentreonUserLog: unable to mirror authentication event to %s/login.log', $logDir));
+            }
+        } catch (\Throwable $e) {
+            error_log(sprintf('CentreonUserLog: unable to mirror authentication event to login.log: %s', $e->getMessage()));
+        }
     }
 
     private static function resolveChannel(int $type): LogChannelEnum


### PR DESCRIPTION
## Description

Follow-up to the authentication logging feature (#10413, merged to `develop`). It hardens the `login.log` mirror — kept transitionally for fail2ban — and brings its two writer sites to parity.

`login.log` is written through two mirror sites:
- `LoggerAuthentication::mirrorToLegacyLoginLog()` — DDD providers (OpenID / SAML / WebSSO).
- `CentreonUserLog::mirrorAuthenticationEventToLegacyFile()` — legacy `centreonAuth` path (local / LDAP logins, the most common case).

Changes:
- **Concurrency:** both sites now append with `FILE_APPEND | LOCK_EX`. `flock` is advisory, so both must lock to prevent concurrent PHP-FPM workers from interleaving and corrupting lines fail2ban then fails to parse.
- **Error handling (legacy writer):** check the write result and swallow any `Throwable` to `error_log`, matching the DDD twin, so mirroring never breaks the login flow.
- **Message hygiene (legacy writer):** neutralize CR, LF and the `|` field delimiter in the message before assembling the pipe-delimited line, matching the DDD twin, so a crafted message can't split or forge records.
- **Comment:** clarify in `Login.php` that LDAP authenticates through the local provider — hence only `Provider::LOCAL` is excluded from the SSO access-log path.
- Adds a unit test covering the legacy mirror sanitization.

## How to test

1. Trigger several concurrent logins (mix local/LDAP via the legacy path and SSO via a DDD provider).
2. Check `/var/log/centreon/login.log`: every mirrored line stays well-formed (`date|uid|page|option|message`), no interleaved or truncated lines.
3. Feed a login message containing CR/LF or a `|`: confirm the mirrored record stays on a single line with those characters replaced by spaces (no extra/forged fields).
4. Confirm fail2ban still parses the file (login success/failure entries match its regex).

## Links

### Jira ticket

Resolves: [MON-201926](https://centreon.atlassian.net/browse/MON-201926)

### PR Github

- Is backported by: #10825 — folded into the dev-25.10.x backport of #10413
- Is backported by: #10826 — folded into the dev-24.10.x backport of #10413
- Relates to: #10413


[MON-201926]: https://centreon.atlassian.net/browse/MON-201926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ