### PR TITLE
chore(docker): pin vault UI port and document the vault profile (backport 25.10)

### DIFF
--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -60,7 +60,7 @@ Currently, the following profiles are available:
 * `poller`: register automatically a poller to centreon web image (:danger: EXPERIMENTAL)
 * `remote-server`: run a Remote Server alongside the Central, each with its own database — registers automatically (see [Remote Server setup](#satellite-remote-server-setup))
 * `glpi`: must be used with `centreon-open-tickets` image to link glpi automatically in open-tickets providers
-* `vault`: register automatically hashicorp vault and migrate credentials
+* `vault`: run a hashicorp vault (dev mode) and migrate credentials automatically (see [Vault setup](#lock-vault-setup))
 * `openid`: run a docker image of keycloak
   * Add the following entry to your **/etc/hosts** : `127.0.0.1 sso-proxy`
   * :warning: On Windows: **C:\Windows\System32\drivers\etc\hosts**
@@ -149,6 +149,23 @@ The following environment variables are available to customize the setup:
 * `REMOTE_SERVER_NAME`: name displayed for the Remote Server in the Central UI (default: `remote-server`)
 * `CENTRAL_API_USERNAME`: API account used for registration (default: `admin`)
 * `CENTRAL_API_PASSWORD`: password for the API account (default: `Centreon!2021`)
+
+## :lock: Vault setup
+
+The `vault` profile runs a HashiCorp Vault (dev mode) and migrates Centreon credentials into it automatically. All the `VAULT_*` values referenced below are test credentials already set in the committed `.env`, so there is nothing to fill in.
+
+* The `web` and `vault` services must be started together, otherwise the auto-configuration does not trigger.
+* Vault UI available at `https://127.0.0.1:8200/ui` (self-signed HTTPS, accept the browser warning).
+* Log in with method **Token**, using the root token from `VAULT_DEV_ROOT_TOKEN_ID` in `.env`.
+* Centreon authenticates via AppRole (policy `central`, secrets stored under `centreon/`) with `VAULT_ROLE_ID` / `VAULT_SECRET_ID` from `.env`. The UI has no AppRole login, so to sign in as this identity, exchange them for a token and paste it in the Token field:
+
+```bash
+# load VAULT_ROLE_ID / VAULT_SECRET_ID from the committed .env into the shell
+set -a; . .github/docker/.env; set +a
+# exchange them for a Vault token (-k trusts the self-signed cert), print only the token
+curl -sk -X POST --data "{\"role_id\":\"$VAULT_ROLE_ID\",\"secret_id\":\"$VAULT_SECRET_ID\"}" \
+  https://127.0.0.1:8200/v1/auth/approle/login | jq -r .auth.client_token
+```
 
 ## :hand: Stop services
 

--- a/.github/docker/centreon-web/alma8/entrypoint/container.d/71-vault.sh
+++ b/.github/docker/centreon-web/alma8/entrypoint/container.d/71-vault.sh
@@ -7,6 +7,7 @@ if [ -n "${VAULT_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${VAULT_HOST}"; then
   sed -i 's@new CurlHttpClient()@new CurlHttpClient(["verify_peer" => false, "verify_host" => false])@' /usr/share/centreon/config/centreon.config.php
   sed -i 's/default_options:/&\n            verify_host: false/' /usr/share/centreon/config/packages/framework.yaml
   sed -i 's/default_options:/&\n            verify_peer: false/' /usr/share/centreon/config/packages/framework.yaml
+  sed -i 's@class: Symfony\\Component\\HttpClient\\AmpHttpClient@&\n        arguments: [{ verify_peer: false, verify_host: false }]@' /usr/share/centreon/config/packages/Centreon.yaml
   sudo -u apache php /usr/share/centreon/bin/console cache:clear
 
   RESPONSE=$(curl -s -w "%{http_code}" -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"security":{"credentials":{"login":"admin","password":"Centreon!2021"}}}' -L "http://localhost:80/centreon/api/latest/login")

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/71-vault.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/71-vault.sh
@@ -7,6 +7,7 @@ if [ -n "${VAULT_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${VAULT_HOST}"; then
   sed -i 's@new CurlHttpClient()@new CurlHttpClient(["verify_peer" => false, "verify_host" => false])@' /usr/share/centreon/config/centreon.config.php
   sed -i 's/default_options:/&\n            verify_host: false/' /usr/share/centreon/config/packages/framework.yaml
   sed -i 's/default_options:/&\n            verify_peer: false/' /usr/share/centreon/config/packages/framework.yaml
+  sed -i 's@class: Symfony\\Component\\HttpClient\\AmpHttpClient@&\n        arguments: [{ verify_peer: false, verify_host: false }]@' /usr/share/centreon/config/packages/Centreon.yaml
   sudo -u apache php /usr/share/centreon/bin/console cache:clear
 
   RESPONSE=$(curl -s -w "%{http_code}" -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"security":{"credentials":{"login":"admin","password":"Centreon!2021"}}}' -L "http://localhost:80/centreon/api/latest/login")

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/71-vault.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/71-vault.sh
@@ -7,6 +7,7 @@ if [ -n "${VAULT_HOST:-}" ] && timeout 0.2 getent ahostsv4 "${VAULT_HOST}"; then
   sed -i 's@new CurlHttpClient()@new CurlHttpClient(["verify_peer" => false, "verify_host" => false])@' /usr/share/centreon/config/centreon.config.php
   sed -i 's/default_options:/&\n            verify_host: false/' /usr/share/centreon/config/packages/framework.yaml
   sed -i 's/default_options:/&\n            verify_peer: false/' /usr/share/centreon/config/packages/framework.yaml
+  sed -i 's@class: Symfony\\Component\\HttpClient\\AmpHttpClient@&\n        arguments: [{ verify_peer: false, verify_host: false }]@' /usr/share/centreon/config/packages/Centreon.yaml
   sudo -u apache php /usr/share/centreon/bin/console cache:clear
 
   RESPONSE=$(curl -s -w "%{http_code}" -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"security":{"credentials":{"login":"admin","password":"Centreon!2021"}}}' -L "http://localhost:80/centreon/api/latest/login")

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     image: "${VAULT_IMAGE:-ghcr.io/centreon/centreon/vault:25.10}"
     env_file:
       - .env
-    ports: ["8200"]
+    ports: ["127.0.0.1:8200:8200"]
     profiles: ["vault"]
 
   openid:


### PR DESCRIPTION
Fixes: [MON-204494](https://centreon.atlassian.net/browse/MON-204494)

Backport of #10963 to `dev-25.10.x`.

Adapted to this branch's OS variants: the `71-vault.sh` fix is applied to `alma8` / `alma9` / `bookworm` (this branch) instead of `alma9` / `alma10` / `trixie` (develop).

## Changes

- **Vault authentication fix**: disable TLS certificate verification for `AmpHttpClient` in `71-vault.sh`, so Centreon can reach the dev Vault's self-signed endpoint — otherwise the AppRole login fails and the config is rejected with _"Vault configuration is invalid"_.
- **UI port**: publish the Vault port on `127.0.0.1:8200:8200` (fixed and scoped to loopback).
- **Documentation**: add a dedicated _Vault setup_ section to the README.


[MON-204494]: https://centreon.atlassian.net/browse/MON-204494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ