### PR TITLE
enh(vault): add VaultEligibilityService as single source of truth

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -66,6 +66,9 @@ services:
         arguments: ['%env(bool:IS_CLOUD_PLATFORM)%', '%env(file:resolve:FILE_FEATURE_FLAGS)%']
         public: true
 
+    Core\Common\Application\VaultEligibilityService:
+        public: true
+
     Adaptation\Database\Connection\Model\ConnectionConfig:
         arguments:
             $host: '%database_host%'

--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -463,6 +463,462 @@ parameters:
 			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
 
 		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/BrokerInputOutputValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/BrokerInputOutputValidatorTest.php
+
+		-
+			message: '#^Access to private property PHPUnit\\Framework\\TestCase\:\:\$output\.$#'
+			identifier: property.private
+			count: 4
+			path: tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 16
+			path: tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Contact/Application/UseCase/FindContactGroups/FindContactGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Contact/Application/UseCase/FindContactGroups/FindContactGroupsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Contact/Application/UseCase/FindContactGroups/FindContactGroupsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Contact/Application/UseCase/FindContactTemplates/FindContactTemplatesTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Contact/Infrastructure/Api/FindContactGroups/FindContactGroupsControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Contact/Infrastructure/Api/FindContactGroups/FindContactGroupsControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Contact/Infrastructure/Api/FindContactGroups/FindContactGroupsControllerTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Contact/Infrastructure/Api/FindContactTemplates/FindContactTemplatesControllerTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/AddDashboard/AddDashboardTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/AddDashboard/AddDashboardTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Dashboard/Application/UseCase/AddDashboard/AddDashboardTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/Dashboard/Application/UseCase/AddDashboard/AddDashboardTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteContactDashboardShare/DeleteContactDashboardShareTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteContactDashboardShare/DeleteContactDashboardShareTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 27
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteContactDashboardShare/DeleteContactDashboardShareTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteContactGroupDashboardShare/DeleteContactGroupDashboardShareTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteContactGroupDashboardShare/DeleteContactGroupDashboardShareTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 27
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteContactGroupDashboardShare/DeleteContactGroupDashboardShareTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteDashboard/DeleteDashboardTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteDashboard/DeleteDashboardTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/Dashboard/Application/UseCase/DeleteDashboard/DeleteDashboardTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 26
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboardsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboardsTest.php
+
+		-
+			message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:expect\(\)\.$#'
+			identifier: method.notFound
+			count: 31
+			path: tests/php/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTopTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTopTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTopTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/FindPerformanceMetricsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/FindPerformanceMetricsTest.php
+
+		-
+			message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:expect\(\)\.$#'
+			identifier: method.notFound
+			count: 6
+			path: tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
+
+		-
+			message: '#^Call to protected method expectException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricTest.php
+
+		-
+			message: '#^Call to protected method expectException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Dashboard/Application/UseCase/FindSingleMetric/FindSingleMetricTest.php
+
+		-
+			message: '#^Call to protected method expectExceptionObject\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboardPanelsDifferenceTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboardTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboardTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 28
+			path: tests/php/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboardTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Application/UseCase/ShareDashboard/ShareDashboardTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Dashboard/Application/UseCase/ShareDashboard/ShareDashboardTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 25
+			path: tests/php/Core/Dashboard/Application/UseCase/ShareDashboard/ShareDashboardTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Dashboard/Application/UseCase/ShareDashboard/ShareDashboardValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 16
+			path: tests/php/Core/Dashboard/Application/UseCase/ShareDashboard/ShareDashboardValidatorTest.php
+
+		-
+			message: '#^Call to protected method atLeast\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Domain/Model/DashboardRightsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Domain/Model/DashboardRightsTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Dashboard/Domain/Model/DashboardRightsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/GraphTemplate/Application/UseCase/FindGraphTemplates/FindGraphTemplatesTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/GraphTemplate/Application/UseCase/FindGraphTemplates/FindGraphTemplatesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/GraphTemplate/Application/UseCase/FindGraphTemplates/FindGraphTemplatesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Host/Application/InheritanceManagerTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Host/Application/InheritanceManagerTest.php
+
+		-
+			message: '#^Access to private property PHPUnit\\Framework\\TestCase\:\:\$groups\.$#'
+			identifier: property.private
+			count: 5
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 25
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 128
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+
+		-
 			message: '#^Cannot call method getId\(\) on string\.$#'
 			identifier: method.nonObject
 			count: 2
@@ -475,6 +931,102 @@ parameters:
 			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
 
 		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostValidationTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 21
+			path: tests/php/Core/Host/Application/UseCase/AddHost/AddHostValidationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 20
+			path: tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 16
+			path: tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Host/Application/UseCase/FindRealTimeHostStatusesCount/FindRealTimeHostStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Host/Application/UseCase/FindRealTimeHostStatusesCount/FindRealTimeHostStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Host/Application/UseCase/FindRealTimeHostStatusesCount/FindRealTimeHostStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Host/Application/UseCase/FindRealTimeHostStatusesCount/FindRealTimeHostStatusesCountTest.php
+
+		-
+			message: '#^Access to private property PHPUnit\\Framework\\TestCase\:\:\$groups\.$#'
+			identifier: property.private
+			count: 5
+			path: tests/php/Core/Host/Application/UseCase/GetHost/GetHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Host/Application/UseCase/GetHost/GetHostTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Host/Application/UseCase/GetHost/GetHostTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 20
+			path: tests/php/Core/Host/Application/UseCase/GetHost/GetHostTest.php
+
+		-
 			message: '#^Cannot call method getId\(\) on string\.$#'
 			identifier: method.nonObject
 			count: 2
@@ -485,6 +1037,54 @@ parameters:
 			identifier: method.nonObject
 			count: 2
 			path: tests/php/Core/Host/Application/UseCase/GetHost/GetHostTest.php
+
+		-
+			message: '#^Access to private property PHPUnit\\Framework\\TestCase\:\:\$groups\.$#'
+			identifier: property.private
+			count: 1
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 25
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 39
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 173
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidationTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostValidationTest.php
 
 		-
 			message: '#^Missing parameter \$alias \(Core\\Common\\Domain\\TrimmedString\|null\) in call to Core\\Host\\Domain\\Model\\SmallHost constructor\.$#'
@@ -551,3 +1151,2037 @@ parameters:
 			identifier: argument.missing
 			count: 5
 			path: tests/php/Core/Host/Domain/Model/SmallHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostCategory/Application/UseCase/AddHostCategory/AddHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 16
+			path: tests/php/Core/HostCategory/Application/UseCase/AddHostCategory/AddHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostCategory/Application/UseCase/DeleteHostCategory/DeleteHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/HostCategory/Application/UseCase/DeleteHostCategory/DeleteHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategory/FindHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategory/FindHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/HostCategory/Application/UseCase/FindHostCategory/FindHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostCategory/Application/UseCase/FindRealTimeHostCategories/FindRealTimeHostCategoriesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/HostCategory/Application/UseCase/FindRealTimeHostCategories/FindRealTimeHostCategoriesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/HostCategory/Application/UseCase/UpdateHostCategory/UpdateHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 30
+			path: tests/php/Core/HostCategory/Application/UseCase/UpdateHostCategory/UpdateHostCategoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/HostGroup/Application/UseCase/AddHostGroup/AddHostGroupTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/HostGroup/Application/UseCase/AddHostGroup/AddHostGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/HostGroup/Application/UseCase/AddHostGroup/AddHostGroupTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroup/DeleteHostGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroup/DeleteHostGroupTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroup/DeleteHostGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroup/DeleteHostGroupTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroups/DeleteHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroups/DeleteHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroups/DeleteHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method onConsecutiveCalls\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroups/DeleteHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method throwException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/DeleteHostGroups/DeleteHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/HostGroup/Application/UseCase/DuplicateHostGroups/DuplicateHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/HostGroup/Application/UseCase/DuplicateHostGroups/DuplicateHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 31
+			path: tests/php/Core/HostGroup/Application/UseCase/DuplicateHostGroups/DuplicateHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/DuplicateHostGroups/DuplicateHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/HostGroup/Application/UseCase/DuplicateHostGroups/DuplicateHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostGroup/Application/UseCase/EnableDisableHostGroups/EnableDisableHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/HostGroup/Application/UseCase/EnableDisableHostGroups/EnableDisableHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostGroup/Application/UseCase/EnableDisableHostGroups/EnableDisableHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method onConsecutiveCalls\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/EnableDisableHostGroups/EnableDisableHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method throwException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/EnableDisableHostGroups/EnableDisableHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostGroup/Application/UseCase/FindHostGroups/FindHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostGroup/Application/UseCase/FindHostGroups/FindHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/HostGroup/Application/UseCase/FindHostGroups/FindHostGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/HostGroup/Application/UseCase/GetHostGroup/GetHostGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/HostGroup/Application/UseCase/GetHostGroup/GetHostGroupTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 22
+			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/HostSeverity/Application/UseCase/AddHostSeverity/AddHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 21
+			path: tests/php/Core/HostSeverity/Application/UseCase/AddHostSeverity/AddHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostSeverity/Application/UseCase/DeleteHostSeverity/DeleteHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/HostSeverity/Application/UseCase/DeleteHostSeverity/DeleteHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostSeverity/Application/UseCase/FindHostSeverities/FindHostSeveritiesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/HostSeverity/Application/UseCase/FindHostSeverities/FindHostSeveritiesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/HostSeverity/Application/UseCase/FindHostSeverities/FindHostSeveritiesTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/HostSeverity/Application/UseCase/FindHostSeverity/FindHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostSeverity/Application/UseCase/FindHostSeverity/FindHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/HostSeverity/Application/UseCase/FindHostSeverity/FindHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostSeverity/Application/UseCase/UpdateHostSeverity/UpdateHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 32
+			path: tests/php/Core/HostSeverity/Application/UseCase/UpdateHostSeverity/UpdateHostSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 67
+			path: tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateValidationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostTemplate/Application/FindHostTemplates/FindHostTemplatesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/HostTemplate/Application/FindHostTemplates/FindHostTemplatesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/HostTemplate/Application/FindHostTemplates/FindHostTemplatesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/HostTemplate/Application/GetHostTemplate/GetHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostTemplate/Application/GetHostTemplate/GetHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/HostTemplate/Application/GetHostTemplate/GetHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 24
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 118
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateValidationTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateValidationTest.php
+
+		-
+			message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:getBaseUri\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/php/Core/Infrastructure/Common/Api/HttpUrlTraitTest.php
+
+		-
+			message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:getBaseUrl\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/php/Core/Infrastructure/Common/Api/HttpUrlTraitTest.php
+
+		-
+			message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:getHost\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: tests/php/Core/Infrastructure/Common/Api/HttpUrlTraitTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Infrastructure/Common/Api/RouterTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Media/Application/UseCase/AddMedia/AddMediaTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Media/Application/UseCase/AddMedia/AddMediaTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Media/Application/UseCase/DeleteMedia/DeleteMediaTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Media/Application/UseCase/DeleteMedia/DeleteMediaTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/Media/Application/UseCase/DeleteMedia/DeleteMediaTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Media/Application/UseCase/GetMedia/GetMediaTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Media/Application/UseCase/GetMedia/GetMediaTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 19
+			path: tests/php/Core/Media/Application/UseCase/GetMedia/GetMediaTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Media/Application/UseCase/MigrateAllMedias/MigrateAllMediasTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Media/Application/UseCase/MigrateAllMedias/MigrateAllMediasTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Media/Application/UseCase/UpdateMedia/UpdateMediaTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Media/Application/UseCase/UpdateMedia/UpdateMediaTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 35
+			path: tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 14
+			path: tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Metric/Application/UseCase/FindMetricsByService/FindMetricsByServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Metric/Application/UseCase/FindMetricsByService/FindMetricsByServiceTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 14
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 32
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
+
+		-
+			message: '#^Method PHPUnit\\Framework\\TestCase\:\:once\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Factory/NewNotificationFactoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Factory/NewNotificationFactoryTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationResourceFactoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationResourceFactoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationResourceFactoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Validator/NotificationValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Notification/Application/UseCase/AddNotification/Validator/NotificationValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Notification/Application/UseCase/DeleteNotification/DeleteNotificationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Notification/Application/UseCase/DeleteNotification/DeleteNotificationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Notification/Application/UseCase/DeleteNotifications/DeleteNotificationsTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/DeleteNotifications/DeleteNotificationsTest.php
+
+		-
+			message: '#^Call to protected method onConsecutiveCalls\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/DeleteNotifications/DeleteNotificationsTest.php
+
+		-
+			message: '#^Call to protected method throwException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/DeleteNotifications/DeleteNotificationsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifiableResources/FindNotifiableResourcesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifiableResources/FindNotifiableResourcesTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifiableRule/FindNotifiableRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifiableRule/FindNotifiableRuleTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifiableRule/FindNotifiableRuleTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Notification/Application/UseCase/FindNotification/FindNotificationTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/FindNotification/FindNotificationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Notification/Application/UseCase/FindNotification/FindNotificationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 14
+			path: tests/php/Core/Notification/Application/UseCase/FindNotification/FindNotificationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifications/FindNotificationsTest.php
+
+		-
+			message: '#^Call to protected method atLeastOnce\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifications/FindNotificationsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifications/FindNotificationsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Notification/Application/UseCase/FindNotifications/FindNotificationsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Notification/Application/UseCase/PartialUpdateNotification/PartialUpdateNotificationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Notification/Application/UseCase/PartialUpdateNotification/PartialUpdateNotificationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/UpdateNotification/Factory/NotificationFactoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Notification/Application/UseCase/UpdateNotification/Factory/NotificationFactoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotificationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotificationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Platform/Application/UseCase/FindFeatures/FindFeaturesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Platform/Application/UseCase/FindFeatures/FindFeaturesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Platform/Infrastructure/Repository/FsReadUpdateRepositoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Platform/Infrastructure/Repository/FsReadUpdateRepositoryTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 28
+			path: tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 14
+			path: tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ResourceAccess/Application/UseCase/FindRules/FindRulesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/ResourceAccess/Application/UseCase/FindRules/FindRulesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRuleTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 29
+			path: tests/php/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRuleTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ResourceAccess/Domain/Model/Dataset/DatasetFilterValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Resources/Infrastructure/API/FindResources/FindResourcesRequestValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/AccessGroup/Application/UseCase/FindLocalUserAccessGroups/FindLocalUserAccessGroupsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Security/AccessGroup/Application/UseCase/FindLocalUserAccessGroups/FindLocalUserAccessGroupsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/AccessGroup/Infrastructure/Api/FindLocalUserAccessGroups/FindLocalUserAccessGroupsControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/AccessGroup/Infrastructure/Api/FindLocalUserAccessGroups/FindLocalUserAccessGroupsControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/AccessGroup/Infrastructure/Api/FindLocalUserAccessGroups/FindLocalUserAccessGroupsControllerTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/Authentication/Application/UseCase/Login/LoginTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/Security/Authentication/Application/UseCase/Login/LoginTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 28
+			path: tests/php/Core/Security/Authentication/Application/UseCase/Login/LoginTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 14
+			path: tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+
+		-
+			message: '#^Call to protected method throwException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/Authentication/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Security/ProviderConfiguration/Application/UseCase/FindProviderConfigurations/FindProviderConfigurationsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Security/ProviderConfiguration/Application/UseCase/FindProviderConfigurations/FindProviderConfigurationsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Application/WebSSO/UpdateWebSSOConfiguration/UseCase/UpdateWebSSOConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/ProviderConfiguration/Application/WebSSO/UpdateWebSSOConfiguration/UseCase/UpdateWebSSOConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Application/WebSSO/UseCase/FindWebSSOConfiguration/FindWebSSOConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/ProviderConfiguration/Application/WebSSO/UseCase/FindWebSSOConfiguration/FindWebSSOConfigurationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method expectException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/OpenId/Api/UpdateOpenIdConfiguration/UpdateOpenIdConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Api/FindWebSSOConfiguration/FindWebSSOConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Api/FindWebSSOConfiguration/FindWebSSOConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Api/FindWebSSOConfiguration/FindWebSSOConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Api/UpdateWebSSOConfiguration/UpdateWebSSOConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Api/UpdateWebSSOConfiguration/UpdateWebSSOConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/ProviderConfiguration/Infrastructure/WebSSO/Api/UpdateWebSSOConfiguration/UpdateWebSSOConfigurationControllerTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 26
+			path: tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Security/Token/Application/UseCase/AddToken/AddTokenValidationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/Token/Application/UseCase/DeleteToken/DeleteTokenTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/Security/Token/Application/UseCase/DeleteToken/DeleteTokenTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/Token/Application/UseCase/FindTokens/FindTokensTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/Token/Application/UseCase/FindTokens/FindTokensTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Security/Token/Application/UseCase/GetToken/GetTokenTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/Token/Application/UseCase/GetToken/GetTokenTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/Token/Application/UseCase/PartialUpdateToken/PartialUpdateTokenTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/Security/Token/Application/UseCase/PartialUpdateToken/PartialUpdateTokenTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Security/Vault/Application/UseCase/DeleteVaultConfiguration/DeleteVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/Vault/Application/UseCase/DeleteVaultConfiguration/DeleteVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigratorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 22
+			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 25
+			path: tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 80
+			path: tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/Service/Application/UseCase/AddService/AddServiceValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 20
+			path: tests/php/Core/Service/Application/UseCase/AddService/AddServiceValidationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Service/Application/UseCase/DeleteServices/DeleteServicesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Service/Application/UseCase/DeleteServices/DeleteServicesTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Service/Application/UseCase/DeleteServices/DeleteServicesTest.php
+
+		-
+			message: '#^Call to protected method onConsecutiveCalls\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Service/Application/UseCase/DeleteServices/DeleteServicesTest.php
+
+		-
+			message: '#^Call to protected method throwException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Service/Application/UseCase/DeleteServices/DeleteServicesTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/Service/Application/UseCase/DeploySevices/DeployServicesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Service/Application/UseCase/DeploySevices/DeployServicesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Service/Application/UseCase/DeploySevices/DeployServicesTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeServiceStatusesCount/FindRealTimeServiceStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeServiceStatusesCount/FindRealTimeServiceStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeServiceStatusesCount/FindRealTimeServiceStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeServiceStatusesCount/FindRealTimeServiceStatusesCountTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeUniqueServiceNames/FindRealTimeUniqueServiceNamesTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeUniqueServiceNames/FindRealTimeUniqueServiceNamesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Service/Application/UseCase/FindRealTimeUniqueServiceNames/FindRealTimeUniqueServiceNamesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Service/Application/UseCase/FindServices/FindServicesTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Service/Application/UseCase/FindServices/FindServicesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/Service/Application/UseCase/FindServices/FindServicesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Service/Application/UseCase/GetService/GetServiceTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Service/Application/UseCase/GetService/GetServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 19
+			path: tests/php/Core/Service/Application/UseCase/GetService/GetServiceTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 24
+			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 99
+			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 21
+			path: tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ServiceCategory/Application/UseCase/DeleteServiceCategory/DeleteServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/ServiceCategory/Application/UseCase/DeleteServiceCategory/DeleteServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ServiceCategory/Application/UseCase/FindRealTimeServiceCategories/FindRealTimeServiceCategoriesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/ServiceCategory/Application/UseCase/FindRealTimeServiceCategories/FindRealTimeServiceCategoriesTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceCategory/Application/UseCase/FindServiceCategories/FindServiceCategoriesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceCategory/Application/UseCase/FindServiceCategories/FindServiceCategoriesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/ServiceCategory/Application/UseCase/FindServiceCategories/FindServiceCategoriesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 20
+			path: tests/php/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceGroup/Application/AddServiceGroup/AddServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/ServiceGroup/Application/AddServiceGroup/AddServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 26
+			path: tests/php/Core/ServiceGroup/Application/AddServiceGroup/AddServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceGroup/Application/DeleteServiceGroup/DeleteServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceGroup/Application/DeleteServiceGroup/DeleteServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ServiceGroup/Application/DeleteServiceGroup/DeleteServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/ServiceGroup/Application/DeleteServiceGroup/DeleteServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/ServiceGroup/Application/FindServiceGroups/FindServiceGroupsTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceGroup/Application/FindServiceGroups/FindServiceGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceGroup/Application/FindServiceGroups/FindServiceGroupsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/ServiceGroup/Application/FindServiceGroups/FindServiceGroupsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceGroup/Application/GetServiceGroup/GetServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ServiceGroup/Application/GetServiceGroup/GetServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/ServiceGroup/Application/GetServiceGroup/GetServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ServiceGroup/Application/UpdateServiceGroup/UpdateServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/ServiceGroup/Application/UpdateServiceGroup/UpdateServiceGroupTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/AddServiceSeverity/AddServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 21
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/AddServiceSeverity/AddServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/DeleteServiceSeverity/DeleteServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/DeleteServiceSeverity/DeleteServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/FindServiceSeverities/FindServiceSeveritiesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/FindServiceSeverities/FindServiceSeveritiesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/FindServiceSeverities/FindServiceSeveritiesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/GetServiceSeverity/GetServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/UpdateServiceSeverity/UpdateServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/ServiceSeverity/Application/UseCase/UpdateServiceSeverity/UpdateServiceSeverityTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 22
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateValidationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplatesTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplatesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplatesTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplatesTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/GetServiceTemplate/GetServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/GetServiceTemplate/GetServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/GetServiceTemplate/GetServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 26
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/GetServiceTemplate/GetServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 19
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 73
+			path: tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Severity/RealTime/Application/UseCase/FindSeverity/FindSeverityTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/TimePeriod/Application/UseCase/AddTimePeriod/AddTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/TimePeriod/Application/UseCase/AddTimePeriod/AddTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/TimePeriod/Application/UseCase/DeleteTimePeriod/DeleteTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/TimePeriod/Application/UseCase/DeleteTimePeriod/DeleteTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/TimePeriod/Application/UseCase/FindTimePeriod/FindTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/TimePeriod/Application/UseCase/FindTimePeriod/FindTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/TimePeriod/Application/UseCase/FindTimePeriod/FindTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/TimePeriod/Application/UseCase/FindTimePeriods/FindTimePeriodsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/TimePeriod/Application/UseCase/FindTimePeriods/FindTimePeriodsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/TimePeriod/Application/UseCase/FindTimePeriods/FindTimePeriodsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/TimePeriod/Application/UseCase/UpdateTimePeriod/UpdateTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/TimePeriod/Application/UseCase/UpdateTimePeriod/UpdateTimePeriodTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/User/Application/UseCase/FindCurrentUserParameters/FindCurrentUserParametersTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/User/Application/UseCase/FindUsers/FindUsersTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/User/Application/UseCase/FindUsers/FindUsersTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/User/Application/UseCase/FindUsers/FindUsersTest.php

--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -1,6 +1,444 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 23
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/FindAcc/FindAccTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/FindAcc/FindAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/FindAccs/FindAccsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/FindAccs/FindAccsTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 16
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 36
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AdditionalConnectorConfiguration/Domain/Model/AccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AdditionalConnectorConfiguration/Domain/Model/NewAccTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AdditionalConnectorConfiguration/Domain/Model/VmWareV6ParametersTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+
+		-
+			message: '#^Call to protected method expectException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+
+		-
+			message: '#^Call to protected method expectException\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/TelegrafValidatorTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method never\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 36
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/CreateHostForAgentConfiguration/CreateHostForAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/DeleteAgentConfiguration/DeleteAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/DeleteAgentConfiguration/DeleteAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/DeleteAgentConfigurationPollerLink/DeleteAgentConfigurationPollerLinkTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 15
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/DeleteAgentConfigurationPollerLink/DeleteAgentConfigurationPollerLinkTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfiguration/FindAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfiguration/FindAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfigurations/FindAgentConfigurationsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfigurations/FindAgentConfigurationsTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 18
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfigurations/FindAgentConfigurationsTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 14
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method atMost\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/ValidatorTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AgentConfiguration/Domain/Model/AgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/AgentConfiguration/Domain/Model/NewAgentConfigurationTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 1
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindHostNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindHostNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 13
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindHostNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindMetaServiceNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindMetaServiceNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindMetaServiceNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 9
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindServiceNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 3
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindServiceNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 20
+			path: tests/php/Core/Application/Configuration/NotificationPolicy/UseCase/FindServiceNotificationPolicyTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 4
+			path: tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 2
+			path: tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 11
+			path: tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 17
+			path: tests/php/Core/Application/RealTime/UseCase/FindHost/FindHostTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 5
+			path: tests/php/Core/Application/RealTime/UseCase/FindMetaService/FindMetaServiceTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 8
+			path: tests/php/Core/Application/RealTime/UseCase/FindMetaService/FindMetaServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 10
+			path: tests/php/Core/Application/RealTime/UseCase/FindMetaService/FindMetaServiceTest.php
+
+		-
+			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 6
+			path: tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 12
+			path: tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 21
+			path: tests/php/Core/Application/RealTime/UseCase/FindService/FindServiceTest.php
+
+		-
+			message: '#^Access to private property PHPUnit\\Framework\\TestCase\:\:\$output\.$#'
+			identifier: property.private
+			count: 8
+			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
+
+		-
+			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 7
+			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
+
+		-
+			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
+			identifier: method.protected
+			count: 20
+			path: tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
+
+		-
 			message: '#^Cannot call method getId\(\) on string\.$#'
 			identifier: method.nonObject
 			count: 3

--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -2481,13 +2481,13 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 22
+			count: 21
 			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
 
 		-
 			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 3
+			count: 2
 			path: tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
 
 		-

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAcc.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAcc.php
@@ -40,7 +40,7 @@ use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 
 final class AddAcc
@@ -57,7 +57,7 @@ final class AddAcc
      * @param AccFactory $factory
      * @param DataStorageEngineInterface $dataStorageEngine
      * @param ContactInterface $user
-     * @param FeatureFlags $flags
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param \Traversable<WriteVaultAccRepositoryInterface> $writeVaultAccRepositories
      * @param WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository
      */
@@ -68,7 +68,7 @@ final class AddAcc
         private readonly AccFactory $factory,
         private readonly DataStorageEngineInterface $dataStorageEngine,
         private readonly ContactInterface $user,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         \Traversable $writeVaultAccRepositories,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
     ) {
@@ -103,7 +103,7 @@ final class AddAcc
                 description: $request->description,
             );
 
-            if ($this->flags->isEnabled('vault_gorgone')) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_gorgone')) {
                 $parameters = $newAcc->getParameters();
 
                 foreach ($this->writeVaultAccRepositories as $repository) {

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAcc.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAcc.php
@@ -36,7 +36,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
@@ -54,7 +54,7 @@ final class DeleteAcc
      * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepository
      * @param ReadMonitoringServerRepositoryInterface $readMonitoringServerRepository
      * @param ContactInterface $user
-     * @param FeatureFlags $flags
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param \Traversable<WriteVaultAccRepositoryInterface> $writeVaultAccRepositories
      * @param WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository
      */
@@ -64,7 +64,7 @@ final class DeleteAcc
         private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
         private readonly ReadMonitoringServerRepositoryInterface $readMonitoringServerRepository,
         private readonly ContactInterface $user,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         \Traversable $writeVaultAccRepositories,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
     ) {
@@ -114,7 +114,7 @@ final class DeleteAcc
                 }
             }
 
-            if ($this->flags->isEnabled('vault_gorgone')) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_gorgone')) {
                 foreach ($this->writeVaultAccRepositories as $repository) {
                     if ($repository->isValidFor($acc->getType())) {
                         $repository->deleteFromVault($acc);

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAcc.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAcc.php
@@ -42,7 +42,7 @@ use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
@@ -66,7 +66,7 @@ final class UpdateAcc
      * @param AccFactory $factory
      * @param DataStorageEngineInterface $dataStorageEngine
      * @param ContactInterface $user
-     * @param FeatureFlags $flags
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param \Traversable<WriteVaultAccRepositoryInterface> $writeVaultAccRepositories
      * @param \Traversable<ReadVaultAccRepositoryInterface> $readVaultAccRepositories
      * @param WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository
@@ -80,7 +80,7 @@ final class UpdateAcc
         private readonly AccFactory $factory,
         private readonly DataStorageEngineInterface $dataStorageEngine,
         private readonly ContactInterface $user,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         \Traversable $writeVaultAccRepositories,
         \Traversable $readVaultAccRepositories,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
@@ -130,7 +130,7 @@ final class UpdateAcc
             $parametersChanged = $decryptedPreviousAcc->getParameters()->getDecryptedData()
                 !== $updatedAcc->getParameters()->getDecryptedData();
 
-            if ($this->flags->isEnabled('vault_gorgone')) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_gorgone')) {
                 $parameters = $updatedAcc->getParameters();
 
                 foreach ($this->writeVaultAccRepositories as $repository) {

--- a/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
@@ -39,7 +39,7 @@ use Core\Broker\Domain\Model\BrokerInputOutputField;
 use Core\Broker\Domain\Model\NewBrokerInputOutput;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 
 /**
@@ -56,7 +56,7 @@ final class AddBrokerInputOutput
         private readonly ContactInterface $user,
         private readonly BrokerInputOutputValidator $validator,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
-        private readonly FeatureFlags $flags,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::BROKER_VAULT_PATH);
     }
@@ -101,7 +101,7 @@ final class AddBrokerInputOutput
                 parameters: $validatedParameters
             );
 
-            if ($this->flags->isEnabled('vault_broker') && $this->writeVaultRepository->isVaultConfigured() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault('vault_broker')) {
                 $this->uuid = $this->getBrokerVaultUuid($request->brokerId);
                 $newOutput = $this->saveInVault($newOutput, $outputFields);
             }

--- a/centreon/src/Core/Common/Application/VaultEligibilityService.php
+++ b/centreon/src/Core/Common/Application/VaultEligibilityService.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Common\Application;
+
+use Core\Common\Infrastructure\FeatureFlags;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+
+class VaultEligibilityService
+{
+    public function __construct(
+        private readonly FeatureFlags $featureFlags,
+        private readonly ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository,
+    ) {
+    }
+
+    public function shouldUseVault(string $featureFlag = 'vault'): bool
+    {
+        return $this->featureFlags->isEnabled($featureFlag)
+            && $this->readVaultConfigurationRepository->exists();
+    }
+}

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -42,6 +42,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Exception\HostException;
@@ -90,6 +91,7 @@ final class AddHost
         private readonly AddHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly WriteRealTimeHostRepositoryInterface $writeRealTimeHostRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
@@ -208,7 +210,7 @@ final class AddHost
             ? (int) $inheritanceMode[0]->getValue()
             : 0;
 
-        if ($this->writeVaultRepository->isVaultConfigured() === true && $request->snmpCommunity !== '') {
+        if ($this->vaultEligibilityService->shouldUseVault() && $request->snmpCommunity !== '') {
             $vaultPaths = $this->writeVaultRepository->upsert(
                 null,
                 [VaultConfiguration::HOST_SNMP_COMMUNITY_KEY => $request->snmpCommunity]
@@ -365,7 +367,7 @@ final class AddHost
                     : ''
                 );
             }
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_HOST' . $macro->getName() => $macro->getValue()],
@@ -423,7 +425,7 @@ final class AddHost
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/Host/Application/UseCase/DeleteHost/DeleteHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/DeleteHost/DeleteHost.php
@@ -34,6 +34,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
@@ -62,6 +63,7 @@ final class DeleteHost
         private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
     ) {
@@ -112,7 +114,7 @@ final class DeleteHost
         $this->debug('Start transaction');
 
         $this->storageEngine->startTransaction();
-        $isVaultActive = $this->writeVaultRepository->isVaultConfigured();
+        $isVaultActive = $this->vaultEligibilityService->shouldUseVault();
         try {
             // Only delete services that are exclusively linked to this host
             $serviceIds = $this->readServiceRepository->findServiceIdsExclusivelyLinkedToHostId($host->getId());

--- a/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHost.php
@@ -47,6 +47,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
@@ -106,6 +107,7 @@ final class PartialUpdateHost
         private readonly PartialUpdateHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
@@ -184,7 +186,7 @@ final class PartialUpdateHost
         try {
             $this->dataStorageEngine->startTransaction();
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveHostUuidFromVault($host);
             }
 
@@ -789,10 +791,10 @@ final class PartialUpdateHost
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -832,7 +834,7 @@ final class PartialUpdateHost
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixedName = '_HOST' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,
@@ -904,7 +906,7 @@ final class PartialUpdateHost
         }
 
         // If vault is not configured, just set the value directly
-        if (! $this->writeVaultRepository->isVaultConfigured()) {
+        if (! $this->vaultEligibilityService->shouldUseVault()) {
             $host->setSnmpCommunity($snmpCommunity ?? '');
 
             return;

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
@@ -42,6 +42,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\InheritanceManager;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
@@ -79,6 +80,7 @@ final class AddHostTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -177,7 +179,7 @@ final class AddHostTemplate
             ? (int) ($inheritanceMode[0])->getValue()
             : 0;
 
-        if ($this->writeVaultRepository->isVaultConfigured() === true && $request->snmpCommunity !== '') {
+        if ($this->vaultEligibilityService->shouldUseVault() && $request->snmpCommunity !== '') {
             $vaultPaths = $this->writeVaultRepository->upsert(
                 null,
                 [VaultConfiguration::HOST_SNMP_COMMUNITY_KEY => $request->snmpCommunity]
@@ -310,7 +312,7 @@ final class AddHostTemplate
                 );
             }
 
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_HOST' . $macro->getName() => $macro->getValue()],
@@ -369,7 +371,7 @@ final class AddHostTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/HostTemplate/Application/UseCase/DeleteHostTemplate/DeleteHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/DeleteHostTemplate/DeleteHostTemplate.php
@@ -34,6 +34,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\HostTemplate\Application\Exception\HostTemplateException;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
@@ -52,6 +53,7 @@ final class DeleteHostTemplate
         private readonly ContactInterface $user,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -95,7 +97,7 @@ final class DeleteHostTemplate
                 return;
             }
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveHostTemplateUuidFromVault($hostTemplate);
                 if ($this->uuid !== null) {
                     $this->writeVaultRepository->delete($this->uuid);

--- a/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
@@ -47,6 +47,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\InheritanceManager;
@@ -93,6 +94,7 @@ final class PartialUpdateHostTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -183,7 +185,7 @@ final class PartialUpdateHostTemplate
         try {
             $this->dataStorageEngine->startTransaction();
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveHostUuidFromVault($hostTemplate);
             }
 
@@ -498,10 +500,10 @@ final class PartialUpdateHostTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -617,7 +619,7 @@ final class PartialUpdateHostTemplate
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixedName = '_HOST' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,
@@ -690,7 +692,7 @@ final class PartialUpdateHostTemplate
         }
 
         // If vault is not configured, just set the value directly
-        if (! $this->writeVaultRepository->isVaultConfigured()) {
+        if (! $this->vaultEligibilityService->shouldUseVault()) {
             $hostTemplate->setSnmpCommunity($snmpCommunity);
 
             return;

--- a/centreon/src/Core/Security/Vault/Application/Exceptions/VaultException.php
+++ b/centreon/src/Core/Security/Vault/Application/Exceptions/VaultException.php
@@ -34,4 +34,9 @@ class VaultException extends \Exception
     {
         return new self(_('No vault configured'));
     }
+
+    public static function vaultNotAvailable(): self
+    {
+        return new self(_('Vault is not available'));
+    }
 }

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -33,7 +33,7 @@ use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
 use Core\Host\Domain\Model\Host;
@@ -57,7 +57,6 @@ use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Exceptions\VaultException;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\Migrator\AccCredentialMigratorInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 
@@ -72,7 +71,7 @@ final class MigrateAllCredentials
 
     /**
      * @param WriteVaultRepositoryInterface $writeVaultRepository
-     * @param ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository
+     * @param VaultEligibilityService $vaultEligibilityService
      * @param ReadHostRepositoryInterface $readHostRepository
      * @param ReadHostMacroRepositoryInterface $readHostMacroRepository
      * @param ReadHostTemplateRepositoryInterface $readHostTemplateRepository
@@ -91,12 +90,11 @@ final class MigrateAllCredentials
      * @param WriteBrokerInputOutputRepositoryInterface $writeBrokerInputOutputRepository
      * @param ReadAccRepositoryInterface $readAccRepository
      * @param WriteAccRepositoryInterface $writeAccRepository
-     * @param FeatureFlags $flags
      * @param \Traversable<AccCredentialMigratorInterface> $accCredentialMigrators
      */
     public function __construct(
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
-        private readonly ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadHostRepositoryInterface $readHostRepository,
         private readonly ReadHostMacroRepositoryInterface $readHostMacroRepository,
         private readonly ReadHostTemplateRepositoryInterface $readHostTemplateRepository,
@@ -115,7 +113,6 @@ final class MigrateAllCredentials
         private readonly WriteBrokerInputOutputRepositoryInterface $writeBrokerInputOutputRepository,
         private readonly ReadAccRepositoryInterface $readAccRepository,
         private readonly WriteAccRepositoryInterface $writeAccRepository,
-        private readonly FeatureFlags $flags,
         \Traversable $accCredentialMigrators,
     ) {
         $this->response = new MigrateAllCredentialsResponse();
@@ -125,8 +122,8 @@ final class MigrateAllCredentials
     public function __invoke(MigrateAllCredentialsPresenterInterface $presenter): void
     {
         try {
-            if ($this->readVaultConfigurationRepository->find() === null) {
-                $presenter->presentResponse(new ErrorResponse(VaultException::noVaultConfigured()));
+            if (! $this->vaultEligibilityService->shouldUseVault()) {
+                $presenter->presentResponse(new ErrorResponse(VaultException::vaultNotAvailable()));
 
                 return;
             }
@@ -140,10 +137,10 @@ final class MigrateAllCredentials
             $openIdConfiguration = $this->readProviderConfigurationRepository->getConfigurationByType(
                 Provider::OPENID
             );
-            $brokerInputOutputs = $this->flags->isEnabled('vault_broker')
+            $brokerInputOutputs = $this->vaultEligibilityService->shouldUseVault('vault_broker')
                 ? $this->readBrokerInputOutputRepository->findAll()
                 : [];
-            $accs = $this->flags->isEnabled('vault_gorgone')
+            $accs = $this->vaultEligibilityService->shouldUseVault('vault_gorgone')
                 ? $this->readAccRepository->findAll()
                 : [];
 

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -41,6 +41,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -97,6 +98,7 @@ final class AddService
         private readonly bool $isCloudPlatform,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly WriteRealTimeServiceRepositoryInterface $writeRealTimeServiceRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
@@ -220,7 +222,7 @@ final class AddService
             }
             $this->info('Add the macro ' . $macro->getName());
 
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_SERVICE' . $macro->getName() => $macro->getValue()],
@@ -500,7 +502,7 @@ final class AddService
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/Service/Application/UseCase/DeleteService/DeleteService.php
+++ b/centreon/src/Core/Service/Application/UseCase/DeleteService/DeleteService.php
@@ -34,6 +34,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
@@ -66,6 +67,7 @@ final class DeleteService
         private readonly ContactInterface $user,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -109,7 +111,7 @@ final class DeleteService
                 $monitoringServerId = $this->readRepository->findMonitoringServerId($serviceId);
                 $this->info("Delete service #{$serviceId}");
 
-                if ($this->writeVaultRepository->isVaultConfigured()) {
+                if ($this->vaultEligibilityService->shouldUseVault()) {
                     $this->retrieveServiceUuidFromVault($serviceId);
                     if ($this->uuid !== null) {
                         $this->writeVaultRepository->delete($this->uuid);

--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateService.php
@@ -45,6 +45,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
@@ -103,6 +104,7 @@ final class PartialUpdateService
         private readonly bool $isCloudPlatform,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
@@ -177,7 +179,7 @@ final class PartialUpdateService
         $this->dataStorageEngine->startTransaction();
         try {
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveServiceUuidFromVault($service->getId());
             }
 
@@ -599,10 +601,10 @@ final class PartialUpdateService
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -667,7 +669,7 @@ final class PartialUpdateService
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixName = '_SERVICE' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
@@ -41,6 +41,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
@@ -92,6 +93,7 @@ final class AddServiceTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -214,7 +216,7 @@ final class AddServiceTemplate
             }
             $this->info('Add the macro ' . $macro->getName());
 
-            if ($this->writeVaultRepository->isVaultConfigured() === true && $macro->isPassword() === true) {
+            if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
                 $vaultPaths = $this->writeVaultRepository->upsert(
                     $this->uuid ?? null,
                     ['_SERVICE' . $macro->getName() => $macro->getValue()],
@@ -499,7 +501,7 @@ final class AddServiceTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
@@ -33,6 +33,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
@@ -57,6 +58,7 @@ final class DeleteServiceTemplate
         private readonly ContactInterface $user,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -101,7 +103,7 @@ final class DeleteServiceTemplate
                 return;
             }
 
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveServiceUuidFromVault($serviceTemplateId);
                 if ($this->uuid !== null) {
                     $this->writeVaultRepository->delete($this->uuid);

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -44,6 +44,7 @@ use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
 use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\HostTemplate\Application\Exception\HostTemplateException;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -94,6 +95,7 @@ final class PartialUpdateServiceTemplate
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
         private readonly ReadCommandRepositoryInterface $readCommandRepository,
+        private readonly VaultEligibilityService $vaultEligibilityService,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -282,7 +284,7 @@ final class PartialUpdateServiceTemplate
         $this->debug('Start transaction');
         $this->storageEngine->startTransaction();
         try {
-            if ($this->writeVaultRepository->isVaultConfigured()) {
+            if ($this->vaultEligibilityService->shouldUseVault()) {
                 $this->retrieveServiceUuidFromVault($serviceTemplate->getId());
             }
 
@@ -404,10 +406,10 @@ final class PartialUpdateServiceTemplate
         }
 
         return [
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($directMacros)
                 : $directMacros,
-            $this->writeVaultRepository->isVaultConfigured()
+            $this->vaultEligibilityService->shouldUseVault()
                 ? $this->retrieveMacrosVaultValues($inheritedMacros)
                 : $inheritedMacros,
             $commandMacros,
@@ -680,7 +682,7 @@ final class PartialUpdateServiceTemplate
      */
     private function updateMacroInVault(Macro $macro, string $action): Macro
     {
-        if ($this->writeVaultRepository->isVaultConfigured() && $macro->isPassword() === true) {
+        if ($this->vaultEligibilityService->shouldUseVault() && $macro->isPassword() === true) {
             $macroPrefixName = '_SERVICE' . $macro->getName();
             $vaultPaths = $this->writeVaultRepository->upsert(
                 $this->uuid ?? null,

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/AddAcc/AddAccTest.php
@@ -42,8 +42,10 @@ use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
 beforeEach(function (): void {
     $this->presenter = new AddAccPresenterStub();
@@ -54,7 +56,10 @@ beforeEach(function (): void {
         factory: $this->factory = $this->createMock(AccFactory::class),
         dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class),
         user: $this->user = $this->createMock(ContactInterface::class),
-        flags: $this->flags = new FeatureFlags(false, ''),
+        vaultEligibilityService: $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
         writeVaultAccRepositories: $this->writeVaultAccRepositories = new \ArrayIterator([]),
         writeMonitoringServerRepository: $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
     );

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/DeleteAcc/DeleteAccTest.php
@@ -36,12 +36,14 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
 beforeEach(function (): void {
     $this->useCase = new DeleteAcc(
@@ -50,7 +52,10 @@ beforeEach(function (): void {
         $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         $this->readMonitoringServerRepository = $this->createMock(ReadMonitoringServerRepositoryInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
+        $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
         $this->writeVaultAccRepositories = new \ArrayIterator([]),
         $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
     );

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Application/UseCase/UpdateAcc/UpdateAccTest.php
@@ -41,12 +41,14 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Core\MonitoringServer\Application\Repository\WriteMonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
 beforeEach(function (): void {
     $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
@@ -61,7 +63,10 @@ beforeEach(function (): void {
         $this->factory = $this->createMock(AccFactory::class),
         $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
+        $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
         $this->writeVaultAccRepositories = new \ArrayIterator([]),
         $this->readVaultAccRepositories = new \ArrayIterator([]),
         $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),

--- a/centreon/tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
+++ b/centreon/tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
@@ -37,8 +37,10 @@ use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Broker\Domain\Model\BrokerInputOutputField;
 use Core\Broker\Domain\Model\Type;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\FeatureFlags;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Tests\Core\Broker\Infrastructure\API\AddBrokerInputOutput\AddBrokerInputOutputPresenterStub;
 
 beforeEach(function (): void {
@@ -82,7 +84,10 @@ beforeEach(function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->validator = $this->createMock(BrokerInputOutputValidator::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
+        $this->vaultEligibilityService = new VaultEligibilityService(
+            new FeatureFlags(false, ''),
+            $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        ),
     );
 });
 

--- a/centreon/tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
+++ b/centreon/tests/php/Core/Common/Application/VaultEligibilityServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Common\Application;
+
+use Core\Common\Application\VaultEligibilityService;
+use Core\Common\Infrastructure\FeatureFlags;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class VaultEligibilityServiceTest extends TestCase
+{
+    /** @var ReadVaultConfigurationRepositoryInterface&MockObject */
+    private ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository;
+
+    protected function setUp(): void
+    {
+        $this->readVaultConfigurationRepository = $this->createMock(ReadVaultConfigurationRepositoryInterface::class);
+    }
+
+    public function testShouldReturnFalseWhenFeatureFlagIsDisabled(): void
+    {
+        $featureFlags = new FeatureFlags(false, '{"vault": 0}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        $this->assertFalse($service->shouldUseVault());
+    }
+
+    public function testShouldReturnFalseWhenFeatureFlagIsEnabledButVaultConfigDoesNotExist(): void
+    {
+        $featureFlags = new FeatureFlags(false, '{"vault": 1}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(false);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        $this->assertFalse($service->shouldUseVault());
+    }
+
+    public function testShouldReturnTrueWhenFeatureFlagIsEnabledAndVaultConfigExists(): void
+    {
+        $featureFlags = new FeatureFlags(false, '{"vault": 1}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        $this->assertTrue($service->shouldUseVault());
+    }
+
+    public function testShouldCheckTheCorrectFeatureFlagWhenACustomFlagNameIsProvided(): void
+    {
+        $featureFlags = new FeatureFlags(false, '{"vault": 0, "vault_broker": 1}');
+        $this->readVaultConfigurationRepository->method('exists')->willReturn(true);
+
+        $service = new VaultEligibilityService($featureFlags, $this->readVaultConfigurationRepository);
+
+        $this->assertFalse($service->shouldUseVault());
+        $this->assertTrue($service->shouldUseVault('vault_broker'));
+    }
+}

--- a/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
@@ -40,6 +40,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\AdminResolver;
 use Core\Domain\Common\GeoCoords;
 use Core\Host\Application\Converter\HostEventConverter;
@@ -96,6 +97,7 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(AddHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        vaultEligibilityService: $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         writeRealTimeHostRepository: $this->writeRealTimeHostRepository = $this->createMock(WriteRealTimeHostRepositoryInterface::class),
         readCommandRepository: $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         writeAccessGroupRepository: $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),

--- a/centreon/tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
@@ -29,6 +29,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
@@ -58,6 +59,7 @@ beforeEach(closure: function (): void {
         readAccessGroupRepository: $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         writeMonitoringServerRepository: $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
         writeVaultRepository: $this->createMock(WriteVaultRepositoryInterface::class),
+        vaultEligibilityService: $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         readHostMacroRepository: $this->createMock(ReadHostMacroRepositoryInterface::class),
         readServiceMacroRepository: $this->createMock(ReadServiceMacroRepositoryInterface::class),
     );

--- a/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/PartialUpdateHost/PartialUpdateHostTest.php
@@ -40,6 +40,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\AdminResolver;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
@@ -91,6 +92,7 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(PartialUpdateHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        vaultEligibilityService: $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         readCommandRepository:  $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         writeAccessGroupRepository: $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         adminResolver: $this->adminResolver = $this->createMock(AdminResolver::class),

--- a/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
@@ -40,6 +40,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Domain\Model\HostEvent;
@@ -83,7 +84,8 @@ beforeEach(function (): void {
         $this->validation = $this->createMock(AddHostTemplateValidation::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
-        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class)
+        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 
     $this->inheritanceModeOption = new Option();

--- a/centreon/tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/DeleteHostTemplate/DeleteHostTemplateTest.php
@@ -29,6 +29,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\HostTemplate\Application\Exception\HostTemplateException;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
 use Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterface;
@@ -52,6 +53,7 @@ beforeEach(function (): void {
         $this->user,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readHostMacroRepository = $this->createMock(ReadHostMacroRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 });
 

--- a/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
@@ -41,6 +41,7 @@ use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Domain\Model\HostEvent;
@@ -89,7 +90,8 @@ beforeEach(function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
-        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class)
+        $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 
     $this->inheritanceModeOption = new Option();

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
@@ -29,7 +29,7 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
-use Core\Common\Infrastructure\FeatureFlags;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\Model\ContactTemplate;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
@@ -53,19 +53,15 @@ use Core\Security\ProviderConfiguration\Domain\Model\GroupsMapping;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Exceptions\VaultException;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\CredentialMigrator;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\MigrateAllCredentials;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\MigrateAllCredentialsResponse;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\Migrator\VmWareV6CredentialMigrator;
-use Core\Security\Vault\Domain\Model\VaultConfiguration;
-use Security\Interfaces\EncryptionInterface;
 
 beforeEach(function (): void {
-    $this->encryption = $this->createMock(EncryptionInterface::class);
     $this->useCase = new MigrateAllCredentials(
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
-        $this->readVaultConfigurationRepository = $this->createMock(ReadVaultConfigurationRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         $this->readHostRepository = $this->createMock(ReadHostRepositoryInterface::class),
         $this->readHostMacroRepository = $this->createMock(ReadHostMacroRepositoryInterface::class),
         $this->readHostTemplateRepository = $this->createMock(ReadHostTemplateRepositoryInterface::class),
@@ -84,39 +80,26 @@ beforeEach(function (): void {
         $this->writeBrokerInputOutputRepository = $this->createMock(WriteBrokerInputOutputRepositoryInterface::class),
         $this->readAccRepository = $this->createMock(ReadAccRepositoryInterface::class),
         $this->writeAccRepository = $this->createMock(WriteAccRepositoryInterface::class),
-        $this->flags = new FeatureFlags(false, ''),
         $this->accCredentialMigrators = new \ArrayIterator([$this->createMock(VmWareV6CredentialMigrator::class)]),
     );
 });
 
 it('should present an Error Response when no vault are configured', function (): void {
-    $this->readVaultConfigurationRepository
+    $this->vaultEligibilityService
         ->expects($this->once())
-        ->method('find')
-        ->willReturn(null);
+        ->method('shouldUseVault')
+        ->willReturn(false);
     $presenter = new MigrateAllCredentialsPresenterStub();
     ($this->useCase)($presenter);
 
     expect($presenter->response)->toBeInstanceOf(ErrorResponse::class)
-        ->and($presenter->response->getMessage())->toBe(VaultException::noVaultConfigured()->getMessage());
+        ->and($presenter->response->getMessage())->toBe(VaultException::vaultNotAvailable()->getMessage());
 });
 
 it('should present a MigrateAllCredentialsResponse when no error occurs', function (): void {
-    $vaultConfiguration = new VaultConfiguration(
-        encryption: $this->encryption,
-        name: 'vault',
-        address: '127.0.0.1',
-        port: 443,
-        rootPath: 'mystorage',
-        encryptedRoleId: 'role-id',
-        encryptedSecretId: 'secret-id',
-        salt: 'labaleine'
-    );
-
-    $this->readVaultConfigurationRepository
-        ->expects($this->once())
-        ->method('find')
-        ->willReturn($vaultConfiguration);
+    $this->vaultEligibilityService
+        ->method('shouldUseVault')
+        ->willReturn(true);
 
     $customConfiguration = new CustomConfiguration([
         'is_active' => true,

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
@@ -37,6 +37,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Domain\YesNoDefault;
 use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -95,6 +96,7 @@ beforeEach(function (): void {
         $this->isCloudPlatform = false,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         $this->writeRealTimeServiceRepository = $this->createMock(WriteRealTimeServiceRepositoryInterface::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),

--- a/centreon/tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/DeleteService/DeleteServiceTest.php
@@ -30,6 +30,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -52,6 +53,7 @@ beforeEach(closure: function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readServiceMacroRepository = $this->createMock(ReadServiceMacroRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 });
 

--- a/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceTest.php
@@ -38,6 +38,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Contact\Domain\AdminResolver;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -93,6 +94,7 @@ beforeEach(closure: function (): void {
         $this->isCloudPlatform = false,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         $this->adminResolver = $this->createMock(AdminResolver::class),

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/Mock.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/Mock.php
@@ -30,6 +30,7 @@ use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\CommandMacro\Application\Repository\ReadCommandMacroRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
@@ -72,6 +73,7 @@ class Mock extends TestCase
             $testCase->writeVaultRepository = $testCase->createMock(WriteVaultRepositoryInterface::class),
             $testCase->readVaultRepository = $testCase->createMock(ReadVaultRepositoryInterface::class),
             $testCase->readCommandRepository = $testCase->createMock(ReadCommandRepositoryInterface::class),
+            $testCase->vaultEligibilityService = $testCase->createMock(VaultEligibilityService::class),
         );
     }
 

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
@@ -30,6 +30,7 @@ use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
@@ -47,6 +48,7 @@ beforeEach(closure: function (): void {
         $this->user = $this->createMock(ContactInterface::class),
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readServiceMacroRepository = $this->createMock(ReadServiceMacroRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
     $this->serviceTemplateLockedFound = new ServiceTemplate(
         1,

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -39,6 +39,7 @@ use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\CommandMacroType;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Domain\YesNoDefault;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
@@ -89,6 +90,7 @@ beforeEach(closure: function (): void {
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
         $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class),
+        $this->vaultEligibilityService = $this->createMock(VaultEligibilityService::class),
     );
 });
 
@@ -652,8 +654,8 @@ it('should load command macros from an inherited template command when the servi
         ->with($serviceTemplateId)
         ->willReturn($serviceTemplate);
 
-    $this->writeVaultRepository
-        ->method('isVaultConfigured')
+    $this->vaultEligibilityService
+        ->method('shouldUseVault')
         ->willReturn(false);
 
     $this->storageEngine

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -34,11 +34,11 @@ use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Converter\HostEventConverter;
 use Core\Infrastructure\Common\Api\Router;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -401,10 +401,8 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     $selectHostStatement = $pearDB->prepare('SELECT * FROM host WHERE host_id = :hostId LIMIT 1');
     foreach ($hosts as $key => $value) {
         if (false === ($key = filter_var($key, FILTER_VALIDATE_INT))) {
@@ -731,7 +729,7 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
                         && str_starts_with(VaultConfiguration::VAULT_PATH_PATTERN, $row['host_snmp_community'])
                         || $macroPasswords !== []
                     ) {
-                        if ($vaultConfiguration !== null) {
+                        if ($vaultEligibilityService->shouldUseVault()) {
                             /** @var ReadVaultRepositoryInterface $readVaultRepository */
                             $readVaultRepository = $kernel->getContainer()->get(
                                 ReadVaultRepositoryInterface::class
@@ -1204,14 +1202,12 @@ function updateHost($hostId = null, $isMassiveChange = false, $configuration = n
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
 
     // Retrieve UUID for vault path before updating values in database.
     $vaultPath = null;
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         $vaultPath = retrieveHostVaultPathFromDatabase($pearDB, $hostId);
     }
 
@@ -1359,7 +1355,7 @@ function updateHost($hostId = null, $isMassiveChange = false, $configuration = n
     }
 
     // If there is a vault configuration write into vault
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         /** @var ReadVaultRepositoryInterface $readVaultRepository */
         $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
 
@@ -1407,14 +1403,12 @@ function updateHost_MC($hostId = null)
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
 
     // Retrieve UUID for vault path before updating values in database.
     $vaultPath = null;
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         $vaultPath = retrieveHostVaultPathFromDatabase($pearDB, $hostId);
     }
 
@@ -1525,7 +1519,7 @@ function updateHost_MC($hostId = null)
     }
 
     // If there is a vault configuration write into vault.
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         try {
             /** @var ReadVaultRepositoryInterface $readVaultRepository */
             $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -31,10 +31,10 @@ use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Api\InternalApiClient;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Infrastructure\Common\Api\Router;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
@@ -470,13 +470,11 @@ function deleteServiceInDB(array $services = []): void
 
     $serviceIds = array_keys($services);
     $kernel = Kernel::createForWeb();
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     /** @var WriteVaultRepositoryInterface $writeVaultRepository */
     $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         deleteResourceSecretsInVault($writeVaultRepository, [], $serviceIds);
     }
 
@@ -704,10 +702,8 @@ function multipleServiceInDB(
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     $selectServiceStatement = $pearDB->prepare('SELECT * FROM service WHERE service_id = :serviceId LIMIT 1');
     foreach ($services as $key => $value) {
         if (filter_var($key, FILTER_VALIDATE_INT) === false) {
@@ -1032,7 +1028,7 @@ function multipleServiceInDB(
                             }
                         }
 
-                        if ($macroPasswords !== [] && $vaultConfiguration !== null) {
+                        if ($macroPasswords !== [] && $vaultEligibilityService->shouldUseVault()) {
                             /** @var ReadVaultRepositoryInterface $readVaultRepository */
                             $readVaultRepository = $kernel->getContainer()->get(
                                 ReadVaultRepositoryInterface::class
@@ -1122,13 +1118,11 @@ function updateServiceForCloud($serviceId = null, $massiveChange = false, $param
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     // Retrieve vault path before updating values in database.
     $vaultPath = null;
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         $vaultPath = retrieveServiceVaultPathFromDatabase($pearDB, $serviceId);
     }
 
@@ -1245,7 +1239,7 @@ function updateServiceForCloud($serviceId = null, $massiveChange = false, $param
         $deleteMacroStatement->execute();
     }
 
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         /** @var ReadVaultRepositoryInterface $readVaultRepository */
         $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
 
@@ -1300,13 +1294,11 @@ function updateService_MCForCloud($serviceId = null, $parameters = [])
     $uuidGenerator = $kernel->getContainer()->get(UUIDGeneratorInterface::class);
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     // Retrieve UUID for vault path before updating values in database.
     $uuid = null;
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         $uuid = retrieveServiceSecretUuidFromDatabase($pearDB, $serviceId);
     }
 
@@ -1447,15 +1439,26 @@ function updateService_MCForCloud($serviceId = null, $parameters = [])
     }
 
     // If there is a vault configuration write into vault
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         try {
+            /** @var ReadVaultRepositoryInterface $readVaultRepository */
+            $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
+
+            /** @var WriteVaultRepositoryInterface $writeVaultRepository */
+            $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
+            $writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
+
+            $updatedPasswordMacros = array_filter($service->getFormattedMacros(), function ($macro) {
+                return $macro['macroPassword'] === '1'
+                    && ! str_starts_with($macro['macroValue'], VaultConfiguration::VAULT_PATH_PATTERN);
+            });
             updateServiceSecretsInVaultFromMC(
-                $vaultConfiguration,
+                $readVaultRepository,
+                $writeVaultRepository,
                 $logger,
-                $uuidGenerator,
                 $uuid,
                 (int) $serviceId,
-                $service->getFormattedMacros()
+                $updatedPasswordMacros
             );
         } catch (Throwable $ex) {
             error_log((string) $ex);
@@ -2163,12 +2166,10 @@ function insertServiceForCloud($submittedValues = [], $onDemandMacro = null)
         return $macro['macro_password'] === '1';
     });
     $kernel = Kernel::createForWeb();
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     // If there is a vault configuration  and macros write into vault
-    if ($vaultConfiguration !== null && $passwordMacros !== []) {
+    if ($vaultEligibilityService->shouldUseVault() && $passwordMacros !== []) {
         try {
             /** @var WriteVaultRepositoryInterface $writeVaultRepository */
             $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
@@ -2400,12 +2401,10 @@ function insertServiceForOnPremise($submittedValues = [], $onDemandMacro = null)
         return $macro['macroPassword'] === '1';
     });
     $kernel = Kernel::createForWeb();
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     // If there is a vault configuration  and macros write into vault
-    if ($vaultConfiguration !== null && $passwordMacros !== []) {
+    if ($vaultEligibilityService->shouldUseVault() && $passwordMacros !== []) {
         try {
             /** @var WriteVaultRepositoryInterface $writeVaultRepository */
             $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
@@ -2502,13 +2501,11 @@ function updateService($service_id = null, $from_MC = false, $params = [])
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
     // Retrieve vault path before updating values in database.
     $vaultPath = null;
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         $vaultPath = retrieveServiceVaultPathFromDatabase($pearDB, $service_id);
     }
 
@@ -2681,7 +2678,7 @@ function updateService($service_id = null, $from_MC = false, $params = [])
         $statement->execute();
     }
 
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         /** @var ReadVaultRepositoryInterface $readVaultRepository */
         $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
 
@@ -2735,14 +2732,12 @@ function updateService_MC($service_id = null, $params = [])
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
     $isServiceTemplate = isset($ret['service_register']) && $ret['service_register'] === '0';
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
 
     // Retrieve UUID for vault path before updating values in database.
     $vaultPath = null;
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         $vaultPath = retrieveServiceVaultPathFromDatabase($pearDB, $service_id);
     }
 
@@ -2963,7 +2958,7 @@ function updateService_MC($service_id = null, $params = [])
     }
 
     // If there is a vault configuration write into vault
-    if ($vaultConfiguration !== null) {
+    if ($vaultEligibilityService->shouldUseVault()) {
         try {
             /** @var ReadVaultRepositoryInterface $readVaultRepository */
             $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);

--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -32,8 +32,8 @@ use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroName;
 use Centreon\Domain\Log\Logger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\VaultEligibilityService;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 
 /**
@@ -495,12 +495,9 @@ function getFromVault(string $vaultPath): array
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    /** @var ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository */
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
-    if ($vaultConfiguration !== null) {
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
+    if ($vaultEligibilityService->shouldUseVault()) {
         /** @var ReadVaultRepositoryInterface $readVaultRepository */
         $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
         try {
@@ -521,12 +518,9 @@ function saveInVault(string $key, string $value): ?string
     $kernel = Kernel::createForWeb();
     /** @var Logger $logger */
     $logger = $kernel->getContainer()->get(Logger::class);
-    /** @var ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository */
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
-    if ($vaultConfiguration !== null) {
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
+    if ($vaultEligibilityService->shouldUseVault()) {
         /** @var ReadVaultRepositoryInterface $readVaultRepository */
         $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
         /** @var WriteVaultRepositoryInterface $writeVaultRepository */
@@ -565,13 +559,9 @@ function deleteFromVault(array $data): void
         $kernel = Kernel::createForWeb();
         /** @var Logger $logger */
         $logger = $kernel->getContainer()->get(Logger::class);
-        /** @var ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository */
-        $readVaultConfigurationRepository = $kernel->getContainer()->get(
-            ReadVaultConfigurationRepositoryInterface::class
-        );
-
-        $vaultConfiguration = $readVaultConfigurationRepository->find();
-        if ($vaultConfiguration !== null) {
+        /** @var VaultEligibilityService $vaultEligibilityService */
+        $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
+        if ($vaultEligibilityService->shouldUseVault()) {
             /** @var ReadVaultRepositoryInterface $readVaultRepository */
             $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
             /** @var WriteVaultRepositoryInterface $writeVaultRepository */


### PR DESCRIPTION
## Description

Create `VaultEligibilityService` as the single source of truth for vault eligibility checks, replacing scattered `isVaultConfigured()` and `FeatureFlags` calls across all domains.

Previously, Host/Service/HostTemplate/ServiceTemplate use cases only checked if the vault was configured (`isVaultConfigured()`), ignoring the `vault` feature flag. When the feature flag was disabled but `vault.json` existed, credentials were still stored in vault. Broker and ACC correctly checked both — but through separate, duplicated logic.

`VaultEligibilityService::shouldUseVault()` encapsulates both checks (feature flag + vault configuration) in one place. All domains now use it consistently.

**Changes across 5 sub-task PRs:**
- #10892 — Service creation + Symfony registration
- #10895 — Core use cases (Host, Service, HostTemplate, ServiceTemplate)
- #10897 — Broker and ACC use cases
- #10898 — MigrateAllCredentials
- #10899 — Legacy DB-Func files (host, service, configResources)

Fixes: [MON-202473](https://centreon.atlassian.net/browse/MON-202473)

[MON-202473]: https://centreon.atlassian.net/browse/MON-202473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ