### PR TITLE
fix(routing): use errors.php for dev error route after Symfony 8.1 upgrade

### DIFF
--- a/centreon/config.new/routes/framework.yaml
+++ b/centreon/config.new/routes/framework.yaml
@@ -1,4 +1,4 @@
 when@dev:
     _errors:
-        resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+        resource: '@FrameworkBundle/Resources/config/routing/errors.php'
         prefix: /_error


### PR DESCRIPTION
## Description

Fixes: [MON-197579](https://centreon.atlassian.net/browse/MON-197579)

The Symfony 7.4 → 8.1 upgrade (#10672) bumped `symfony/framework-bundle` to 8.1.0, which removed `Resources/config/routing/errors.xml` in favor of `errors.php`. The dev-only error route in `config.new/routes/framework.yaml` still referenced the deleted `.xml` file.

Under `APP_ENV=dev`, Symfony loads the `when@dev` block, fails to resolve the resource, and **every** request returns HTTP 500. Users on the default `APP_ENV=prod` are unaffected.


[MON-197579]: https://centreon.atlassian.net/browse/MON-197579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ