### PR TITLE
fix(knowledge): update query builders and enforce TLS

### DIFF
--- a/centreon/www/class/centreon-knowledge/procedures.class.php
+++ b/centreon/www/class/centreon-knowledge/procedures.class.php
@@ -19,6 +19,9 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 define('PROCEDURE_SIMPLE_MODE', 0);
 define('PROCEDURE_INHERITANCE_MODE', 1);
 require_once _CENTREON_PATH_ . '/www/class/centreon-knowledge/wikiApi.class.php';
@@ -84,31 +87,27 @@ class procedures
     {
         $tplArr = [];
 
-        $dbResult = $this->centreon_DB->query(
-            'SELECT service_description, service_template_model_stm_id '
+        $query = 'SELECT service_description, service_template_model_stm_id '
             . 'FROM service '
-            . "WHERE service_id = '" . $service_id . "' LIMIT 1"
+            . 'WHERE service_id = :service_id LIMIT 1';
+        $row = $this->centreon_DB->fetchAssociative(
+            $query,
+            QueryParameters::create([QueryParameter::int('service_id', (int) $service_id)])
         );
-        $row = $dbResult->fetch();
-        if (isset($row['service_template_model_stm_id']) && $row['service_template_model_stm_id'] != '') {
-            $dbResult->closeCursor();
+        if ($row !== false && isset($row['service_template_model_stm_id']) && $row['service_template_model_stm_id'] != '') {
             $service_id = $row['service_template_model_stm_id'];
             if ($row['service_description']) {
                 $tplArr[$service_id] = html_entity_decode($row['service_description'], ENT_QUOTES);
             }
             while (1) {
-                $dbResult = $this->centreon_DB->query(
-                    'SELECT service_description, service_template_model_stm_id '
-                    . 'FROM service '
-                    . "WHERE service_id = '" . $service_id . "' LIMIT 1"
+                $row = $this->centreon_DB->fetchAssociative(
+                    $query,
+                    QueryParameters::create([QueryParameter::int('service_id', (int) $service_id)])
                 );
-                $row = $dbResult->fetch();
-                $dbResult->closeCursor();
-                if ($row['service_description']) {
-                    $tplArr[$service_id] = html_entity_decode($row['service_description'], ENT_QUOTES);
-                } else {
+                if ($row === false || ! $row['service_description']) {
                     break;
                 }
+                $tplArr[$service_id] = html_entity_decode($row['service_description'], ENT_QUOTES);
                 if ($row['service_template_model_stm_id']) {
                     $service_id = $row['service_template_model_stm_id'];
                 } else {
@@ -135,24 +134,23 @@ class procedures
         }
 
         $tplArr = [];
-        $dbResult = $this->centreon_DB->query(
+        $templateRelations = $this->centreon_DB->fetchAllAssociative(
             'SELECT host_tpl_id '
             . 'FROM `host_template_relation` '
-            . "WHERE host_host_id = '" . $host_id . "' "
-            . 'ORDER BY `order`'
+            . 'WHERE host_host_id = :host_id '
+            . 'ORDER BY `order`',
+            QueryParameters::create([QueryParameter::int('host_id', (int) $host_id)])
         );
-        $statement = $this->centreon_DB->prepare(
-            'SELECT host_name '
-            . 'FROM host '
-            . 'WHERE host_id = :host_id LIMIT 1'
-        );
-        while ($row = $dbResult->fetch()) {
-            $statement->bindValue(':host_id', $row['host_tpl_id'], PDO::PARAM_INT);
-            $statement->execute();
-            $hTpl = $statement->fetch(PDO::FETCH_ASSOC);
-            $tplArr[$row['host_tpl_id']] = html_entity_decode($hTpl['host_name'], ENT_QUOTES);
+        $hostNameQuery = 'SELECT host_name FROM host WHERE host_id = :host_id LIMIT 1';
+        foreach ($templateRelations as $row) {
+            $hTpl = $this->centreon_DB->fetchAssociative(
+                $hostNameQuery,
+                QueryParameters::create([QueryParameter::int('host_id', (int) $row['host_tpl_id'])])
+            );
+            if ($hTpl !== false) {
+                $tplArr[$row['host_tpl_id']] = html_entity_decode($hTpl['host_name'], ENT_QUOTES);
+            }
         }
-        unset($row, $hTpl);
 
         return $tplArr;
     }

--- a/centreon/www/class/centreon-knowledge/wikiApi.class.php
+++ b/centreon/www/class/centreon-knowledge/wikiApi.class.php
@@ -19,6 +19,9 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 require_once realpath(__DIR__ . '/../../../config/centreon.config.php');
 require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreon-knowledge/wiki.class.php';
@@ -62,9 +65,6 @@ class WikiApi
     /** @var array */
     private $tokens;
 
-    /** @var mixed */
-    private $noSslCertificate;
-
     /**
      * WikiApi constructor.
      */
@@ -76,7 +76,6 @@ class WikiApi
         $this->url = $config['kb_wiki_url'] . '/api.php';
         $this->username = $config['kb_wiki_account'];
         $this->password = $config['kb_wiki_password'];
-        $this->noSslCertificate = $config['kb_wiki_certificate'];
         $this->curl = $this->getCurl();
         $this->version = $this->getWikiVersion();
     }
@@ -381,22 +380,22 @@ class WikiApi
      */
     public function updateLinkForHost($hostName): void
     {
-        $resHost = $this->db->query(
-            "SELECT host_id FROM host WHERE host_name LIKE '" . $hostName . "'"
+        $hostRow = $this->db->fetchAssociative(
+            'SELECT host_id FROM host WHERE host_name LIKE :hostName',
+            QueryParameters::create([QueryParameter::string('hostName', $hostName)])
         );
-
-        $hostRow = $resHost->fetch();
 
         if ($hostRow !== false) {
             $url = self::PROXY_URL . '?host_name=$HOSTNAME$';
-            $statement = $this->db->prepare(
+            $this->db->executeStatement(
                 'UPDATE extended_host_information '
                 . 'SET ehi_notes_url = :url '
-                . 'WHERE host_host_id = :hostId'
+                . 'WHERE host_host_id = :hostId',
+                QueryParameters::create([
+                    QueryParameter::string('url', $url),
+                    QueryParameter::int('hostId', (int) $hostRow['host_id']),
+                ])
             );
-            $statement->bindValue(':url', $url, PDO::PARAM_STR);
-            $statement->bindValue(':hostId', $hostRow['host_id'], PDO::PARAM_INT);
-            $statement->execute();
         }
     }
 
@@ -408,26 +407,30 @@ class WikiApi
      */
     public function updateLinkForService($hostName, $serviceDescription): void
     {
-        $resService = $this->db->query(
+        $serviceRow = $this->db->fetchAssociative(
             'SELECT service_id '
             . 'FROM service, host, host_service_relation '
-            . "WHERE host.host_name LIKE '" . $hostName . "' "
-            . "AND service.service_description LIKE '" . $serviceDescription . "' "
+            . 'WHERE host.host_name LIKE :hostName '
+            . 'AND service.service_description LIKE :serviceDescription '
             . 'AND host_service_relation.host_host_id = host.host_id '
-            . 'AND host_service_relation.service_service_id = service.service_id '
+            . 'AND host_service_relation.service_service_id = service.service_id ',
+            QueryParameters::create([
+                QueryParameter::string('hostName', $hostName),
+                QueryParameter::string('serviceDescription', $serviceDescription),
+            ])
         );
-        $serviceRow = $resService->fetch();
 
         if ($serviceRow !== false) {
             $url = self::PROXY_URL . '?host_name=$HOSTNAME$&service_description=$SERVICEDESC$';
-            $statement = $this->db->prepare(
+            $this->db->executeStatement(
                 'UPDATE extended_service_information '
                 . 'SET esi_notes_url = :url '
-                . 'WHERE service_service_id = :serviceId'
+                . 'WHERE service_service_id = :serviceId',
+                QueryParameters::create([
+                    QueryParameter::string('url', $url),
+                    QueryParameter::int('serviceId', (int) $serviceRow['service_id']),
+                ])
             );
-            $statement->bindValue(':url', $url, PDO::PARAM_STR);
-            $statement->bindValue(':serviceId', $serviceRow['service_id'], PDO::PARAM_INT);
-            $statement->execute();
         }
     }
 
@@ -438,22 +441,23 @@ class WikiApi
      */
     public function updateLinkForServiceTemplate($serviceName): void
     {
-        $resService = $this->db->query(
+        $serviceTemplateRow = $this->db->fetchAssociative(
             'SELECT service_id FROM service '
-            . "WHERE service_description LIKE '" . $serviceName . "' "
+            . 'WHERE service_description LIKE :serviceName ',
+            QueryParameters::create([QueryParameter::string('serviceName', $serviceName)])
         );
-        $serviceTemplateRow = $resService->fetch();
 
         if ($serviceTemplateRow !== false) {
             $url = self::PROXY_URL . '?host_name=$HOSTNAME$&service_description=$SERVICEDESC$';
-            $statement = $this->db->prepare(
+            $this->db->executeStatement(
                 'UPDATE extended_service_information '
                 . 'SET esi_notes_url = :url '
-                . 'WHERE service_service_id = :serviceId'
+                . 'WHERE service_service_id = :serviceId',
+                QueryParameters::create([
+                    QueryParameter::string('url', $url),
+                    QueryParameter::int('serviceId', (int) $serviceTemplateRow['service_id']),
+                ])
             );
-            $statement->bindValue(':url', $url, PDO::PARAM_STR);
-            $statement->bindValue(':serviceId', $serviceTemplateRow['service_id'], PDO::PARAM_INT);
-            $statement->execute();
         }
     }
 
@@ -467,10 +471,6 @@ class WikiApi
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_POST, true);
         curl_setopt($curl, CURLOPT_COOKIEFILE, '');
-        if ($this->noSslCertificate == 1) {
-            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-            curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
-        }
 
         return $curl;
     }

--- a/centreon/www/include/configuration/configKnowledge/display-services.php
+++ b/centreon/www/include/configuration/configKnowledge/display-services.php
@@ -32,17 +32,15 @@ if (! isset($limit) || (int) $limit < 0) {
     $limit = $centreon->optGen['maxViewConfiguration'];
 }
 
+$allowedOrders = ['ASC' => 'ASC', 'DESC' => 'DESC'];
+$allowedOrderColumns = ['host_name' => 'host_name', 'service_description' => 'service_description'];
+
 $order = 'ASC';
 $orderBy = 'host_name';
 
-// Use whitelist as we can't bind ORDER BY values
 if (! empty($_POST['order']) && ! empty($_POST['orderby'])) {
-    if (in_array($_POST['order'], ['ASC', 'DESC'])) {
-        $order = $_POST['order'];
-    }
-    if (in_array($_POST['orderby'], ['host_name', 'service_description'])) {
-        $orderBy = $_POST['orderby'];
-    }
+    $order = $allowedOrders[$_POST['order']] ?? 'ASC';
+    $orderBy = $allowedOrderColumns[$_POST['orderby']] ?? 'host_name';
 }
 
 require_once './include/common/autoNumLimit.php';


### PR DESCRIPTION
## Description

Migrate unprepared SQL queries to the ConnectionInterface API (fetchAssociative / executeStatement / QueryParameters) in the Knowledge Base integration files, and remove the option to disable TLS certificate verification on the MediaWiki cURL connection.

Backport of #10756

Fixes: MON-201974

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

- Configure a MediaWiki Knowledge Base integration (Administration > Parameters > Knowledge Base)
- Navigate to Configuration > Knowledge Base > Services
- Verify the listing loads correctly with sorting (host_name / service_description, ASC / DESC)
- Trigger a synchronization and verify host/service/service-template wiki links are updated correctly
- If MediaWiki uses HTTPS, verify the connection enforces TLS certificate validation

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).