### PR TITLE
fix(broker): resolve db selector by logical name

### DIFF
--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -581,10 +581,10 @@ class Broker extends AbstractObjectJSON
 
         // Execute the query
         switch ($s_db) {
-            case db:
+            case 'centreon':
                 $db = $this->backend_instance->db;
                 break;
-            case dbcstg:
+            case 'centreon_storage':
                 $db = $this->backend_instance->db_cs;
                 break;
             default:


### PR DESCRIPTION
Fixes: [MON-204564](https://centreon.atlassian.net/browse/MON-204564)

Backport of #10973.

Central poller configuration generation returned HTTP 500 with `Unknown database "centreon_storage"` whenever the Centreon databases are not named the stock `centreon` / `centreon_storage`.

`getInfoDb()` resolves broker macros whose `D=` key is a **logical** database selector (`centreon` / `centreon_storage`). The switch matching that selector was comparing against the `db` / `dbcstg` constants, which hold the **physical** configured database names, so the logical selector matched no case and hit the throwing `default`.

This restores string-literal matching for the logical selector while keeping the `default` guard and the parameterized queries introduced in #10731.


[MON-204564]: https://centreon.atlassian.net/browse/MON-204564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ