### PR TITLE
feat(test): add graphite and influxdb broker output compose profiles

### DIFF
--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -79,6 +79,12 @@ Currently, the following profiles are available:
 * `squid-simple`: run a docker image of squid without authentication (centreon configuration must be done manually)
 * `squid-basic-auth`: run a docker image of squid with authentication (centreon configuration must be done manually)
 * `mediawiki`: run a docker image of mediawiki (centreon configuration must be done manually)
+* `graphite`: run a Graphite (`graphite-statsd`) receiver and auto-configure a Centreon Broker Graphite output pointing to it — for testing the Broker output cache
+  * the Broker output is configured automatically on startup, with macro-enriched naming `centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$`
+  * Verify ingestion: `curl "http://<graphite-ip>/render?target=centreon.metric.**&format=json"` — after a force check, the cache-resolved host/service names must appear in the received metric paths
+* `influxdb`: run an InfluxDB 1.8 receiver and auto-configure a Centreon Broker InfluxDB output pointing to it (same purpose as `graphite`)
+  * Verify ingestion: `curl -G "http://<influxdb-ip>:8086/query" --data-urlencode "db=centreon" --data-urlencode "q=SHOW MEASUREMENTS"`
+  * the two profiles are independent — enable `graphite`, `influxdb`, or both
 
 > [!NOTE]
 > docker image for `poller` service (`centreon-poller-alma9`) is built on centreon-collect repository<br/>

--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -81,9 +81,9 @@ Currently, the following profiles are available:
 * `mediawiki`: run a docker image of mediawiki (centreon configuration must be done manually)
 * `graphite`: run a Graphite (`graphite-statsd`) receiver and auto-configure a Centreon Broker Graphite output pointing to it — for testing the Broker output cache
   * the Broker output is configured automatically on startup, with macro-enriched naming `centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$`
-  * Verify ingestion: `curl "http://<graphite-ip>/render?target=centreon.metric.**&format=json"` — after a force check, the cache-resolved host/service names must appear in the received metric paths
+  * Verify ingestion (from the web container, using the service hostname): `docker compose exec web curl -s "http://graphite/render?target=centreon.metric.**&format=json"` — after a force check, the cache-resolved host/service names must appear in the received metric paths
 * `influxdb`: run an InfluxDB 1.8 receiver and auto-configure a Centreon Broker InfluxDB output pointing to it (same purpose as `graphite`)
-  * Verify ingestion: `curl -G "http://<influxdb-ip>:8086/query" --data-urlencode "db=centreon" --data-urlencode "q=SHOW MEASUREMENTS"`
+  * Verify ingestion: `docker compose exec web curl -s -G "http://influxdb:8086/query" --data-urlencode "db=centreon" --data-urlencode "q=SHOW MEASUREMENTS"`
   * the two profiles are independent — enable `graphite`, `influxdb`, or both
 
 > [!NOTE]

--- a/.github/docker/centreon-web/alma10/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma10/Dockerfile.dependencies
@@ -145,6 +145,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-gorgone-${MAJOR_VERSION}.${GORGONE_MINOR_VERSION} \
     centreon-engine-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-broker-cbd-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
+    centreon-broker-graphite-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
+    centreon-broker-influxdb-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-connector-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}
 else
   dnf install -y \
@@ -152,6 +154,8 @@ else
     centreon-gorgone \
     centreon-engine \
     centreon-broker-cbd \
+    centreon-broker-graphite \
+    centreon-broker-influxdb \
     centreon-connector
 fi
 

--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
@@ -10,60 +10,60 @@ PASS='Centreon!2021'
 
 api_token() {
   jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
-    | curl -s -d @- -L "${API}/login" | jq -r '.security.token'
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token // empty'
 }
 
-add_output() { # $1=token  $2=json payload
-  curl -s -o /dev/null -w '%{http_code}' \
+add_output() { # $1=token  $2=label  $3=json payload
+  code=$(curl -s -o /tmp/broker-output-resp -w '%{http_code}' \
     -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
-    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$2"
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
+  if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
+    echo "75-broker-outputs: $2 output created (HTTP ${code})"
+  else
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat /tmp/broker-output-resp 2>/dev/null)" >&2
+  fi
 }
 
-TOKEN=""
-configured=0
+graphite=false
+influxdb=false
+[ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}" >/dev/null && graphite=true
+[ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}" >/dev/null && influxdb=true
 
-if [ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}"; then
+if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
   TOKEN=$(api_token)
-  # $HOST$ / $SERVICE$ / ... are Broker naming macros kept literal; $host is the jq arg.
-  payload=$(jq -nc --arg host "${GRAPHITE_HOST}" '{
-    name: "graphite-output",
-    type: 30,
-    parameters: {
-      db_host: $host, db_port: 2003, db_user: "", db_password: "",
-      queries_per_transaction: 0,
-      metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
-      status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      filters_category: ["neb", "storage"]
-    }
-  }')
-  add_output "${TOKEN}" "${payload}"
-  configured=1
-fi
-
-if [ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}"; then
-  [ -z "${TOKEN}" ] && TOKEN=$(api_token)
-  payload=$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
-    name: "influxdb-output",
-    type: 31,
-    parameters: {
-      cache: "no",
-      db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
-      metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      metrics_column: [], status_column: [],
-      filters_category: ["neb", "storage"]
-    }
-  }')
-  add_output "${TOKEN}" "${payload}"
-  configured=1
-fi
-
-if [ "${configured}" -eq 1 ]; then
-  # Reload cbd so it picks up the new outputs. centengine is left as-is: its
-  # config is unchanged, and the container systemctl shim cannot restart it.
-  # Sourced by the entrypoint runner -> tolerate the shim's non-zero return.
-  sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
-  sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
-  systemctl restart cbd || true
+  if [ -z "${TOKEN}" ]; then
+    echo "75-broker-outputs: authentication failed, skipping broker output configuration" >&2
+  else
+    if [ "${graphite}" = true ]; then
+      add_output "${TOKEN}" graphite "$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+        name: "graphite-output", type: 30,
+        parameters: {
+          db_host: $host, db_port: 2003, db_user: "", db_password: "",
+          queries_per_transaction: 0,
+          metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+          status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    if [ "${influxdb}" = true ]; then
+      add_output "${TOKEN}" influxdb "$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+        name: "influxdb-output", type: 31,
+        parameters: {
+          cache: "no",
+          db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+          metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          metrics_column: [], status_column: [],
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+    # config is unchanged, and the container systemctl shim cannot restart it.
+    sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
+  fi
 fi
 :

--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
@@ -4,13 +4,13 @@
 # profile receivers, through the configuration REST API (the UI path): it sets
 # the event subscription (filters) and cache that the CLAPI path leaves unset.
 
-BROKER_ID=1
+BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
 API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
 PASS='Centreon!2021'
 
 api_token() {
-  curl -s -d "{\"security\":{\"credentials\":{\"login\":\"admin\",\"password\":\"${PASS}\"}}}" \
-    -L "${API}/login" | jq -r '.security.token'
+  jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token'
 }
 
 add_output() { # $1=token  $2=json payload

--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# Configure Broker Graphite/InfluxDB outputs toward the "graphite"/"influxdb"
+# profile receivers, through the configuration REST API (the UI path): it sets
+# the event subscription (filters) and cache that the CLAPI path leaves unset.
+
+BROKER_ID=1
+API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
+PASS='Centreon!2021'
+
+api_token() {
+  curl -s -d "{\"security\":{\"credentials\":{\"login\":\"admin\",\"password\":\"${PASS}\"}}}" \
+    -L "${API}/login" | jq -r '.security.token'
+}
+
+add_output() { # $1=token  $2=json payload
+  curl -s -o /dev/null -w '%{http_code}' \
+    -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$2"
+}
+
+TOKEN=""
+configured=0
+
+if [ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}"; then
+  TOKEN=$(api_token)
+  # $HOST$ / $SERVICE$ / ... are Broker naming macros kept literal; $host is the jq arg.
+  payload=$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+    name: "graphite-output",
+    type: 30,
+    parameters: {
+      db_host: $host, db_port: 2003, db_user: "", db_password: "",
+      queries_per_transaction: 0,
+      metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+      status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      filters_category: ["neb", "storage"]
+    }
+  }')
+  add_output "${TOKEN}" "${payload}"
+  configured=1
+fi
+
+if [ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}"; then
+  [ -z "${TOKEN}" ] && TOKEN=$(api_token)
+  payload=$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+    name: "influxdb-output",
+    type: 31,
+    parameters: {
+      cache: "no",
+      db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+      metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      metrics_column: [], status_column: [],
+      filters_category: ["neb", "storage"]
+    }
+  }')
+  add_output "${TOKEN}" "${payload}"
+  configured=1
+fi
+
+if [ "${configured}" -eq 1 ]; then
+  # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+  # config is unchanged, and the container systemctl shim cannot restart it.
+  # Sourced by the entrypoint runner -> tolerate the shim's non-zero return.
+  sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+  sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+  systemctl restart cbd || true
+fi
+:

--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
@@ -14,14 +14,16 @@ api_token() {
 }
 
 add_output() { # $1=token  $2=label  $3=json payload
-  code=$(curl -s -o /tmp/broker-output-resp -w '%{http_code}' \
+  resp=$(mktemp)
+  code=$(curl -s -o "${resp}" -w '%{http_code}' \
     -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
     -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
   if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
     echo "75-broker-outputs: $2 output created (HTTP ${code})"
   else
-    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat /tmp/broker-output-resp 2>/dev/null)" >&2
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat "${resp}" 2>/dev/null)" >&2
   fi
+  rm -f "${resp}"
 }
 
 graphite=false

--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/75-broker-outputs.sh
@@ -7,6 +7,7 @@
 BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
 API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
 PASS='Centreon!2021'
+WEB_USER=$(id apache >/dev/null 2>&1 && echo apache || echo www-data)  # apache on RHEL, www-data on Debian
 
 api_token() {
   jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
@@ -63,8 +64,8 @@ if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
     fi
     # Reload cbd so it picks up the new outputs. centengine is left as-is: its
     # config is unchanged, and the container systemctl shim cannot restart it.
-    sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
-    sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
     systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
   fi
 fi

--- a/.github/docker/centreon-web/alma9/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma9/Dockerfile.dependencies
@@ -149,6 +149,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-gorgone-${MAJOR_VERSION}.${GORGONE_MINOR_VERSION} \
     centreon-engine-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-broker-cbd-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
+    centreon-broker-graphite-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
+    centreon-broker-influxdb-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-connector-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}
 else
   dnf install -y \
@@ -156,6 +158,8 @@ else
     centreon-gorgone \
     centreon-engine \
     centreon-broker-cbd \
+    centreon-broker-graphite \
+    centreon-broker-influxdb \
     centreon-connector
 fi
 

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
@@ -10,60 +10,60 @@ PASS='Centreon!2021'
 
 api_token() {
   jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
-    | curl -s -d @- -L "${API}/login" | jq -r '.security.token'
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token // empty'
 }
 
-add_output() { # $1=token  $2=json payload
-  curl -s -o /dev/null -w '%{http_code}' \
+add_output() { # $1=token  $2=label  $3=json payload
+  code=$(curl -s -o /tmp/broker-output-resp -w '%{http_code}' \
     -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
-    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$2"
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
+  if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
+    echo "75-broker-outputs: $2 output created (HTTP ${code})"
+  else
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat /tmp/broker-output-resp 2>/dev/null)" >&2
+  fi
 }
 
-TOKEN=""
-configured=0
+graphite=false
+influxdb=false
+[ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}" >/dev/null && graphite=true
+[ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}" >/dev/null && influxdb=true
 
-if [ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}"; then
+if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
   TOKEN=$(api_token)
-  # $HOST$ / $SERVICE$ / ... are Broker naming macros kept literal; $host is the jq arg.
-  payload=$(jq -nc --arg host "${GRAPHITE_HOST}" '{
-    name: "graphite-output",
-    type: 30,
-    parameters: {
-      db_host: $host, db_port: 2003, db_user: "", db_password: "",
-      queries_per_transaction: 0,
-      metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
-      status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      filters_category: ["neb", "storage"]
-    }
-  }')
-  add_output "${TOKEN}" "${payload}"
-  configured=1
-fi
-
-if [ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}"; then
-  [ -z "${TOKEN}" ] && TOKEN=$(api_token)
-  payload=$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
-    name: "influxdb-output",
-    type: 31,
-    parameters: {
-      cache: "no",
-      db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
-      metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      metrics_column: [], status_column: [],
-      filters_category: ["neb", "storage"]
-    }
-  }')
-  add_output "${TOKEN}" "${payload}"
-  configured=1
-fi
-
-if [ "${configured}" -eq 1 ]; then
-  # Reload cbd so it picks up the new outputs. centengine is left as-is: its
-  # config is unchanged, and the container systemctl shim cannot restart it.
-  # Sourced by the entrypoint runner -> tolerate the shim's non-zero return.
-  sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
-  sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
-  systemctl restart cbd || true
+  if [ -z "${TOKEN}" ]; then
+    echo "75-broker-outputs: authentication failed, skipping broker output configuration" >&2
+  else
+    if [ "${graphite}" = true ]; then
+      add_output "${TOKEN}" graphite "$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+        name: "graphite-output", type: 30,
+        parameters: {
+          db_host: $host, db_port: 2003, db_user: "", db_password: "",
+          queries_per_transaction: 0,
+          metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+          status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    if [ "${influxdb}" = true ]; then
+      add_output "${TOKEN}" influxdb "$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+        name: "influxdb-output", type: 31,
+        parameters: {
+          cache: "no",
+          db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+          metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          metrics_column: [], status_column: [],
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+    # config is unchanged, and the container systemctl shim cannot restart it.
+    sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
+  fi
 fi
 :

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
@@ -4,13 +4,13 @@
 # profile receivers, through the configuration REST API (the UI path): it sets
 # the event subscription (filters) and cache that the CLAPI path leaves unset.
 
-BROKER_ID=1
+BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
 API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
 PASS='Centreon!2021'
 
 api_token() {
-  curl -s -d "{\"security\":{\"credentials\":{\"login\":\"admin\",\"password\":\"${PASS}\"}}}" \
-    -L "${API}/login" | jq -r '.security.token'
+  jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token'
 }
 
 add_output() { # $1=token  $2=json payload

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# Configure Broker Graphite/InfluxDB outputs toward the "graphite"/"influxdb"
+# profile receivers, through the configuration REST API (the UI path): it sets
+# the event subscription (filters) and cache that the CLAPI path leaves unset.
+
+BROKER_ID=1
+API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
+PASS='Centreon!2021'
+
+api_token() {
+  curl -s -d "{\"security\":{\"credentials\":{\"login\":\"admin\",\"password\":\"${PASS}\"}}}" \
+    -L "${API}/login" | jq -r '.security.token'
+}
+
+add_output() { # $1=token  $2=json payload
+  curl -s -o /dev/null -w '%{http_code}' \
+    -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$2"
+}
+
+TOKEN=""
+configured=0
+
+if [ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}"; then
+  TOKEN=$(api_token)
+  # $HOST$ / $SERVICE$ / ... are Broker naming macros kept literal; $host is the jq arg.
+  payload=$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+    name: "graphite-output",
+    type: 30,
+    parameters: {
+      db_host: $host, db_port: 2003, db_user: "", db_password: "",
+      queries_per_transaction: 0,
+      metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+      status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      filters_category: ["neb", "storage"]
+    }
+  }')
+  add_output "${TOKEN}" "${payload}"
+  configured=1
+fi
+
+if [ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}"; then
+  [ -z "${TOKEN}" ] && TOKEN=$(api_token)
+  payload=$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+    name: "influxdb-output",
+    type: 31,
+    parameters: {
+      cache: "no",
+      db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+      metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      metrics_column: [], status_column: [],
+      filters_category: ["neb", "storage"]
+    }
+  }')
+  add_output "${TOKEN}" "${payload}"
+  configured=1
+fi
+
+if [ "${configured}" -eq 1 ]; then
+  # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+  # config is unchanged, and the container systemctl shim cannot restart it.
+  # Sourced by the entrypoint runner -> tolerate the shim's non-zero return.
+  sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+  sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+  systemctl restart cbd || true
+fi
+:

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
@@ -14,14 +14,16 @@ api_token() {
 }
 
 add_output() { # $1=token  $2=label  $3=json payload
-  code=$(curl -s -o /tmp/broker-output-resp -w '%{http_code}' \
+  resp=$(mktemp)
+  code=$(curl -s -o "${resp}" -w '%{http_code}' \
     -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
     -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
   if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
     echo "75-broker-outputs: $2 output created (HTTP ${code})"
   else
-    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat /tmp/broker-output-resp 2>/dev/null)" >&2
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat "${resp}" 2>/dev/null)" >&2
   fi
+  rm -f "${resp}"
 }
 
 graphite=false

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
@@ -7,6 +7,7 @@
 BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
 API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
 PASS='Centreon!2021'
+WEB_USER=$(id apache >/dev/null 2>&1 && echo apache || echo www-data)  # apache on RHEL, www-data on Debian
 
 api_token() {
   jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
@@ -63,8 +64,8 @@ if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
     fi
     # Reload cbd so it picks up the new outputs. centengine is left as-is: its
     # config is unchanged, and the container systemctl shim cannot restart it.
-    sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
-    sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
     systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
   fi
 fi

--- a/.github/docker/centreon-web/trixie/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/trixie/Dockerfile.dependencies
@@ -162,6 +162,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-broker=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-broker-graphite=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
+    centreon-broker-influxdb=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-connector-perl=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-connector-ssh=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1 \
     centreon-connector=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb13u1
@@ -171,6 +173,8 @@ else
     centreon-gorgone \
     centreon-engine \
     centreon-broker-cbd \
+    centreon-broker-graphite \
+    centreon-broker-influxdb \
     centreon-connector
 fi
 

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
@@ -10,60 +10,60 @@ PASS='Centreon!2021'
 
 api_token() {
   jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
-    | curl -s -d @- -L "${API}/login" | jq -r '.security.token'
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token // empty'
 }
 
-add_output() { # $1=token  $2=json payload
-  curl -s -o /dev/null -w '%{http_code}' \
+add_output() { # $1=token  $2=label  $3=json payload
+  code=$(curl -s -o /tmp/broker-output-resp -w '%{http_code}' \
     -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
-    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$2"
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
+  if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
+    echo "75-broker-outputs: $2 output created (HTTP ${code})"
+  else
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat /tmp/broker-output-resp 2>/dev/null)" >&2
+  fi
 }
 
-TOKEN=""
-configured=0
+graphite=false
+influxdb=false
+[ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}" >/dev/null && graphite=true
+[ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}" >/dev/null && influxdb=true
 
-if [ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}"; then
+if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
   TOKEN=$(api_token)
-  # $HOST$ / $SERVICE$ / ... are Broker naming macros kept literal; $host is the jq arg.
-  payload=$(jq -nc --arg host "${GRAPHITE_HOST}" '{
-    name: "graphite-output",
-    type: 30,
-    parameters: {
-      db_host: $host, db_port: 2003, db_user: "", db_password: "",
-      queries_per_transaction: 0,
-      metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
-      status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      filters_category: ["neb", "storage"]
-    }
-  }')
-  add_output "${TOKEN}" "${payload}"
-  configured=1
-fi
-
-if [ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}"; then
-  [ -z "${TOKEN}" ] && TOKEN=$(api_token)
-  payload=$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
-    name: "influxdb-output",
-    type: 31,
-    parameters: {
-      cache: "no",
-      db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
-      metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
-      metrics_column: [], status_column: [],
-      filters_category: ["neb", "storage"]
-    }
-  }')
-  add_output "${TOKEN}" "${payload}"
-  configured=1
-fi
-
-if [ "${configured}" -eq 1 ]; then
-  # Reload cbd so it picks up the new outputs. centengine is left as-is: its
-  # config is unchanged, and the container systemctl shim cannot restart it.
-  # Sourced by the entrypoint runner -> tolerate the shim's non-zero return.
-  sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
-  sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
-  systemctl restart cbd || true
+  if [ -z "${TOKEN}" ]; then
+    echo "75-broker-outputs: authentication failed, skipping broker output configuration" >&2
+  else
+    if [ "${graphite}" = true ]; then
+      add_output "${TOKEN}" graphite "$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+        name: "graphite-output", type: 30,
+        parameters: {
+          db_host: $host, db_port: 2003, db_user: "", db_password: "",
+          queries_per_transaction: 0,
+          metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+          status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    if [ "${influxdb}" = true ]; then
+      add_output "${TOKEN}" influxdb "$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+        name: "influxdb-output", type: 31,
+        parameters: {
+          cache: "no",
+          db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+          metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          metrics_column: [], status_column: [],
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+    # config is unchanged, and the container systemctl shim cannot restart it.
+    sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
+  fi
 fi
 :

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
@@ -4,13 +4,13 @@
 # profile receivers, through the configuration REST API (the UI path): it sets
 # the event subscription (filters) and cache that the CLAPI path leaves unset.
 
-BROKER_ID=1
+BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
 API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
 PASS='Centreon!2021'
 
 api_token() {
-  curl -s -d "{\"security\":{\"credentials\":{\"login\":\"admin\",\"password\":\"${PASS}\"}}}" \
-    -L "${API}/login" | jq -r '.security.token'
+  jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token'
 }
 
 add_output() { # $1=token  $2=json payload

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# Configure Broker Graphite/InfluxDB outputs toward the "graphite"/"influxdb"
+# profile receivers, through the configuration REST API (the UI path): it sets
+# the event subscription (filters) and cache that the CLAPI path leaves unset.
+
+BROKER_ID=1
+API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
+PASS='Centreon!2021'
+
+api_token() {
+  curl -s -d "{\"security\":{\"credentials\":{\"login\":\"admin\",\"password\":\"${PASS}\"}}}" \
+    -L "${API}/login" | jq -r '.security.token'
+}
+
+add_output() { # $1=token  $2=json payload
+  curl -s -o /dev/null -w '%{http_code}' \
+    -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$2"
+}
+
+TOKEN=""
+configured=0
+
+if [ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}"; then
+  TOKEN=$(api_token)
+  # $HOST$ / $SERVICE$ / ... are Broker naming macros kept literal; $host is the jq arg.
+  payload=$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+    name: "graphite-output",
+    type: 30,
+    parameters: {
+      db_host: $host, db_port: 2003, db_user: "", db_password: "",
+      queries_per_transaction: 0,
+      metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+      status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      filters_category: ["neb", "storage"]
+    }
+  }')
+  add_output "${TOKEN}" "${payload}"
+  configured=1
+fi
+
+if [ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}"; then
+  [ -z "${TOKEN}" ] && TOKEN=$(api_token)
+  payload=$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+    name: "influxdb-output",
+    type: 31,
+    parameters: {
+      cache: "no",
+      db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+      metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+      metrics_column: [], status_column: [],
+      filters_category: ["neb", "storage"]
+    }
+  }')
+  add_output "${TOKEN}" "${payload}"
+  configured=1
+fi
+
+if [ "${configured}" -eq 1 ]; then
+  # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+  # config is unchanged, and the container systemctl shim cannot restart it.
+  # Sourced by the entrypoint runner -> tolerate the shim's non-zero return.
+  sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+  sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+  systemctl restart cbd || true
+fi
+:

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
@@ -14,14 +14,16 @@ api_token() {
 }
 
 add_output() { # $1=token  $2=label  $3=json payload
-  code=$(curl -s -o /tmp/broker-output-resp -w '%{http_code}' \
+  resp=$(mktemp)
+  code=$(curl -s -o "${resp}" -w '%{http_code}' \
     -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
     -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
   if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
     echo "75-broker-outputs: $2 output created (HTTP ${code})"
   else
-    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat /tmp/broker-output-resp 2>/dev/null)" >&2
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat "${resp}" 2>/dev/null)" >&2
   fi
+  rm -f "${resp}"
 }
 
 graphite=false

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/75-broker-outputs.sh
@@ -7,6 +7,7 @@
 BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
 API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
 PASS='Centreon!2021'
+WEB_USER=$(id apache >/dev/null 2>&1 && echo apache || echo www-data)  # apache on RHEL, www-data on Debian
 
 api_token() {
   jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
@@ -63,8 +64,8 @@ if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
     fi
     # Reload cbd so it picks up the new outputs. centengine is left as-is: its
     # config is unchanged, and the container systemctl shim cannot restart it.
-    sudo -u apache centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
-    sudo -u apache centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
     systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
   fi
 fi

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -102,7 +102,7 @@ services:
   # InfluxDB 1.8 speaks the 1.x line protocol the Broker output uses; INFLUXDB_DB
   # pre-creates the target db.
   graphite:
-    image: "${GRAPHITE_IMAGE:-graphiteapp/graphite-statsd:latest}"
+    image: "${GRAPHITE_IMAGE:-graphiteapp/graphite-statsd:1.1.10-5}"
     ports: ["2003", "80"]
     profiles: ["graphite"]
 

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       OPENID_HOST: sso-proxy
       SAML_HOST: saml
       LDAP_HOST: openldap
+      GRAPHITE_HOST: graphite
+      INFLUXDB_HOST: influxdb
       CENTREON_DATASET: ${CENTREON_DATASET:-1}
       CENTREON_LANG: ${CENTREON_LANG:-en_US}
       DATABASE_PARTITIONING: ${DATABASE_PARTITIONING:-1}
@@ -95,6 +97,21 @@ services:
     image: "${LDAP_IMAGE:-ghcr.io/centreon/centreon/ldap:26.05}"
     ports: ["389"]
     profiles: ["openldap", "ldap"]
+
+  # Receivers for the Broker outputs (independent "graphite"/"influxdb" profiles).
+  # InfluxDB 1.8 speaks the 1.x line protocol the Broker output uses; INFLUXDB_DB
+  # pre-creates the target db.
+  graphite:
+    image: "${GRAPHITE_IMAGE:-graphiteapp/graphite-statsd:latest}"
+    ports: ["2003", "80"]
+    profiles: ["graphite"]
+
+  influxdb:
+    image: "${INFLUXDB_IMAGE:-influxdb:1.8}"
+    environment:
+      INFLUXDB_DB: centreon
+    ports: ["8086"]
+    profiles: ["influxdb"]
 
   squid-simple:
     image: docker.centreon.com/centreon/mon-squid-simple:latest


### PR DESCRIPTION
Add two independent docker-compose profiles, `graphite` and `influxdb`, to the test environment, to exercise the Centreon Broker Graphite/InfluxDB outputs against real receivers (Graphite `graphite-statsd`, InfluxDB 1.8).

## What it does

- Enabling `--profile graphite` and/or `--profile influxdb` starts the matching receiver and auto-configures the corresponding Broker output on web startup.
- The output is created through the configuration REST API (`POST /configuration/broker/{id}/outputs`) — the same path the UI uses — so it gets the event subscription (`filters_category`) and `cache` settings that a CLAPI `ADDOUTPUT` leaves unset (without which Broker never routes events to the output).
- Naming uses the cache macros (`$INSTANCE$`, `$HOST$`, `$SERVICE$`, `$SERV_TAG_CAT_NAME$`, `$METRIC$`) so the cache-resolved identity is observable on the receiver side.
- The two profiles are independent (one without the other, or both).

## Image change

The graphite/influxdb Broker output modules are not shipped in the base image; they are added to `Dockerfile.dependencies` so they install at build time, version-consistent with `broker-core` and `engine`. They stay dormant unless an output of that type is configured.

## Verification

Locally validated end to end: outputs auto-created at startup, Graphite ingests metrics with resolved macros, InfluxDB receives writes.

- Graphite: `curl "http://<graphite-ip>/render?target=centreon.metric.**&format=json"`
- InfluxDB: `curl -G "http://<influxdb-ip>:8086/query" --data-urlencode "db=centreon" --data-urlencode "q=SHOW MEASUREMENTS"`

Refs: MON-197673