### PR TITLE
enh(vault): use VaultEligibilityService in MigrateAllCredentials

### DIFF
--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -2481,13 +2481,13 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 22
+			count: 21
 			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
 
 		-
 			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 3
+			count: 2
 			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
 
 		-

--- a/centreon/src/Core/Security/Vault/Application/Exceptions/VaultException.php
+++ b/centreon/src/Core/Security/Vault/Application/Exceptions/VaultException.php
@@ -34,4 +34,9 @@ class VaultException extends \Exception
     {
         return new self(_('No vault configured'));
     }
+
+    public static function vaultNotAvailable(): self
+    {
+        return new self(_('Vault is not available'));
+    }
 }

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -33,7 +33,7 @@ use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Domain\Model\Host;
@@ -57,7 +57,6 @@ use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Exceptions\VaultException;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\Migrator\AccCredentialMigratorInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 
@@ -72,7 +71,7 @@ final class MigrateAllCredentials
 
     /**
      * @param WriteVaultRepositoryInterface $writeVaultRepository
-     * @param ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param ReadHostRepositoryInterface $readHostRepository
      * @param ReadHostMacroRepositoryInterface $readHostMacroRepository
      * @param ReadHostTemplateRepositoryInterface $readHostTemplateRepository
@@ -91,12 +90,11 @@ final class MigrateAllCredentials
      * @param WriteBrokerInputOutputRepositoryInterface $writeBrokerInputOutputRepository
      * @param ReadAccRepositoryInterface $readAccRepository
      * @param WriteAccRepositoryInterface $writeAccRepository
-     * @param FeatureFlags $flags
      * @param \Traversable<AccCredentialMigratorInterface> $accCredentialMigrators
      */
     public function __construct(
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
-        private readonly ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
@@ -115,7 +113,6 @@ final class MigrateAllCredentials
         private readonly WriteBrokerInputOutputRepositoryInterface $writeBrokerInputOutputRepository,
         private readonly ReadAccRepositoryInterface $readAccRepository,
         private readonly WriteAccRepositoryInterface $writeAccRepository,
-        private readonly FeatureFlags $flags,
         \Traversable $accCredentialMigrators,
     ) {
         $this->response = new MigrateAllCredentialsResponse();
@@ -125,7 +122,7 @@ final class MigrateAllCredentials
     public function __invoke(MigrateAllCredentialsPresenterInterface $presenter): void
     {
         try {
-            if ($this->readVaultConfigurationRepository->find() === null) {
+            if (! $this->vaultEligibilityService->shouldUseVault()) {
                 $presenter->presentResponse(new ErrorResponse(VaultException::noVaultConfigured()));
 
                 return;
@@ -140,10 +137,10 @@ final class MigrateAllCredentials
             $openIdConfiguration = $this->readProviderConfigurationRepository->getConfigurationByType(
                 Provider::OPENID
             );
-            $brokerInputOutputs = $this->flags->isEnabled('vault_broker')
+            $brokerInputOutputs = $this->vaultEligibilityService->shouldUseVault('vault_broker')
                 ? $this->readBrokerInputOutputRepository->findAll()
                 : [];
-            $accs = $this->flags->isEnabled('vault_gorgone')
+            $accs = $this->vaultEligibilityService->shouldUseVault('vault_gorgone')
                 ? $this->readAccRepository->findAll()
                 : [];
 

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -123,7 +123,7 @@ final class MigrateAllCredentials
     {
         try {
             if (! $this->vaultEligibilityService->shouldUseVault()) {
-                $presenter->presentResponse(new ErrorResponse(VaultException::noVaultConfigured()));
+                $presenter->presentResponse(new ErrorResponse(VaultException::vaultNotAvailable()));
 
                 return;
             }

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
@@ -29,7 +29,7 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\Model\ContactTemplate;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
@@ -53,19 +53,15 @@ use Core\Security\ProviderConfiguration\Domain\Model\GroupsMapping;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Exceptions\VaultException;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\CredentialMigrator;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\MigrateAllCredentials;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\MigrateAllCredentialsResponse;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\Migrator\VmWareV6CredentialMigrator;
-use Core\Security\Vault\Domain\Model\VaultConfiguration;
-use Security\Interfaces\EncryptionInterface;
 
 beforeEach(function (): void {
-    $this->encryption = $this->createMock(EncryptionInterface::class);
     $this->useCase = new MigrateAllCredentials(
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
-        $this->readVaultConfigurationRepository = $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         $this->readHostRepository = $this->createMock(ReadHostRepositoryInterface::class),
         $this->readHostMacroRepository = $this->createMock(ReadHostMacroRepositoryInterface::class),
         $this->readHostTemplateRepository = $this->createMock(ReadHostTemplateRepositoryInterface::class),
@@ -84,16 +80,15 @@ beforeEach(function (): void {
         $this->writeBrokerInputOutputRepository = $this->createMock(WriteBrokerInputOutputRepositoryInterface::class),
         $this->readAccRepository = $this->createMock(ReadAccRepositoryInterface::class),
         $this->writeAccRepository = $this->createMock(WriteAccRepositoryInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
         $this->accCredentialMigrators = new \ArrayIterator([$this->createMock(VmWareV6CredentialMigrator::class)]),
     );
 });
 
 it('should present an Error Response when no vault are configured', function (): void {
-    $this->readVaultConfigurationRepository
+    $this->vaultEligibilityService
         ->expects($this->once())
-        ->method('find')
-        ->willReturn(null);
+        ->method('shouldUseVault')
+        ->willReturn(false);
     $presenter = new MigrateAllCredentialsPresenterStub();
     ($this->useCase)($presenter);
 
@@ -102,21 +97,9 @@ it('should present an Error Response when no vault are configured', function ():
 });
 
 it('should present a MigrateAllCredentialsResponse when no error occurs', function (): void {
-    $vaultConfiguration = new VaultConfiguration(
-        encryption: $this->encryption,
-        name: 'vault',
-        address: '127.0.0.1',
-        port: 443,
-        rootPath: 'mystorage',
-        encryptedRoleId: 'role-id',
-        encryptedSecretId: 'secret-id',
-        salt: 'labaleine'
-    );
-
-    $this->readVaultConfigurationRepository
-        ->expects($this->once())
-        ->method('find')
-        ->willReturn($vaultConfiguration);
+    $this->vaultEligibilityService
+        ->method('shouldUseVault')
+        ->willReturn(true);
 
     $customConfiguration = new CustomConfiguration([
         'is_active' => true,

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
@@ -93,7 +93,7 @@ it('should present an Error Response when no vault are configured', function ():
     ($this->useCase)($presenter);
 
     expect($presenter->response)->toBeInstanceOf(ErrorResponse::class)
-        ->and($presenter->response->getMessage())->toBe(VaultException::noVaultConfigured()->getMessage());
+        ->and($presenter->response->getMessage())->toBe(VaultException::vaultNotAvailable()->getMessage());
 });
 
 it('should present a MigrateAllCredentialsResponse when no error occurs', function (): void {


### PR DESCRIPTION
## Description

Replace `FeatureFlags` and `ReadVaultConfigurationRepositoryInterface` with `VaultEligibilityService` in `MigrateAllCredentials` use case. This consolidates the vault eligibility check (feature flag + vault config existence) into a single source of truth.

- Early return now uses `shouldUseVault()` instead of `readVaultConfigurationRepository->find() === null`
- Host/service reads no longer need individual flag gates (protected by the early return)
- Broker/ACC reads use `shouldUseVault('vault_broker')` / `shouldUseVault('vault_gorgone')`
- Tests and PHPStan baseline updated accordingly

Fixes: [MON-202482](https://centreon.atlassian.net/browse/MON-202482)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Disable the vault feature flag
2. Ensure `vault.json` exists on the platform
3. Run the MigrateAllCredentials use case — it should return an error (vault not eligible) instead of proceeding with migration
4. Enable the vault feature flag — migration should proceed normally

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-202482]: https://centreon.atlassian.net/browse/MON-202482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ