### PR TITLE
fix(ci): quote the reserved jq keyword 'module' in the Pulp delivery manifest

### DIFF
--- a/.github/scripts/pulp/manifest.sh
+++ b/.github/scripts/pulp/manifest.sh
@@ -38,7 +38,7 @@ manifest_write() {
     --arg content_url "$content_url" \
     --argjson packages "$packages" \
     '{
-      module: $module,
+      "module": $module,
       distrib: $distrib,
       package_type: $package_type,
       stability: $stability,


### PR DESCRIPTION
## Description

Follow-up fix to the Pulp delivery (MON-200796). `manifest_write` in `.github/scripts/pulp/manifest.sh` built the manifest object with a **bare `module:` key**. `module` is a **reserved keyword in jq**, so stricter jq builds (the CI runner's) reject the program with `syntax error, unexpected module, expecting IDENT` and the step exits 3.

Because the packages are uploaded/published **before** `manifest_write`, the package is actually delivered, but the (non-blocking) `deliver-pulp` / `promote-pulp` step is marked failed and the M6 `::warning::` fires. This affected every Pulp delivery and promotion (deb + rpm).

Observed on the `awie` run: https://github.com/centreon/centreon/actions/runs/28999040799/job/86055821966#step:3:356 (el10 package delivered, then `jq: error: syntax error, unexpected module`).

## Fix

Quote the key (`"module"`) so the manifest compiles on every jq version. The emitted JSON is identical and its `.module` consumers (check scripts) are unchanged. Verified: `manifest_write` now produces valid JSON.

Refs: MON-200796