### PR TITLE
fix(logging): remove RT2 leftover debug file write

### DIFF
--- a/centreon-open-tickets/phpstan.legacy.www.baseline.neon
+++ b/centreon-open-tickets/phpstan.legacy.www.baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
 
 		-
-			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) fp must contain 3 or more characters\.$#'
-			count: 3
-			path: www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
-
-		-
 			message: '#^\[CENTREON\-RULE\]\: \(VariableLengthCustomRule\) ch must contain 3 or more characters\.$#'
 			count: 2
 			path: www/modules/centreon-open-tickets/providers/Serena/SerenaProvider.class.php

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/RequestTracker2/RequestTracker2Provider.class.php
@@ -481,9 +481,6 @@ class RequestTracker2Provider extends AbstractProvider
             }
         }
 
-        $fp = fopen('/var/opt/rh/rh-php71/log/php-fpm/debug.txt', 'a+');
-        fwrite($fp, print_r($argument, true));
-        fclose($fp);
         if ($this->callRest('ticket', $argument) == 1) {
             return -1;
         }


### PR DESCRIPTION
## Summary
- Remove the RequestTracker2 leftover debug `fopen`/`fwrite` file write
- Drop obsolete PHPStan baseline entry for the removed `$fp`

Backport of https://github.com/centreon/centreon/pull/10831 to `dev-24.10.x`

## References

Fixes: [MON-204311](https://centreon.atlassian.net/browse/MON-204311)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MON-204311]: https://centreon.atlassian.net/browse/MON-204311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ