### PR TITLE
feat(ci): promote centreontrapd/snmptrapd Docker images to Pulp on stable release only

### DIFF
--- a/.github/scripts/docker-push-to-pulp.sh
+++ b/.github/scripts/docker-push-to-pulp.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Promote a Docker image already built and validated on Harbor to Pulp, our
+# public delivery registry (MON-204486/MON-201979). Harbor stays the internal
+# system of record for candidate + testing images; this script only runs once
+# a stable release lands (stability == 'stable'), copying the already-built
+# Harbor image straight to Pulp with the release version as tag.
+#
+# Meant to be invoked from a workflow step with `continue-on-error: true`:
+# this script fails fast internally (set -e) but the caller decides that a
+# Pulp-side failure never blocks the stable release itself — Harbor delivery
+# already happened independently. The caller is expected to surface a
+# visible warning when this script fails, since a failure here means a
+# stable release did not reach the public registry.
+#
+# The image is rebuilt as a manifest list referencing only the per-platform
+# manifests from Harbor, deliberately excluding the OCI attestation/referrers
+# manifest (SLSA/in-toto provenance) that docker/build-push-action attaches
+# by default: Pulp's container registry returns a deterministic 500 when
+# committing a manifest that includes that attestation subject (confirmed via
+# a provenance:false before/after test in centreon-collect). Harbor keeps
+# full provenance; only the Pulp copy omits it.
+#
+# Expected env vars:
+#   PULP_URL             e.g. https://pulp-api.apps.centreon.com
+#   PULP_OIDC_AUDIENCE   e.g. https://pulp.dev.centreon.io
+#   BASE_PATH            Pulp container path, e.g. centreon/centreon-centreontrapd-trixie
+#   HARBOR_IMAGE         source image ref on Harbor, no tag
+#   HARBOR_TAG           source tag on Harbor to promote (e.g. major_version "24.10")
+#   PULP_TAGS            space-separated list of tags to create on Pulp (e.g. "24.10.5 24.10")
+#   MODULE, OS, STABILITY, PLATFORMS
+#   ACTIONS_ID_TOKEN_REQUEST_TOKEN / ACTIONS_ID_TOKEN_REQUEST_URL (injected by GitHub Actions when the job has `id-token: write`)
+set -euo pipefail
+
+PULP_IMAGE="pulp-api.apps.centreon.com/$BASE_PATH"
+
+echo "::group::Fetch GitHub OIDC token for Pulp"
+OIDC_TOKEN=$(curl -sS \
+  -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$PULP_OIDC_AUDIENCE" \
+  | jq -r '.value')
+if [[ -z "$OIDC_TOKEN" || "$OIDC_TOKEN" == "null" ]]; then
+  echo "::error::Failed to obtain a GitHub OIDC token for Pulp"
+  exit 1
+fi
+echo "::add-mask::$OIDC_TOKEN"
+echo "::endgroup::"
+
+echo "::group::Ensure Pulp container distribution exists"
+EXISTING=$(curl -sS \
+  -H "Authorization: Github $OIDC_TOKEN" \
+  -G --data-urlencode "base_path=$BASE_PATH" \
+  "$PULP_URL/api/v3/distributions/container/container/" \
+  | jq -r '.results[0].pulp_href // empty')
+if [[ -z "$EXISTING" ]]; then
+  echo "Distribution $BASE_PATH not found, creating..."
+  TASK_HREF=$(curl -sS -f -X POST \
+    -H "Authorization: Github $OIDC_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\":\"$BASE_PATH\",\"base_path\":\"$BASE_PATH\"}" \
+    "$PULP_URL/api/v3/distributions/container/container/" \
+    | jq -r '.task')
+  echo "Waiting for creation task $TASK_HREF to complete..."
+  TASK_STATE=""
+  for _ in $(seq 1 30); do
+    TASK_STATE=$(curl -sS -H "Authorization: Github $OIDC_TOKEN" "$PULP_URL$TASK_HREF" | jq -r '.state')
+    echo "  task state: $TASK_STATE"
+    if [[ "$TASK_STATE" == "completed" ]]; then
+      break
+    elif [[ "$TASK_STATE" == "failed" || "$TASK_STATE" == "canceled" ]]; then
+      echo "::error::Pulp distribution creation task ended in state '$TASK_STATE'"
+      exit 1
+    fi
+    sleep 2
+  done
+  if [[ "$TASK_STATE" != "completed" ]]; then
+    echo "::error::Timed out waiting for Pulp distribution creation task to complete"
+    exit 1
+  fi
+else
+  echo "Distribution $BASE_PATH exists: $EXISTING"
+fi
+echo "::endgroup::"
+
+echo "::group::Login to Pulp registry via OIDC"
+PULP_JWT=$(curl -sS \
+  -H "Authorization: Github $OIDC_TOKEN" \
+  "$PULP_URL/token/?service=pulp-api.apps.centreon.com&scope=repository:${BASE_PATH}:push,pull" \
+  | jq -r '.token // empty')
+if [[ -z "$PULP_JWT" ]]; then
+  echo "::error::Failed to fetch Pulp JWT (token service returned empty)"
+  exit 1
+fi
+echo "::add-mask::$PULP_JWT"
+mkdir -p ~/.docker
+EXISTING_CONFIG=$(cat ~/.docker/config.json 2>/dev/null || echo '{}')
+echo "$EXISTING_CONFIG" | jq --arg jwt "$PULP_JWT" \
+  '.auths["pulp-api.apps.centreon.com"] = {"registrytoken": $jwt}' \
+  > ~/.docker/config.json
+echo "::endgroup::"
+
+echo "::group::Resolve Harbor per-platform manifests (excluding attestation/provenance)"
+SRC_REF="$HARBOR_IMAGE:$HARBOR_TAG"
+RAW_MANIFEST=$(docker buildx imagetools inspect "$SRC_REF" --raw)
+mapfile -t PLATFORM_DIGESTS < <(echo "$RAW_MANIFEST" | jq -r '.manifests[] | select(.platform.architecture != "unknown") | .digest')
+if [[ ${#PLATFORM_DIGESTS[@]} -eq 0 ]]; then
+  echo "::error::No platform manifests found for $SRC_REF"
+  exit 1
+fi
+SRC_REFS=()
+for digest in "${PLATFORM_DIGESTS[@]}"; do
+  SRC_REFS+=("$HARBOR_IMAGE@$digest")
+  echo "  platform manifest: $digest"
+done
+echo "::endgroup::"
+
+retry_imagetools_create() {
+  local dest="$1"; shift
+  local attempt max_attempts=5 delay=5
+  for attempt in $(seq 1 "$max_attempts"); do
+    if docker buildx imagetools create --tag "$dest" "$@"; then
+      return 0
+    fi
+    if [[ "$attempt" -eq "$max_attempts" ]]; then
+      break
+    fi
+    echo "imagetools create failed (attempt $attempt/$max_attempts), retrying in ${delay}s..."
+    sleep "$delay"
+    delay=$((delay * 2))
+  done
+  return 1
+}
+
+echo "::group::Publish Pulp stable tags (manifest list, no rebuild, no attestation)"
+for tag in $PULP_TAGS; do
+  echo "Publishing $PULP_IMAGE:$tag from $SRC_REF (${#SRC_REFS[@]} platform manifest(s))"
+  retry_imagetools_create "$PULP_IMAGE:$tag" "${SRC_REFS[@]}"
+done
+echo "::endgroup::"
+
+echo "::group::Set Pulp labels on container distribution"
+ARCHITECTURES=$(echo "$PLATFORMS" | tr ',' '\n' | sed 's|linux/||' | tr '\n' ' ' | sed 's/ $//')
+HREF=$(curl -fsSL -H "Authorization: Github $OIDC_TOKEN" \
+  -G --data-urlencode "base_path=$BASE_PATH" \
+  "$PULP_URL/api/v3/distributions/container/container/" \
+  | jq -r '.results[0].pulp_href')
+if [[ -z "$HREF" || "$HREF" == "null" ]]; then
+  echo "::error::Distribution not found for base_path=$BASE_PATH"
+  exit 1
+fi
+RESPONSE=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" -X PATCH -H "Authorization: Github $OIDC_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"pulp_labels\": {\"module\": \"$MODULE\", \"os\": \"$OS\", \"stability\": \"$STABILITY\", \"tags\": \"$PULP_TAGS\", \"architectures\": \"$ARCHITECTURES\"}}" \
+  "$PULP_URL$HREF")
+HTTP_STATUS=$(echo "$RESPONSE" | grep -o "HTTP_STATUS:[0-9]*" | cut -d: -f2)
+BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+echo "Pulp response ($HTTP_STATUS): $BODY"
+if [[ "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "202" ]]; then
+  echo "::error::Failed to set Pulp labels (HTTP $HTTP_STATUS)"
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "Pulp stable promote complete: $PULP_IMAGE ($PULP_TAGS)"

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -21,7 +21,6 @@ on:
       - '.github/workflows/docker-trapd.yml'
     tags:
       - "centreon-web-*"
-      - "centreon-pulp-promote-test-*" # TEMPORARY: MON-201979 smoke test only, revert before merge
   pull_request:
     paths:
       - '.github/docker/centreon-snmptrapd/**'

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -21,6 +21,7 @@ on:
       - '.github/workflows/docker-trapd.yml'
     tags:
       - "centreon-web-*"
+      - "centreon-pulp-promote-test-*" # TEMPORARY: MON-201979 smoke test only, revert before merge
   pull_request:
     paths:
       - '.github/docker/centreon-snmptrapd/**'

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - develop
       - dev-[2-9][0-9].[0-9][0-9].x
+      - "release-[2-9][0-9].[0-9][0-9]-next"
+      - "hotfix-[2-9][0-9].[0-9][0-9]-next"
     paths:
       - '.github/docker/centreon-snmptrapd/**'
       - '.github/docker/centreon-centreontrapd/**'
@@ -17,6 +19,8 @@ on:
       - 'centreon/bin/centreontrapd'
       - 'centreon/bin/centreontrapdforward'
       - '.github/workflows/docker-trapd.yml'
+    tags:
+      - "centreon-web-*"
   pull_request:
     paths:
       - '.github/docker/centreon-snmptrapd/**'
@@ -121,7 +125,9 @@ jobs:
 
   dockerize:
     needs: [get-environment, package-centreon-trap, package-perl-libs]
-    if: ${{ needs.get-environment.outputs.skip_workflow == 'false' }}
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -365,4 +371,79 @@ jobs:
           docker buildx imagetools create \
             --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
             "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
+        shell: bash
+
+  promote-docker-to-pulp:
+    needs: [get-environment]
+    if: |
+      needs.get-environment.outputs.stability == 'stable' &&
+      github.event_name != 'workflow_dispatch' &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+    runs-on: centreon-ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [centreon-snmptrapd, centreon-centreontrapd]
+        operating_system: [trixie]
+    name: promote ${{ matrix.component }}-${{ matrix.operating_system }} to Pulp stable
+    # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
+    # that dockerize tagged the image with while that branch was 'testing'. release_type comes
+    # from the annotated component tag's message ("release ..."/"hotfix ...", see
+    # .github/actions/release-new/action.yml), not from this event's own ref.
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Resolve release bundle tag
+        id: resolve-bundle-tag
+        # release-new (.github/actions/release-new) tags the release bundle
+        # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
+        # this component's stable tag, so it's always among the tags pointing
+        # at HEAD here. Soft failure: no match just means no bundle tag to add.
+        run: |
+          BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
+          echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
+        shell: bash
+
+      - name: Login to Harbor registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
+        continue-on-error: true
+        id: promote-pulp
+        env:
+          PULP_URL: https://pulp-api.apps.centreon.com
+          PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
+          BASE_PATH: centreon/${{ matrix.component }}-${{ matrix.operating_system }}
+          HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}
+          HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
+          PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
+          MODULE: ${{ matrix.component }}
+          OS: ${{ matrix.operating_system }}
+          STABILITY: ${{ needs.get-environment.outputs.stability }}
+          PLATFORMS: linux/amd64,linux/arm64
+        run: bash .github/scripts/docker-push-to-pulp.sh
+        shell: bash
+
+      - name: Warn if Pulp stable delivery failed
+        if: steps.promote-pulp.outcome == 'failure'
+        run: |
+          echo "::warning::Pulp delivery failed for ${{ matrix.component }}-${{ matrix.operating_system }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
         shell: bash


### PR DESCRIPTION
## Summary
- Add a `promote-docker-to-pulp` job to `docker-trapd.yml` that copies the already-built, already-tested Harbor image straight to Pulp (`docker buildx imagetools create`, no rebuild) only when `stability == 'stable'`, mirroring the design just validated for centreon-engine/broker/gorgone in centreon-collect (MON-204486).
- Add `.github/scripts/docker-push-to-pulp.sh`, ported as-is from centreon-collect: resolves per-platform Harbor manifests via `docker buildx imagetools inspect`, excludes the OCI attestation/referrers manifest (confirmed root cause of a Pulp 500 in centreon-collect), publishes to Pulp, and PATCHes Pulp container labels.
- Add `release-[2-9][0-9].[0-9][0-9]-next` / `hotfix-[2-9][0-9].[0-9][0-9]-next` branches and the `centreon-web-*` tag trigger to `docker-trapd.yml`'s `push` block (same pattern already proven in `web.yml`, since centreontrapd/snmptrapd version off the same `insertBaseConf.sql` file as centreon-web).
- Gate the existing `dockerize` job on `stability != 'stable'`: on the stable-tag run, the image was already built and tested during the release/hotfix branch's own "testing" run, so it isn't rebuilt.
- Non-blocking by design: the Pulp promote step is `continue-on-error: true` with a visible `::warning::` on failure, so a missed Pulp delivery is never silent and never blocks the stable release itself (which already succeeded on Harbor independently).

## Context
Supersedes draft PR #10842, which added Pulp as a third tag in the *same unguarded* build step that #10999 (MON-204507) just fixed — reproducing the "published before tested" bug for Pulp. This PR builds on top of #10999 instead (already merged to `develop`), and reuses its already-tested build/promote split.

Jira: MON-201979 (depends on MON-204507, resolved via #10999).

## Test plan
- [x] `actionlint` clean on `docker-trapd.yml` (aside from the pre-existing self-hosted `centreon-ubuntu-22.04` runner-label false positive, also present in `web.yml`)
- [ ] **Not yet exercised end-to-end**: like MON-204486, the `promote-docker-to-pulp` job explicitly excludes `workflow_dispatch` (`github.event_name != 'workflow_dispatch'`), so it cannot be smoke-tested via manual dispatch. Validating requires either pushing a disposable tag matching `centreon-web-*` against a throwaway branch state, or waiting for the next real stable release. Flagging this explicitly rather than claiming it works.
- [ ] Confirm Pulp already trusts this repo's GitHub OIDC issuer for the audience used here (reusing the flow already debugged in #10842's earlier CI runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)