### PR TITLE
enh(security): upgrade onelogin/php-saml to 4.3.2

### DIFF
--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -41,7 +41,7 @@
     "justinrainbow/json-schema": "5.3.*",
     "monolog/monolog": "3.7.*",
     "nelmio/cors-bundle": "2.5.*",
-    "onelogin/php-saml": "~4.3.1",
+    "onelogin/php-saml": "4.3.*",
     "openpsa/quickform": "3.3.*",
     "pear/pear-core-minimal": "1.10.*",
     "phpdocumentor/reflection-docblock": "5.4.*",

--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -14959,9 +14959,9 @@
         "ext-xmlwriter": "*",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Description

Backport of #10801.

Upgrade `onelogin/php-saml` from `~4.3.1` to `4.3.*` to pull in `robrichards/xmlseclibs` 3.1.5 which fixes a critical GCM authentication tag validation vulnerability (CVE-2026-32313).

Fixes: [MON-201989](https://centreon.atlassian.net/browse/MON-201989)

[MON-201989]: https://centreon.atlassian.net/browse/MON-201989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ