### PR TITLE
enh(vault): add VaultEligibilityService

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -66,6 +66,9 @@ services:
         arguments: ['%env(bool:IS_CLOUD_PLATFORM)%', '%env(file:resolve:FILE_FEATURE_FLAGS)%']
         public: true
 
+    Core\Common\Application\VaultEligibilityService:
+        public: true
+
     Adaptation\Database\Connection\Model\ConnectionConfig:
         arguments:
             $host: '%database_host%'

--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -505,12 +505,6 @@ parameters:
 			path: tests/php/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsTest.php
 
 		-
-			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
-			identifier: method.protected
-			count: 1
-			path: tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
-
-		-
 			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
 			count: 3

--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -505,6 +505,12 @@ parameters:
 			path: tests/php/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsTest.php
 
 		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
+
+		-
 			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
 			count: 3

--- a/centreon/src/Core/Common/Application/VaultEligibilityService.php
+++ b/centreon/src/Core/Common/Application/VaultEligibilityService.php
@@ -26,7 +26,7 @@ namespace Core\Common\Application;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
-final class VaultEligibilityService
+class VaultEligibilityService
 {
     public function __construct(
         private readonly FeatureFlags $featureFlags,

--- a/centreon/src/Core/Common/Application/VaultEligibilityService.php
+++ b/centreon/src/Core/Common/Application/VaultEligibilityService.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Common\Application;
+
+use Core\Common\Infrastructure\FeatureFlags;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+
+final class VaultEligibilityService
+{
+    public function __construct(
+        private readonly FeatureFlags $featureFlags,
+        private readonly ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository,
+    ) {
+    }
+
+    public function shouldUseVault(string $featureFlag = 'vault'): bool
+    {
+        return $this->featureFlags->isEnabled($featureFlag)
+            && $this->readVaultConfigurationRepository->exists();
+    }
+}

--- a/centreon/tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
+++ b/centreon/tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Common\Application;
+
+use Core\Common\Application\VaultEligibilityService;
+use Core\Common\Infrastructure\FeatureFlags;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+
+beforeEach(function (): void {
+    $this->readVaultConfigurationRepository = $this->createMock(ReadVaultConfigurationRepositoryInterface::class);
+});
+
+it(
+    'should return false when feature flag is disabled',
+    function (): void {
+        $featureFlags = new FeatureFlags(false, '{"vault": 0}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        expect($service->shouldUseVault())->toBeFalse();
+    }
+);
+
+it(
+    'should return false when feature flag is enabled but vault config does not exist',
+    function (): void {
+        $featureFlags = new FeatureFlags(false, '{"vault": 1}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(false);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        expect($service->shouldUseVault())->toBeFalse();
+    }
+);
+
+it(
+    'should return true when feature flag is enabled and vault config exists',
+    function (): void {
+        $featureFlags = new FeatureFlags(false, '{"vault": 1}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        expect($service->shouldUseVault())->toBeTrue();
+    }
+);
+
+it(
+    'should check the correct feature flag when a custom flag name is provided',
+    function (): void {
+        $featureFlags = new FeatureFlags(false, '{"vault": 0, "vault_broker": 1}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        expect($service->shouldUseVault())->toBeFalse();
+        expect($service->shouldUseVault('vault_broker'))->toBeTrue();
+    }
+);

--- a/centreon/tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
+++ b/centreon/tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
@@ -26,56 +26,57 @@ namespace Tests\Core\Common\Application;
 use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-beforeEach(function (): void {
-    $this->readVaultConfigurationRepository = $this->createMock(ReadVaultConfigurationRepositoryInterface::class);
-});
+final class VaultEligibilityServiceTest extends TestCase
+{
+    /** @var ReadVaultConfigurationRepositoryInterface&MockObject */
+    private ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository;
 
-it(
-    'should return false when feature flag is disabled',
-    function (): void {
+    protected function setUp(): void
+    {
+        $this->readVaultConfigurationRepository = $this->createMock(ReadVaultConfigurationRepositoryInterface::class);
+    }
+
+    public function testShouldReturnFalseWhenFeatureFlagIsDisabled(): void
+    {
         $featureFlags = new FeatureFlags(false, '{"vault": 0}');
         $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
 
         $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
 
-        expect($service->shouldUseVault())->toBeFalse();
+        $this->assertFalse($service->shouldUseVault());
     }
-);
 
-it(
-    'should return false when feature flag is enabled but vault config does not exist',
-    function (): void {
+    public function testShouldReturnFalseWhenFeatureFlagIsEnabledButVaultConfigDoesNotExist(): void
+    {
         $featureFlags = new FeatureFlags(false, '{"vault": 1}');
         $this->readVaultConfigurationRepository->method('exists')->willReturn(false);
 
         $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
 
-        expect($service->shouldUseVault())->toBeFalse();
+        $this->assertFalse($service->shouldUseVault());
     }
-);
 
-it(
-    'should return true when feature flag is enabled and vault config exists',
-    function (): void {
+    public function testShouldReturnTrueWhenFeatureFlagIsEnabledAndVaultConfigExists(): void
+    {
         $featureFlags = new FeatureFlags(false, '{"vault": 1}');
         $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
 
         $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
 
-        expect($service->shouldUseVault())->toBeTrue();
+        $this->assertTrue($service->shouldUseVault());
     }
-);
 
-it(
-    'should check the correct feature flag when a custom flag name is provided',
-    function (): void {
+    public function testShouldCheckTheCorrectFeatureFlagWhenACustomFlagNameIsProvided(): void
+    {
         $featureFlags = new FeatureFlags(false, '{"vault": 0, "vault_broker": 1}');
         $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
 
         $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
 
-        expect($service->shouldUseVault())->toBeFalse();
-        expect($service->shouldUseVault('vault_broker'))->toBeTrue();
+        $this->assertFalse($service->shouldUseVault());
+        $this->assertTrue($service->shouldUseVault('vault_broker'));
     }
-);
+}


### PR DESCRIPTION
## Description

Add a `VaultEligibilityService` in `src/Core/Common/Application/` that provides a single source of truth for checking whether the vault should be used for writes. The service checks both the vault feature flag and the vault configuration file existence before allowing vault operations.

Method: `shouldUseVault(string $featureFlag = 'vault'): bool`

The service is registered in `config/packages/Centreon.yaml` with `public: true` to ensure usage in legacy.

Unit tests cover 4 scenarios: flag disabled, flag enabled without config, flag enabled with config, and custom flag name.

**Fixes** MON-202479

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).