### PR TITLE
fix(logging): tech-debt follow-ups for the structured upgrade logging flow

### DIFF
--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -348,3 +348,69 @@ But fail2ban jails are bound to a **file path** (`logpath = /var/log/centreon/lo
 - **`$userId` is `null` early, populated once resolved.** Don't fabricate a fake id (e.g. `0`) — `null` is the signal that the user was not authenticated at this stage.
 - **Provider always set.** Use the `AuthProviderEnum` cases; do not pass a free-form string. The enum is the single source of truth of which providers exist.
 - **Don't duplicate on both channels.** A security event goes to `prod.access.log` via the facade. The technical trace (stack trace, ldap_error, HTTP body) belongs to `prod.web.log` via `Logger::create(LogChannelEnum::WEB)`.
+
+---
+
+## 13. Writing upgrade scripts (`Update-*.php`)
+
+Each upgrade ships under `www/install/php/Update-<version>.php` (DB DDL/DML + business migration). It runs either through the DDD command — `UpdateCommandHandler` brackets each step with its `runStep()` helper and emits the logs, while `DbalUpdateRepository` only performs the operations — or through the legacy web wizard (`process_step4/5` + `DbWriteUpdateRepository`, which logs inline via `executeStep()`). Either way the `php_script` step is bracketed (start / completed / failure). **Inside the script itself, trace each meaningful action through `LoggerUpgrade` so operators get a play-by-play view in `prod.upgrade.log`.**
+
+The legacy web upgrade splits the flow across two steps: `process_step4.php` runs the version updates (`runUpdate`), `process_step5.php` runs the post-update (`runPostUpdate`) under a `post_update` step — grep both when tracking a step name.
+
+### Facade API
+
+```php
+use Adaptation\Log\LoggerUpgrade;
+
+LoggerUpgrade::create()->info($version, "Adding column X to table Y");
+LoggerUpgrade::create()->error($version, "Schema check failed", $exception);
+
+LoggerUpgrade::create()->stepFailure($version, $stepName, $message, $exception);
+LoggerUpgrade::create()->step($version, $stepName, $message);
+```
+
+| Method | Monolog level | When to use |
+|---|---|---|
+| `start($from, $to)` | `INFO` | Begin of the global upgrade flow (emitted by `UpdateCommandHandler` / `process_step4.php`, **not** by individual scripts). |
+| `success($from, $to, $durationMs)` | `INFO` | End of the global upgrade flow, with measured duration. |
+| `failure($from, $to, $message, $e)` | `ERROR` | Global upgrade aborted (catch-all in the handler). Emitted only once `start` has been emitted, so the lifecycle stays balanced; a failure raised **before** `start` (validation / lock / version read) is reported as an `upgrade.error` instead, never a dangling `failure`. |
+| `step($version, $stepName, $message)` | `INFO` | Sub-step **start** / progress (`monitoring_sql`, `php_script`, …). `status: running`. Emitted by the repositories; rarely needed inside an upgrade script. |
+| `stepCompleted($version, $stepName, $durationMs, $message)` | `INFO` | Sub-step **completion**. `status: completed`, carries `duration_ms` in the context (not just the message), so completed steps are queryable without parsing text. |
+| `stepFailure($version, $stepName, $message, $e)` | `ERROR` | A bracketed step threw. Emitted by the step bracket itself (e.g. `UpdateCommandHandler::runStep`, `DbWriteUpdateRepository::executeStep`, or `process_step5.php` for `post_update`). An upgrade script must **not** re-emit it for `php_script` (the bracket already logs the re-thrown exception); a script only emits it for `php_script_rollback`, when the rollback itself fails. |
+| **`info($version, $message)`** | `INFO` | **Trace a meaningful action** (entering a function, finished an `ALTER TABLE`, skipped because already migrated, …). This is the workhorse inside upgrade scripts. |
+| **`error($version, $message, $e)`** | `ERROR` | Free-form error inside a script that you choose not to re-throw (rare — usually you re-throw and let the surrounding `try/catch` call `stepFailure`). |
+
+### Recommended pattern
+
+Start from `www/install/php/Update-next.php.tpl` — the canonical skeleton, kept in sync with the flow (its `try/catch`, transaction guard and rollback handling are ready to use). It is intentionally a bare skeleton; for a complete worked example of the points below, read the latest shipped script, e.g. `www/install/php/Update-26.07.0.php`. The shape:
+
+- **Wrap each business action in its own callable** and set `$errorMessage` to a human description **before** running it — including immediately before `startTransaction()` and `commitTransaction()`, which are themselves distinct actions — so the final failure message reports which action actually failed.
+- **Trace intent and outcome** with `info($version, …)`; log skip branches too — they prove the script is safely re-entrant.
+- **Run DML inside a transaction** guarded by `isTransactionActive()`, and log "Rolling back…" only inside the `if` that actually rolls back.
+- **On failure, just re-throw**, chaining the root cause as `previous`. The surrounding step bracket (`UpdateCommandHandler::runStep` / `DbWriteUpdateRepository::executeStep`) already logs the `php_script` `stepFailure` from the re-thrown exception, and the global flow (`UpdateCommandHandler` / `process_step4.php`) then writes the final `failure`. Do **not** emit a `php_script` `stepFailure` from the script — that double-logs the step. The only `stepFailure` a script emits itself is `php_script_rollback`, when the rollback fails. A silent return breaks the chain.
+
+### Sample output (`prod.upgrade.log`)
+
+```
+upgrade.INFO: Upgrade started from 25.10.0 to 25.11.0
+  {"event":"upgrade.start","status":"started","from_version":"25.10.0","to_version":"25.11.0"}
+upgrade.INFO: Starting step 'php_script'
+  {"event":"upgrade.step","status":"running","version":"25.11.0","step":"php_script"}
+upgrade.INFO: Adding vmware_updated field into nagios_server table
+  {"event":"upgrade.info","status":"info","version":"25.11.0"}
+upgrade.INFO: Step 'php_script' completed in 124ms
+  {"event":"upgrade.step_completed","status":"completed","version":"25.11.0","step":"php_script","duration_ms":124}
+upgrade.INFO: Upgrade from 25.10.0 to 25.11.0 completed successfully
+  {"event":"upgrade.success","status":"success","from_version":"25.10.0","to_version":"25.11.0","duration_ms":4242}
+```
+
+On failure, the step bracket writes `upgrade.step_failure` (ERROR) and the global flow writes a final `upgrade.failure` carrying the from→to versions and the wrapped exception.
+
+### Best practices
+
+- **One business action = one `info` line** before it runs (intent) and one after (outcome). Skip branches deserve their own line so operators can read the log top-to-bottom without re-deriving control flow.
+- **Carry `$version` on every call** — the field is what lets SIEM/Grafana partition the file per release.
+- **No PII, no secrets** in the message or the context. The file is shipped to operators / SOC pipelines; the same redaction rules as `prod.access.log` apply.
+- **Don't duplicate the surrounding `step` log** — the repository already brackets the script with `step` / `stepFailure`. Inside the script, use `info` / `error` (free-form) and let `stepFailure` be raised by the outer `try/catch`.
+- **Idempotent actions still log** — even "skipped because already migrated" is signal: it confirms the migration was applied on a previous run and the script is safely re-entrant.
+- **Re-throw on failure**. Returning silently after logging masks the failure from the surrounding `UpdateCommandHandler` / `process_step4` which then misses the final `upgrade.failure` record.

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -353,7 +353,9 @@ But fail2ban jails are bound to a **file path** (`logpath = /var/log/centreon/lo
 
 ## 13. Writing upgrade scripts (`Update-*.php`)
 
-Each upgrade ships under `www/install/php/Update-<version>.php` (DB DDL/DML + business migration). It runs either through the DDD command — `UpdateCommandHandler` brackets each step with its `runStep()` helper and emits the logs, while `DbalUpdateRepository` only performs the operations — or through the legacy web wizard (`process_step4/5` + `DbWriteUpdateRepository`, which logs inline via `executeStep()`). Either way the `php_script` step is bracketed (start / completed / failure). **Inside the script itself, trace each meaningful action through `LoggerUpgrade` so operators get a play-by-play view in `prod.upgrade.log`.**
+> **24.10.x scope.** On this branch, upgrades run exclusively through the legacy web wizard (`process_step4/5` + `DbWriteUpdateRepository`). The DDD command path (`UpdateCommandHandler` / `DbalUpdateRepository`) is available from 25.10 onwards. The API table below documents both paths for completeness; only the legacy path applies here.
+
+Each upgrade ships under `www/install/php/Update-<version>.php` (DB DDL/DML + business migration). It runs either through the DDD command — `UpdateCommandHandler` brackets each step with its `runStep()` helper and emits the logs, while `DbalUpdateRepository` only performs the operations (25.10+) — or through the legacy web wizard (`process_step4/5` + `DbWriteUpdateRepository`, which logs inline via `executeStep()`). Either way the `php_script` step is bracketed (start / completed / failure). **Inside the script itself, trace each meaningful action through `LoggerUpgrade` so operators get a play-by-play view in `prod.upgrade.log`.**
 
 The legacy web upgrade splits the flow across two steps: `process_step4.php` runs the version updates (`runUpdate`), `process_step5.php` runs the post-update (`runPostUpdate`) under a `post_update` step — grep both when tracking a step name.
 
@@ -382,7 +384,7 @@ LoggerUpgrade::create()->step($version, $stepName, $message);
 
 ### Recommended pattern
 
-Start from `www/install/php/Update-next.php.tpl` — the canonical skeleton, kept in sync with the flow (its `try/catch`, transaction guard and rollback handling are ready to use). It is intentionally a bare skeleton; for a complete worked example of the points below, read the latest shipped script, e.g. `www/install/php/Update-26.07.0.php`. The shape:
+Start from `www/install/php/Update-next.php.tpl` — the canonical skeleton, kept in sync with the flow (its `try/catch`, transaction guard and rollback handling are ready to use). It is intentionally a bare skeleton; for a complete worked example of the points below, read the latest shipped script, e.g. `www/install/php/Update-24.10.28.php`. The shape:
 
 - **Wrap each business action in its own callable** and set `$errorMessage` to a human description **before** running it — including immediately before `startTransaction()` and `commitTransaction()`, which are themselves distinct actions — so the final failure message reports which action actually failed.
 - **Trace intent and outcome** with `info($version, …)`; log skip branches too — they prove the script is safely re-entrant.

--- a/centreon/src/Adaptation/Log/LoggerUpgrade.php
+++ b/centreon/src/Adaptation/Log/LoggerUpgrade.php
@@ -61,9 +61,9 @@ final class LoggerUpgrade
     }
 
     public function failure(
-        string $message,
         ?string $fromVersion,
         ?string $toVersion,
+        string $message,
         ?\Throwable $exception = null,
     ): void {
         $this->write(
@@ -99,9 +99,9 @@ final class LoggerUpgrade
     }
 
     public function stepFailure(
-        string $message,
         string $version,
         string $stepName,
+        string $message,
         ?\Throwable $exception = null,
     ): void {
         $context = $this->versionContext('upgrade.step_failure', 'failure', $version, $exception);

--- a/centreon/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
+++ b/centreon/src/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepository.php
@@ -90,9 +90,9 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
             $callable();
         } catch (\Throwable $exception) {
             LoggerUpgrade::create()->stepFailure(
-                "Step '{$stepName}' failed: {$exception->getMessage()}",
                 $version,
                 $stepName,
+                "Step '{$stepName}' failed: {$exception->getMessage()}",
                 $exception
             );
 
@@ -153,6 +153,7 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      *
      * @param string $version
      *
+     * @throws \Adaptation\Database\Connection\Exception\ConnectionException when switching to the monitoring database fails
      * @throws RepositoryException when a SQL statement fails or the progress file cannot be written
      */
     private function runMonitoringSql(string $version): void
@@ -187,6 +188,7 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      *
      * @param string $version
      *
+     * @throws \Adaptation\Database\Connection\Exception\ConnectionException when switching to the configuration database fails
      * @throws RepositoryException when a SQL statement fails or the progress file cannot be written
      */
     private function runConfigurationSql(string $version): void
@@ -306,17 +308,28 @@ class DbWriteUpdateRepository extends AbstractRepositoryDRB implements WriteUpda
      * @param string $tmpFile
      * @param int $count
      *
-     * @throws RepositoryException when the temporary file exists but is not writable
+     * @throws RepositoryException when the temporary file is not writable or the resume cursor cannot be fully written
      */
     private function writeExecutedQueriesCountInTemporaryFile(string $tmpFile, int $count): void
     {
         if (file_exists($tmpFile) && ! is_writable($tmpFile)) {
             throw new RepositoryException(sprintf('Cannot write in temporary file: %s', $tmpFile));
         }
-        // A failed write (missing parent dir on a fresh run, full disk, partial write) must not
-        // be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
-        if (file_put_contents($tmpFile, $count) === false) {
-            throw new RepositoryException(sprintf('Cannot write in temporary file: %s', $tmpFile));
+        // A failed or partial write (missing parent dir on a fresh run, full disk, interrupted write) must
+        // not be silent: the count is the SQL resume cursor, and a stale one re-runs applied statements.
+        // Compare the bytes written against the payload byte length to catch a truncated write.
+        // file_put_contents() collapses most failures to false; the short-count branch below is
+        // defence-in-depth for a genuine partial write (e.g. a full disk) and is hard to trigger in tests.
+        $payload = (string) $count;
+        $expectedBytes = mb_strlen($payload, '8bit');
+        $bytesWritten = file_put_contents($tmpFile, $payload);
+        if ($bytesWritten === false || $bytesWritten !== $expectedBytes) {
+            throw new RepositoryException(sprintf(
+                'Partial or failed write of the resume cursor (%s of %d bytes) in temporary file: %s',
+                $bytesWritten === false ? 'none' : (string) $bytesWritten,
+                $expectedBytes,
+                $tmpFile
+            ));
         }
     }
 

--- a/centreon/tests/php/Adaptation/Log/LoggerUpgradeTest.php
+++ b/centreon/tests/php/Adaptation/Log/LoggerUpgradeTest.php
@@ -37,9 +37,17 @@ function loggerUpgradeWithSpy(): array
         /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
         public array $records = [];
 
+        /**
+         * @param array<string, mixed> $context
+         * @param mixed $level
+         */
         public function log($level, string|Stringable $message, array $context = []): void
         {
-            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            $this->records[] = [
+                'level' => is_scalar($level) ? (string) $level : '',
+                'message' => (string) $message,
+                'context' => $context,
+            ];
         }
     };
 
@@ -79,20 +87,32 @@ it('emits the success with the measured duration', function (): void {
         ->and($record['context']['duration_ms'])->toBe(4242);
 });
 
-it('emits a failure as an ERROR and attaches the throwable, with nullable versions', function (): void {
+it('emits a failure as an ERROR routing the versions to from/to and attaching the throwable', function (): void {
     [$facade, $spy] = loggerUpgradeWithSpy();
     $exception = new RuntimeException('boom');
 
-    $facade->failure('upgrade aborted', null, null, $exception);
+    // Distinct, non-null versions pin the version-first argument order by value: a swap back to a
+    // message-first signature would route 'upgrade aborted' into from_version and fail these assertions.
+    $facade->failure('25.10.0', '25.11.0', 'upgrade aborted', $exception);
 
     $record = $spy->records[0];
     expect($record['level'])->toBe(LogLevel::ERROR)
         ->and($record['message'])->toBe('upgrade aborted')
         ->and($record['context']['event'])->toBe('upgrade.failure')
         ->and($record['context']['status'])->toBe('failure')
-        ->and($record['context']['from_version'])->toBeNull()
-        ->and($record['context']['to_version'])->toBeNull()
+        ->and($record['context']['from_version'])->toBe('25.10.0')
+        ->and($record['context']['to_version'])->toBe('25.11.0')
         ->and($record['context']['exception'])->toBe($exception);
+});
+
+it('accepts null versions on failure (pre-start abort with no known from/to)', function (): void {
+    [$facade, $spy] = loggerUpgradeWithSpy();
+
+    $facade->failure(null, null, 'upgrade aborted', new RuntimeException('boom'));
+
+    $record = $spy->records[0];
+    expect($record['context']['from_version'])->toBeNull()
+        ->and($record['context']['to_version'])->toBeNull();
 });
 
 it('emits a step start as a running upgrade.step carrying the step name', function (): void {
@@ -125,12 +145,16 @@ it('emits a step failure as an ERROR with the step name and the throwable', func
     [$facade, $spy] = loggerUpgradeWithSpy();
     $exception = new RuntimeException('SQL failed');
 
-    $facade->stepFailure('step failed', '25.11.0', 'configuration_sql', $exception);
+    $facade->stepFailure('25.11.0', 'configuration_sql', 'step failed', $exception);
 
+    // Assert every slot by value so the version-first order is pinned: version, step and message
+    // are distinct strings, so a swapped argument order would land in the wrong context key.
     $record = $spy->records[0];
     expect($record['level'])->toBe(LogLevel::ERROR)
+        ->and($record['message'])->toBe('step failed')
         ->and($record['context']['event'])->toBe('upgrade.step_failure')
         ->and($record['context']['status'])->toBe('failure')
+        ->and($record['context']['version'])->toBe('25.11.0')
         ->and($record['context']['step'])->toBe('configuration_sql')
         ->and($record['context']['exception'])->toBe($exception);
 });

--- a/centreon/tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php
+++ b/centreon/tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php
@@ -37,9 +37,17 @@ beforeEach(function (): void {
         /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
         public array $records = [];
 
+        /**
+         * @param array<string, mixed> $context
+         * @param mixed $level
+         */
         public function log($level, string|\Stringable $message, array $context = []): void
         {
-            $this->records[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+            $this->records[] = [
+                'level' => is_scalar($level) ? (string) $level : '',
+                'message' => (string) $message,
+                'context' => $context,
+            ];
         }
     };
 
@@ -109,6 +117,7 @@ it('logs a step failure and re-throws the original exception when the step throw
         ->and($stepFailure['level'])->toBe(LogLevel::ERROR)
         ->and($stepFailure['context']['event'])->toBe('upgrade.step_failure')
         ->and($stepFailure['context']['status'])->toBe('failure')
+        ->and($stepFailure['context']['version'])->toBe('24.10.1')
         ->and($stepFailure['context']['step'])->toBe('configuration_sql')
         ->and($stepFailure['context']['exception'])->toBe($failure);
 });
@@ -146,5 +155,31 @@ it('throws when the temporary resume file exists but is not writable', function 
     } finally {
         chmod($tmpFile, 0o644);
         @unlink($tmpFile);
+    }
+});
+
+it('throws when the resume cursor write fails entirely', function (): void {
+    // A regular file used as a parent makes file_put_contents() fail (ENOTDIR) and return false,
+    // exercising the write-failure branch itself rather than the earlier is_writable guard.
+    $blocker = sys_get_temp_dir() . '/centreon-upgrade-blocker-' . uniqid();
+    file_put_contents($blocker, 'x');
+    $tmpFile = $blocker . '/cursor.tmp';
+
+    // The failed write emits an expected E_WARNING; swallow it so only our exception is asserted.
+    set_error_handler(
+        static fn (int $severity, string $message): bool => $severity === E_WARNING
+            && str_contains($message, 'file_put_contents')
+            && str_contains($message, $tmpFile)
+    );
+    try {
+        (new \ReflectionClass($this->repository))
+            ->getMethod('writeExecutedQueriesCountInTemporaryFile')
+            ->invoke($this->repository, $tmpFile, 5);
+        $this->fail('Expected the failed write to abort the step');
+    } catch (RepositoryException $exception) {
+        expect($exception->getMessage())->toContain('temporary file');
+    } finally {
+        restore_error_handler();
+        @unlink($blocker);
     }
 });

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -222,24 +222,19 @@ try {
     // TODO add your function calls to update the configuration database structure here
 
     // Transactional queries for configuration database
+    $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
     // TODO add your function calls to update the configuration database data here
 
+    $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();
 
     LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
 
 } catch (Throwable $throwable) {
-    LoggerUpgrade::create()->stepFailure(
-        "UPGRADE - {$version}: {$errorMessage}",
-        $version,
-        'php_script',
-        $throwable
-    );
-
     try {
         if ($pearDB->isTransactionActive()) {
             LoggerUpgrade::create()->info($version, "Rolling back transaction after error: {$errorMessage}");
@@ -247,15 +242,15 @@ try {
         }
     } catch (ConnectionException $rollbackException) {
         LoggerUpgrade::create()->stepFailure(
-            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $version,
             'php_script_rollback',
+            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $rollbackException
         );
 
         throw new RuntimeException(
-            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
-            previous: $rollbackException
+            message: "UPGRADE - {$version}: " . $errorMessage,
+            previous: $throwable
         );
     }
 

--- a/centreon/www/install/php/Update-next.php.tpl
+++ b/centreon/www/install/php/Update-next.php.tpl
@@ -46,24 +46,19 @@ try {
     // TODO add your function calls to update the configuration database structure here
 
     // Transactional queries for configuration database
+    $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
     // TODO add your function calls to update the configuration database data here
 
+    $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();
 
     LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
 
 } catch (Throwable $throwable) {
-    LoggerUpgrade::create()->stepFailure(
-        "UPGRADE - {$version}: {$errorMessage}",
-        $version,
-        'php_script',
-        $throwable
-    );
-
     try {
         if ($pearDB->isTransactionActive()) {
             LoggerUpgrade::create()->info($version, "Rolling back transaction after error: {$errorMessage}");
@@ -71,15 +66,15 @@ try {
         }
     } catch (ConnectionException $rollbackException) {
         LoggerUpgrade::create()->stepFailure(
-            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $version,
             'php_script_rollback',
+            "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
             $rollbackException
         );
 
         throw new RuntimeException(
-            message: "UPGRADE - {$version}: error while rolling back the upgrade operation for : {$errorMessage}",
-            previous: $rollbackException
+            message: "UPGRADE - {$version}: " . $errorMessage,
+            previous: $throwable
         );
     }
 

--- a/centreon/www/install/step_upgrade/process/process_step4.php
+++ b/centreon/www/install/step_upgrade/process/process_step4.php
@@ -54,7 +54,7 @@ try {
     $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
     LoggerUpgrade::create()->success($current, $next, $durationMs);
 } catch (Throwable $e) {
-    LoggerUpgrade::create()->failure($e->getMessage(), $current, $next, $e);
+    LoggerUpgrade::create()->failure($current, $next, $e->getMessage(), $e);
     exitUpgradeProcess(1, $current, $next, $e->getMessage());
 }
 

--- a/centreon/www/install/step_upgrade/process/process_step5.php
+++ b/centreon/www/install/step_upgrade/process/process_step5.php
@@ -74,9 +74,9 @@ try {
     );
 } catch (Throwable $e) {
     LoggerUpgrade::create()->stepFailure(
-        "Post-update phase failed: {$e->getMessage()}",
         $currentVersion,
         'post_update',
+        "Post-update phase failed: {$e->getMessage()}",
         $e
     );
     exitUpgradeProcess(


### PR DESCRIPTION
## Description

Tech-debt follow-ups on the structured upgrade logging flow (origin #10416), fixed on `develop` first:

- Chain the **root-cause** exception (not the rollback one) when an upgrade script's rollback itself fails, so the original failure reaches the global flow.
- Set `$errorMessage` **before** `startTransaction()`/`commitTransaction()` so a transaction failure reports the right action instead of a stale one.
- Detect partial/failed writes of the SQL resume cursor (`DbWriteUpdateRepository`) and complete the related `@throws` (incl. the `ConnectionException` from `switchToDb()`).
- Unify `LoggerUpgrade` argument order to **version-first** for `failure()`/`stepFailure()` — all params are `string`, so the previous message-first order let a silent swap pollute the per-release `version` field used by SIEM/Grafana.
- Stop the legacy `php_script` catch from emitting a **duplicate** `upgrade.step_failure`: the surrounding step bracket already logs it; the script only logs `php_script_rollback`.
- Doc fix in `doc/php/logging.md` ("Recommended pattern": skeleton `.tpl` vs worked example).

Tests: `DbWriteUpdateRepository` coverage and pin the version-first argument order by value in `LoggerUpgradeTest`.

Note: `UpdateCommandHandler` and `DbalUpdateRepository` do not exist on 24.10.x (replaced by the legacy web wizard path), so their changes are excluded from this backport.

## How to test

- From `centreon/`, run the touched suites — all green:
  - `php vendor/bin/pest tests/php/Adaptation/Log/LoggerUpgradeTest.php`
  - `php vendor/bin/pest tests/php/Core/Platform/Infrastructure/Repository/DbWriteUpdateRepositoryTest.php`

## Links

### Jira ticket

Resolves: [MON-201970](https://centreon.atlassian.net/browse/MON-201970)

### PR Github

Backports: #10866

[MON-201970]: https://centreon.atlassian.net/browse/MON-201970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ