### PR TITLE
refactor(contact): remove deprecated eraseCredentials()

### DIFF
--- a/centreon/src/Centreon/Domain/Contact/Contact.php
+++ b/centreon/src/Centreon/Domain/Contact/Contact.php
@@ -581,18 +581,6 @@ class Contact implements UserInterface, ContactInterface
     }
 
     /**
-     * Removes sensitive data from the user.
-     *
-     * This is important if, at any given point, sensitive information like
-     * the plain-text password is stored on this object.
-     */
-    #[\Deprecated]
-    public function eraseCredentials(): void
-    {
-        // Nothing to do. But we must to define this method
-    }
-
-    /**
      * @inheritDoc
      */
     public function hasAccessToApiConfiguration(): bool


### PR DESCRIPTION
Fixes: [MON-195024](https://centreon.atlassian.net/browse/MON-195024)

## Description

Symfony 8.1 removed `eraseCredentials()` from `UserInterface`, which now
declares only `getRoles()` and `getUserIdentifier()`. The implementation on
`Contact` was already empty and `#[\Deprecated]`, is no longer part of any
interface, and has no callers in the codebase — dead code. This removes it.

The ticket's other target, `CredentialUser`, was already cleaned up during the
Symfony 7.4 → 8.1 upgrade (#10672), so only this file remained.

## Validation
- php-cs-fixer (legacy config): no changes
- PHPStan (legacy src): no errors
- `git grep eraseCredentials` across `src/`, `www/`, `tests/`: no matches


[MON-195024]: https://centreon.atlassian.net/browse/MON-195024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ