### PR TITLE
enh(vault): migrate Core use cases to VaultEligibilityService

### DIFF
--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -897,7 +897,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 24
+			count: 25
 			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
 
 		-
@@ -951,7 +951,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 14
+			count: 15
 			path: tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
 
 		-
@@ -1047,7 +1047,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 24
+			count: 25
 			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
 
 		-
@@ -1503,7 +1503,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 17
+			count: 18
 			path: tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
 
 		-
@@ -1533,7 +1533,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 7
+			count: 8
 			path: tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
 
 		-
@@ -1581,7 +1581,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 23
+			count: 24
 			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
 
 		-
@@ -2511,7 +2511,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 24
+			count: 25
 			path: tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
 
 		-
@@ -2541,7 +2541,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 9
+			count: 10
 			path: tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
 
 		-
@@ -2679,7 +2679,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 23
+			count: 24
 			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
 
 		-
@@ -2979,7 +2979,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 6
+			count: 7
 			path: tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
 
 		-
@@ -3057,7 +3057,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 18
+			count: 19
 			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
 
 		-

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -42,6 +42,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Exception\HostException;
@@ -90,6 +91,7 @@ final class AddHost
         private readonly AddHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly WriteRealTimeHostRepositoryInterface $writeRealTimeHostRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
@@ -208,7 +210,7 @@ final class AddHost
             ? (int) $inheritanceMode[0]->getValue()
             : 0;
 
-        if ($this->writeVaultRepository->isVaultConfigured() === true && $request->snmpCommunity !== '') {
+        if ($this->vaultEligibilityService->shouldUseVault() && $request->snmpCommunity !== '') {
             $vaultPaths = $this->writeVaultRepository->upsert(
                 null,
                 [VaultConfiguration::HOST_SNMP_COMMUNITY_KEY => $request->snmpCommunity]
@@ -365,7 +367,7 @@ final class AddHost
                     : ''
                 );
             }
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_HOST' . $macro->getName() => $macro->getValue()],
@@ -423,7 +425,7 @@ final class AddHost
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/Host/Application/UseCase/DeleteHost/DeleteHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/DeleteHost/DeleteHost.php
@@ -34,6 +34,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
@@ -62,6 +63,7 @@ final class DeleteHost
         private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
     ) {
@@ -112,7 +114,7 @@ final class DeleteHost
         $this->debug('Start transaction');
 
         $this->storageEngine->startTransaction();
-        $isVaultActive = $this->writeVaultRepository->isVaultConfigured();
+        $isVaultActive = $this->vaultEligibilityService->shouldUseVault();
         try {
             // Only delete services that are exclusively linked to this host
             $serviceIds = $this->readServiceRepository->findServiceIdsExclusivelyLinkedToHostId($host->getId());

--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -47,6 +47,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
@@ -106,6 +107,7 @@ final class PartialUpdateHost
         private readonly PartialUpdateHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
@@ -184,7 +186,7 @@ final class PartialUpdateHost
         try {
             $this->dataStorageEngine->startTransaction();
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveHostUuidFromVault($host);
             }
 
@@ -789,10 +791,10 @@ final class PartialUpdateHost
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -832,7 +834,7 @@ final class PartialUpdateHost
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixedName = '_HOST' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,
@@ -904,7 +906,7 @@ final class PartialUpdateHost
         }
 
         // If vault is not configured, just set the value directly
-        if (! $this->writeVaultRepository->isVaultConfigured()) {
+        if (! $this->vaultEligibilityService->shouldUseVault()) {
             $host->setSnmpCommunity($snmpCommunity ?? '');
 
             return;

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
@@ -42,6 +42,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\InheritanceManager;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
@@ -79,6 +80,7 @@ final class AddHostTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -177,7 +179,7 @@ final class AddHostTemplate
             ? (int) ($inheritanceMode[0])->getValue()
             : 0;
 
-        if ($this->writeVaultRepository->isVaultConfigured() === true && $request->snmpCommunity !== '') {
+        if ($this->vaultEligibilityService->shouldUseVault() && $request->snmpCommunity !== '') {
             $vaultPaths = $this->writeVaultRepository->upsert(
                 null,
                 [VaultConfiguration::HOST_SNMP_COMMUNITY_KEY => $request->snmpCommunity]
@@ -310,7 +312,7 @@ final class AddHostTemplate
                 );
             }
 
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_HOST' . $macro->getName() => $macro->getValue()],
@@ -369,7 +371,7 @@ final class AddHostTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/HostTemplate/Application/UseCase/DeleteHostTemplate/DeleteHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/DeleteHostTemplate/DeleteHostTemplate.php
@@ -34,6 +34,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\HostTemplate\Application\Exception\HostTemplateException;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
@@ -52,6 +53,7 @@ final class DeleteHostTemplate
         private readonly ContactInterface $user,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -95,7 +97,7 @@ final class DeleteHostTemplate
                 return;
             }
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveHostTemplateUuidFromVault($hostTemplate);
                 if ($this->uuid !== null) {
                     $this->writeVaultRepository->delete($this->uuid);

--- a/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
@@ -47,6 +47,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\InheritanceManager;
@@ -93,6 +94,7 @@ final class PartialUpdateHostTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -183,7 +185,7 @@ final class PartialUpdateHostTemplate
         try {
             $this->dataStorageEngine->startTransaction();
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveHostUuidFromVault($hostTemplate);
             }
 
@@ -498,10 +500,10 @@ final class PartialUpdateHostTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -617,7 +619,7 @@ final class PartialUpdateHostTemplate
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixedName = '_HOST' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,
@@ -690,7 +692,7 @@ final class PartialUpdateHostTemplate
         }
 
         // If vault is not configured, just set the value directly
-        if (! $this->writeVaultRepository->isVaultConfigured()) {
+        if (! $this->vaultEligibilityService->shouldUseVault()) {
             $hostTemplate->setSnmpCommunity($snmpCommunity);
 
             return;

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -41,6 +41,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -97,6 +98,7 @@ final class AddService
         private readonly bool $isCloudPlatform,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly WriteRealTimeServiceRepositoryInterface $writeRealTimeServiceRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
@@ -220,7 +222,7 @@ final class AddService
             }
             $this->info('Add the macro ' . $macro->getName());
 
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_SERVICE' . $macro->getName() => $macro->getValue()],
@@ -500,7 +502,7 @@ final class AddService
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/Service/Application/UseCase/DeleteService/DeleteService.php
+++ b/centreon/src/Core/Service/Application/UseCase/DeleteService/DeleteService.php
@@ -34,6 +34,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
@@ -66,6 +67,7 @@ final class DeleteService
         private readonly ContactInterface $user,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -109,7 +111,7 @@ final class DeleteService
                 $monitoringServerId = $this->readRepository->findMonitoringServerId($serviceId);
                 $this->info("Delete service #{$serviceId}");
 
-                if ($this->writeVaultRepository->isVaultConfigured()) {
+                if ($this->vaultEligibilityService->shouldUseVault()) {
                     $this->retrieveServiceUuidFromVault($serviceId);
                     if ($this->uuid !== null) {
                         $this->writeVaultRepository->delete($this->uuid);

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
@@ -45,6 +45,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
@@ -103,6 +104,7 @@ final class PartialUpdateService
         private readonly bool $isCloudPlatform,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
@@ -177,7 +179,7 @@ final class PartialUpdateService
         $this->dataStorageEngine->startTransaction();
         try {
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveServiceUuidFromVault($service->getId());
             }
 
@@ -599,10 +601,10 @@ final class PartialUpdateService
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -667,7 +669,7 @@ final class PartialUpdateService
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixName = '_SERVICE' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
@@ -41,6 +41,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
@@ -92,6 +93,7 @@ final class AddServiceTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -214,7 +216,7 @@ final class AddServiceTemplate
             }
             $this->info('Add the macro ' . $macro->getName());
 
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_SERVICE' . $macro->getName() => $macro->getValue()],
@@ -499,7 +501,7 @@ final class AddServiceTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
@@ -33,6 +33,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
@@ -57,6 +58,7 @@ final class DeleteServiceTemplate
         private readonly ContactInterface $user,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -101,7 +103,7 @@ final class DeleteServiceTemplate
                 return;
             }
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveServiceUuidFromVault($serviceTemplateId);
                 if ($this->uuid !== null) {
                     $this->writeVaultRepository->delete($this->uuid);

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -44,6 +44,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\HostTemplate\Application\Exception\HostTemplateException;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -94,6 +95,7 @@ final class PartialUpdateServiceTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -282,7 +284,7 @@ final class PartialUpdateServiceTemplate
         $this->debug('Start transaction');
         $this->storageEngine->startTransaction();
         try {
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveServiceUuidFromVault($serviceTemplate->getId());
             }
 
@@ -404,10 +406,10 @@ final class PartialUpdateServiceTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -680,7 +682,7 @@ final class PartialUpdateServiceTemplate
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixName = '_SERVICE' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,

--- a/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
@@ -40,6 +40,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Host\Application\Converter\HostEventConverter;
@@ -96,6 +97,7 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(AddHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        vaultEligibilityService: $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         writeRealTimeHostRepository: $this->writeRealTimeHostRepository = $this->createMock(WriteRealTimeHostRepositoryInterface::class),
         readCommandRepository: $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         writeAccessGroupRepository: $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),

--- a/centreon/tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
@@ -29,6 +29,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
@@ -58,6 +59,7 @@ beforeEach(closure: function (): void {
         readAccessGroupRepository: $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         writeMonitoringServerRepository: $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
         writeVaultRepository: $this->createMock(WriteVaultRepositoryInterface::class),
+        vaultEligibilityService: $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         readHostMacroRepository: $this->createMock(ReadHostMacroRepositoryInterface::class),
         readServiceMacroRepository: $this->createMock(ReadServiceMacroRepositoryInterface::class),
     );

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
@@ -40,6 +40,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
@@ -91,6 +92,7 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(PartialUpdateHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        vaultEligibilityService: $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         readCommandRepository:  $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         writeAccessGroupRepository: $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         adminResolver: $this->adminResolver = $this->createMock(AdminResolver::class),

--- a/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
@@ -40,6 +40,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Domain\Model\HostEvent;
@@ -83,7 +84,8 @@ beforeEach(function (): void {
         $this->validation = $this->createMock(AddHostTemplateValidation::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
-        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class)
+        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 
     $this->inheritanceModeOption = new Option();

--- a/centreon/tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
@@ -29,6 +29,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\HostTemplate\Application\Exception\HostTemplateException;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
 use Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterface;
@@ -52,6 +53,7 @@ beforeEach(function (): void {
         $this->user,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readHostMacroRepository = $this->createMock(ReadHostMacroRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 });
 

--- a/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
@@ -41,6 +41,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Domain\Model\HostEvent;
@@ -89,7 +90,8 @@ beforeEach(function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
-        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class)
+        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 
     $this->inheritanceModeOption = new Option();

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
@@ -37,6 +37,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Domain\YesNoDefault;
 use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -95,6 +96,7 @@ beforeEach(function (): void {
         $this->isCloudPlatform = false,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         $this->writeRealTimeServiceRepository = $this->createMock(WriteRealTimeServiceRepositoryInterface::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),

--- a/centreon/tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
@@ -30,6 +30,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -52,6 +53,7 @@ beforeEach(closure: function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readServiceMacroRepository = $this->createMock(ReadServiceMacroRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 });
 

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
@@ -38,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -93,6 +94,7 @@ beforeEach(closure: function (): void {
         $this->isCloudPlatform = false,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         $this->adminResolver = $this->createMock(AdminResolver::class),

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/Mock.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/Mock.php
@@ -30,6 +30,7 @@ use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\CommandMacro\Application\Repository\ReadCommandMacroRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -72,6 +73,7 @@ class Mock extends TestCase
             $testCase->writeVaultRepository = $testCase->createMock(WriteVaultRepositoryInterface::class),
             $testCase->readVaultRepository = $testCase->createMock(ReadVaultRepositoryInterface::class),
             $testCase->readCommandRepository = $testCase->createMock(ReadCommandRepositoryInterface::class),
+            $testCase->vaultEligibilityService = $testCase->createMock(VaultEligibilityService::class),
         );
     }
 

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
@@ -30,6 +30,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
@@ -47,6 +48,7 @@ beforeEach(closure: function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readServiceMacroRepository = $this->createMock(ReadServiceMacroRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
     $this->serviceTemplateLockedFound = new ServiceTemplate(
         1,

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -39,6 +39,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Domain\YesNoDefault;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -89,6 +90,7 @@ beforeEach(closure: function (): void {
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 });
 
@@ -652,8 +654,8 @@ it('should load command macros from an inherited template command when the servi
         ->with($serviceTemplateId)
         ->willReturn($serviceTemplate);
 
-    $this->writeVaultRepository
-        ->method('isVaultConfigured')
+    $this->vaultEligibilityService
+        ->method('shouldUseVault')
         ->willReturn(false);
 
     $this->storageEngine


### PR DESCRIPTION
## Description

Migrate all 12 Core use cases (Host, HostTemplate, Service, ServiceTemplate — Add/Delete/PartialUpdate) from `writeVaultRepository->isVaultConfigured()` to `VaultEligibilityService->shouldUseVault()`.

This ensures vault credentials are only stored when both the feature flag is enabled AND the vault configuration exists.

Fixes: [MON-202480](https://centreon.atlassian.net/browse/MON-202480)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Enable the vault feature flag and configure a valid vault.json
2. Create a host with SNMP community — credentials should be stored in vault
3. Disable the vault feature flag (set to 0) while keeping vault.json present
4. Create another host with SNMP community — credentials must NOT be stored in vault

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-202480]: https://centreon.atlassian.net/browse/MON-202480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ