### PR TITLE
fix(dashboard): restore federated path for BA diagram & availability widgets

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-baavailability/src/index.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-baavailability/src/index.tsx
@@ -33,6 +33,7 @@ const Widget = ({
       panelOptions={panelOptions}
       refreshCount={refreshCount}
       isFromPreview={isFromPreview}
+      path="/bi/widget/baavailability"
       playlistHash={playlistHash}
       queryClient={queryClient}
       widgetPrefixQuery={widgetPrefixQuery}

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-batree/src/index.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-batree/src/index.tsx
@@ -33,6 +33,7 @@ const Widget = ({
       globalRefreshInterval={globalRefreshInterval}
       refreshCount={refreshCount}
       id={id}
+      path="/bam/widget"
       playlistHash={playlistHash}
       queryClient={queryClient}
       widgetPrefixQuery={widgetPrefixQuery}


### PR DESCRIPTION
## Description

The BA Diagram (`centreon-widget-batree`) and BA Availability (`centreon-widget-baavailability`) widgets rendered `<FederatedComponent>` without a `path` prop. Without `path`, `getLoadableComponents` returns every federated module unfiltered and `getFederatedComponents` runs `pluck('federatedComponents', undefined)` on modules lacking that config, throwing `Cannot read properties of undefined (reading 'fantasy-land/map')` and crashing the UI when a BA is selected.

The `path` prop was accidentally dropped during the dev-25.10.x backport #10341 while adding `isInViewport`; develop kept it. This restores the correct path for both widgets.

Fixes: [MON-204293](https://centreon.atlassian.net/browse/MON-204293)
Fixes: [MON-204296](https://centreon.atlassian.net/browse/MON-204296)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. On a dashboard, add the **Business Activity Diagram** widget, select type + a BA resource → the widget preview renders instead of crashing with `fantasy-land/map`.
2. Repeat with the **Business Activity Availability** widget → renders correctly.
3. Confirm the **Business Activity status timeline** widget still works (unchanged reference).

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [ ] I have commented my code, especially new classes, functions or any legacy code modified.
- [ ] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-204293]: https://centreon.atlassian.net/browse/MON-204293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-204296]: https://centreon.atlassian.net/browse/MON-204296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ