### PR TITLE
fix(logging): tech-debt follow-ups for the structured upgrade logging flow

### DIFF
--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -904,7 +904,7 @@ use Adaptation\Log\LoggerUpgrade;
 LoggerUpgrade::create()->info($version, "Adding column X to table Y");
 LoggerUpgrade::create()->error($version, "Schema check failed", $exception);
 
-LoggerUpgrade::create()->stepFailure($message, $version, $stepName, $exception);
+LoggerUpgrade::create()->stepFailure($version, $stepName, $message, $exception);
 LoggerUpgrade::create()->step($version, $stepName, $message);
 ```
 
@@ -912,21 +912,21 @@ LoggerUpgrade::create()->step($version, $stepName, $message);
 |---|---|---|
 | `start($from, $to)` | `INFO` | Begin of the global upgrade flow (emitted by `UpdateCommandHandler` / `process_step4.php`, **not** by individual scripts). |
 | `success($from, $to, $durationMs)` | `INFO` | End of the global upgrade flow, with measured duration. |
-| `failure($message, $from, $to, $e)` | `ERROR` | Global upgrade aborted (catch-all in the handler). |
+| `failure($from, $to, $message, $e)` | `ERROR` | Global upgrade aborted (catch-all in the handler). Emitted only once `start` has been emitted, so the lifecycle stays balanced; a failure raised **before** `start` (validation / lock / version read) is reported as an `upgrade.error` instead, never a dangling `failure`. |
 | `step($version, $stepName, $message)` | `INFO` | Sub-step **start** / progress (`monitoring_sql`, `php_script`, …). `status: running`. Emitted by the repositories; rarely needed inside an upgrade script. |
 | `stepCompleted($version, $stepName, $durationMs, $message)` | `INFO` | Sub-step **completion**. `status: completed`, carries `duration_ms` in the context (not just the message), so completed steps are queryable without parsing text. |
-| `stepFailure($message, $version, $stepName, $e)` | `ERROR` | A bracketed step threw. Primarily emitted by the repositories / handler; also used inside an upgrade script's catch block with the `php_script` step name (or `php_script_rollback` when the rollback itself fails). |
+| `stepFailure($version, $stepName, $message, $e)` | `ERROR` | A bracketed step threw. Emitted by the step bracket itself (e.g. `UpdateCommandHandler::runStep`, `DbWriteUpdateRepository::executeStep`, or `process_step5.php` for `post_update`). An upgrade script must **not** re-emit it for `php_script` (the bracket already logs the re-thrown exception); a script only emits it for `php_script_rollback`, when the rollback itself fails. |
 | **`info($version, $message)`** | `INFO` | **Trace a meaningful action** (entering a function, finished an `ALTER TABLE`, skipped because already migrated, …). This is the workhorse inside upgrade scripts. |
 | **`error($version, $message, $e)`** | `ERROR` | Free-form error inside a script that you choose not to re-throw (rare — usually you re-throw and let the surrounding `try/catch` call `stepFailure`). |
 
 ### Recommended pattern
 
-Copy `www/install/php/Update-next.php.tpl` — it is the canonical skeleton and is kept in sync with the flow. Its shape:
+Start from `www/install/php/Update-next.php.tpl` — the canonical skeleton, kept in sync with the flow (its `try/catch`, transaction guard and rollback handling are ready to use). It is intentionally a bare skeleton; for a complete worked example of the points below, read the latest shipped script, e.g. `www/install/php/Update-26.07.0.php`. The shape:
 
-- **Wrap each business action in its own callable** and set `$errorMessage` to a human description **before** running it, so the catch-all `stepFailure` reports which action failed.
+- **Wrap each business action in its own callable** and set `$errorMessage` to a human description **before** running it — including immediately before `startTransaction()` and `commitTransaction()`, which are themselves distinct actions — so the final failure message reports which action actually failed.
 - **Trace intent and outcome** with `info($version, …)`; log skip branches too — they prove the script is safely re-entrant.
 - **Run DML inside a transaction** guarded by `isTransactionActive()`, and log "Rolling back…" only inside the `if` that actually rolls back.
-- **On failure, call `stepFailure(...)`** with the `php_script` step name (`php_script_rollback` if the rollback itself fails), then **re-throw**: the global flow (`UpdateCommandHandler` / `process_step4.php`) catches it and writes the final `failure`. A silent return breaks that chain.
+- **On failure, just re-throw**, chaining the root cause as `previous`. The surrounding step bracket (`UpdateCommandHandler::runStep` / `DbWriteUpdateRepository::executeStep`) already logs the `php_script` `stepFailure` from the re-thrown exception, and the global flow (`UpdateCommandHandler` / `process_step4.php`) then writes the final `failure`. Do **not** emit a `php_script` `stepFailure` from the script — that double-logs the step. The only `stepFailure` a script emits itself is `php_script_rollback`, when the rollback fails. A silent return breaks the chain.
 
 ### Sample output (`prod.upgrade.log`)
 
@@ -943,7 +943,7 @@ upgrade.INFO: Upgrade from 25.10.0 to 25.11.0 completed successfully
   {"event":"upgrade.success","status":"success","from_version":"25.10.0","to_version":"25.11.0","duration_ms":4242}
 ```
 
-On failure, the failing action writes `upgrade.step_failure` (ERROR) and the global flow writes a final `upgrade.failure` carrying the from→to versions and the wrapped exception.
+On failure, the step bracket writes `upgrade.step_failure` (ERROR) and the global flow writes a final `upgrade.failure` carrying the from→to versions and the wrapped exception.
 
 ### Best practices
 

--- a/centreon/src/Adaptation/Log/LoggerUpgrade.php
+++ b/centreon/src/Adaptation/Log/LoggerUpgrade.php
@@ -61,9 +61,9 @@ final class LoggerUpgrade
     }
 
     public function failure(
-        string $message,
         ?string $fromVersion,
         ?string $toVersion,
+        string $message,
         ?\Throwable $exception = null,
     ): void {
         $this->write(
@@ -99,9 +99,9 @@ final class LoggerUpgrade
     }
 
     public function stepFailure(
-        string $message,
         string $version,
         string $stepName,
+        string $message,
         ?\Throwable $exception = null,
     ): void {
         $context = $this->versionContext('upgrade.step_failure', 'failure', $version, $exception);

--- a/centreon/src/App/Upgrade/Application/Command/UpdateCommandHandler.php
+++ b/centreon/src/App/Upgrade/Application/Command/UpdateCommandHandler.php
@@ -58,6 +58,7 @@ final readonly class UpdateCommandHandler
         $startedAt = microtime(true);
         $currentVersion = null;
         $targetVersion = null;
+        $startEmitted = false;
 
         try {
             $this->dbmsVersionValidator->validateOrFail();
@@ -76,6 +77,7 @@ final readonly class UpdateCommandHandler
                 $targetVersion = $availableUpdates === [] ? $currentVersion : end($availableUpdates);
 
                 LoggerUpgrade::create()->start($currentVersion, $targetVersion);
+                $startEmitted = true;
 
                 // The handler owns step sequencing and logging; the repository only runs each operation.
                 foreach ($availableUpdates as $version) {
@@ -102,7 +104,15 @@ final readonly class UpdateCommandHandler
                 $this->updateLocker->unlock();
             }
         } catch (\Throwable $exception) {
-            LoggerUpgrade::create()->failure($exception->getMessage(), $currentVersion, $targetVersion, $exception);
+            if ($startEmitted) {
+                // The lifecycle is open: close it with a balanced upgrade.failure.
+                LoggerUpgrade::create()->failure($currentVersion, $targetVersion, $exception->getMessage(), $exception);
+            } else {
+                // The failure happened before start() (validation / lock / version read), so there is no
+                // start to balance: emit a standalone upgrade.error instead of a dangling failure, keeping
+                // the attempt visible in the upgrade channel.
+                LoggerUpgrade::create()->error($currentVersion ?? 'unknown', $exception->getMessage(), $exception);
+            }
 
             throw $exception;
         }
@@ -115,7 +125,7 @@ final readonly class UpdateCommandHandler
         try {
             $action();
         } catch (\Throwable $exception) {
-            LoggerUpgrade::create()->stepFailure($exception->getMessage(), $version, $step, $exception);
+            LoggerUpgrade::create()->stepFailure($version, $step, $exception->getMessage(), $exception);
 
             throw $exception;
         }

--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
@@ -192,10 +192,21 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         if (file_exists($tmpFile) && ! is_writable($tmpFile)) {
             throw new \RuntimeException(sprintf('Cannot write in temporary file: %s', $tmpFile));
         }
-        // A failed write (missing parent dir on a fresh run, full disk, partial write) must not
-        // be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
-        if (file_put_contents($tmpFile, $count) === false) {
-            throw new \RuntimeException(sprintf('Cannot write in temporary file: %s', $tmpFile));
+        // A failed or partial write (missing parent dir on a fresh run, full disk, interrupted write) must
+        // not be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
+        // Compare the bytes written against the payload byte length to catch a truncated write.
+        // file_put_contents() collapses most failures to false; the short-count branch below is
+        // defence-in-depth for a genuine partial write (e.g. a full disk) and is hard to trigger in tests.
+        $payload = (string) $count;
+        $expectedBytes = mb_strlen($payload, '8bit');
+        $bytesWritten = file_put_contents($tmpFile, $payload);
+        if ($bytesWritten === false || $bytesWritten !== $expectedBytes) {
+            throw new \RuntimeException(sprintf(
+                'Partial or failed write of the resume cursor (%s of %d bytes) in temporary file: %s',
+                $bytesWritten === false ? 'none' : (string) $bytesWritten,
+                $expectedBytes,
+                $tmpFile
+            ));
         }
     }
 }

--- a/centreon/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
+++ b/centreon/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
@@ -90,9 +90,9 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
             $callable();
         } catch (\Throwable $exception) {
             LoggerUpgrade::create()->stepFailure(
-                "Step '{$stepName}' failed: {$exception->getMessage()}",
                 $version,
                 $stepName,
+                "Step '{$stepName}' failed: {$exception->getMessage()}",
                 $exception
             );
 
@@ -153,6 +153,7 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      *
      * @param string $version
      *
+     * @throws \Adaptation\Database\Connection\Exception\ConnectionException when switching to the monitoring database fails
      * @throws RepositoryException when a SQL statement fails or the progress file cannot be written
      */
     private function runMonitoringSql(string $version): void
@@ -187,6 +188,7 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      *
      * @param string $version
      *
+     * @throws \Adaptation\Database\Connection\Exception\ConnectionException when switching to the configuration database fails
      * @throws RepositoryException when a SQL statement fails or the progress file cannot be written
      */
     private function runConfigurationSql(string $version): void
@@ -306,17 +308,28 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * @param string $tmpFile
      * @param int $count
      *
-     * @throws RepositoryException when the temporary file exists but is not writable
+     * @throws RepositoryException when the temporary file is not writable or the resume cursor cannot be fully written
      */
     private function writeExecutedQueriesCountInTemporaryFile(string $tmpFile, int $count): void
     {
         if (file_exists($tmpFile) && ! is_writable($tmpFile)) {
             throw new RepositoryException(sprintf('Cannot write in temporary file: %s', $tmpFile));
         }
-        // A failed write (missing parent dir on a fresh run, full disk, partial write) must not
-        // be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
-        if (file_put_contents($tmpFile, $count) === false) {
-            throw new RepositoryException(sprintf('Cannot write in temporary file: %s', $tmpFile));
+        // A failed or partial write (missing parent dir on a fresh run, full disk, interrupted write) must
+        // not be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
+        // Compare the bytes written against the payload byte length to catch a truncated write.
+        // file_put_contents() collapses most failures to false; the short-count branch below is
+        // defence-in-depth for a genuine partial write (e.g. a full disk) and is hard to trigger in tests.
+        $payload = (string) $count;
+        $expectedBytes = mb_strlen($payload, '8bit');
+        $bytesWritten = file_put_contents($tmpFile, $payload);
+        if ($bytesWritten === false || $bytesWritten !== $expectedBytes) {
+            throw new RepositoryException(sprintf(
+                'Partial or failed write of the resume cursor (%s of %d bytes) in temporary file: %s',
+                $bytesWritten === false ? 'none' : (string) $bytesWritten,
+                $expectedBytes,
+                $tmpFile
+            ));
         }
     }
 

--- a/centreon/tests/php/Adaptation/Log/LoggerUpgradeTest.php
+++ b/centreon/tests/php/Adaptation/Log/LoggerUpgradeTest.php
@@ -37,9 +37,17 @@ function loggerUpgradeWithSpy(): array
         /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
         public array $records = [];
 
+        /**
+         * @param array<string, mixed> $context
+         * @param mixed $level
+         */
         public function log($level, string|Stringable $message, array $context = []): void
         {
-            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            $this->records[] = [
+                'level' => is_scalar($level) ? (string) $level : '',
+                'message' => (string) $message,
+                'context' => $context,
+            ];
         }
     };
 
@@ -79,20 +87,32 @@ it('emits the success with the measured duration', function (): void {
         ->and($record['context']['duration_ms'])->toBe(4242);
 });
 
-it('emits a failure as an ERROR and attaches the throwable, with nullable versions', function (): void {
+it('emits a failure as an ERROR routing the versions to from/to and attaching the throwable', function (): void {
     [$facade, $spy] = loggerUpgradeWithSpy();
     $exception = new RuntimeException('boom');
 
-    $facade->failure('upgrade aborted', null, null, $exception);
+    // Distinct, non-null versions pin the version-first argument order by value: a swap back to a
+    // message-first signature would route 'upgrade aborted' into from_version and fail these assertions.
+    $facade->failure('25.10.0', '25.11.0', 'upgrade aborted', $exception);
 
     $record = $spy->records[0];
     expect($record['level'])->toBe(LogLevel::ERROR)
         ->and($record['message'])->toBe('upgrade aborted')
         ->and($record['context']['event'])->toBe('upgrade.failure')
         ->and($record['context']['status'])->toBe('failure')
-        ->and($record['context']['from_version'])->toBeNull()
-        ->and($record['context']['to_version'])->toBeNull()
+        ->and($record['context']['from_version'])->toBe('25.10.0')
+        ->and($record['context']['to_version'])->toBe('25.11.0')
         ->and($record['context']['exception'])->toBe($exception);
+});
+
+it('accepts null versions on failure (pre-start abort with no known from/to)', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+
+    $facade->failure(null, null, 'upgrade aborted', new RuntimeException('boom'));
+
+    $record = $spy->records[0];
+    expect($record['context']['from_version'])->toBeNull()
+        ->and($record['context']['to_version'])->toBeNull();
 });
 
 it('emits a step start as a running upgrade.step carrying the step name', function (): void {
@@ -125,12 +145,16 @@ it('emits a step failure as an ERROR with the step name and the throwable', func
     [$facade, $spy] = loggerUpgradeWithSpy();
     $exception = new RuntimeException('SQL failed');
 
-    $facade->stepFailure('step failed', '25.11.0', 'configuration_sql', $exception);
+    $facade->stepFailure('25.11.0', 'configuration_sql', 'step failed', $exception);
 
+    // Assert every slot by value so the version-first order is pinned: version, step and message
+    // are distinct strings, so a swapped argument order would land in the wrong context key.
     $record = $spy->records[0];
     expect($record['level'])->toBe(LogLevel::ERROR)
+        ->and($record['message'])->toBe('step failed')
         ->and($record['context']['event'])->toBe('upgrade.step_failure')
         ->and($record['context']['status'])->toBe('failure')
+        ->and($record['context']['version'])->toBe('25.11.0')
         ->and($record['context']['step'])->toBe('configuration_sql')
         ->and($record['context']['exception'])->toBe($exception);
 });

--- a/centreon/tests/php/App/Upgrade/Application/Command/UpdateCommandHandlerTest.php
+++ b/centreon/tests/php/App/Upgrade/Application/Command/UpdateCommandHandlerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\App\Upgrade\Application\Command;
 
+use Adaptation\Log\LoggerUpgrade;
 use App\Upgrade\Application\CacheClearer;
 use App\Upgrade\Application\Command\UpdateCommand;
 use App\Upgrade\Application\Command\UpdateCommandHandler;
@@ -32,6 +33,7 @@ use App\Upgrade\Domain\Repository\ModuleRepository;
 use App\Upgrade\Domain\Repository\WidgetRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
 use Tests\App\Upgrade\Infrastructure\Double\FakeUpdateLocker;
 use Tests\App\Upgrade\Infrastructure\Double\FakeUpdateRepository;
 use Tests\App\Upgrade\Infrastructure\Double\FakeUpdateScriptFinder;
@@ -56,6 +58,9 @@ final class UpdateCommandHandlerTest extends TestCase
 
     private UpdateCommandHandler $handler;
 
+    /** @var AbstractLogger&object{records: list<array{level: string, message: string, context: array<string, mixed>}>} */
+    private AbstractLogger $loggerSpy;
+
     protected function setUp(): void
     {
         $this->updateRepository = new FakeUpdateRepository();
@@ -77,6 +82,38 @@ final class UpdateCommandHandlerTest extends TestCase
             $this->engineContextWriter,
             $this->cacheClearer,
         );
+
+        // Record the emitted upgrade events so the start/failure lifecycle can be asserted without
+        // writing to the real upgrade channel. The facade is a singleton with a private constructor,
+        // so the spy is wired through reflection.
+        $this->loggerSpy = new class () extends AbstractLogger {
+            /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            /**
+             * @param array<string, mixed> $context
+             * @param mixed $level
+             */
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [
+                    'level' => is_scalar($level) ? (string) $level : '',
+                    'message' => (string) $message,
+                    'context' => $context,
+                ];
+            }
+        };
+
+        $reflection = new \ReflectionClass(LoggerUpgrade::class);
+        $facade = $reflection->newInstanceWithoutConstructor();
+        $reflection->getProperty('logger')->setValue($facade, $this->loggerSpy);
+        $reflection->getProperty('instance')->setValue(null, $facade);
+    }
+
+    protected function tearDown(): void
+    {
+        // Drop the spy-backed singleton so it cannot leak into other test files sharing the process.
+        (new \ReflectionClass(LoggerUpgrade::class))->getProperty('instance')->setValue(null, null);
     }
 
     public function testHappyPathNoUpdatesAvailable(): void
@@ -106,20 +143,37 @@ final class UpdateCommandHandlerTest extends TestCase
     {
         $this->locker->lockAvailable = false;
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/already in progress/');
+        try {
+            ($this->handler)(new UpdateCommand());
+            self::fail('Expected the lock failure to propagate');
+        } catch (\RuntimeException $exception) {
+            self::assertMatchesRegularExpression('/already in progress/', $exception->getMessage());
+        }
 
-        ($this->handler)(new UpdateCommand());
+        // A lock failure happens before start(): it is surfaced as a standalone upgrade.error,
+        // never a dangling upgrade.failure.
+        $events = $this->emittedEvents();
+        self::assertNotContains('upgrade.start', $events);
+        self::assertNotContains('upgrade.failure', $events);
+        self::assertContains('upgrade.error', $events);
     }
 
     public function testThrowsWhenCurrentVersionCannotBeRetrieved(): void
     {
         $this->updateRepository->currentVersion = null;
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/current platform version/');
+        try {
+            ($this->handler)(new UpdateCommand());
+            self::fail('Expected the unreadable version to propagate');
+        } catch (\RuntimeException $exception) {
+            self::assertMatchesRegularExpression('/current platform version/', $exception->getMessage());
+        }
 
-        ($this->handler)(new UpdateCommand());
+        // The version is read before start(): a failure here is surfaced as a standalone upgrade.error.
+        $events = $this->emittedEvents();
+        self::assertNotContains('upgrade.start', $events);
+        self::assertNotContains('upgrade.failure', $events);
+        self::assertContains('upgrade.error', $events);
     }
 
     public function testThrowsWhenCurrentVersionIsBlank(): void
@@ -221,5 +275,94 @@ final class UpdateCommandHandlerTest extends TestCase
         $this->cacheClearer->expects(self::once())->method('clear');
 
         ($this->handler)(new UpdateCommand());
+    }
+
+    public function testEmitsAnErrorButNoFailureWhenItFailsBeforeStart(): void
+    {
+        // A failure raised before start() (here DBMS validation) must not emit a dangling
+        // upgrade.failure with no matching upgrade.start; instead a standalone upgrade.error keeps
+        // the aborted attempt visible in the upgrade channel (and it is still re-thrown).
+        $this->dbmsValidator
+            ->method('validateOrFail')
+            ->willThrowException(new \RuntimeException('MariaDB version 10.5 required'));
+
+        try {
+            ($this->handler)(new UpdateCommand());
+            self::fail('Expected the validation failure to propagate');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('MariaDB version 10.5 required', $exception->getMessage());
+        }
+
+        $events = $this->emittedEvents();
+        self::assertNotContains('upgrade.start', $events);
+        self::assertNotContains('upgrade.failure', $events);
+        self::assertContains('upgrade.error', $events);
+
+        // The error carries the current version (unknown here, as it failed before the version was read)
+        // and the original message, pinning the handler call-site argument order.
+        $error = $this->recordFor('upgrade.error');
+        self::assertSame('unknown', $error['context']['version']);
+        self::assertSame('MariaDB version 10.5 required', $error['message']);
+    }
+
+    public function testEmitsFailureAfterStartWhenAStepFails(): void
+    {
+        // A failure raised after start() must emit a balanced upgrade.failure, preceded by upgrade.start.
+        $this->cacheClearer->method('clear')->willThrowException(new \RuntimeException('cache clear failed'));
+
+        try {
+            ($this->handler)(new UpdateCommand());
+            self::fail('Expected the cache clear failure to propagate');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('cache clear failed', $exception->getMessage());
+        }
+
+        $events = $this->emittedEvents();
+        self::assertContains('upgrade.start', $events);
+        self::assertContains('upgrade.failure', $events);
+        // The post-start branch is exclusive: it must not also emit the pre-start upgrade.error.
+        self::assertNotContains('upgrade.error', $events);
+        self::assertLessThan(
+            array_search('upgrade.failure', $events, true),
+            array_search('upgrade.start', $events, true),
+            'upgrade.start must be emitted before upgrade.failure'
+        );
+
+        // The failure routes the versions into from/to and the original message, pinning the handler
+        // call-site argument order (currentVersion == targetVersion here, no updates available).
+        $failure = $this->recordFor('upgrade.failure');
+        self::assertSame('24.10.0', $failure['context']['from_version']);
+        self::assertSame('24.10.0', $failure['context']['to_version']);
+        self::assertSame('cache clear failed', $failure['message']);
+    }
+
+    /**
+     * @return list<string> the ordered list of emitted upgrade event names
+     */
+    private function emittedEvents(): array
+    {
+        $events = [];
+        foreach ($this->loggerSpy->records as $record) {
+            $event = $record['context']['event'] ?? null;
+            if (is_string($event)) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * @return array{level: string, message: string, context: array<string, mixed>} the first record for the event
+     */
+    private function recordFor(string $event): array
+    {
+        foreach ($this->loggerSpy->records as $record) {
+            if (($record['context']['event'] ?? null) === $event) {
+                return $record;
+            }
+        }
+
+        self::fail(sprintf('No %s event was emitted', $event));
     }
 }

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepositoryTest.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepositoryTest.php
@@ -192,6 +192,65 @@ final class DbalUpdateRepositoryTest extends TestCase
         $this->repository($filesystem)->backupInstallDirectory(self::VERSION);
     }
 
+    public function testWriteExecutedQueriesCountWritesTheResumeCursor(): void
+    {
+        $this->realFilesystem->mkdir($this->installDir . '/tmp');
+        $tmpFile = $this->installDir . '/tmp/cursor-' . uniqid() . '.tmp';
+
+        (new \ReflectionMethod(DbalUpdateRepository::class, 'writeExecutedQueriesCount'))
+            ->invoke($this->repository(), $tmpFile, 7);
+
+        self::assertSame('7', file_get_contents($tmpFile));
+    }
+
+    public function testWriteExecutedQueriesCountThrowsWhenFileIsNotWritable(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            self::markTestSkipped('Permission bits are bypassed when running as root.');
+        }
+
+        $this->realFilesystem->mkdir($this->installDir . '/tmp');
+        $tmpFile = $this->installDir . '/tmp/cursor-' . uniqid() . '.tmp';
+        file_put_contents($tmpFile, '0');
+        chmod($tmpFile, 0o444);
+
+        try {
+            (new \ReflectionMethod(DbalUpdateRepository::class, 'writeExecutedQueriesCount'))
+                ->invoke($this->repository(), $tmpFile, 3);
+            self::fail('Expected a non-writable resume file to abort the write');
+        } catch (\RuntimeException $exception) {
+            self::assertStringContainsString('temporary file', $exception->getMessage());
+        } finally {
+            chmod($tmpFile, 0o644);
+        }
+    }
+
+    public function testWriteExecutedQueriesCountThrowsWhenTheWriteFailsEntirely(): void
+    {
+        // A regular file used as a parent makes file_put_contents() fail (ENOTDIR) and return false,
+        // exercising the write-failure branch itself rather than the earlier is_writable guard.
+        $this->realFilesystem->mkdir($this->installDir . '/tmp');
+        $blocker = $this->installDir . '/tmp/blocker-' . uniqid();
+        file_put_contents($blocker, 'x');
+        $tmpFile = $blocker . '/cursor.tmp';
+
+        // The failed write emits an expected E_WARNING; swallow it so only our exception is asserted.
+        set_error_handler(
+            static fn (int $severity, string $message): bool => $severity === E_WARNING
+                && str_contains($message, 'file_put_contents')
+                && str_contains($message, $tmpFile)
+        );
+        try {
+            (new \ReflectionMethod(DbalUpdateRepository::class, 'writeExecutedQueriesCount'))
+                ->invoke($this->repository(), $tmpFile, 5);
+            self::fail('Expected the failed write to abort the write');
+        } catch (\RuntimeException $exception) {
+            self::assertStringContainsString('temporary file', $exception->getMessage());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     private function repository(?Filesystem $filesystem = null): DbalUpdateRepository
     {
         return new DbalUpdateRepository(

--- a/centreon/tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php
+++ b/centreon/tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php
@@ -37,9 +37,17 @@ beforeEach(function (): void {
         /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
         public array $records = [];
 
+        /**
+         * @param array<string, mixed> $context
+         * @param mixed $level
+         */
         public function log($level, string|\Stringable $message, array $context = []): void
         {
-            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            $this->records[] = [
+                'level' => is_scalar($level) ? (string) $level : '',
+                'message' => (string) $message,
+                'context' => $context,
+            ];
         }
     };
 
@@ -109,6 +117,7 @@ it('logs a step failure and re-throws the original exception when the step throw
         ->and($stepFailure['level'])->toBe(LogLevel::ERROR)
         ->and($stepFailure['context']['event'])->toBe('upgrade.step_failure')
         ->and($stepFailure['context']['status'])->toBe('failure')
+        ->and($stepFailure['context']['version'])->toBe('24.10.1')
         ->and($stepFailure['context']['step'])->toBe('configuration_sql')
         ->and($stepFailure['context']['exception'])->toBe($failure);
 });
@@ -146,5 +155,31 @@ it('throws when the temporary resume file exists but is not writable', function 
     } finally {
         chmod($tmpFile, 0o644);
         @unlink($tmpFile);
+    }
+});
+
+it('throws when the resume cursor write fails entirely', function (): void {
+    // A regular file used as a parent makes file_put_contents() fail (ENOTDIR) and return false,
+    // exercising the write-failure branch itself rather than the earlier is_writable guard.
+    $blocker = sys_get_temp_dir() . '/centreon-upgrade-blocker-' . uniqid();
+    file_put_contents($blocker, 'x');
+    $tmpFile = $blocker . '/cursor.tmp';
+
+    // The failed write emits an expected E_WARNING; swallow it so only our exception is asserted.
+    set_error_handler(
+        static fn (int $severity, string $message): bool => $severity === E_WARNING
+            && str_contains($message, 'file_put_contents')
+            && str_contains($message, $tmpFile)
+    );
+    try {
+        (new \ReflectionClass($this->repository))
+            ->getMethod('writeExecutedQueriesCountInTemporaryFile')
+            ->invoke($this->repository, $tmpFile, 5);
+        $this->fail('Expected the failed write to abort the step');
+    } catch (RepositoryException $exception) {
+        expect($exception->getMessage())->toContain('temporary file');
+    } finally {
+        restore_error_handler();
+        @unlink($blocker);
     }
 });

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -222,24 +222,19 @@ try {
     // TODO add your function calls to update the configuration database structure here
 
     // Transactional queries for configuration database
+    $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
     // TODO add your function calls to update the configuration database data here
 
+    $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();
 
     LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
 
 } catch (Throwable $throwable) {
-    LoggerUpgrade::create()->stepFailure(
-        "UPGRADE - {$version}: {$errorMessage}",
-        $version,
-        'php_script',
-        $throwable
-    );
-
     try {
         if ($pearDB->isTransactionActive()) {
             LoggerUpgrade::create()->info($version, "Rolling back transaction after error: {$errorMessage}");
@@ -247,15 +242,15 @@ try {
         }
     } catch (ConnectionException $rollbackException) {
         LoggerUpgrade::create()->stepFailure(
-            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $version,
             'php_script_rollback',
+            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $rollbackException
         );
 
         throw new RuntimeException(
-            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
-            previous: $rollbackException
+            message: "UPGRADE - {$version}: " . $errorMessage,
+            previous: $throwable
         );
     }
 

--- a/centreon/www/install/php/Update-next.php.tpl
+++ b/centreon/www/install/php/Update-next.php.tpl
@@ -46,24 +46,19 @@ try {
     // TODO add your function calls to update the configuration database structure here
 
     // Transactional queries for configuration database
+    $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
     // TODO add your function calls to update the configuration database data here
 
+    $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();
 
     LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
 
 } catch (Throwable $throwable) {
-    LoggerUpgrade::create()->stepFailure(
-        "UPGRADE - {$version}: {$errorMessage}",
-        $version,
-        'php_script',
-        $throwable
-    );
-
     try {
         if ($pearDB->isTransactionActive()) {
             LoggerUpgrade::create()->info($version, "Rolling back transaction after error: {$errorMessage}");
@@ -71,15 +66,15 @@ try {
         }
     } catch (ConnectionException $rollbackException) {
         LoggerUpgrade::create()->stepFailure(
-            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $version,
             'php_script_rollback',
+            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $rollbackException
         );
 
         throw new RuntimeException(
-            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
-            previous: $rollbackException
+            message: "UPGRADE - {$version}: " . $errorMessage,
+            previous: $throwable
         );
     }
 

--- a/centreon/www/install/step_upgrade/process/process_step4.php
+++ b/centreon/www/install/step_upgrade/process/process_step4.php
@@ -53,7 +53,7 @@ try {
     $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
     LoggerUpgrade::create()->success($current, $next, $durationMs);
 } catch (Throwable $e) {
-    LoggerUpgrade::create()->failure($e->getMessage(), $current, $next, $e);
+    LoggerUpgrade::create()->failure($current, $next, $e->getMessage(), $e);
     exitUpgradeProcess(1, $current, $next, $e->getMessage());
 }
 

--- a/centreon/www/install/step_upgrade/process/process_step5.php
+++ b/centreon/www/install/step_upgrade/process/process_step5.php
@@ -73,9 +73,9 @@ try {
     );
 } catch (Throwable $e) {
     LoggerUpgrade::create()->stepFailure(
-        "Post-update phase failed: {$e->getMessage()}",
         $currentVersion,
         'post_update',
+        "Post-update phase failed: {$e->getMessage()}",
         $e
     );
     exitUpgradeProcess(


### PR DESCRIPTION
## Description

Tech-debt follow-ups on the structured upgrade logging flow (origin #10416), fixed on `develop` first:

- Chain the **root-cause** exception (not the rollback one) when an upgrade script's rollback itself fails, so the original failure reaches the global flow.
- Set `$errorMessage` **before** `startTransaction()`/`commitTransaction()` so a transaction failure reports the right action instead of a stale one.
- Detect partial/failed writes of the SQL resume cursor (`DbWrite` + `Dbal` repositories) and complete the related `@throws` (incl. the `ConnectionException` from `switchToDb()`).
- Unify `LoggerUpgrade` argument order to **version-first** for `failure()`/`stepFailure()` — all params are `string`, so the previous message-first order let a silent swap pollute the per-release `version` field used by SIEM/Grafana.
- Stop the legacy `php_script` catch from emitting a **duplicate** `upgrade.step_failure`: the surrounding step bracket already logs it; the script only logs `php_script_rollback`.
- Keep the global lifecycle **balanced**: emit `upgrade.failure` only once `upgrade.start` has been emitted; a failure raised before start (validation / lock / version read) is reported as a standalone `upgrade.error` instead of a dangling failure.
- Doc fix in `doc/php/logging.md` ("Recommended pattern": skeleton `.tpl` vs worked example).

Tests: forward-port the `DbWriteUpdateRepository` coverage from the backports, add the symmetric `DbalUpdateRepository::writeExecutedQueriesCount` coverage, and pin the version-first argument order by value in `LoggerUpgradeTest`.

## How to test

- From `centreon/`, run the touched suites — all green:
  - `php vendor/bin/pest tests/php/Adaptation/Log/LoggerUpgradeTest.php`
  - `php vendor/bin/pest tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php`

## Links

### Jira ticket

Resolves: [MON-201971](https://centreon.atlassian.net/browse/MON-201971)

### PR Github

Backports: #10834

[MON-201971]: https://centreon.atlassian.net/browse/MON-201971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ