### PR TITLE
enh(ci): update actions/checkout to v7.0.0 in get-changes-triggers

### DIFF
--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Checkout sources
         if: inputs.base_sha != ''
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-tags: true
 


### PR DESCRIPTION
Fixes: [MON-204287](https://centreon.atlassian.net/browse/MON-204287)

Backport of #10936 to `release-24.10-next`. https://github.com/centreon/centreon/pull/10938

The `fetch-tags` input used by the `Checkout sources` step of `.github/workflows/get-changes-triggers.yml` only works properly starting from `actions/checkout` v6.0.2. This PR bumps the action to v7.0.0, pinned to commit `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`.

[MON-204287]: https://centreon.atlassian.net/browse/MON-204287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ