### PR TITLE
test(web): link custom db-name e2e test to new Xray case

### DIFF
--- a/centreon/tests/e2e/features/Web-server-configuration/03-custom-db-name.feature
+++ b/centreon/tests/e2e/features/Web-server-configuration/03-custom-db-name.feature
@@ -3,7 +3,7 @@ Feature: Central poller configuration generation with non-standard database name
   I want the central poller configuration to be generated successfully
   So that my configuration can be deployed regardless of the physical database names
 
-  @MON-204575
+  @MON-204816
   Scenario: Generate central poller configuration with non-standard database names
     Given a platform whose databases are not named centreon or centreon_storage
     When the administrator exports the central poller configuration


### PR DESCRIPTION
Fixes: [MON-204816](https://centreon.atlassian.net/browse/MON-204816)

Repoint the Xray tag of the custom database-name e2e test so it stays linked to a valid test case.

The previous test case `MON-204575` was deleted and recreated as `MON-204816`. This updates the scenario tag in `03-custom-db-name.feature` accordingly (`@MON-204575` → `@MON-204816`).

Test-only change — no product code is affected. The test covers the non-regression of [MON-204259](https://centreon.atlassian.net/browse/MON-204259) (central poller config generation with non-standard database names).

[MON-204816]: https://centreon.atlassian.net/browse/MON-204816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-204259]: https://centreon.atlassian.net/browse/MON-204259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ