### PR TITLE
enh(vault): migrate Broker and ACC use cases to VaultEligibilityService

### DIFF
--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -9,7 +9,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 9
+			count: 10
 			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
 
 		-
@@ -33,7 +33,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 8
+			count: 9
 			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
 
 		-
@@ -75,7 +75,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 15
+			count: 16
 			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
 
 		-
@@ -429,7 +429,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 6
+			count: 7
 			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
 
 		-

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAcc.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAcc.php
@@ -40,7 +40,7 @@ use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 
 final class AddAcc
@@ -57,7 +57,7 @@ final class AddAcc
      * @param AccFactory $factory
      * @param DataStorageEngineInterface $dataStorageEngine
      * @param ContactInterface $user
-     * @param FeatureFlags $flags
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param \Traversable<WriteVaultAccRepositoryInterface> $writeVaultAccRepositories
      * @param WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository
      */
@@ -68,7 +68,7 @@ final class AddAcc
         private readonly AccFactory $factory,
         private readonly DataStorageEngineInterface $dataStorageEngine,
         private readonly ContactInterface $user,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         \Traversable $writeVaultAccRepositories,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
     ) {
@@ -103,7 +103,7 @@ final class AddAcc
                 description: $request->description,
             );
 
-            if ($this->flags->isEnabled('vault_gorgone')) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_gorgone')) {
                 $parameters = $newAcc->getParameters();
 
                 foreach ($this->writeVaultAccRepositories as $repository) {

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAcc.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAcc.php
@@ -36,7 +36,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
@@ -54,7 +54,7 @@ final class DeleteAcc
      * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepository
      * @param ReadMonitoringServerRepositoryInterface $readMonitoringServerRepository
      * @param ContactInterface $user
-     * @param FeatureFlags $flags
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param \Traversable<WriteVaultAccRepositoryInterface> $writeVaultAccRepositories
      * @param WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository
      */
@@ -64,7 +64,7 @@ final class DeleteAcc
         private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
         private readonly ReadMonitoringServerRepositoryInterface $readMonitoringServerRepository,
         private readonly ContactInterface $user,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         \Traversable $writeVaultAccRepositories,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
     ) {
@@ -114,7 +114,7 @@ final class DeleteAcc
                 }
             }
 
-            if ($this->flags->isEnabled('vault_gorgone')) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_gorgone')) {
                 foreach ($this->writeVaultAccRepositories as $repository) {
                     if ($repository->isValidFor($acc->getType())) {
                         $repository->deleteFromVault($acc);

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAcc.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAcc.php
@@ -42,7 +42,7 @@ use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
@@ -66,7 +66,7 @@ final class UpdateAcc
      * @param AccFactory $factory
      * @param DataStorageEngineInterface $dataStorageEngine
      * @param ContactInterface $user
-     * @param FeatureFlags $flags
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param \Traversable<WriteVaultAccRepositoryInterface> $writeVaultAccRepositories
      * @param \Traversable<ReadVaultAccRepositoryInterface> $readVaultAccRepositories
      * @param WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository
@@ -80,7 +80,7 @@ final class UpdateAcc
         private readonly AccFactory $factory,
         private readonly DataStorageEngineInterface $dataStorageEngine,
         private readonly ContactInterface $user,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         \Traversable $writeVaultAccRepositories,
         \Traversable $readVaultAccRepositories,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
@@ -130,7 +130,7 @@ final class UpdateAcc
             $parametersChanged = $decryptedPreviousAcc->getParameters()->getDecryptedData()
                 !== $updatedAcc->getParameters()->getDecryptedData();
 
-            if ($this->flags->isEnabled('vault_gorgone')) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_gorgone')) {
                 $parameters = $updatedAcc->getParameters();
 
                 foreach ($this->writeVaultAccRepositories as $repository) {

--- a/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
@@ -39,7 +39,7 @@ use Core\Broker\Domain\Model\BrokerInputOutputField;
 use Core\Broker\Domain\Model\NewBrokerInputOutput;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 
 /**
@@ -56,7 +56,7 @@ final class AddBrokerInputOutput
         private readonly ContactInterface $user,
         private readonly BrokerInputOutputValidator $validator,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::BROKER_VAULT_PATH);
     }
@@ -101,7 +101,7 @@ final class AddBrokerInputOutput
                 parameters: $validatedParameters
             );
 
-            if ($this->flags->isEnabled('vault_broker') && $this->writeVaultRepository->isVaultConfigured() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_broker')) {
                 $this->uuid = $this->getBrokerVaultUuid($request->brokerId);
                 $newOutput = $this->saveInVault($newOutput, $outputFields);
             }

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
@@ -42,8 +42,10 @@ use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
 beforeEach(function (): void {
     $this->presenter = new AddAccPresenterStub();
@@ -54,7 +56,10 @@ beforeEach(function (): void {
         factory: $this->factory = $this->createMock(AccFactory::class),
         dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class),
         user: $this->user = $this->createMock(ContactInterface::class),
-        flags: $this->flags = new FeatureFlags(false, ''),
+        vaultEligibilityService: $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
         writeVaultAccRepositories: $this->writeVaultAccRepositories = new \ArrayIterator([]),
         writeMonitoringServerRepository: $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
     );

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
@@ -36,12 +36,14 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
 beforeEach(function (): void {
     $this->useCase = new DeleteAcc(
@@ -50,7 +52,10 @@ beforeEach(function (): void {
         $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         $this->readMonitoringServerRepository = $this->createMock(ReadMonitoringServerRepositoryInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
+        $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
         $this->writeVaultAccRepositories = new \ArrayIterator([]),
         $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
     );

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
@@ -41,12 +41,14 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
 beforeEach(function (): void {
     $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
@@ -61,7 +63,10 @@ beforeEach(function (): void {
         $this->factory = $this->createMock(AccFactory::class),
         $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
+        $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
         $this->writeVaultAccRepositories = new \ArrayIterator([]),
         $this->readVaultAccRepositories = new \ArrayIterator([]),
         $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),

--- a/centreon/tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
+++ b/centreon/tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
@@ -37,8 +37,10 @@ use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Broker\Domain\Model\BrokerInputOutputField;
 use Core\Broker\Domain\Model\Type;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Tests\Core\Broker\Infrastructure\API\AddBrokerInputOutput\AddBrokerInputOutputPresenterStub;
 
 beforeEach(function (): void {
@@ -82,7 +84,10 @@ beforeEach(function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->validator = $this->createMock(BrokerInputOutputValidator::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
+        $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
     );
 });
 


### PR DESCRIPTION
## Description

Migrate Broker and ACC use cases to use `VaultEligibilityService->shouldUseVault()` instead of directly checking feature flags and vault configuration separately.

- **Broker**: `AddBrokerInputOutput` — replaces `flags->isEnabled('vault_broker') && writeVaultRepository->isVaultConfigured()` with `vaultEligibilityService->shouldUseVault('vault_broker')`
- **ACC**: `AddAcc`, `DeleteAcc`, `UpdateAcc` — replaces `flags->isEnabled('vault_gorgone')` with `vaultEligibilityService->shouldUseVault('vault_gorgone')`

Fixes: [MON-202481](https://centreon.atlassian.net/browse/MON-202481)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Enable vault feature flag (`vault_broker` and `vault_gorgone`) and configure a valid vault.json
2. Add a broker output — credentials should be stored in vault
3. Disable the feature flags while keeping vault.json present
4. Add another broker output — credentials must NOT be stored in vault
5. Repeat with ACC (additional connector configuration)

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-202481]: https://centreon.atlassian.net/browse/MON-202481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ