### PR TITLE
fix(open-tickets): enforce smarty security policy and ACL on rule config

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/AbstractProvider.class.php
@@ -467,7 +467,75 @@ abstract class AbstractProvider
         $tpl->loadPlugin('smarty_function_service_get_servicegroups');
         $tpl->loadPlugin('smarty_function_sortgroup');
 
+        $this->enableSmartySecurity($tpl);
+
         return $tpl;
+    }
+
+    /**
+     * Apply a restrictive Smarty security policy to the engine used to render
+     * user-configured rule fields (message_confirm, format_popup, url, body
+     * lists, provider field mappings, ...).
+     *
+     * Those fields are stored verbatim and rendered through {eval}, so with no
+     * security policy an authenticated user can inject template code to read
+     * arbitrary files, dump environment secrets or execute PHP. The policy keeps
+     * the templating features the module legitimately relies on ({if}, {foreach},
+     * {$var}, {include} of module templates, formatting modifiers) while blocking
+     * the dangerous ones. Because {eval} reuses this Smarty instance, the policy
+     * also applies to the evaluated payload.
+     *
+     * @param SmartyBC $tpl
+     *
+     * @throws SmartyException
+     *
+     * @return void
+     */
+    protected function enableSmartySecurity(SmartyBC $tpl): void
+    {
+        $security = new Smarty_Security($tpl);
+
+        // Restrict {include}/{fetch} file access to the module "providers"
+        // directory only (every legitimate template include resolves there):
+        // blocks reads of /etc/passwd, .env, gorgone/broker/engine config files.
+        $providersDir = realpath($this->centreon_open_tickets_path . 'providers');
+        $security->secure_dir = $providersDir !== false ? [$providersDir] : [];
+        $security->trusted_uri = [];
+        $security->streams = ['file'];
+
+        // Block server-side variable disclosure: $smarty.env dumps APP_SECRET /
+        // MAP_SECRET, $smarty.server exposes the environment, etc.
+        $security->disabled_special_smarty_vars = [
+            'env', 'server', 'get', 'post', 'cookies', 'request', 'session', 'globals',
+        ];
+        $security->allow_constants = false;
+        $security->allow_super_globals = false;
+
+        // No direct static class access from templates: a non-empty allowlist
+        // that no real class name matches blocks every static class/method call.
+        $security->static_classes = ['none'];
+
+        // Allow only a safe, display-oriented set of raw PHP functions/modifiers.
+        // Smarty's own modifiers (date_format, cat, regex_replace, escape, ...) are
+        // governed by $allowed_modifiers (left empty = all allowed) and remain
+        // available; the lists below only gate raw PHP functions, which is where
+        // the RCE risk lives (e.g. {$value|system}).
+        $security->php_functions = [
+            'isset', 'empty', 'count', 'sizeof', 'in_array', 'is_array',
+            'is_string', 'is_null', 'time',
+        ];
+        $security->php_modifiers = [
+            // pre-registered by SmartyBC for backward compatibility
+            'count', 'sizeof', 'in_array', 'is_array', 'time', 'urlencode',
+            'rawurlencode', 'json_encode', 'strtotime', 'number_format', 'is_string',
+            // common safe formatting helpers used in rule templates
+            'strlen', 'strtoupper', 'strtolower', 'ucfirst', 'ucwords', 'trim',
+            'ltrim', 'rtrim', 'substr', 'str_replace', 'sprintf', 'nl2br', 'date',
+            'htmlentities', 'htmlspecialchars', 'implode', 'explode', 'wordwrap',
+        ];
+
+        // {php} / {include_php} are disabled automatically once security is on.
+        $tpl->enableSecurity($security);
     }
 
     /**

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/call.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/call.php
@@ -51,6 +51,13 @@ if (! isset($_POST['data']) && ! isset($_REQUEST['action'])) {
         ? $get_information['action'] : ($_REQUEST['action'] ?? 'none');
     if (! isset($actions[$action])) {
         $resultat = ['code' => 1, 'msg' => 'Action not good.'];
+    } elseif (
+        in_array($action, ['get-form-config', 'save-form-config', 'validate-format-popup'], true)
+        && $centreon->user->access->page(60420) === CentreonACL::ACL_ACCESS_NONE
+    ) {
+        // Rule configuration actions require access to the Open Tickets "Rules"
+        // page (topology 60420); a bare authenticated session is not enough.
+        $resultat = ['code' => 1, 'msg' => 'Insufficient privileges.'];
     } else {
         include $actions[$action];
     }


### PR DESCRIPTION
## Description

Rule fields rendered through Smarty `{eval}` (confirm message, popup format, ticket url, body lists and provider field mappings) were compiled with no security policy, and the rule configuration endpoint only checked for an authenticated session.

## Changes

**`providers/Abstract/AbstractProvider.class.php`** — apply a Smarty security policy when rendering user-configured rule fields (via a new `enableSmartySecurity()` called from `initSmartyTemplate()`, so all providers and every `{eval}` sink are covered at once):

- restrict `{include}`/`{fetch}` file access to the module `providers/` directory only;
- block server-side special variables (`$smarty.env`, `$smarty.server`, `$smarty.get/post/cookies/request/session`);
- disable constants, superglobals and static class access;
- allow only a curated set of raw PHP functions/modifiers.

Legitimate templating is preserved: `{if}`, `{foreach}`, `{$var}`, includes of module templates, Smarty native modifiers (`date_format`, `cat`, `regex_replace`, `escape`, …) and `$smarty.now`.

**`views/rules/ajax/call.php`** — require access to the Open Tickets "Rules" page (topology `60420`) for the configuration actions (`get-form-config`, `save-form-config`, `validate-format-popup`). Ticket operator actions (`submit-ticket`, `close-ticket`, `service-ack`, …) are unchanged.

## Notes / follow-ups

- The include scope and the `$smarty.env` vs `$smarty.now` handling follow the module owner's guidance on the ticket.
- Still open (tracked separately): confirming the PHP modifier/function allowlist against real customer rules, deciding on `{while}`/`{for}` loops, applying the same ACL guard to the provider-specific ajax endpoints (`Itop`, `EasyVistaRest`), and backporting to the maintained branches.

## Test done

- [ ] Reproduce the reported requests and confirm they are now blocked
- [ ] Regression: default and existing rules still render (popup, body, confirm message, ticket url, mappings)

Refs: MON-202535