### PR TITLE
fix(logging): tighten exception-key guard and interface masking

### DIFF
--- a/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Logging/PayloadSanitizer.php
@@ -51,6 +51,7 @@ final readonly class PayloadSanitizer
 {
     public const MAX_DEPTH = 3;
     public const MAX_VALUE_LENGTH = 1024;
+    public const RUNTIME_CLASS_KEY = '__runtime_class__';
 
     /**
      * @param class-string|null $contextClass class whose `#[Sensitive]`
@@ -99,13 +100,16 @@ final readonly class PayloadSanitizer
 
             $result = [];
             foreach ($data as $key => $value) {
-                // `context.exception` carries one of two legitimate shapes: a raw
-                // Throwable (handed to ExceptionFormatterProcessor downstream) or an
-                // already-structured exception array (ExceptionFormatter::format),
-                // whose nested chain is deeper than MAX_DEPTH and must not be
-                // truncated. Leave both intact; any other type under this key falls
-                // through to the normal masking walk.
-                if ($key === 'exception' && ($value instanceof \Throwable || \is_array($value))) {
+                if ($key === self::RUNTIME_CLASS_KEY) {
+                    continue;
+                }
+
+                // `context.exception`: a raw Throwable passes through for
+                // ExceptionFormatterProcessor; a structured exception array
+                // (ExceptionFormatter::format output) passes through to
+                // avoid depth truncation. Any other array falls through to
+                // the normal masking walk.
+                if ($key === 'exception' && ($value instanceof \Throwable || $this->isStructuredException($value))) {
                     $result[$key] = $value;
 
                     continue;
@@ -121,8 +125,13 @@ final readonly class PayloadSanitizer
 
                 $childContext = (\is_string($key) ? ($subClasses[$key] ?? null) : null);
 
-                // A `#[Sensitive]` class masks every value typed as it,
-                // so the whole sub-payload is redacted without descending.
+                // When the normalizer embedded the concrete runtime class,
+                // prefer it over the declared type so that #[Sensitive] on
+                // the concrete class is honoured even behind an interface.
+                if (\is_array($value) && isset($value[self::RUNTIME_CLASS_KEY]) && \is_string($value[self::RUNTIME_CLASS_KEY]) && class_exists($value[self::RUNTIME_CLASS_KEY])) {
+                    $childContext = $value[self::RUNTIME_CLASS_KEY];
+                }
+
                 if ($childContext !== null
                     && class_exists($childContext)
                     && SensitivityScanner::scan($childContext)['classSensitive']
@@ -194,6 +203,21 @@ final readonly class PayloadSanitizer
         return \mb_strlen($value) > self::MAX_VALUE_LENGTH
             ? mb_substr($value, 0, self::MAX_VALUE_LENGTH) . '…[truncated]'
             : $value;
+    }
+
+    /**
+     * Recognises the output shape of {@see ExceptionFormatter::format()}:
+     * `['exceptions' => [['type' => …, 'message' => …, 'trace' => …], …]]`.
+     */
+    private function isStructuredException(mixed $value): bool
+    {
+        if (! \is_array($value) || ! isset($value['exceptions']) || ! \is_array($value['exceptions'])) {
+            return false;
+        }
+
+        $first = $value['exceptions'][0] ?? null;
+
+        return \is_array($first) && isset($first['type'], $first['message'], $first['trace']);
     }
 
     /**

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/InnerPayloadInterface.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/InnerPayloadInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
+
+interface InnerPayloadInterface
+{
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/InterfaceTypedCommand.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/Attribute/Fake/InterfaceTypedCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Logging\Attribute\Fake;
+
+final readonly class InterfaceTypedCommand
+{
+    public function __construct(
+        public InnerPayloadInterface $inner,
+        public string $label,
+    ) {
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
@@ -28,9 +28,12 @@ use App\Shared\Infrastructure\Logging\PayloadSanitizer;
 use App\Shared\Infrastructure\Logging\SensitiveKeywordDenylist;
 use PHPUnit\Framework\TestCase;
 use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\CardHolderCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\InterfaceTypedCommand;
 use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\MethodSecretCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\NestedInnerPayload;
 use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\NestedPayloadCommand;
 use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\SecretsCommand;
+use Tests\App\Shared\Infrastructure\Logging\Attribute\Fake\SensitiveValueObject;
 
 final class PayloadSanitizerTest extends TestCase
 {
@@ -280,5 +283,72 @@ final class PayloadSanitizerTest extends TestCase
             ],
             $sanitised,
         );
+    }
+
+    public function testPassesThroughAlreadyStructuredExceptionArray(): void
+    {
+        $structured = [
+            'exceptions' => [
+                ['type' => 'RuntimeException', 'message' => 'boom', 'code' => 0, 'file' => 'F.php', 'line' => 1, 'trace' => []],
+                ['type' => 'LogicException', 'message' => 'cause', 'code' => 0, 'file' => 'G.php', 'line' => 2, 'trace' => []],
+            ],
+        ];
+
+        $sanitised = $this->sanitizer->sanitize([
+            'exception' => $structured,
+            'note' => 'context',
+        ]);
+
+        \assert(\is_array($sanitised));
+        self::assertSame($structured, $sanitised['exception']);
+        self::assertSame('context', $sanitised['note']);
+    }
+
+    public function testMasksArrayUnderExceptionKeyThatIsNotAStructuredException(): void
+    {
+        $sanitised = $this->sanitizer->sanitize([
+            'exception' => ['request' => ['password' => 'leaked']],
+            'note' => 'context',
+        ]);
+
+        \assert(\is_array($sanitised));
+        \assert(\is_array($sanitised['exception']));
+        \assert(\is_array($sanitised['exception']['request']));
+        self::assertSame('***', $sanitised['exception']['request']['password']);
+        self::assertSame('context', $sanitised['note']);
+    }
+
+    public function testMasksSensitivePropertyBehindInterfaceType(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(
+            ['inner' => [
+                PayloadSanitizer::RUNTIME_CLASS_KEY => NestedInnerPayload::class,
+                'passcode' => '482031',
+                'label' => 'two-factor',
+            ], 'label' => 'cmd'],
+            InterfaceTypedCommand::class,
+        );
+
+        self::assertSame(
+            ['inner' => ['passcode' => '***', 'label' => 'two-factor'], 'label' => 'cmd'],
+            $sanitised,
+        );
+    }
+
+    public function testMasksWholeValueOfSensitiveClassBehindInterfaceType(): void
+    {
+        $sanitised = $this->sanitizer->sanitize(
+            [
+                'inner' => [
+                    PayloadSanitizer::RUNTIME_CLASS_KEY => SensitiveValueObject::class,
+                    'number' => 'card-number-test',
+                    'holder' => 'admin',
+                ],
+                'label' => 'default card',
+            ],
+            InterfaceTypedCommand::class,
+        );
+
+        self::assertSame(['inner' => '***', 'label' => 'default card'], $sanitised);
     }
 }


### PR DESCRIPTION
## Description

- `PayloadSanitizer` passed through any array under the `exception` key without masking. Now only raw `\Throwable` instances and structured exception arrays (output of `ExceptionFormatter::format()`) are exempt; arbitrary arrays are walked and masked normally.
- Properties typed as interfaces lost their runtime class after normalization, so `#[Sensitive]` attributes on concrete implementations were ignored. `PayloadSanitizer` now reads a `__runtime_class__` key in nested objects to resolve the concrete class for attribute-driven masking.

## How to test

```bash
cd centreon
php vendor/bin/phpunit tests/php/App/Shared/Infrastructure/Logging/PayloadSanitizerTest.php
```

- `testPassesThroughAlreadyStructuredExceptionArray` — verifies that properly structured exception arrays still pass through.
- `testMasksArrayUnderExceptionKeyThatIsNotAStructuredException` — verifies that a non-exception array under the `exception` key is now masked.
- `testMasksSensitivePropertyBehindInterfaceType` — verifies that `#[Sensitive]` on a concrete class behind an interface is honoured.
- `testMasksWholeValueOfSensitiveClassBehindInterfaceType` — verifies wholesale masking of a class-level `#[Sensitive]` behind an interface.

## Links

### Jira ticket

Fixes: [MON-202127](https://centreon.atlassian.net/browse/MON-202127)

### PR Github

Backports: #10869

[MON-202127]: https://centreon.atlassian.net/browse/MON-202127