### PR TITLE
feat(ci): drive CI matrices from package matrix

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -255,22 +255,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bookworm]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma8
-            distrib: el8
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: deb
-            tag_suffix: -bookworm
-            distrib: bookworm
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -214,22 +214,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bookworm]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma8
-            distrib: el8
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: deb
-            tag_suffix: -bookworm
-            distrib: bookworm
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -705,6 +705,46 @@ jobs:
 
             core.setOutput('previous_release_bundle_tag', previousStableBundleTag);
 
+      - name: Get operating systems matrix for package and dockerize jobs
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        id: get_package_matrix
+        env:
+          STABILITY: ${{ steps.get_stability.outputs.stability }}
+          IS_CLOUD: ${{ steps.detect_cloud_version.outputs.isCloud }}
+          HAS_UPLOAD_ARTIFACTS: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'upload-artifacts') }}
+          HAS_SYSTEM: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'system') }}
+          HAS_DATABASE: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'database') }}
+          IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
+        with:
+          script: |
+            const stability = process.env.STABILITY;
+            const isCloud = process.env.IS_CLOUD === 'true';
+            const isFullRun = ['unstable', 'testing', 'stable'].includes(stability)
+              || process.env.IS_NIGHTLY === 'true'
+              || process.env.HAS_UPLOAD_ARTIFACTS === 'true'
+              || process.env.HAS_SYSTEM === 'true'
+              || process.env.HAS_DATABASE === 'true';
+
+            const distribMap = {
+              alma9:    { distrib: 'el9',      package_extension: 'rpm' },
+              alma8:    { distrib: 'el8',      package_extension: 'rpm' },
+              bookworm: { distrib: 'bookworm', package_extension: 'deb' },
+            };
+
+            const allDistribs = Object.entries(distribMap).map(([os, info]) => ({
+              operating_system: os,
+              ...info,
+            }));
+
+            const cloudDistribs = allDistribs.filter(d => d.operating_system === 'alma9');
+            const onPremMainDistribs = allDistribs.filter(d => d.operating_system === 'alma9');
+            const isCloudTestingOrStable = isCloud && ['testing', 'stable'].includes(stability);
+            const result = isCloudTestingOrStable ? cloudDistribs : isFullRun ? allDistribs : isCloud ? cloudDistribs : onPremMainDistribs;
+
+            console.log('package_matrix', result);
+
+            return result;
+
       - name: Detect operating systems and databases to test
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: get_os_database_matrix
@@ -712,6 +752,7 @@ jobs:
           IS_CLOUD: ${{ steps.detect_cloud_version.outputs.isCloud }}
           IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
           LABELS: ${{ steps.has_skip_label.outputs.labels }}
+          PACKAGE_MATRIX: ${{ steps.get_package_matrix.outputs.result }}
         with:
           script: |
             const alma9_mariadb = {
@@ -763,9 +804,19 @@ jobs:
               return configs[configIndex];
             };
 
-            const configs = [alma9_mariadb, alma8_mariadb, bookworm_mysql];
+            const packagedOperatingSystems = JSON.parse(process.env.PACKAGE_MATRIX).map(d => d.operating_system);
 
-            const main = alma9_mariadb;
+            const configs = [alma9_mariadb, alma8_mariadb, bookworm_mysql]
+              .filter(c => packagedOperatingSystems.includes(c.operating_system));
+
+            if (configs.length === 0) {
+              core.setFailed(`No test configuration matches the packaged operating systems: ${packagedOperatingSystems.join(', ')}`);
+              return {};
+            }
+
+            // Fall back to the first packaged configuration when the preferred
+            // operating system is not part of the package matrix
+            const main = configs.find(c => c.operating_system === 'alma9') ?? configs[0];
 
             let matrix = {
               "main": [main],
@@ -796,46 +847,6 @@ jobs:
 
             return matrix;
 
-      - name: Get operating systems matrix for package and dockerize jobs
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        id: get_package_matrix
-        env:
-          STABILITY: ${{ steps.get_stability.outputs.stability }}
-          IS_CLOUD: ${{ steps.detect_cloud_version.outputs.isCloud }}
-          HAS_UPLOAD_ARTIFACTS: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'upload-artifacts') }}
-          HAS_SYSTEM: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'system') }}
-          HAS_DATABASE: ${{ contains(fromJSON(steps.has_skip_label.outputs.labels), 'database') }}
-          IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
-        with:
-          script: |
-            const stability = process.env.STABILITY;
-            const isCloud = process.env.IS_CLOUD === 'true';
-            const isFullRun = ['unstable', 'testing', 'stable'].includes(stability)
-              || process.env.IS_NIGHTLY === 'true'
-              || process.env.HAS_UPLOAD_ARTIFACTS === 'true'
-              || process.env.HAS_SYSTEM === 'true'
-              || process.env.HAS_DATABASE === 'true';
-
-            const distribMap = {
-              alma9:    { distrib: 'el9',      package_extension: 'rpm' },
-              alma8:    { distrib: 'el8',      package_extension: 'rpm' },
-              bookworm: { distrib: 'bookworm', package_extension: 'deb' },
-            };
-
-            const allDistribs = Object.entries(distribMap).map(([os, info]) => ({
-              operating_system: os,
-              ...info,
-            }));
-
-            const cloudDistrib = allDistribs.find(d => d.operating_system === 'alma9');
-            const onPremMainDistrib = allDistribs.find(d => d.operating_system === 'alma9');
-            const isCloudTestingOrStable = isCloud && ['testing', 'stable'].includes(stability);
-            const result = isCloudTestingOrStable ? [cloudDistrib] : isFullRun ? allDistribs : isCloud ? [cloudDistrib] : [onPremMainDistrib];
-
-            console.log('package_matrix', result);
-
-            return result;
-
       - name: Display info in job summary
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
@@ -855,6 +866,8 @@ jobs:
           LABELS: ${{ steps.has_skip_label.outputs.labels }}
           TARGET_STABILITY: ${{ steps.get_stability.outputs.target_stability }}
           PR_PATH: ${{ steps.pr_path.outputs.result || '[]' }}
+          PACKAGE_MATRIX: ${{ steps.get_package_matrix.outputs.result }}
+          OS_DATABASE_MATRIX: ${{ steps.get_os_database_matrix.outputs.result }}
         with:
           script: |
             const notFound = '<em>not found</em>';
@@ -865,8 +878,8 @@ jobs:
               ['latest_major_version', process.env.LATEST_MAJOR_VERSION],
               ['is_cloud', process.env.IS_CLOUD],
               ['previous_release_bundle_tag', process.env.PREVIOUS_RELEASE_BUNDLE_TAG || notFound],
-              ['linked_dev_branch', process.env.LINKED_DEV_BRANCH],
-              ['linked_stable_branch', process.env.LINKED_STABLE_BRANCH],
+              ['linked_dev_branch', process.env.LINKED_DEV_BRANCH || notFound],
+              ['linked_stable_branch', process.env.LINKED_STABLE_BRANCH || notFound],
               ['major_version', process.env.MAJOR_VERSION],
               ['minor_version', process.env.MINOR_VERSION],
               ['release', process.env.RELEASE],
@@ -876,34 +889,53 @@ jobs:
               ['is_nightly', process.env.IS_NIGHTLY],
               ['skip_workflow', process.env.SKIP_WORKFLOW],
               ['labels', process.env.LABELS],
+              ['target_stability', process.env.TARGET_STABILITY || notPr],
             ];
 
-            outputTable.push(['target_stability', process.env.TARGET_STABILITY || notPr]);
+            const packageMatrix = JSON.parse(process.env.PACKAGE_MATRIX);
+            const packageTable = [
+              [{data: 'Operating system', header: true}, {data: 'Distrib', header: true}, {data: 'Package extension', header: true}],
+              ...packageMatrix.map(d => [d.operating_system, d.distrib, d.package_extension]),
+            ];
+
+            const osDatabaseMatrix = JSON.parse(process.env.OS_DATABASE_MATRIX);
+            const osDatabaseTable = [
+              [{data: 'Matrix', header: true}, {data: 'Operating system', header: true}, {data: 'Database', header: true}, {data: 'Test tags', header: true}],
+              ...Object.entries(osDatabaseMatrix).flatMap(([matrixName, entries]) =>
+                entries.map(e => [matrixName, e.operating_system, e.database, e.test_tags])
+              ),
+            ];
 
             core.summary
               .addHeading(`${context.workflow} environment outputs`)
-              .addTable(outputTable);
+              .addTable(outputTable)
+              .addHeading('Package matrix', 2)
+              .addTable(packageTable)
+              .addHeading('Operating systems and databases matrix', 2)
+              .addTable(osDatabaseTable);
 
             if (process.env.GITHUB_EVENT_NAME === "pull_request") {
               const prPath = JSON.parse(process.env.PR_PATH);
-              const mainBranchName = prPath.pop();
-              let codeBlock = `
-                %%{ init: { 'gitGraph': { 'mainBranchName': '${mainBranchName}', 'showCommitLabel': false } } }%%
-                gitGraph
-                  commit`;
-              prPath.reverse().forEach((branchName) => {
-                codeBlock = `${codeBlock}
-                  branch ${branchName}
-                  checkout ${branchName}
-                  commit`;
-              });
+              if (prPath.length >= 2) {
+                const mainBranchName = prPath.pop();
+                let codeBlock = `
+                  %%{ init: { 'gitGraph': { 'mainBranchName': '${mainBranchName}', 'showCommitLabel': false } } }%%
+                  gitGraph
+                    commit`;
+                prPath.reverse().forEach((branchName) => {
+                  codeBlock = `${codeBlock}
+                    branch ${branchName}
+                    checkout ${branchName}
+                    commit`;
+                });
 
-              core.summary
-                .addHeading('Git workflow')
-                .addCodeBlock(
-                  codeBlock,
-                  "mermaid"
-                );
+                core.summary
+                  .addHeading('Git workflow')
+                  .addCodeBlock(
+                    codeBlock,
+                    "mermaid"
+                  );
+              }
             }
 
-            core.summary.write();
+            await core.summary.write();

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -84,22 +84,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bookworm]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma8
-            distrib: el8
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: deb
-            tag_suffix: -bookworm
-            distrib: bookworm
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-24.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -317,22 +317,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bookworm]
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma8
-            distrib: el8
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: deb
-            tag_suffix: -bookworm
-            distrib: bookworm
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     runs-on: ubuntu-22.04
 
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     name: package ${{ matrix.distrib }}
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -674,21 +674,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - package_extension: rpm
-            tag_suffix: -alma8
-            distrib: el8
-          - package_extension: rpm
-            tag_suffix: -alma9
-            distrib: el9
-          - package_extension: deb
-            tag_suffix: -bookworm
-            distrib: bookworm
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
 
     name: package ${{ matrix.distrib }}
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}${{ matrix.tag_suffix }}
+      image: ghcr.io/centreon/delivery-tooling/packaging:${{ needs.get-environment.outputs.major_version }}-${{ matrix.operating_system }}
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Fixes: [MON-203151](https://centreon.atlassian.net/browse/MON-203151)

Backport of #10912 (`dev-25.10.x`) to `dev-24.10.x`, adapted to the 24.10 distributions (`alma8`, `alma9`, `bookworm` — no `alma10` on this series). Manual adaptation, not a clean cherry-pick.

## Description

- The `get_package_matrix` step is moved before the `get_os_database_matrix` step, and the OS/database test configurations are filtered on the operating systems present in the package matrix, with a fail-fast guard when no configuration matches.
- The packaging jobs of the `web`, `awie`, `dsm`, `ha` and `open-tickets` workflows are driven by the `package_matrix` output instead of a hardcoded distribution matrix.
- The environment job summary displays the package matrix and the OS/database matrix as tables.

## Differences with the develop PR

- The cloud distribution list stays `alma9` only (no `alma10` on 24.10).
- This series has no `cloud` entry in the OS/database matrix; only `main`, `operating_systems` and `databases` are filtered.

See #10901 for the full description and validation runs.

[MON-203151]: https://centreon.atlassian.net/browse/MON-203151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ