### PR TITLE
chore(deps): prune stale symfony.lock recipe entries

### DIFF
--- a/centreon/symfony.lock
+++ b/centreon/symfony.lock
@@ -1,7 +1,4 @@
 {
-    "adlawson/vfs": {
-        "version": "0.12.1"
-    },
     "api-platform/core": {
         "version": "4.1",
         "recipe": {
@@ -27,9 +24,6 @@
     },
     "behat/mink-selenium2-driver": {
         "version": "v1.4.0"
-    },
-    "behat/transliterator": {
-        "version": "v1.3.0"
     },
     "cebe/php-openapi": {
         "version": "1.5.2"
@@ -101,9 +95,6 @@
     },
     "enshrined/svg-sanitize": {
         "version": "0.14.1"
-    },
-    "facade/ignition-contracts": {
-        "version": "1.0.2"
     },
     "friends-of-behat/mink": {
         "version": "v1.9.0"
@@ -209,9 +200,6 @@
     "pear/pear_exception": {
         "version": "v1.0.2"
     },
-    "php-http/message-factory": {
-        "version": "v1.0.2"
-    },
     "phpdocumentor/reflection-common": {
         "version": "2.2.0"
     },
@@ -221,17 +209,8 @@
     "phpdocumentor/type-resolver": {
         "version": "1.5.0"
     },
-    "phpspec/prophecy": {
-        "version": "1.14.0"
-    },
     "phpstan/phpdoc-parser": {
         "version": "0.5.7"
-    },
-    "phpstan/phpstan": {
-        "version": "0.12.99"
-    },
-    "phpstan/phpstan-beberlei-assert": {
-        "version": "0.12.6"
     },
     "phpunit/phpunit": {
         "version": "10.5",
@@ -288,21 +267,6 @@
     },
     "riverline/multipart-parser": {
         "version": "2.0.8"
-    },
-    "sebastian/resource-operations": {
-        "version": "3.0.3"
-    },
-    "sensio/framework-extra-bundle": {
-        "version": "5.2",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "5.2",
-            "ref": "fb7e19da7f013d0d422fa9bce16f5c510e27609b"
-        },
-        "files": [
-            "config/packages/sensio_framework_extra.yaml"
-        ]
     },
     "smarty-gettext/smarty-gettext": {
         "version": "1.6.2"
@@ -443,15 +407,6 @@
             "config/packages/lock.yaml"
         ]
     },
-    "symfony/maker-bundle": {
-        "version": "1.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
-        }
-    },
     "symfony/messenger": {
         "version": "7.3",
         "recipe": {
@@ -481,9 +436,6 @@
             "config/packages/prod/monolog.yaml",
             "config/packages/test/monolog.yaml"
         ]
-    },
-    "symfony/options-resolver": {
-        "version": "v4.4.30"
     },
     "symfony/panther": {
         "version": "2.4",
@@ -520,15 +472,6 @@
     },
     "symfony/polyfill-mbstring": {
         "version": "v1.23.1"
-    },
-    "symfony/polyfill-php73": {
-        "version": "v1.23.0"
-    },
-    "symfony/polyfill-php80": {
-        "version": "v1.23.1"
-    },
-    "symfony/polyfill-php81": {
-        "version": "v1.23.0"
     },
     "symfony/property-access": {
         "version": "v4.4.30"
@@ -567,9 +510,6 @@
     },
     "symfony/security-csrf": {
         "version": "v5.2.12"
-    },
-    "symfony/security-guard": {
-        "version": "v4.4.27"
     },
     "symfony/security-http": {
         "version": "v4.4.30"


### PR DESCRIPTION
Fixes: [MON-202485](https://centreon.atlassian.net/browse/MON-202485)

Prunes stale Symfony Flex recipe entries from `centreon/symfony.lock` — top-level keys naming packages no longer present in `composer.lock`. These orphaned entries accumulated because Flex only prunes on real uninstall events, which never fired when packages were removed via manual `composer.json` edits or `composer remove --no-install/--no-scripts`.

Deletions-only diff — no config/recipe file changes. 15 stale entries removed.

Every remaining top-level key in `symfony.lock` now maps to an installed package in `composer.lock`.


[MON-202485]: https://centreon.atlassian.net/browse/MON-202485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ