### PR TITLE
fix(ci): poll workflow runs filtered by trigger event in check-status

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -49,8 +49,75 @@ jobs:
               'check-qa-validation',
             ];
             const failureConclusions = ['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure', 'stale'];
+            const maxPolls = 120;
+            const startedAt = Date.now();
 
-            for (let i = 0; i < 120; i++) {
+            const runState = (run) => run.status === 'completed' ? run.conclusion : run.status;
+
+            const runIcon = (run) => {
+              if (run.status !== 'completed') return '⏳';
+              if (run.conclusion === 'success') return '✅';
+              if (['skipped', 'neutral'].includes(run.conclusion)) return '⏭️';
+              return '❌';
+            };
+
+            const runDuration = (run) => {
+              if (run.status !== 'completed') return '—';
+              const seconds = Math.max(0, Math.round((new Date(run.updated_at) - new Date(run.run_started_at)) / 1000));
+              return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
+            };
+
+            const writeSummary = async (title, latestRuns, failedJobs, polls) => {
+              core.summary.addHeading(title, 3);
+              core.summary.addTable([
+                [
+                  { data: 'Workflow', header: true },
+                  { data: 'Conclusion', header: true },
+                  { data: 'Duration', header: true },
+                  { data: 'Run', header: true }
+                ],
+                ...latestRuns.map((run) => [
+                  run.name,
+                  `${runIcon(run)} ${runState(run)}`,
+                  runDuration(run),
+                  `<a href="${run.html_url}">#${run.run_number}</a>`
+                ])
+              ]);
+              if (failedJobs.length > 0) {
+                core.summary.addHeading(`${failedJobs.length} job(s) failed`, 4);
+                core.summary.addList(failedJobs.map(({ name, conclusion, url }) => `<a href="${url}">${name} (${conclusion})</a>`));
+              }
+              const elapsed = Math.round((Date.now() - startedAt) / 1000);
+              core.summary.addRaw(`Evaluated ${latestRuns.length} workflow run(s) in ${polls} poll(s) over ${Math.floor(elapsed / 60)}m ${String(elapsed % 60).padStart(2, '0')}s.`, true);
+              core.summary.addRaw(`Allowed events: ${allowedEvents.join(', ')} — excluded workflows: ${excludedWorkflows.join(', ')}.`, true);
+              await core.summary.write();
+            };
+
+            const listFailedJobs = async (run) => {
+              const runLevelFailure = { name: run.name, conclusion: run.conclusion, url: run.html_url };
+              try {
+                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  filter: 'latest',
+                  per_page: 100
+                });
+
+                const failedJobs = jobs
+                  .filter(({ conclusion }) => failureConclusions.includes(conclusion))
+                  .map(({ conclusion, name, html_url }) => ({ name: `${run.name} / ${name}`, conclusion, url: html_url }));
+                // a run can fail without any failed job (startup_failure...)
+                return failedJobs.length > 0 ? failedJobs : [runLevelFailure];
+              } catch (error) {
+                core.warning(`Cannot list jobs of workflow run ${run.id}: ${error.message}`);
+                return [runLevelFailure];
+              }
+            };
+
+            let latestRuns = [];
+
+            for (let i = 0; i < maxPolls; i++) {
               let runs = [];
               try {
                 runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
@@ -85,61 +152,44 @@ jobs:
                   }
                 });
 
-              const failedRuns = [];
-              const pendingRuns = [];
-              latestRunPerWorkflow.forEach((run) => {
-                if (run.status !== 'completed') {
-                  pendingRuns.push(run);
-                } else if (failureConclusions.includes(run.conclusion)) {
-                  failedRuns.push(run);
-                }
-                console.log(`workflow run ${run.name} => ${run.status === 'completed' ? run.conclusion : run.status}`);
+              latestRuns = [...latestRunPerWorkflow.values()].sort((a, b) => a.name.localeCompare(b.name));
+              const pendingRuns = latestRuns.filter((run) => run.status !== 'completed');
+              const failedRuns = latestRuns.filter((run) => run.status === 'completed' && failureConclusions.includes(run.conclusion));
+
+              core.startGroup(`Poll #${i + 1} — ${pendingRuns.length} in progress, ${latestRuns.length - pendingRuns.length} completed, ${failedRuns.length} failed`);
+              latestRuns.forEach((run) => {
+                console.log(`${runIcon(run)} ${run.name} => ${runState(run)}`);
               });
+              core.endGroup();
 
               if (failedRuns.length > 0) {
                 const failedJobs = [];
                 for await (const run of failedRuns) {
-                  try {
-                    const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      run_id: run.id,
-                      filter: 'latest',
-                      per_page: 100
-                    });
-
-                    const failedJobsOfRun = jobs
-                      .filter(({ conclusion }) => failureConclusions.includes(conclusion))
-                      .map(({ conclusion, name, html_url }) => `<a href="${html_url}">${run.name} / ${name} (${conclusion})</a>`);
-                    // a run can fail without any failed job (startup_failure...)
-                    if (failedJobsOfRun.length === 0) {
-                      failedJobsOfRun.push(`<a href="${run.html_url}">${run.name} (${run.conclusion})</a>`);
-                    }
-                    failedJobs.push(...failedJobsOfRun);
-                  } catch (error) {
-                    core.warning(`Cannot list jobs of workflow run ${run.id}: ${error.message}`);
-                    failedJobs.push(`<a href="${run.html_url}">${run.name} (${run.conclusion})</a>`);
-                  }
+                  failedJobs.push(...await listFailedJobs(run));
                 }
 
-                core.summary.addRaw(`${failedJobs.length} job(s) failed:`, true)
-                core.summary.addList(failedJobs);
-                core.summary.write();
+                failedJobs.forEach(({ name, conclusion, url }) => {
+                  core.error(`${name} (${conclusion}): ${url}`);
+                });
 
+                await writeSummary(`❌ ${failedRuns.length} workflow run(s) failed`, latestRuns, failedJobs, i + 1);
                 core.setFailed(`${failedRuns.length} workflow run(s) failed`);
                 return;
               }
 
               if (pendingRuns.length === 0) {
+                await writeSummary('✅ All workflow runs completed successfully', latestRuns, [], i + 1);
                 core.info("All workflows are ok");
                 return;
               }
 
-              core.info(`${pendingRuns.length} workflow run(s) in progress`);
-
               await new Promise((resolve) => setTimeout(resolve, 30000));
             }
 
+            latestRuns.filter((run) => run.status !== 'completed').forEach((run) => {
+              core.error(`Still in progress after timeout: ${run.name}: ${run.html_url}`);
+            });
+            await writeSummary('❌ Timeout — some workflow runs are still in progress', latestRuns, [], maxPolls);
             core.setFailed("Timeout: some jobs are still in progress");
 
   get-environment:

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -22,15 +22,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RATE_LIMIT=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit)
-          echo "current rest api rate usage:"
-          echo "$RATE_LIMIT" | jq .rate
-          echo ""
-          echo ""
-          echo "current graphql rate usage:"
-          echo "$RATE_LIMIT" | jq .resources.graphql
-          echo ""
-          echo ""
+          RATE_LIMIT=$(curl -sf -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit) || {
+            echo "::warning::Cannot fetch API rate limit usage"
+            exit 0
+          }
+
+          echo "$RATE_LIMIT" | jq -r '
+            { rest: .rate, graphql: .resources.graphql } | to_entries[] |
+            "\(.key): \(.value.used)/\(.value.limit) used, \(.value.remaining) remaining, resets at \(.value.reset | todate)"
+          '
+
+          echo "$RATE_LIMIT" | jq -r '
+            { rest: .rate, graphql: .resources.graphql } | to_entries[] |
+            select(.value.remaining < .value.limit / 10) |
+            "::warning title=GitHub API rate limit::\(.key) API rate limit almost reached: \(.value.remaining)/\(.value.limit) requests remaining until \(.value.reset | todate)"
+          '
 
       - name: Check workflow run statuses
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -18,7 +18,7 @@ jobs:
   check-status:
     runs-on: ubuntu-24.04
     steps:
-      - name: Check workflow statuses and display token usage
+      - name: Display API rate limit usage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -32,7 +32,8 @@ jobs:
           echo ""
           echo ""
 
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Check workflow run statuses
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -147,7 +147,8 @@ jobs:
               }
 
               // the listing is eventually consistent, do not trust it until it contains the current run
-              if (!runs.some((run) => run.id === context.runId)) {
+              const currentRun = runs.find((run) => run.id === context.runId);
+              if (!currentRun) {
                 core.warning("Current workflow run is not listed yet, retrying");
                 await new Promise((resolve) => setTimeout(resolve, 30000));
                 continue;
@@ -157,7 +158,9 @@ jobs:
               const latestRunPerWorkflow = new Map();
               runs
                 .filter((run) => allowedEvents.includes(run.event))
-                .filter((run) => run.id !== context.runId)
+                // exclude the whole check-status workflow, not only the current run: a sibling run on the
+                // same commit (PR reopened without new commit...) must not gate the merge either
+                .filter((run) => run.workflow_id !== currentRun.workflow_id)
                 .filter((run) => !excludedWorkflows.includes(run.name))
                 .forEach((run) => {
                   const latestRun = latestRunPerWorkflow.get(run.workflow_id);
@@ -178,7 +181,7 @@ jobs:
 
               if (failedRuns.length > 0) {
                 const failedJobs = [];
-                for await (const run of failedRuns) {
+                for (const run of failedRuns) {
                   const failedJobsOfRun = await listFailedJobs(run);
                   // one annotation per failed workflow run, GitHub only displays 10 annotations per step
                   core.error(`${run.name} (${run.conclusion}): ${failedJobsOfRun.length} failed job(s): ${run.html_url}`);

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -22,12 +22,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          RATE_LIMIT=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit)
           echo "current rest api rate usage:"
-          curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit | jq .rate
+          echo "$RATE_LIMIT" | jq .rate
           echo ""
           echo ""
           echo "current graphql rate usage:"
-          curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit | jq .resources.graphql
+          echo "$RATE_LIMIT" | jq .resources.graphql
           echo ""
           echo ""
 

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -50,6 +50,8 @@ jobs:
             ];
             const failureConclusions = ['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure', 'stale'];
             const maxPolls = 120;
+            // matrices can produce hundreds of failed jobs, keep the summary readable
+            const maxDisplayedFailedJobs = 20;
             const startedAt = Date.now();
 
             const runState = (run) => run.status === 'completed' ? run.conclusion : run.status;
@@ -85,7 +87,13 @@ jobs:
               ]);
               if (failedJobs.length > 0) {
                 core.summary.addHeading(`${failedJobs.length} job(s) failed`, 4);
-                core.summary.addList(failedJobs.map(({ name, conclusion, url }) => `<a href="${url}">${name} (${conclusion})</a>`));
+                const displayedFailedJobs = failedJobs
+                  .slice(0, maxDisplayedFailedJobs)
+                  .map(({ name, conclusion, url }) => `<a href="${url}">${name} (${conclusion})</a>`);
+                if (failedJobs.length > maxDisplayedFailedJobs) {
+                  displayedFailedJobs.push(`… and ${failedJobs.length - maxDisplayedFailedJobs} more, see the workflow runs above`);
+                }
+                core.summary.addList(displayedFailedJobs);
               }
               const elapsed = Math.round((Date.now() - startedAt) / 1000);
               core.summary.addRaw(`Evaluated ${latestRuns.length} workflow run(s) in ${polls} poll(s) over ${Math.floor(elapsed / 60)}m ${String(elapsed % 60).padStart(2, '0')}s.`, true);
@@ -165,12 +173,11 @@ jobs:
               if (failedRuns.length > 0) {
                 const failedJobs = [];
                 for await (const run of failedRuns) {
-                  failedJobs.push(...await listFailedJobs(run));
+                  const failedJobsOfRun = await listFailedJobs(run);
+                  // one annotation per failed workflow run, GitHub only displays 10 annotations per step
+                  core.error(`${run.name} (${run.conclusion}): ${failedJobsOfRun.length} failed job(s): ${run.html_url}`);
+                  failedJobs.push(...failedJobsOfRun);
                 }
-
-                failedJobs.forEach(({ name, conclusion, url }) => {
-                  core.error(`${name} (${conclusion}): ${url}`);
-                });
 
                 await writeSummary(`❌ ${failedRuns.length} workflow run(s) failed`, latestRuns, failedJobs, i + 1);
                 core.setFailed(`${failedRuns.length} workflow run(s) failed`);

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -34,77 +34,108 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
-            await exec.exec("sleep 20s");
+            // let workflow runs triggered by the same event register before the first evaluation
+            await new Promise((resolve) => setTimeout(resolve, 20000));
 
-            const excludedJobs = [
+            // only runs triggered by these events gate the merge (manual workflow_dispatch or push runs on the same commit must not)
+            const allowedEvents = ['pull_request'];
+            // workflows which are required status checks on their own
+            const excludedWorkflows = [
               'check-qa-validation',
             ];
+            const failureConclusions = ['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure', 'stale'];
 
             for (let i = 0; i < 120; i++) {
-              const failure = [];
-              const cancelled = [];
-              const pending = [];
+              let runs = [];
+              try {
+                runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  head_sha: process.env.PR_HEAD_SHA,
+                  per_page: 100
+                });
+              } catch (error) {
+                core.warning(`Cannot list workflow runs, retrying: ${error.message}`);
+                await new Promise((resolve) => setTimeout(resolve, 30000));
+                continue;
+              }
 
-              const result = await github.rest.checks.listSuitesForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: process.env.PR_HEAD_SHA
-              });
-              result.data.check_suites.forEach(({ app: { slug }, conclusion, id }) => {
-                if (slug === 'github-actions') {
-                  if (conclusion === 'failure' || conclusion === 'cancelled') {
-                    failure.push(id);
-                  } else if (conclusion === null) {
-                    pending.push(id);
+              // the listing is eventually consistent, do not trust it until it contains the current run
+              if (!runs.some((run) => run.id === context.runId)) {
+                core.warning("Current workflow run is not listed yet, retrying");
+                await new Promise((resolve) => setTimeout(resolve, 30000));
+                continue;
+              }
+
+              // keep only the latest run of each workflow to ignore runs superseded by a re-trigger (labeled, unlabeled...)
+              const latestRunPerWorkflow = new Map();
+              runs
+                .filter((run) => allowedEvents.includes(run.event))
+                .filter((run) => run.id !== context.runId)
+                .filter((run) => !excludedWorkflows.includes(run.name))
+                .forEach((run) => {
+                  const latestRun = latestRunPerWorkflow.get(run.workflow_id);
+                  if (!latestRun || run.run_number > latestRun.run_number) {
+                    latestRunPerWorkflow.set(run.workflow_id, run);
                   }
-                  console.log(`check suite ${id} => ${conclusion === null ? 'pending' : conclusion}`);
+                });
+
+              const failedRuns = [];
+              const pendingRuns = [];
+              latestRunPerWorkflow.forEach((run) => {
+                if (run.status !== 'completed') {
+                  pendingRuns.push(run);
+                } else if (failureConclusions.includes(run.conclusion)) {
+                  failedRuns.push(run);
                 }
+                console.log(`workflow run ${run.name} => ${run.status === 'completed' ? run.conclusion : run.status}`);
               });
 
-              if (pending.length === 0) {
-                core.setFailed("Cannot get pull request check status");
+              if (failedRuns.length > 0) {
+                const failedJobs = [];
+                for await (const run of failedRuns) {
+                  try {
+                    const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      run_id: run.id,
+                      filter: 'latest',
+                      per_page: 100
+                    });
+
+                    const failedJobsOfRun = jobs
+                      .filter(({ conclusion }) => failureConclusions.includes(conclusion))
+                      .map(({ conclusion, name, html_url }) => `<a href="${html_url}">${run.name} / ${name} (${conclusion})</a>`);
+                    // a run can fail without any failed job (startup_failure...)
+                    if (failedJobsOfRun.length === 0) {
+                      failedJobsOfRun.push(`<a href="${run.html_url}">${run.name} (${run.conclusion})</a>`);
+                    }
+                    failedJobs.push(...failedJobsOfRun);
+                  } catch (error) {
+                    core.warning(`Cannot list jobs of workflow run ${run.id}: ${error.message}`);
+                    failedJobs.push(`<a href="${run.html_url}">${run.name} (${run.conclusion})</a>`);
+                  }
+                }
+
+                core.summary.addRaw(`${failedJobs.length} job(s) failed:`, true)
+                core.summary.addList(failedJobs);
+                core.summary.write();
+
+                core.setFailed(`${failedRuns.length} workflow run(s) failed`);
                 return;
               }
 
-              if (failure.length > 0) {
-                let failureMessage = '';
-                const failedCheckRuns = [];
-                for await (const suite_id of failure) {
-                  const resultCheckRuns = await github.rest.checks.listForSuite({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    check_suite_id: suite_id
-                  });
-
-                  resultCheckRuns.data.check_runs.forEach(({ conclusion, name, html_url }) => {
-                    if (['failure', 'cancelled'].includes(conclusion) && ! excludedJobs.includes(name)) {
-                      failedCheckRuns.push(`<a href="${html_url}">${name} (${conclusion})</a>`);
-                    }
-                  });
-                }
-
-                core.summary.addRaw(`${failedCheckRuns.length} job(s) failed:`, true)
-                core.summary.addList(failedCheckRuns);
-                core.summary.write();
-
-                if (failedCheckRuns.length > 0) {
-                  core.setFailed(`${failedCheckRuns.length} job(s) failed`);
-                  return;
-                }
-              }
-
-              if (pending.length === 1) {
+              if (pendingRuns.length === 0) {
                 core.info("All workflows are ok");
                 return;
               }
 
-              core.info(`${pending.length} workflows in progress`);
+              core.info(`${pendingRuns.length} workflow run(s) in progress`);
 
-              await exec.exec("sleep 30s");
+              await new Promise((resolve) => setTimeout(resolve, 30000));
             }
 
             core.setFailed("Timeout: some jobs are still in progress");
@@ -145,7 +176,7 @@ jobs:
 
               const { title, body } = pull.data;
 
-              [title, body].forEach((text) => {
+              [title, body ?? ''].forEach((text) => {
                 const linkedPrMatches = text.matchAll(/(?:#|\/pull\/)(\d+)/g);
                 if (linkedPrMatches) {
                   [...linkedPrMatches].forEach((match) => {


### PR DESCRIPTION
Fixes: [MON-204193](https://centreon.atlassian.net/browse/MON-204193)

## Description

`check-status` is the single required status check gating PR merges. It currently polls the **check suites** attached to the PR head commit, which has several flaws. This PR reworks it to poll **workflow runs** (`GET /actions/runs?head_sha=...`) instead.

### What this fixes

- **Trigger event filtering**: check suites carry no trigger event information, so a manual `workflow_dispatch` (or `push`) run on the PR head commit was wrongly awaited and could fail `check-status`. Runs are now filtered on an explicit event allowlist (`pull_request` only).
- **Silent 30-item cap**: `listSuitesForRef` was not paginated, so only the first 30 check suites were evaluated. The runs listing is now paginated (`per_page: 100`).
- **Fragile self-exclusion**: the loop exited on `pending.length === 1`, assuming the only pending suite was `check-status` itself; any lingering unrelated run broke that assumption. The current run is now excluded by `run.id`.
- **Incomplete failure detection**: only `failure` and `cancelled` conclusions were treated as failures — `timed_out`, `action_required`, `startup_failure` and `stale` were silently treated as success. They now fail the check.
- **Superseded runs**: only the latest run of each workflow is evaluated, so runs superseded by a re-trigger (`labeled`/`unlabeled` events) are ignored.
- **Transient API errors** no longer fail the job immediately; the iteration is retried.
- **Eventually consistent listing**: the result is not trusted until the listing contains the current run (restores the safety of the previous `pending.length === 0` guard).
- `check-cherry-pick` no longer crashes when the PR body is empty (`body` is `null` in the API response).

### Behavior changes

- `check-qa-validation` was previously awaited while pending and only excluded from failure detection; it is now fully excluded from the evaluation (it is an independent required status check with its own lifecycle).
- Job-level links in the failure summary are kept, now prefixed with the workflow name (`workflow / job (conclusion)`).

### Logs & job summary

- Per-poll status lines are grouped into collapsible log groups whose title carries the in progress / completed / failed counters.
- Each failed workflow run emits one error annotation carrying its failed jobs count (GitHub only displays 10 annotations per step, and matrices can produce hundreds of failed jobs).
- A job summary is now always written (success, failure and timeout) with a table of the evaluated workflow runs (conclusion, duration, link), the failed jobs list (capped at 20 entries with a remainder count), the poll count, the elapsed time and the applied event/workflow filters. Previously a summary was only written on failure, and a timeout did not tell which runs were still pending.

### Follow-ups

- Same rework on `centreon-collect` and `centreon-modules` (tracked in MON-204193).

[MON-204193]: https://centreon.atlassian.net/browse/MON-204193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

