### PR TITLE
fix(ci): rename the reserved jq 'module' variable in the delivery manifest

### DIFF
--- a/.github/scripts/pulp/manifest.sh
+++ b/.github/scripts/pulp/manifest.sh
@@ -38,7 +38,7 @@ manifest_write() {
     --arg content_url "$content_url" \
     --argjson packages "$packages" \
     '{
-      module: $module,
+      "module": $module,
       distrib: $distrib,
       package_type: $package_type,
       stability: $stability,

--- a/.github/scripts/pulp/manifest.sh
+++ b/.github/scripts/pulp/manifest.sh
@@ -29,8 +29,10 @@ manifest_write() {
     packages=$(printf '%s\n' "${MANIFEST_ENTRIES[@]}" | jq -s '.')
   fi
 
+  # NB: the jq variable is named module_name, not module — `module` is a reserved
+  # jq keyword and `$module` fails to parse on stricter jq builds (the CI runner)
   jq -n \
-    --arg module "$module" \
+    --arg module_name "$module" \
     --arg distrib "$distrib" \
     --arg package_type "$package_type" \
     --arg stability "$stability" \
@@ -38,7 +40,7 @@ manifest_write() {
     --arg content_url "$content_url" \
     --argjson packages "$packages" \
     '{
-      "module": $module,
+      "module": $module_name,
       distrib: $distrib,
       package_type: $package_type,
       stability: $stability,


### PR DESCRIPTION
## Description

Follow-up to #11001. That PR quoted the manifest object key (`"module":`), but the delivery/promotion still failed with the same `jq: syntax error, unexpected module, expecting IDENT or __loc__` on the CI runner.

Root cause: `manifest_write` also referenced the value through a **jq variable `$module`** (created by `--arg module`). `module` is a **reserved jq keyword**, so `$module` fails to parse on stricter jq builds (the runner's), even though lenient builds (jq 1.7) accept it. The step fails *after* the package is uploaded/published, so the package is delivered but the non-blocking Pulp step is red and the M6 warning fires — for every Pulp deliver and promote, deb and rpm.

Observed again on: https://github.com/centreon/centreon/actions/runs/29000593011/job/86060408153#step:3:349 (key already quoted, still `unexpected module`).

## Fix

Rename the jq argument `module` → `module_name` (reference `$module_name`); the emitted `"module"` key and its `.module` consumers (check scripts) are unchanged. Verified: `manifest_write` produces valid JSON and no reserved `module` token remains in any jq program.

Refs: MON-200796