### PR TITLE
fix(web): parameterize queries in legacy classes

### DIFF
--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -889,13 +889,16 @@ class CentreonConfigCentreonBroker
      */
     public function getForms($config_id, $tag, $page, $tpl)
     {
-        $query = "SELECT config_key, config_value, config_group_id, grp_level, parent_grp_id, fieldIndex
-            FROM cfg_centreonbroker_info WHERE config_id = %d
-            AND config_group = '%s'
+        $query = 'SELECT config_key, config_value, config_group_id, grp_level, parent_grp_id, fieldIndex
+            FROM cfg_centreonbroker_info WHERE config_id = :configId
+            AND config_group = :configGroup
             AND subgrp_id IS NULL
-            ORDER BY config_group_id";
+            ORDER BY config_group_id';
         try {
-            $res = $this->db->query(sprintf($query, $config_id, $tag));
+            $res = $this->db->prepare($query);
+            $res->bindValue(':configId', (int) $config_id, PDO::PARAM_INT);
+            $res->bindValue(':configGroup', $tag, PDO::PARAM_STR);
+            $res->execute();
         } catch (PDOException $e) {
             return [];
         }

--- a/centreon/www/class/centreonCriticality.class.php
+++ b/centreon/www/class/centreonCriticality.class.php
@@ -258,20 +258,32 @@ class CentreonCriticality
         $limit = null,
     ) {
         $sql = 'SELECT hc_id, hc_name, level, icon_id, hc_comment
-                FROM hostcategories 
+                FROM hostcategories
                 WHERE level IS NOT NULL ';
+        $bindParams = [];
         if (! is_null($searchString) && $searchString != '') {
-            $sql .= " AND hc_name LIKE '%" . $this->db->escape($searchString) . "%' ";
+            $sql .= ' AND hc_name LIKE :searchString ';
+            $bindParams[':searchString'] = '%' . $searchString . '%';
         }
         if (! is_null($orderBy) && ! is_null($sort)) {
+            // ORDER BY column and direction cannot be bound as parameters, so they
+            // are validated against explicit allowlists.
+            $allowedOrderBy = ['hc_id', 'hc_name', 'level', 'icon_id', 'hc_comment'];
+            $allowedSort = ['ASC', 'DESC'];
+            $orderBy = in_array($orderBy, $allowedOrderBy, true) ? $orderBy : 'level';
+            $sort = in_array(strtoupper((string) $sort), $allowedSort, true) ? strtoupper((string) $sort) : 'ASC';
             $sql .= " ORDER BY {$orderBy} {$sort} ";
         }
         if (! is_null($offset) && ! is_null($limit)) {
-            $sql .= " LIMIT {$offset},{$limit}";
+            $sql .= ' LIMIT ' . (int) $offset . ',' . (int) $limit;
         }
-        $res = $this->db->query($sql);
+        $res = $this->db->prepare($sql);
+        foreach ($bindParams as $param => $value) {
+            $res->bindValue($param, $value, PDO::PARAM_STR);
+        }
+        $res->execute();
         $elements = [];
-        while ($row = $res->fetchRow()) {
+        while ($row = $res->fetch()) {
             $elements[$row['hc_id']] = [];
             $elements[$row['hc_id']]['hc_name'] = $row['hc_name'];
             $elements[$row['hc_id']]['level'] = $row['level'];

--- a/centreon/www/class/centreonHostgroups.class.php
+++ b/centreon/www/class/centreonHostgroups.class.php
@@ -356,16 +356,21 @@ class CentreonHostgroups
      */
     public function getHostsByHostgroupName($hgName)
     {
-        $hostList = [];
-        $query = 'SELECT host_name, host_id  '
+        $rows = $this->DB->fetchAllAssociative(
+            'SELECT host_name, host_id '
             . 'FROM hostgroup_relation hgr, host h, hostgroup hg '
             . 'WHERE hgr.host_host_id = h.host_id '
             . 'AND hgr.hostgroup_hg_id = hg.hg_id '
             . "AND h.host_activate = '1' "
-            . "AND hg.hg_name = '" . $this->DB->escape($hgName) . "'";
-        $result = $this->DB->query($query);
-        while ($elem = $result->fetchrow()) {
-            $hostList[] = ['host' => $elem['host_name'], 'host_id' => $elem['host_id'], 'hg_name' => $hgName];
+            . 'AND hg.hg_name = :hg_name',
+            QueryParameters::create([
+                QueryParameter::string('hg_name', (string) $hgName),
+            ])
+        );
+
+        $hostList = [];
+        foreach ($rows as $row) {
+            $hostList[] = ['host' => $row['host_name'], 'host_id' => $row['host_id'], 'hg_name' => $hgName];
         }
 
         return $hostList;

--- a/centreon/www/class/centreonInstance.class.php
+++ b/centreon/www/class/centreonInstance.class.php
@@ -250,7 +250,6 @@ class CentreonInstance
     {
         global $centreon;
 
-        $selectedInstances = '';
         $items = [];
 
         if (empty($values)) {
@@ -262,28 +261,33 @@ class CentreonInstance
             $pollerAcl = $centreon->user->access->getPollers();
         }
 
-        $listValues = '';
-        $queryValues = [];
-        foreach ($values as $k => $v) {
-            $multipleValues = explode(',', $v);
-            foreach ($multipleValues as $item) {
-                $listValues .= ':pId_' . $item . ', ';
-                $queryValues['pId_' . $item] = (int) $item;
+        $pollerIdPlaceholders = [];
+        $instanceIdPlaceholders = [];
+        $boundInstanceIds = [];
+        $index = 0;
+        foreach ($values as $value) {
+            foreach (explode(',', $value) as $instanceId) {
+                $pollerIdPlaceholder = ':pollerId_' . $index;
+                $instanceIdPlaceholder = ':instanceId_' . $index;
+                $pollerIdPlaceholders[] = $pollerIdPlaceholder;
+                $instanceIdPlaceholders[] = $instanceIdPlaceholder;
+                $boundInstanceIds[$pollerIdPlaceholder] = (int) $instanceId;
+                $boundInstanceIds[$instanceIdPlaceholder] = (int) $instanceId;
+                $index++;
             }
         }
-        $listValues = rtrim($listValues, ', ');
-        $selectedInstances .= " AND rel.instance_id IN ({$listValues}) ";
 
         $query = 'SELECT DISTINCT p.name as name, p.id  as id FROM cfg_resource r, nagios_server p, '
             . 'cfg_resource_instance_relations rel '
             . ' WHERE r.resource_id = rel.resource_id'
             . ' AND p.id = rel.instance_id '
-            . ' AND p.id IN (' . $listValues . ')' . $selectedInstances
+            . ' AND p.id IN (' . implode(', ', $pollerIdPlaceholders) . ')'
+            . ' AND rel.instance_id IN (' . implode(', ', $instanceIdPlaceholders) . ') '
             . ' ORDER BY p.name';
 
         $stmt = $this->db->prepare($query);
-        foreach ($queryValues as $key => $id) {
-            $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
+        foreach ($boundInstanceIds as $placeholder => $id) {
+            $stmt->bindValue($placeholder, $id, PDO::PARAM_INT);
         }
         $stmt->execute();
         while ($data = $stmt->fetch()) {


### PR DESCRIPTION
## Description

Convert several legacy web query builders to use prepared statements with bound parameters and allowlisted identifiers.

[MON-204476](https://centreon.atlassian.net/browse/MON-204476)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Broker configuration: open a broker config with output tags in `Configuration > Pollers > Broker configuration` each tag section loads with its existing values.
- Poller select2: on a host or ACL form referencing pollers, the preselected poller name renders correctly.
- `CLAPI RTDOWNTIME` with a hostgroup selector (HG;<name>;...) returns the expected host list.
- Host severities list `Configuration > Hosts > Categories > Severities`, list loads, pagination and sort still work, an invalid order value falls back to level ASC.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-204476]: https://centreon.atlassian.net/browse/MON-204476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ