### PR TITLE
fix(config) Reindex multipleGroup array values in the stream connector output

### DIFF
--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -512,6 +512,7 @@ class CentreonConfigCentreonBroker
         if (isset($this->arrayMultiple)) {
             foreach ($this->arrayMultiple as $key => $multipleGroup) {
                 ksort($multipleGroup);
+                $multipleGroup = array_values($multipleGroup);
                 $cdata->addJsData('clone-values-' . $key, htmlspecialchars(
                     json_encode($multipleGroup),
                     ENT_QUOTES


### PR DESCRIPTION
## Description

Reindex multipleGroup array values in the stream connector output

Backport of https://github.com/centreon/centreon/pull/10835

**Fixes** MON-201888

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

Same as original PR — edit a Broker configuration with a Stream Connector output, add LUA parameters, delete one, save, and verify the remaining parameters are still visible with correct indexes.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).