### PR TITLE
fix(logging): remove the RequestTracker2 leftover debug file write

### DIFF
--- a/centreon-open-tickets/phpstan.legacy.www.baseline.neon
+++ b/centreon-open-tickets/phpstan.legacy.www.baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
 
 		-
-			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) fp must contain 3 or more characters\.$#'
-			count: 3
-			path: www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
-
-		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) ch must contain 3 or more characters\.$#'
 			count: 2
 			path: www/modules/centreon-open-tickets/providers/Serena/SerenaProvider.class.php

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
@@ -481,9 +481,6 @@ class RequestTracker2Provider extends AbstractProvider
             }
         }
 
-        $fp = fopen('/var/opt/rh/rh-php71/log/php-fpm/debug.txt', 'a+');
-        fwrite($fp, print_r($argument, true));
-        fclose($fp);
         if ($this->callRest('ticket', $argument) == 1) {
             return -1;
         }


### PR DESCRIPTION
## Description

Remove a leftover debug file write in the RequestTracker2 open-tickets provider (part of MON-201908 — nothing in the modules should bypass the unified logging pipeline).

`RequestTracker2Provider` wrote the full ticket `$argument` (`print_r`) to a hardcoded debug file (`/var/opt/.../debug.txt`) on every ticket creation, via a leftover `fopen`/`fwrite`/`fclose`. This bypassed the platform logging pipeline entirely. Removed (3 lines), behaviour otherwise unchanged.

## How to test

1. Create a ticket through the RequestTracker2 provider.
2. Confirm ticket creation still works and no `/var/opt/.../debug.txt` file is written anymore.

## Links

### Jira ticket

Resolves: [MON-201908](https://centreon.atlassian.net/browse/MON-201908)

### PR Github

- Relates to: #10823 — unified Monolog pipeline socle (MON-201902 initiative)


[MON-201908]: https://centreon.atlassian.net/browse/MON-201908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ