### PR TITLE
feat(test): add graphite and influxdb broker output compose profiles (backport 24.10)

### DIFF
--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -78,6 +78,12 @@ Currently, the following profiles are available:
 * `squid-simple`: run a docker image of squid without authentication (centreon configuration must be done manually)
 * `squid-basic-auth`: run a docker image of squid with authentication (centreon configuration must be done manually)
 * `mediawiki`: run a docker image of mediawiki (centreon configuration must be done manually)
+* `graphite`: run a Graphite (`graphite-statsd`) receiver and auto-configure a Centreon Broker Graphite output pointing to it — for testing the Broker output cache
+  * the Broker output is configured automatically on startup, with macro-enriched naming `centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$`
+  * Verify ingestion (from the web container, using the service hostname): `docker compose exec web curl -s "http://graphite/render?target=centreon.metric.**&format=json"` — after a force check, the cache-resolved host/service names must appear in the received metric paths
+* `influxdb`: run an InfluxDB 1.8 receiver and auto-configure a Centreon Broker InfluxDB output pointing to it (same purpose as `graphite`)
+  * Verify ingestion: `docker compose exec web curl -s -G "http://influxdb:8086/query" --data-urlencode "db=centreon" --data-urlencode "q=SHOW MEASUREMENTS"`
+  * the two profiles are independent — enable `graphite`, `influxdb`, or both
 
 > [!NOTE]
 > docker image for `poller` service (`centreon-poller-alma9`) is built on centreon-collect repository<br/>

--- a/.github/docker/centreon-web/alma8/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma8/Dockerfile.dependencies
@@ -132,6 +132,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-engine-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-broker-cbmod-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-broker-cbd-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
+    centreon-broker-graphite-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
+    centreon-broker-influxdb-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION} \
     centreon-connector-${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}
 else
   dnf install -y \
@@ -140,6 +142,8 @@ else
     centreon-engine \
     centreon-broker-cbmod \
     centreon-broker-cbd \
+    centreon-broker-graphite \
+    centreon-broker-influxdb \
     centreon-connector
 fi
 

--- a/.github/docker/centreon-web/alma8/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma8/entrypoint/container.d/75-broker-outputs.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Configure Broker Graphite/InfluxDB outputs toward the "graphite"/"influxdb"
+# profile receivers, through the configuration REST API (the UI path): it sets
+# the event subscription (filters) and cache that the CLAPI path leaves unset.
+
+BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
+API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
+PASS='Centreon!2021'
+WEB_USER=$(id apache >/dev/null 2>&1 && echo apache || echo www-data)  # apache on RHEL, www-data on Debian
+
+api_token() {
+  jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token // empty'
+}
+
+add_output() { # $1=token  $2=label  $3=json payload
+  resp=$(mktemp)
+  code=$(curl -s -o "${resp}" -w '%{http_code}' \
+    -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
+  if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
+    echo "75-broker-outputs: $2 output created (HTTP ${code})"
+  else
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat "${resp}" 2>/dev/null)" >&2
+  fi
+  rm -f "${resp}"
+}
+
+graphite=false
+influxdb=false
+[ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}" >/dev/null && graphite=true
+[ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}" >/dev/null && influxdb=true
+
+if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
+  TOKEN=$(api_token)
+  if [ -z "${TOKEN}" ]; then
+    echo "75-broker-outputs: authentication failed, skipping broker output configuration" >&2
+  else
+    if [ "${graphite}" = true ]; then
+      add_output "${TOKEN}" graphite "$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+        name: "graphite-output", type: 30,
+        parameters: {
+          db_host: $host, db_port: 2003, db_user: "", db_password: "",
+          queries_per_transaction: 0,
+          metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+          status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    if [ "${influxdb}" = true ]; then
+      add_output "${TOKEN}" influxdb "$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+        name: "influxdb-output", type: 31,
+        parameters: {
+          cache: "no",
+          db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+          metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          metrics_column: [], status_column: [],
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+    # config is unchanged, and the container systemctl shim cannot restart it.
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
+  fi
+fi
+:

--- a/.github/docker/centreon-web/alma9/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma9/Dockerfile.dependencies
@@ -128,6 +128,8 @@ dnf install -y \
   centreon-gorgone \
   centreon-engine \
   centreon-broker-cbd \
+  centreon-broker-graphite \
+  centreon-broker-influxdb \
   centreon-connector
 
 dnf clean all --enablerepo=*

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/75-broker-outputs.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Configure Broker Graphite/InfluxDB outputs toward the "graphite"/"influxdb"
+# profile receivers, through the configuration REST API (the UI path): it sets
+# the event subscription (filters) and cache that the CLAPI path leaves unset.
+
+BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
+API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
+PASS='Centreon!2021'
+WEB_USER=$(id apache >/dev/null 2>&1 && echo apache || echo www-data)  # apache on RHEL, www-data on Debian
+
+api_token() {
+  jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token // empty'
+}
+
+add_output() { # $1=token  $2=label  $3=json payload
+  resp=$(mktemp)
+  code=$(curl -s -o "${resp}" -w '%{http_code}' \
+    -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
+  if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
+    echo "75-broker-outputs: $2 output created (HTTP ${code})"
+  else
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat "${resp}" 2>/dev/null)" >&2
+  fi
+  rm -f "${resp}"
+}
+
+graphite=false
+influxdb=false
+[ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}" >/dev/null && graphite=true
+[ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}" >/dev/null && influxdb=true
+
+if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
+  TOKEN=$(api_token)
+  if [ -z "${TOKEN}" ]; then
+    echo "75-broker-outputs: authentication failed, skipping broker output configuration" >&2
+  else
+    if [ "${graphite}" = true ]; then
+      add_output "${TOKEN}" graphite "$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+        name: "graphite-output", type: 30,
+        parameters: {
+          db_host: $host, db_port: 2003, db_user: "", db_password: "",
+          queries_per_transaction: 0,
+          metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+          status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    if [ "${influxdb}" = true ]; then
+      add_output "${TOKEN}" influxdb "$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+        name: "influxdb-output", type: 31,
+        parameters: {
+          cache: "no",
+          db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+          metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          metrics_column: [], status_column: [],
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+    # config is unchanged, and the container systemctl shim cannot restart it.
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
+  fi
+fi
+:

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -142,6 +142,8 @@ if [[ "$STABILITY" == "stable" ]]; then
     centreon-broker=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-core=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbd=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-broker-graphite=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
+    centreon-broker-influxdb=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-broker-cbmod=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-connector-perl=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
     centreon-connector-ssh=${MAJOR_VERSION}.${COLLECT_MINOR_VERSION}-*+deb12u1 \
@@ -153,6 +155,8 @@ else
     centreon-engine \
     centreon-broker-cbmod \
     centreon-broker-cbd \
+    centreon-broker-graphite \
+    centreon-broker-influxdb \
     centreon-connector
 fi
 

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/75-broker-outputs.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/75-broker-outputs.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Configure Broker Graphite/InfluxDB outputs toward the "graphite"/"influxdb"
+# profile receivers, through the configuration REST API (the UI path): it sets
+# the event subscription (filters) and cache that the CLAPI path leaves unset.
+
+BROKER_ID=1   # central-broker-master config id (always 1 in the test dataset)
+API="http://${CENTREON_INTERNAL_API_BASE_URL:-127.0.0.1:80}/centreon/api/latest"
+PASS='Centreon!2021'
+WEB_USER=$(id apache >/dev/null 2>&1 && echo apache || echo www-data)  # apache on RHEL, www-data on Debian
+
+api_token() {
+  jq -nc --arg pass "${PASS}" '{security: {credentials: {login: "admin", password: $pass}}}' \
+    | curl -s -d @- -L "${API}/login" | jq -r '.security.token // empty'
+}
+
+add_output() { # $1=token  $2=label  $3=json payload
+  resp=$(mktemp)
+  code=$(curl -s -o "${resp}" -w '%{http_code}' \
+    -X POST -H "X-AUTH-TOKEN: $1" -H "Content-Type: application/json" \
+    -L "${API}/configuration/broker/${BROKER_ID}/outputs" --data "$3")
+  if [ "${code:-0}" -ge 200 ] && [ "${code:-0}" -lt 300 ]; then
+    echo "75-broker-outputs: $2 output created (HTTP ${code})"
+  else
+    echo "75-broker-outputs: failed to create $2 output (HTTP ${code}): $(cat "${resp}" 2>/dev/null)" >&2
+  fi
+  rm -f "${resp}"
+}
+
+graphite=false
+influxdb=false
+[ -n "${GRAPHITE_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${GRAPHITE_HOST}" >/dev/null && graphite=true
+[ -n "${INFLUXDB_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${INFLUXDB_HOST}" >/dev/null && influxdb=true
+
+if [ "${graphite}" = true ] || [ "${influxdb}" = true ]; then
+  TOKEN=$(api_token)
+  if [ -z "${TOKEN}" ]; then
+    echo "75-broker-outputs: authentication failed, skipping broker output configuration" >&2
+  else
+    if [ "${graphite}" = true ]; then
+      add_output "${TOKEN}" graphite "$(jq -nc --arg host "${GRAPHITE_HOST}" '{
+        name: "graphite-output", type: 30,
+        parameters: {
+          db_host: $host, db_port: 2003, db_user: "", db_password: "",
+          queries_per_transaction: 0,
+          metric_naming: "centreon.metric.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$.$METRIC$",
+          status_naming: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    if [ "${influxdb}" = true ]; then
+      add_output "${TOKEN}" influxdb "$(jq -nc --arg host "${INFLUXDB_HOST}" --arg pass "${PASS}" '{
+        name: "influxdb-output", type: 31,
+        parameters: {
+          cache: "no",
+          db_host: $host, db_port: 8086, db_user: "centreon", db_password: $pass, db_name: "centreon",
+          metrics_timeseries: "centreon.metrics.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          status_timeseries: "centreon.status.$INSTANCE$.$HOST$.$SERVICE$.$SERV_TAG_CAT_NAME$",
+          metrics_column: [], status_column: [],
+          filters_category: ["neb", "storage"]
+        }
+      }')"
+    fi
+    # Reload cbd so it picks up the new outputs. centengine is left as-is: its
+    # config is unchanged, and the container systemctl shim cannot restart it.
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a POLLERGENERATE -v 1
+    sudo -u "${WEB_USER}" centreon -u admin -p "${PASS}" -a CFGMOVE -v 1
+    systemctl restart cbd || echo "75-broker-outputs: cbd restart returned non-zero (check cbd logs)"
+  fi
+fi
+:

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       OPENID_HOST: sso-proxy
       SAML_HOST: saml
       LDAP_HOST: openldap
+      GRAPHITE_HOST: graphite
+      INFLUXDB_HOST: influxdb
       CENTREON_DATASET: ${CENTREON_DATASET:-1}
       CENTREON_LANG: ${CENTREON_LANG:-en_US}
       DEBUG: ${DEBUG:-0}
@@ -55,6 +57,21 @@ services:
     image: "${LDAP_IMAGE:-ghcr.io/centreon/centreon/ldap:24.10}"
     ports: ["389"]
     profiles: ["openldap", "ldap"]
+
+  # Receivers for the Broker outputs (independent "graphite"/"influxdb" profiles).
+  # InfluxDB 1.8 speaks the 1.x line protocol the Broker output uses; INFLUXDB_DB
+  # pre-creates the target db.
+  graphite:
+    image: "${GRAPHITE_IMAGE:-graphiteapp/graphite-statsd:1.1.10-5}"
+    ports: ["2003", "80"]
+    profiles: ["graphite"]
+
+  influxdb:
+    image: "${INFLUXDB_IMAGE:-influxdb:1.8}"
+    environment:
+      INFLUXDB_DB: centreon
+    ports: ["8086"]
+    profiles: ["influxdb"]
 
   squid-simple:
     image: docker.centreon.com/centreon/mon-squid-simple:latest


### PR DESCRIPTION
Backport of #10848 to `dev-24.10.x` (same as #10918 for 25.10).

Adds the independent `graphite` and `influxdb` docker-compose profiles that start a receiver and auto-configure the matching Centreon Broker output via the configuration REST API (macro-enriched naming to make cache resolution observable). Full rationale in the develop PR: https://github.com/centreon/centreon/pull/10848

## ⚠️ Difference vs the develop PR — OS matrix

Not a plain cherry-pick: the web image OS set differs between branches.

| | develop | dev-24.10.x |
| --- | --- | --- |
| OS images | alma9, alma10, trixie | **alma8, alma9, bookworm** |

- `alma10` and `trixie` are not present on 24.10 → omitted.
- `alma8` and `bookworm` are 24.10-specific → the feature was added to them.
- The entrypoint script is OS-agnostic (resolves the web user, `apache` on RHEL / `www-data` on Debian), so the same script is used for the three OS.
- `Dockerfile.dependencies` was adapted per OS (RPM for alma8/alma9, apt `+deb12u1` for bookworm) to bundle the `centreon-broker-graphite` / `centreon-broker-influxdb` modules at build time.

## Commits

1. architecture — compose profiles + env + README + entrypoint script
2. per-OS — bundle the broker output modules in each web image (alma8, alma9, bookworm)

Refs: MON-203226