### PR TITLE
feat(host-config): add parent/child host relations to the Cloud form

### DIFF
--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -843,8 +843,8 @@ function updateHostInDB_MC($hostId = null)
     updateHost_MC($hostId);
 
     if ($isCloudPlatform) {
-        resetHostHostParent($hostId);
-        resetHostHostChild($hostId);
+        // Parent/child host relations are managed on the add/modify form only (not massive change),
+        // so they must be left untouched here to avoid wiping existing relationships.
         resetHostContactGroup($hostId);
         resetHostContact($hostId);
     }
@@ -2757,11 +2757,12 @@ function insertHostInAPI(array $formData): int|false
             updateHostTemplateService($hostId);
         }
 
+        if (! $isTemplate) {
+            updateHostHostParent($hostId, $formData);
+            updateHostHostChild($hostId);
+        }
+
         if (! $isCloudPlatform) {
-            if (! $isTemplate) {
-                updateHostHostParent($hostId, $formData);
-                updateHostHostChild($hostId);
-            }
             updateHostContactGroup($hostId, $formData);
             updateHostContact($hostId, $formData);
         }
@@ -2866,11 +2867,12 @@ function updateHostInAPI(int $hostId, array $formData): bool
             updateHostTemplateService($hostId);
         }
 
+        if (! $isTemplate) {
+            updateHostHostParent($hostId, $formData);
+            updateHostHostChild($hostId);
+        }
+
         if (! $isCloudPlatform) {
-            if (! $isTemplate) {
-                updateHostHostParent($hostId, $formData);
-                updateHostHostChild($hostId);
-            }
             updateHostContactGroup($hostId, $formData);
             updateHostContact($hostId, $formData);
         }

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -812,6 +812,11 @@ if ($o === HOST_MASSIVE_CHANGE) {
 
 $form->addElement('select2', 'host_hcs', _('Host Categories'), [], $attributes['host_categories']);
 
+if ($isCloudPlatform && $o !== HOST_MASSIVE_CHANGE) {
+    $form->addElement('select2', 'host_parents', _('Parent Hosts'), [], $attributes['host_parents']);
+    $form->addElement('select2', 'host_childs', _('Child Hosts'), [], $attributes['host_child']);
+}
+
 if ($o === HOST_MASSIVE_CHANGE) {
     $mc_mod_nsid = [];
     $mc_mod_nsid[] = $form->createElement('radio', 'mc_mod_nsid', null, _('Incremental'), '0');

--- a/centreon/www/include/configuration/configObject/host/formHostCloud.ihtml
+++ b/centreon/www/include/configuration/configObject/host/formHostCloud.ihtml
@@ -196,6 +196,16 @@
 					<td class="FormRowField"><img class="helpTooltip" name="hostcategories"> {$form.host_hcs.label}</td>
 					<td class="FormRowValue">{$form.host_hcs.html} </td>
 				</tr>
+				<!-- PARENT HOSTS RELATIONS -->
+				<tr class="list_one">
+					<td class="FormRowField"><img class="helpTooltip" name="parents"> {$form.host_parents.label}</td>
+					<td class="FormRowValue">{$form.host_parents.html} </td>
+				</tr>
+				<!-- CHILD HOSTS RELATIONS -->
+				<tr class="list_two">
+					<td class="FormRowField"><img class="helpTooltip" name="child_hosts"> {$form.host_childs.label}</td>
+					<td class="FormRowValue">{$form.host_childs.html} </td>
+				</tr>
 			{else}
 				<!-- HOST CATEGORIE RELATIONS -->
 				{if $o == "mc"}


### PR DESCRIPTION
## Description

Adds the **Parent Hosts** and **Child Hosts** relationship fields to the **Cloud** host configuration form (add/modify), mirroring the on-prem Relations section. Previously these fields were on-prem only.

Ref: MON-199533

## What changed

- **`formHost.php`** — register the `host_parents` / `host_childs` select2 elements on Cloud (add/modify, not massive change), reusing the existing attribute/dataset-route configs.
- **`formHostCloud.ihtml`** — render the two fields in the Relations area, for real hosts only (`!isTemplate`).
- **`DB-Func.php`** — persist the relations on Cloud add/modify via the existing `host_hostparent_relation` helpers (`updateHostHostParent` / `updateHostHostChild`), the same path on-prem already uses after the AddHost API call. Also removed the Cloud massive-change reset of parent/child relations so a mass change no longer silently wipes them.

No Core API / schema / DTO changes were needed: parent/child relations are persisted via the legacy relation helpers, not through the AddHost/PartialUpdateHost API — on-prem does the same.

## Scope

Add / modify single-host form. Massive change is intentionally excluded (the reset that would wipe relations there was removed). Can be extended to massive change (incremental/replacement modes) in a follow-up if wanted.

## Testing

Verified end-to-end on a Cloud dev instance:
- Fields render as select2 widgets in the Relations section, no PHP errors.
- Creating a host with a parent writes the `host_hostparent_relation` row.
- Editing shows the saved parent and (reverse) child relations correctly.