### PR TITLE
fix(ci): xray: make e2e report discovery robust to single-artifact layout

### DIFF
--- a/.github/workflows/xray-api-import-results.yml
+++ b/.github/workflows/xray-api-import-results.yml
@@ -129,7 +129,7 @@ jobs:
             results_file="merged-junit.xml"
             import_endpoint="https://xray.cloud.getxray.app/api/v2/import/execution/junit/multipart"
           else
-            mapfile -t files < <(find "$REPORT_PATH" -type f -path "*xray-reports*" \( -name "report.json" -o -name "cucumber-report.json" \))
+            mapfile -t files < <(find "$REPORT_PATH" -type f \( -name "report.json" -o -name "cucumber-report.json" -o -name "*-report.json" \))
             results_file="cucumber-report-merged.json"
             import_endpoint="https://xray.cloud.getxray.app/api/v2/import/execution/cucumber/multipart"
           fi


### PR DESCRIPTION
Makes the e2e Xray report discovery robust to the single-artifact (flat) layout.

When a component has a single e2e feature, `download-artifact` extracts the lone matching artifact flat into the report path (no per-artifact subdirectory), so the path no longer contains "xray-reports". The previous `find -path "*xray-reports*"` filter then matched nothing and the import failed with "No cucumber result files found". Components with multiple features created subdirectories (name contains "xray-reports") and worked by chance.

The `-path "*xray-reports*"` filter is redundant — the download step already scopes to `*-xray-reports-*` artifacts — so it is dropped. Feature-scoped report names (`*-report.json`) are also accepted:

    find "$REPORT_PATH" -type f ( -name "report.json" -o -name "cucumber-report.json" -o -name "*-report.json" )

Already fixed on the 25.10 and 24.10 LTS branches (via the backport PRs); this brings develop in line.

Refs: MON-204348
