### PR TITLE
fix(logging): align NameConverterInterface test stub with Symfony 8.1 signature

### DIFF
--- a/centreon/tests/php/App/Shared/Infrastructure/Messenger/LoggingMiddlewareTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Messenger/LoggingMiddlewareTest.php
@@ -327,12 +327,12 @@ final class LoggingMiddlewareTest extends TestCase
     {
         // A normalizer failure (here a throwing name converter) must not break dispatch: warn and log a `__class` placeholder.
         $throwingConverter = new class () implements NameConverterInterface {
-            public function normalize(string $propertyName): string
+            public function normalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
             {
                 throw new \RuntimeException('name conversion failed');
             }
 
-            public function denormalize(string $propertyName): string
+            public function denormalize(string $propertyName, ?string $class = null, ?string $format = null, array $context = []): string
             {
                 return $propertyName;
             }


### PR DESCRIPTION
## Description

The anonymous class implementing `NameConverterInterface` in `LoggingMiddlewareTest` was missing the `$class`, `$format`, and `$context` parameters added in Symfony 8.1, causing 6 PHPStan errors on develop after the Symfony upgrade (#10672).

**Fixes** fix/symfony81-nameconverter-compat

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

- Run `composer run stan:new` — should pass with 0 errors (previously 6 errors on the test file)

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).