### PR TITLE
feat(ci): ship cloud packages for alma9 and alma10

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -255,22 +255,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el9, el10, trixie]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: rpm
-            tag_suffix: -alma10
-            distrib: el10
-          - package_extension: deb
-            tag_suffix: -trixie
-            distrib: trixie
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -214,22 +214,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el9, el10, trixie]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: rpm
-            tag_suffix: -alma10
-            distrib: el10
-          - package_extension: deb
-            tag_suffix: -trixie
-            distrib: trixie
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -829,6 +829,13 @@ jobs:
             const configs = [alma9_mysql_8_0, alma10_mariadb_11_8, trixie_mysql_8_4]
               .filter(c => packagedOperatingSystems.includes(c.operating_system));
 
+            if (configs.length === 0) {
+              core.setFailed(`No test configuration matches the packaged operating systems: ${packagedOperatingSystems.join(', ')}`);
+              return {};
+            }
+
+            // Fall back to the first packaged configuration when the preferred
+            // operating system is not part of the package matrix
             const cloud = configs.find(c => c.operating_system === 'alma9') ?? configs[0];
 
             let main = configs.find(c => c.operating_system === 'alma10') ?? configs[0];
@@ -888,6 +895,8 @@ jobs:
           PHP_VERSION: ${{ steps.get_php_version.outputs.php_version }}
           TARGET_STABILITY: ${{ steps.get_stability.outputs.target_stability }}
           PR_PATH: ${{ steps.pr_path.outputs.result || '[]' }}
+          PACKAGE_MATRIX: ${{ steps.get_package_matrix.outputs.result }}
+          OS_DATABASE_MATRIX: ${{ steps.get_os_database_matrix.outputs.result }}
         with:
           script: |
             const notFound = '<em>not found</em>';
@@ -898,9 +907,9 @@ jobs:
               ['latest_major_version', process.env.LATEST_MAJOR_VERSION],
               ['is_cloud', process.env.IS_CLOUD],
               ['previous_release_bundle_tag', process.env.PREVIOUS_RELEASE_BUNDLE_TAG || notFound],
-              ['delivery_type', process.env.DELIVERY_TYPE],
-              ['linked_dev_branch', process.env.LINKED_DEV_BRANCH],
-              ['linked_stable_branch', process.env.LINKED_STABLE_BRANCH],
+              ['delivery_type', process.env.DELIVERY_TYPE || notFound],
+              ['linked_dev_branch', process.env.LINKED_DEV_BRANCH || notFound],
+              ['linked_stable_branch', process.env.LINKED_STABLE_BRANCH || notFound],
               ['major_version', process.env.MAJOR_VERSION],
               ['minor_version', process.env.MINOR_VERSION],
               ['release', process.env.RELEASE],
@@ -910,35 +919,54 @@ jobs:
               ['is_nightly', process.env.IS_NIGHTLY],
               ['skip_workflow', process.env.SKIP_WORKFLOW],
               ['labels', process.env.LABELS],
-              ['php_version', process.env.PHP_VERSION],
+              ['php_version', process.env.PHP_VERSION || notFound],
+              ['target_stability', process.env.TARGET_STABILITY || notPr],
             ];
 
-            outputTable.push(['target_stability', process.env.TARGET_STABILITY || notPr]);
+            const packageMatrix = JSON.parse(process.env.PACKAGE_MATRIX);
+            const packageTable = [
+              [{data: 'Operating system', header: true}, {data: 'Distrib', header: true}, {data: 'Package extension', header: true}],
+              ...packageMatrix.map(d => [d.operating_system, d.distrib, d.package_extension]),
+            ];
+
+            const osDatabaseMatrix = JSON.parse(process.env.OS_DATABASE_MATRIX);
+            const osDatabaseTable = [
+              [{data: 'Matrix', header: true}, {data: 'Operating system', header: true}, {data: 'Database', header: true}, {data: 'Test tags', header: true}],
+              ...Object.entries(osDatabaseMatrix).flatMap(([matrixName, entries]) =>
+                entries.map(e => [matrixName, e.operating_system, e.database, e.test_tags])
+              ),
+            ];
 
             core.summary
               .addHeading(`${context.workflow} environment outputs`)
-              .addTable(outputTable);
+              .addTable(outputTable)
+              .addHeading('Package matrix', 2)
+              .addTable(packageTable)
+              .addHeading('Operating systems and databases matrix', 2)
+              .addTable(osDatabaseTable);
 
             if (process.env.GITHUB_EVENT_NAME === "pull_request") {
               const prPath = JSON.parse(process.env.PR_PATH);
-              const mainBranchName = prPath.pop();
-              let codeBlock = `
-                %%{ init: { 'gitGraph': { 'mainBranchName': '${mainBranchName}', 'showCommitLabel': false } } }%%
-                gitGraph
-                  commit`;
-              prPath.reverse().forEach((branchName) => {
-                codeBlock = `${codeBlock}
-                  branch ${branchName}
-                  checkout ${branchName}
-                  commit`;
-              });
+              if (prPath.length >= 2) {
+                const mainBranchName = prPath.pop();
+                let codeBlock = `
+                  %%{ init: { 'gitGraph': { 'mainBranchName': '${mainBranchName}', 'showCommitLabel': false } } }%%
+                  gitGraph
+                    commit`;
+                prPath.reverse().forEach((branchName) => {
+                  codeBlock = `${codeBlock}
+                    branch ${branchName}
+                    checkout ${branchName}
+                    commit`;
+                });
 
-              core.summary
-                .addHeading('Git workflow')
-                .addCodeBlock(
-                  codeBlock,
-                  "mermaid"
-                );
+                core.summary
+                  .addHeading('Git workflow')
+                  .addCodeBlock(
+                    codeBlock,
+                    "mermaid"
+                  );
+              }
             }
 
-            core.summary.write();
+            await core.summary.write();

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -725,6 +725,46 @@ jobs:
 
             core.setOutput('previous_release_bundle_tag', previousStableBundleTag);
 
+      - name: Get operating systems matrix for package and dockerize jobs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        id: get_package_matrix
+        env:
+          STABILITY: ${{ steps.get_stability.outputs.stability }}
+          IS_CLOUD: ${{ steps.detect_cloud_version.outputs.isCloud }}
+          HAS_UPLOAD_ARTIFACTS: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'upload-artifacts') }}
+          HAS_SYSTEM: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'system') }}
+          HAS_DATABASE: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'database') }}
+          IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
+        with:
+          script: |
+            const stability = process.env.STABILITY;
+            const isCloud = process.env.IS_CLOUD === 'true';
+            const isFullRun = ['unstable', 'testing', 'stable'].includes(stability)
+              || process.env.IS_NIGHTLY === 'true'
+              || process.env.HAS_UPLOAD_ARTIFACTS === 'true'
+              || process.env.HAS_SYSTEM === 'true'
+              || process.env.HAS_DATABASE === 'true';
+
+            const distribMap = {
+              alma9:    { distrib: 'el9',      package_extension: 'rpm' },
+              alma10:   { distrib: 'el10',     package_extension: 'rpm' },
+              trixie:   { distrib: 'trixie',   package_extension: 'deb' },
+            };
+
+            const allDistribs = Object.entries(distribMap).map(([os, info]) => ({
+              operating_system: os,
+              ...info,
+            }));
+
+            const cloudDistribs = allDistribs.filter(d => ['alma9', 'alma10'].includes(d.operating_system));
+            const onPremMainDistribs = allDistribs.filter(d => d.operating_system === 'alma10');
+            const isCloudTestingOrStable = isCloud && ['testing', 'stable'].includes(stability);
+            const result = isCloudTestingOrStable ? cloudDistribs : isFullRun ? allDistribs : isCloud ? cloudDistribs : onPremMainDistribs;
+
+            console.log('package_matrix', result);
+
+            return result;
+
       - name: Detect operating systems and databases to test
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: get_os_database_matrix
@@ -732,6 +772,7 @@ jobs:
           IS_CLOUD: ${{ steps.detect_cloud_version.outputs.isCloud }}
           IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
           LABELS: ${{ steps.has_skip_label.outputs.labels }}
+          PACKAGE_MATRIX: ${{ steps.get_package_matrix.outputs.result }}
         with:
           script: |
             const alma10_mariadb_11_8 = {
@@ -783,11 +824,14 @@ jobs:
               return configs[configIndex];
             };
 
-            const configs = [alma9_mysql_8_0, alma10_mariadb_11_8, trixie_mysql_8_4];
+            const packagedOperatingSystems = JSON.parse(process.env.PACKAGE_MATRIX).map(d => d.operating_system);
 
-            const cloud = alma9_mysql_8_0;
+            const configs = [alma9_mysql_8_0, alma10_mariadb_11_8, trixie_mysql_8_4]
+              .filter(c => packagedOperatingSystems.includes(c.operating_system));
 
-            let main = alma10_mariadb_11_8;
+            const cloud = configs.find(c => c.operating_system === 'alma9') ?? configs[0];
+
+            let main = configs.find(c => c.operating_system === 'alma10') ?? configs[0];
             if (process.env.IS_CLOUD === 'true') {
               main = cloud;
             }
@@ -822,46 +866,6 @@ jobs:
             console.log(matrix);
 
             return matrix;
-
-      - name: Get operating systems matrix for package and dockerize jobs
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        id: get_package_matrix
-        env:
-          STABILITY: ${{ steps.get_stability.outputs.stability }}
-          IS_CLOUD: ${{ steps.detect_cloud_version.outputs.isCloud }}
-          HAS_UPLOAD_ARTIFACTS: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'upload-artifacts') }}
-          HAS_SYSTEM: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'system') }}
-          HAS_DATABASE: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'database') }}
-          IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
-        with:
-          script: |
-            const stability = process.env.STABILITY;
-            const isCloud = process.env.IS_CLOUD === 'true';
-            const isFullRun = ['unstable', 'testing', 'stable'].includes(stability)
-              || process.env.IS_NIGHTLY === 'true'
-              || process.env.HAS_UPLOAD_ARTIFACTS === 'true'
-              || process.env.HAS_SYSTEM === 'true'
-              || process.env.HAS_DATABASE === 'true';
-
-            const distribMap = {
-              alma9:    { distrib: 'el9',      package_extension: 'rpm' },
-              alma10:   { distrib: 'el10',     package_extension: 'rpm' },
-              trixie:   { distrib: 'trixie',   package_extension: 'deb' },
-            };
-
-            const allDistribs = Object.entries(distribMap).map(([os, info]) => ({
-              operating_system: os,
-              ...info,
-            }));
-
-            const cloudDistrib = allDistribs.find(d => d.operating_system === 'alma9');
-            const onPremMainDistrib = allDistribs.filter(d => d.operating_system === 'alma10');
-            const isCloudTestingOrStable = isCloud && ['testing', 'stable'].includes(stability);
-            const result = isCloudTestingOrStable ? [cloudDistrib] : isFullRun ? allDistribs : isCloud ? [cloudDistrib] : [onPremMainDistrib];
-
-            console.log('package_matrix', result);
-
-            return result;
 
       - name: Display info in job summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -84,22 +84,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el9, el10, trixie]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: rpm
-            tag_suffix: -alma10
-            distrib: el10
-          - package_extension: deb
-            tag_suffix: -trixie
-            distrib: trixie
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -334,22 +334,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el9, el10, trixie]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: rpm
-            tag_suffix: -alma10
-            distrib: el10
-          - package_extension: deb
-            tag_suffix: -trixie
-            distrib: trixie
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -805,21 +805,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: rpm
-            tag_suffix: -alma10
-            distrib: el10
-          - package_extension: deb
-            tag_suffix: -trixie
-            distrib: trixie
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     name: package ${{ matrix.distrib }}
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Fixes: [MON-203151](https://centreon.atlassian.net/browse/MON-203151)

## Description

In `get-environment.yml`:

- The cloud distribution list of the `get_package_matrix` step now includes both `alma9` and `alma10` (it was restricted to `alma9` only).
- The `get_package_matrix` step is moved before the `get_os_database_matrix` step, and the OS/database test configurations are filtered on the operating systems present in the package matrix. Tests can no longer target a distribution for which no package is built.
- The package matrix no longer returns a nested array for on-prem non-full runs (`[onPremMainDistrib]` where `onPremMainDistrib` was already an array).
- The `get_os_database_matrix` step now fails fast with an explicit error if no test configuration matches the packaged operating systems, instead of propagating an undefined entry to downstream jobs.

The packaging jobs of the `web`, `awie`, `dsm`, `ha` and `open-tickets` workflows are now driven by the `package_matrix` output instead of a hardcoded distribution matrix (`el9`, `el10`, `trixie`), so packaging follows the same distribution scope as dockerize and delivery jobs. The packaging container image tag is derived from `matrix.operating_system`, replacing the `tag_suffix` matrix field.

The "Display info in job summary" step is also improved:

- The package matrix and the OS/database matrix are displayed as tables in the job summary.
- Fallbacks for undefined values are harmonized (`delivery_type`, `linked_dev_branch`, `linked_stable_branch`, `php_version`).
- The git workflow mermaid graph is skipped when the PR path could not be resolved, instead of rendering an invalid graph.

## Resulting matrices per scenario

| Scenario | Package matrix (packaging + dockerize + delivery) | OS/database matrix |
|---|---|---|
| Cloud PR (canary) | alma9, alma10 | alma9 (mysql 8.0) |
| Cloud testing/stable | alma9, alma10 | alma9 (mysql 8.0) |
| On-prem PR (canary) | alma10 | alma10 (mariadb 11.8) |
| Full run (unstable, nightly, `upload-artifacts`/`system`/`database` labels) | alma9, alma10, trixie | unchanged behavior |

The OS/database matrix is now always a subset of the packaged distributions, including when the `system`/`database` labels expand it.

## Validation

Manual `workflow_dispatch` runs of the `awie` workflow on this branch:

- [Run 28580083546](https://github.com/centreon/centreon/actions/runs/28580083546) (before packaging alignment): fully green — package matrix `alma9 + alma10`, `dockerize alma9` and `dockerize alma10` built, e2e tests correctly restricted to `alma9 / mysql:8.0`.
- [Run 28580845741](https://github.com/centreon/centreon/actions/runs/28580845741) (with packaging alignment): packaging jobs restricted to the package matrix (`el9`, `el10` — no `trixie`).

[MON-203151]: https://centreon.atlassian.net/browse/MON-203151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ