### PR TITLE
fix(ci): don't promote floating docker tag before e2e tests pass (centreontrapd/snmptrapd)

### DIFF
--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -6,6 +6,12 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      test_promote:
+        description: 'TEMP (MON-204507 validation): force a promote-docker-tag test run against disposable "mon-204507-test-promote*" tags. Revert before merge.'
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - develop
@@ -188,8 +194,12 @@ jobs:
         env:
           RAW_REF: ${{ github.head_ref || github.ref_name }}
           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+          TEST_PROMOTE: ${{ github.event.inputs.test_promote }}
         run: |
-          if [[ "$RAW_REF" == "develop" ]]; then
+          if [[ "$TEST_PROMOTE" == "true" ]]; then
+            echo "tag=mon-204507-test-promote-candidate" >> "$GITHUB_OUTPUT"
+            echo "additional_tag=mon-204507-test-promote-floating" >> "$GITHUB_OUTPUT"
+          elif [[ "$RAW_REF" == "develop" ]]; then
             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -6,12 +6,6 @@ concurrency:
 
 on:
   workflow_dispatch:
-    inputs:
-      test_promote:
-        description: 'TEMP (MON-204507 validation): force a promote-docker-tag test run against disposable "mon-204507-test-promote*" tags. Revert before merge.'
-        required: false
-        type: boolean
-        default: false
   push:
     branches:
       - develop
@@ -194,12 +188,8 @@ jobs:
         env:
           RAW_REF: ${{ github.head_ref || github.ref_name }}
           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-          TEST_PROMOTE: ${{ github.event.inputs.test_promote }}
         run: |
-          if [[ "$TEST_PROMOTE" == "true" ]]; then
-            echo "tag=mon-204507-test-promote-candidate" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=mon-204507-test-promote-floating" >> "$GITHUB_OUTPUT"
-          elif [[ "$RAW_REF" == "develop" ]]; then
+          if [[ "$RAW_REF" == "develop" ]]; then
             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -129,8 +129,12 @@ jobs:
         component: [centreon-snmptrapd, centreon-centreontrapd]
         operating_system: [trixie]
     name: dockerize ${{ matrix.component }}-${{ matrix.operating_system }}
+    # Matrix job outputs come from the last completed matrix leg. Safe here
+    # because compute-tag only depends on the ref/major_version, never on
+    # matrix.component or matrix.operating_system, so every leg produces the same tag.
     outputs:
       image_tag: ${{ steps.compute-tag.outputs.tag }}
+      additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
 
     steps:
       - name: Checkout sources
@@ -216,7 +220,6 @@ jobs:
           push: true
           tags: |
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
-            ${{ steps.compute-tag.outputs.additional_tag != '' && format('{0}/{1}-{2}:{3}', vars.DOCKER_INTERNAL_REGISTRY_URL, matrix.component, matrix.operating_system, steps.compute-tag.outputs.additional_tag) || '' }}
 
   docker-boot-test:
     needs: [get-environment, dockerize]
@@ -331,3 +334,35 @@ jobs:
       - name: Dump compose logs on failure
         if: failure()
         run: docker compose -f .github/docker/centreon-trapd/docker-compose.config-wiring-test.yml -p centreon-trapd-config-wiring-test logs
+
+  promote-docker-tag:
+    needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
+    if: |
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      needs.dockerize.outputs.additional_tag != ''
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [centreon-snmptrapd, centreon-centreontrapd]
+        operating_system: [trixie]
+    name: promote ${{ matrix.component }}-${{ matrix.operating_system }} floating tag
+    steps:
+      - name: Login to registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Promote floating tag (manifest retag, no rebuild)
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
+            "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
+        shell: bash


### PR DESCRIPTION
## Summary
- `dockerize` (docker-trapd.yml) now pushes only the versioned candidate tag; the floating tag (`develop`) is no longer pushed unguarded in the same `docker/build-push-action` step.
- Added `additional_tag` to the `dockerize` job outputs.
- Added a new `promote-docker-tag` job that retags the floating tag via `docker buildx imagetools create` (manifest retag, no rebuild), gated on `docker-boot-test` and `docker-config-wiring-test` (added in MON-204506, #10977) both succeeding.

This mirrors the pattern already applied to centreon-engine/centreon-broker/centreon-gorgone in centreon-collect (MON-203216).

## Why
`centreontrapd-trixie:develop` / `snmptrapd-trixie:develop` previously kept pointing at whatever was last pushed even if the image was broken, since nothing validated it before the floating tag moved.

## Note on CI
On this PR, `additional_tag` is empty (not on `develop`), so `promote-docker-tag` is correctly skipped by design — the PR's CI validates packaging/build/boot-test/config-wiring-test, not the promote step itself. The promote step is first exercised post-merge on `develop`, same as MON-203216's validation path.

## Related
- Depends on MON-204506 (e2e tests, merged: #10977).
- Draft PR #10842 (MON-201979) adds a Pulp push to this same previously-unguarded build step. It needs rework on top of this split (build vs. promote) before it can be merged as-is — flagging so it isn't merged in its current form in the meantime.

Jira: https://centreon.atlassian.net/browse/MON-204507

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [x] Diff reviewed against MON-203216 reference (`collect.yml` / `docker-gorgone.yml` `promote-docker-tag` jobs)
- [x] CI: packaging + dockerize + docker-boot-test + docker-config-wiring-test green on this PR
- [x] Post-merge on develop: confirm `promote-docker-tag` runs and retags `develop` floating tag only after tests pass