### PR TITLE
feat(metric): expose min and max in FindMetricsByService API

### DIFF
--- a/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/Metric.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/Metric.yaml
@@ -26,3 +26,11 @@ properties:
     type: number
     format: float
     nullable: true
+  min:
+    type: number
+    format: float
+    nullable: true
+  max:
+    type: number
+    format: float
+    nullable: true

--- a/centreon/src/Core/Metric/Application/UseCase/FindMetricsByService/FindMetricsByService.php
+++ b/centreon/src/Core/Metric/Application/UseCase/FindMetricsByService/FindMetricsByService.php
@@ -106,6 +106,8 @@ final class FindMetricsByService
             $metricDto->warningLowThreshold = $metric->getWarningLowThreshold();
             $metricDto->criticalHighThreshold = $metric->getCriticalHighThreshold();
             $metricDto->criticalLowThreshold = $metric->getCriticalLowThreshold();
+            $metricDto->min = $metric->getMin();
+            $metricDto->max = $metric->getMax();
             $metricsDto[] = $metricDto;
         }
         $response->metricsDto = $metricsDto;

--- a/centreon/src/Core/Metric/Application/UseCase/FindMetricsByService/MetricDto.php
+++ b/centreon/src/Core/Metric/Application/UseCase/FindMetricsByService/MetricDto.php
@@ -40,4 +40,8 @@ class MetricDto
     public ?float $criticalHighThreshold = null;
 
     public ?float $criticalLowThreshold = null;
+
+    public ?float $min = null;
+
+    public ?float $max = null;
 }

--- a/centreon/src/Core/Metric/Domain/Model/Metric.php
+++ b/centreon/src/Core/Metric/Domain/Model/Metric.php
@@ -37,6 +37,10 @@ class Metric
 
     private ?float $criticalLowThreshold = null;
 
+    private ?float $min = null;
+
+    private ?float $max = null;
+
     /**
      * @param int $id
      * @param string $name
@@ -131,5 +135,29 @@ class Metric
     public function getCriticalLowThreshold(): ?float
     {
         return $this->criticalLowThreshold;
+    }
+
+    public function setMin(?float $min): self
+    {
+        $this->min = $min;
+
+        return $this;
+    }
+
+    public function getMin(): ?float
+    {
+        return $this->min;
+    }
+
+    public function setMax(?float $max): self
+    {
+        $this->max = $max;
+
+        return $this;
+    }
+
+    public function getMax(): ?float
+    {
+        return $this->max;
     }
 }

--- a/centreon/src/Core/Metric/Infrastructure/API/FindMetricsByService/FindMetricsByServicePresenter.php
+++ b/centreon/src/Core/Metric/Infrastructure/API/FindMetricsByService/FindMetricsByServicePresenter.php
@@ -51,6 +51,8 @@ final class FindMetricsByServicePresenter extends AbstractPresenter implements F
                 'warning_low_threshold' => $metric->warningLowThreshold,
                 'critical_high_threshold' => $metric->criticalHighThreshold,
                 'critical_low_threshold' => $metric->criticalLowThreshold,
+                'min' => $metric->min,
+                'max' => $metric->max,
             ], $response->metricsDto));
         }
     }

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbMetricFactory.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbMetricFactory.php
@@ -36,7 +36,9 @@ class DbMetricFactory
      *    warn: float|null,
      *    warn_low: float|null,
      *    crit: float|null,
-     *    crit_low: float|null
+     *    crit_low: float|null,
+     *    min: float|null,
+     *    max: float|null
      *  } $record
      *
      * @return Metric
@@ -49,6 +51,8 @@ class DbMetricFactory
             ->setWarningHighThreshold($record['warn'])
             ->setWarningLowThreshold($record['warn_low'])
             ->setCriticalHighThreshold($record['crit'])
-            ->setCriticalLowThreshold($record['crit_low']);
+            ->setCriticalLowThreshold($record['crit_low'])
+            ->setMin($record['min'])
+            ->setMax($record['max']);
     }
 }

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -261,7 +261,9 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
      *    warn: float|null,
      *    warn_low: float|null,
      *    crit: float|null,
-     *    crit_low: float|null
+     *    crit_low: float|null,
+     *    min: float|null,
+     *    max: float|null
      *  }
      * > $records
      *
@@ -358,7 +360,7 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
     {
         $query = <<<'SQL'
             SELECT DISTINCT metric_id as id, metric_name as name, unit_name, current_value, warn,
-            warn_low, crit, crit_low
+            warn_low, crit, crit_low, `min`, `max`
             FROM  `:dbstg`.metrics m
                 INNER JOIN  `:dbstg`.index_data id ON m.index_id =  id.id
             SQL;

--- a/centreon/tests/php/Core/Metric/Application/UseCase/FindMetricsByService/FindMetricsByServiceTest.php
+++ b/centreon/tests/php/Core/Metric/Application/UseCase/FindMetricsByService/FindMetricsByServiceTest.php
@@ -48,14 +48,18 @@ beforeEach(function (): void {
             ->setWarningHighThreshold(100)
             ->setWarningLowThreshold(50)
             ->setCriticalHighThreshold(300)
-            ->setCriticalLowThreshold(100),
+            ->setCriticalLowThreshold(100)
+            ->setMin(0)
+            ->setMax(1000),
         (new Metric(2, 'anothermetric'))
             ->setUnit('%')
             ->setCurrentValue(10)
             ->setWarningHighThreshold(50)
             ->setWarningLowThreshold(0)
             ->setCriticalHighThreshold(100)
-            ->setCriticalLowThreshold(50),
+            ->setCriticalLowThreshold(50)
+            ->setMin(0)
+            ->setMax(100),
     ];
 });
 
@@ -155,6 +159,8 @@ it('should present an FindMetricsByServiceResponse when metrics are correctly fo
         ->and($presenter->data->metricsDto[0]->warningLowThreshold)->toBe(50.0)
         ->and($presenter->data->metricsDto[0]->criticalHighThreshold)->toBe(300.0)
         ->and($presenter->data->metricsDto[0]->criticalLowThreshold)->toBe(100.0)
+        ->and($presenter->data->metricsDto[0]->min)->toBe(0.0)
+        ->and($presenter->data->metricsDto[0]->max)->toBe(1000.0)
         ->and($presenter->data->metricsDto[1]->id)->toBe(2)
         ->and($presenter->data->metricsDto[1]->name)->toBe('anothermetric')
         ->and($presenter->data->metricsDto[1]->unit)->toBe('%')
@@ -162,7 +168,9 @@ it('should present an FindMetricsByServiceResponse when metrics are correctly fo
         ->and($presenter->data->metricsDto[1]->warningHighThreshold)->toBe(50.0)
         ->and($presenter->data->metricsDto[1]->warningLowThreshold)->toBe(0.0)
         ->and($presenter->data->metricsDto[1]->criticalHighThreshold)->toBe(100.0)
-        ->and($presenter->data->metricsDto[1]->criticalLowThreshold)->toBe(50.0);
+        ->and($presenter->data->metricsDto[1]->criticalLowThreshold)->toBe(50.0)
+        ->and($presenter->data->metricsDto[1]->min)->toBe(0.0)
+        ->and($presenter->data->metricsDto[1]->max)->toBe(100.0);
 });
 
 it('should present an FindMetricsByServiceResponse when metrics are correctly found as non-admin', function (): void {
@@ -189,6 +197,8 @@ it('should present an FindMetricsByServiceResponse when metrics are correctly fo
         ->and($presenter->data->metricsDto[0]->warningLowThreshold)->toBe(50.0)
         ->and($presenter->data->metricsDto[0]->criticalHighThreshold)->toBe(300.0)
         ->and($presenter->data->metricsDto[0]->criticalLowThreshold)->toBe(100.0)
+        ->and($presenter->data->metricsDto[0]->min)->toBe(0.0)
+        ->and($presenter->data->metricsDto[0]->max)->toBe(1000.0)
         ->and($presenter->data->metricsDto[1]->id)->toBe(2)
         ->and($presenter->data->metricsDto[1]->name)->toBe('anothermetric')
         ->and($presenter->data->metricsDto[1]->unit)->toBe('%')
@@ -196,5 +206,7 @@ it('should present an FindMetricsByServiceResponse when metrics are correctly fo
         ->and($presenter->data->metricsDto[1]->warningHighThreshold)->toBe(50.0)
         ->and($presenter->data->metricsDto[1]->warningLowThreshold)->toBe(0.0)
         ->and($presenter->data->metricsDto[1]->criticalHighThreshold)->toBe(100.0)
-        ->and($presenter->data->metricsDto[1]->criticalLowThreshold)->toBe(50.0);
+        ->and($presenter->data->metricsDto[1]->criticalLowThreshold)->toBe(50.0)
+        ->and($presenter->data->metricsDto[1]->min)->toBe(0.0)
+        ->and($presenter->data->metricsDto[1]->max)->toBe(100.0);
 });


### PR DESCRIPTION
## Description

Backport of #10807 to `dev-25.10.x`.

The `FindMetricsByService` Centreon API did not expose the `min` and `max` values of metrics.

The new fields are additive and nullable. Unit tests and the OpenAPI schema were updated accordingly.

This is a prerequisite for the map editor security backport ([MON-201508](https://centreon.atlassian.net/browse/MON-201508)): the map studio editor's metric selection is migrated to this endpoint and needs `min`/`max` for the gauge editor.

Fixes: [MON-204749](https://centreon.atlassian.net/browse/MON-204749)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

Call `GET /monitoring/hosts/{host_id}/services/{service_id}/metrics` (the `FindMetricsByService` endpoint) for a host/service that has metrics, and verify the response now includes `min` and `max` for each metric, matching the values stored in the `centstorage.metrics` table.

[MON-201508]: https://centreon.atlassian.net/browse/MON-201508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-204749]: https://centreon.atlassian.net/browse/MON-204749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ