### PR TITLE
enh(logging): remove debug_level from options table and DEBUG_LEVEL env var

### DIFF
--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -386,13 +386,6 @@ function updateDebugConfigData($gopt_id = null)
         'debug_centreontrapd',
         isset($ret['debug_centreontrapd']) && $ret['debug_centreontrapd'] ? 1 : 0
     );
-    updateOption(
-        $pearDB,
-        'debug_level',
-        $ret['debug_level']
-    );
-
-    enableApplicationDebug((int) $ret['debug_level']);
 
     $centreon->initOptGen($pearDB);
 }
@@ -985,20 +978,3 @@ function updateRemoteAccessCredentials($db, $form, $centreonEncryption): void
     }
 }
 
-/**
- * Add or remove the debug level from environments files.
- *
- * @param bool $enable
- * @param int $level
- */
-function enableApplicationDebug(int $level = 100)
-{
-    $env = new Utility\EnvironmentFileManager(_CENTREON_PATH_);
-    $env->load();
-    if ($level !== 0) {
-        $env->add('DEBUG_LEVEL', $level);
-    } else {
-        $env->delete('DEBUG_LEVEL');
-    }
-    $env->save();
-}

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -977,4 +977,3 @@ function updateRemoteAccessCredentials($db, $form, $centreonEncryption): void
         }
     }
 }
-

--- a/centreon/www/include/Administration/parameters/debug/form.ihtml
+++ b/centreon/www/include/Administration/parameters/debug/form.ihtml
@@ -13,7 +13,6 @@
     </tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="tip_logs_directory">{$form.debug_path.label}</td><td class="FormRowValue">{$form.debug_path.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="tip_authentication_debug">{$form.debug_auth.label}</td><td class="FormRowValue">{$form.debug_auth.html}</td></tr>
-	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="tip_debug_level">{$form.debug_level.label}</td><td class="FormRowValue">{$form.debug_level.html}</td></tr>
 	<tr class="list_one">
 		<td class="FormRowField">
 			<div class="formRowLabel">

--- a/centreon/www/include/Administration/parameters/debug/form.php
+++ b/centreon/www/include/Administration/parameters/debug/form.php
@@ -41,22 +41,6 @@ $form->addElement('header', 'debug', _('Debug'));
 $form->addElement('text', 'debug_path', _('Logs Directory'), $attrsText);
 
 $form->addElement('checkbox', 'debug_auth', _('Authentication debug'));
-$form->addElement(
-    'select',
-    'debug_level',
-    _('Debug level'),
-    [
-        000 => 'None',
-        100 => 'Debug',
-        200 => 'Info',
-        250 => 'Notice',
-        300 => 'Warning',
-        400 => 'Error',
-        500 => 'Critical',
-        550 => 'Alert',
-        600 => 'Emergency',
-    ]
-);
 $form->addElement('checkbox', 'debug_sql', _('SQL debug'));
 $form->addElement('checkbox', 'debug_nagios_import', _('Monitoring Engine Import debug'));
 $form->addElement('checkbox', 'debug_rrdtool', _('RRDTool debug'));

--- a/centreon/www/include/Administration/parameters/debug/help.php
+++ b/centreon/www/include/Administration/parameters/debug/help.php
@@ -33,4 +33,3 @@ $help['tip_sql_debug'] = dgettext('help', 'Enables SQL debug.');
 $help['tip_centcore_debug'] = dgettext('help', 'Enables Centcore debug.');
 $help['tip_centstorage_debug'] = dgettext('help', 'Enables Centstorage debug.');
 $help['tip_centreontrapd_debug'] = dgettext('help', 'Enables Centreontrapd debug.');
-$help['tip_debug_level'] = dgettext('help', 'Set the lowest log level: Debug => Info => Notice => Warning => Error => Critical => Alert => Emergency');

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -33,7 +33,6 @@ $errorMessage = '';
  * @var ConnectionInterface $pearDB
  * @var ConnectionInterface $pearDBO
  */
-
 $removeDebugLevelFromOptions = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = "Unable to remove 'debug_level' from options table";
     LoggerUpgrade::create()->info($version, "Removing 'debug_level' from options table");

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -34,7 +34,18 @@ $errorMessage = '';
  * @var ConnectionInterface $pearDBO
  */
 
-// TODO add your functions here
+$removeDebugLevelFromOptions = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = "Unable to remove 'debug_level' from options table";
+    LoggerUpgrade::create()->info($version, "Removing 'debug_level' from options table");
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            DELETE FROM `options` WHERE `key` = 'debug_level'
+            SQL
+    );
+
+    LoggerUpgrade::create()->info($version, "Successfully removed 'debug_level' from options table");
+};
 
 try {
     LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
@@ -51,7 +62,7 @@ try {
         $pearDB->startTransaction();
     }
 
-    // TODO add your function calls to update the configuration database data here
+    $removeDebugLevelFromOptions();
 
     $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();


### PR DESCRIPTION
## Description

- Remove the `debug_level` dropdown from *Administration > Parameters > Debug*
- Remove `enableApplicationDebug()` — sole writer of the `DEBUG_LEVEL` env var
- Add upgrade migration to delete `debug_level` from the `options` table
- `DEBUG_LEVEL` was confirmed as a ghost variable — written to `.env` but never read anywhere across centreon, centreon-collect, and centreon-modules
- Debug verbosity is now controlled solely via `APP_DEBUG` (MON-201789)

## How to test

1. Upgrade from a previous version and verify:
   - The Debug page (*Administration > Parameters > Debug*) no longer shows the "Debug Level" dropdown
   - All remaining toggles (`debug_auth`, `debug_sql`, etc.) still display and can be saved
   - `debug_level` key is removed from the `options` table
2. Fresh install: no `debug_level` key in `options` table
3. Verify `APP_DEBUG=1` enables DEBUG-level logging on all Monolog channels

## Links

### Jira ticket

Resolves: [MON-204604](https://centreon.atlassian.net/browse/MON-204604)


[MON-204604]: https://centreon.atlassian.net/browse/MON-204604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ