### PR TITLE
fix: rspack 2 lazy compilation and shared tree-shaking regressions

### DIFF
--- a/centreon/packages/js-config/rspack/base/index.js
+++ b/centreon/packages/js-config/rspack/base/index.js
@@ -46,6 +46,7 @@ const getBaseConfiguration = ({
     moduleName &&
     new rspack.container.ModuleFederationPlugin({
       filename: 'remoteEntry.[chunkhash:8].js',
+      injectTreeShakingUsedExports: false,
       library: { name: moduleName, type: 'umd' },
       name: moduleName,
       shared: [

--- a/centreon/packages/js-config/rspack/patch/dev.js
+++ b/centreon/packages/js-config/rspack/patch/dev.js
@@ -2,6 +2,7 @@ module.exports = {
 	getDevConfiguration: () => ({
 		cache: true,
 		devtool: "eval-cheap-module-source-map",
+		lazyCompilation: false,
 		optimization: {
 			splitChunks: false,
 		},


### PR DESCRIPTION
Following the upgrade to Rspack 2 (#10817), two regressions broke pages when a module built with Rspack 1 is installed (e.g. BAM):

- **Extension manager crash** — `(0, a.default) is not a function` in `@mui/system`. Rspack 2's Module Federation shared-dependency tree-shaking pruned the `default` re-export of MUI when an Rspack 1 remote was federated into the Rspack 2 host. Disabled via `injectTreeShakingUsedExports: false`.
- **No access to the UI** — `Problem communicating active modules to the server: HTTP 404` on `/_rspack/lazy/trigger`. The Rspack 2 CLI auto-enables top-level `lazyCompilation` for web-only apps; since the bundle is served cross-origin through the Centreon backend, the lazy trigger endpoint is unreachable. Disabled via top-level `lazyCompilation: false` (dev only).

These tests passed on #10817 because the Cypress config strips `ModuleFederationPlugin`, so neither the federated-remote nor the cross-origin serving scenario is exercised in CI.
