### PR TITLE
fix(ci): force base-10 arithmetic when computing NEXT_MAJOR_VERSION

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -123,7 +123,7 @@ runs:
           BUMP_MAJOR_RIGHT="01"
         else
           BUMP_MAJOR_LEFT=$MAJOR_LEFT
-          BUMP_MAJOR_RIGHT=$(( $MAJOR_RIGHT + 1 ))
+          BUMP_MAJOR_RIGHT=$(( 10#$MAJOR_RIGHT + 1 ))
         fi
 
         export NEXT_MAJOR_VERSION="$BUMP_MAJOR_LEFT.$BUMP_MAJOR_RIGHT"


### PR DESCRIPTION
Fixes: [MON-204491](https://centreon.atlassian.net/browse/MON-204491)

Since `MAJOR_VERSION` moved to `26.09`, the `package-nfpm` action fails to compute `NEXT_MAJOR_VERSION`:

```
09: value too great for base (error token is "09")
```

Bash parses numbers with a leading zero as octal, and `09` is not a valid octal number (`26.09` is the first version to trigger this — only `08` and `09` are invalid). The step keeps going, so packaging jobs stay green, but `BUMP_MAJOR_RIGHT` is left empty and `NEXT_MAJOR_VERSION` becomes `26.` instead of `26.10`. Every dependency constraint `< ${NEXT_MAJOR_VERSION}` then becomes `< 26.`, which no `26.09.x` package can satisfy — e.g. `centreon-common` requiring `centreon-broker < 26.` makes `dnf install` fail in downstream jobs (see [this centreon-collect gorgone run](https://github.com/centreon/centreon-collect/actions/runs/28790786185)).

The fix forces base-10 arithmetic: `$(( 10#$MAJOR_RIGHT + 1 ))`. Behavior is unchanged for all previously working versions (`26.05` → `26.6`, `26.12` → `27.01`), and `26.09` now correctly yields `26.10`.

The same fix is applied to the packaging actions of the centreon-collect, centreon and centreon-modules repositories.

**How to test**: run a packaging workflow on this branch; the log must not contain `value too great for base`, and produced packages must carry `< 26.10` constraints instead of `< 26.` (`rpm -qpR`).


[MON-204491]: https://centreon.atlassian.net/browse/MON-204491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ