### PR TITLE
feat(views): modern AJAX listing with side panel for Graph templates

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
@@ -7,13 +7,11 @@ Feature: Modern AJAX listing common features
     Given a user is logged in Centreon
     And some service templates exist
 
-  @TEST_LISTING-001
   Scenario: AJAX listing loads data without page reload
     When the user navigates to the service templates listing
     Then the listing table is rendered via AJAX
     And the table contains service template rows
 
-  @TEST_LISTING-002
   Scenario: Search filters listing results
     When the user navigates to the service templates listing
     And the user types a search term in the search field
@@ -21,7 +19,6 @@ Feature: Modern AJAX listing common features
     Then only matching service templates are displayed
     And the pagination reflects the filtered count
 
-  @TEST_LISTING-003
   Scenario: Pagination navigates between pages
     When the user navigates to the service templates listing
     Then the pagination shows the total number of items
@@ -29,14 +26,12 @@ Feature: Modern AJAX listing common features
     Then the listing shows the second page of results
     And the current page indicator shows page 2
 
-  @TEST_LISTING-004
   Scenario: Rows per page selector changes limit
     When the user navigates to the service templates listing
     And the user changes the rows per page to 10
     Then the listing shows at most 10 rows
     And the pagination is recalculated
 
-  @TEST_LISTING-005
   Scenario: Locked elements checkbox toggles locked templates visibility
     When the user navigates to the service templates listing
     And the locked checkbox is checked
@@ -44,34 +39,29 @@ Feature: Modern AJAX listing common features
     When the user unchecks the locked checkbox and searches
     Then locked service templates are hidden from the listing
 
-  @TEST_LISTING-006
   Scenario: Locked templates have disabled checkboxes and dup inputs
     When the user navigates to the service templates listing
     And the locked checkbox is checked
     Then locked rows have disabled selection checkboxes
     And locked rows have disabled duplication inputs
 
-  @TEST_LISTING-007
   Scenario: Bulk duplication works via the More actions dropdown
     When the user navigates to the service templates listing
     And the user selects a service template checkbox
     And the user selects Duplicate from the More actions dropdown
     Then a duplicated service template appears in the listing
 
-  @TEST_LISTING-008
   Scenario: Bulk deletion works via the More actions dropdown
     When the user navigates to the service templates listing
     And the user selects a service template checkbox
     And the user selects Delete from the More actions dropdown
     Then the service template is removed from the listing
 
-  @TEST_LISTING-009
   Scenario: Clicking a service template name navigates to the edit form
     When the user navigates to the service templates listing
     And the user clicks on a service template name
     Then the service template edit form is displayed
 
-  @TEST_LISTING-010
   Scenario: Session state persists search and pagination across navigation
     When the user navigates to the service templates listing
     And the user types a search term in the search field

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features.feature
@@ -1,0 +1,82 @@
+Feature: Modern AJAX listing common features
+    As a Centreon admin
+    I want the modernized listing pages to work correctly
+    So that I can manage configuration objects efficiently
+
+  Background:
+    Given a user is logged in Centreon
+    And some service templates exist
+
+  @TEST_LISTING-001
+  Scenario: AJAX listing loads data without page reload
+    When the user navigates to the service templates listing
+    Then the listing table is rendered via AJAX
+    And the table contains service template rows
+
+  @TEST_LISTING-002
+  Scenario: Search filters listing results
+    When the user navigates to the service templates listing
+    And the user types a search term in the search field
+    And the user clicks the search button
+    Then only matching service templates are displayed
+    And the pagination reflects the filtered count
+
+  @TEST_LISTING-003
+  Scenario: Pagination navigates between pages
+    When the user navigates to the service templates listing
+    Then the pagination shows the total number of items
+    When the user clicks page 2
+    Then the listing shows the second page of results
+    And the current page indicator shows page 2
+
+  @TEST_LISTING-004
+  Scenario: Rows per page selector changes limit
+    When the user navigates to the service templates listing
+    And the user changes the rows per page to 10
+    Then the listing shows at most 10 rows
+    And the pagination is recalculated
+
+  @TEST_LISTING-005
+  Scenario: Locked elements checkbox toggles locked templates visibility
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked service templates are visible in the listing
+    When the user unchecks the locked checkbox and searches
+    Then locked service templates are hidden from the listing
+
+  @TEST_LISTING-006
+  Scenario: Locked templates have disabled checkboxes and dup inputs
+    When the user navigates to the service templates listing
+    And the locked checkbox is checked
+    Then locked rows have disabled selection checkboxes
+    And locked rows have disabled duplication inputs
+
+  @TEST_LISTING-007
+  Scenario: Bulk duplication works via the More actions dropdown
+    When the user navigates to the service templates listing
+    And the user selects a service template checkbox
+    And the user selects Duplicate from the More actions dropdown
+    Then a duplicated service template appears in the listing
+
+  @TEST_LISTING-008
+  Scenario: Bulk deletion works via the More actions dropdown
+    When the user navigates to the service templates listing
+    And the user selects a service template checkbox
+    And the user selects Delete from the More actions dropdown
+    Then the service template is removed from the listing
+
+  @TEST_LISTING-009
+  Scenario: Clicking a service template name navigates to the edit form
+    When the user navigates to the service templates listing
+    And the user clicks on a service template name
+    Then the service template edit form is displayed
+
+  @TEST_LISTING-010
+  Scenario: Session state persists search and pagination across navigation
+    When the user navigates to the service templates listing
+    And the user types a search term in the search field
+    And the user clicks the search button
+    And the user clicks on a service template name
+    And the user navigates back to the service templates listing
+    Then the search field still contains the search term
+    And the listing shows the same filtered results

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
@@ -1,0 +1,344 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const serviceTemplatesPage = PAGES.configuration.servicesTemplatesLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('a user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+Given('some service templates exist', () => {
+  // The default Centreon install includes many service templates (generic-active-service, etc.)
+  // Add a custom one for targeted testing
+  cy.addServiceTemplate({
+    name: 'test_listing_template',
+    template: 'generic-active-service'
+  });
+  cy.addServiceTemplate({
+    name: 'test_listing_other',
+    template: 'generic-active-service'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitListingAndWait(): void {
+  cy.visit(serviceTemplatesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  // Wait for AJAX data to load (tbody should have real rows, not just loading)
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  // Wait for table body to be populated after an AJAX call
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: AJAX listing loads data without page reload
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the service templates listing', () => {
+  visitListingAndWait();
+});
+
+Then('the listing table is rendered via AJAX', () => {
+  // The modern listing uses cl-listing-table class and #clTableBody
+  cy.getIframeBody()
+    .find('table.cl-listing-table')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .should('exist');
+});
+
+Then('the table contains service template rows', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+  // Verify our test template is visible
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search filters listing results
+// ---------------------------------------------------------------------------
+
+When('the user types a search term in the search field', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .clear()
+    .type('test_listing_template');
+});
+
+When('the user clicks the search button', () => {
+  cy.getIframeBody()
+    .find('#clSearchBtn')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('only matching service templates are displayed', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_other')
+    .should('not.exist');
+});
+
+Then('the pagination reflects the filtered count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .should('contain', '1-');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination navigates between pages
+// ---------------------------------------------------------------------------
+
+Then('the pagination shows the total number of items', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+When('the user clicks page 2', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop a.cl-page-num')
+    .contains('2')
+    .click();
+  waitForAjaxRefresh();
+});
+
+Then('the listing shows the second page of results', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('the current page indicator shows page 2', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop span.cl-page-current')
+    .should('contain', '2');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Rows per page selector changes limit
+// ---------------------------------------------------------------------------
+
+When('the user changes the rows per page to 10', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop select.cl-limit-select')
+    .select('10');
+  waitForAjaxRefresh();
+});
+
+Then('the listing shows at most 10 rows', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.at.most', 10);
+});
+
+Then('the pagination is recalculated', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /1-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked elements checkbox
+// ---------------------------------------------------------------------------
+
+When('the locked checkbox is checked', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .then($cb => {
+      if (!$cb.is(':checked')) {
+        cy.wrap($cb).click();
+        cy.getIframeBody().find('#clSearchBtn').click();
+        waitForAjaxRefresh();
+      }
+    });
+});
+
+Then('locked service templates are visible in the listing', () => {
+  // With locked checked, count the total rows
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .as('countWithLocked');
+});
+
+When('the user unchecks the locked checkbox and searches', () => {
+  cy.getIframeBody()
+    .find('#displayLocked')
+    .uncheck();
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('locked service templates are hidden from the listing', () => {
+  // Without locked, the count should be less or equal
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .its('length')
+    .then(countWithoutLocked => {
+      cy.get('@countWithLocked').then(countWithLocked => {
+        expect(countWithoutLocked).to.be.at.most(countWithLocked as unknown as number);
+      });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Locked templates have disabled checkboxes and dup inputs
+// ---------------------------------------------------------------------------
+
+Then('locked rows have disabled selection checkboxes', () => {
+  // Find a row with a disabled checkbox (locked row)
+  cy.getIframeBody()
+    .find('#clTableBody .cl-col-picker input[type="checkbox"][disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+Then('locked rows have disabled duplication inputs', () => {
+  cy.getIframeBody()
+    .find('#clTableBody input.cl-dup-input[disabled]')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk duplication
+// ---------------------------------------------------------------------------
+
+When('the user selects a service template checkbox', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .parents('tr')
+    .find('.cl-col-picker input[type="checkbox"]')
+    .click();
+});
+
+When('the user selects Duplicate from the More actions dropdown', () => {
+  // Override onchange to avoid confirm dialog
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Duplicate');
+});
+
+Then('a duplicated service template appears in the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template_1')
+    .should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Bulk deletion
+// ---------------------------------------------------------------------------
+
+When('the user selects Delete from the More actions dropdown', () => {
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
+    );
+  cy.getIframeBody()
+    .find('select[name="o1"]')
+    .select('Delete');
+});
+
+Then('the service template is removed from the listing', () => {
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('not.exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on a service template name', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('a', 'test_listing_template')
+    .click();
+});
+
+Then('the service template edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="service_description"]');
+  cy.getIframeBody()
+    .find('input[name="service_description"]')
+    .should('have.value', 'test_listing_template');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the service templates listing', () => {
+  cy.visit(serviceTemplatesPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody()
+    .find('#clSearchInput')
+    .should('have.value', 'test_listing_template');
+});
+
+Then('the listing shows the same filtered results', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('test_listing_template')
+    .should('exist');
+});

--- a/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/01-listing-common-features/index.ts
@@ -70,12 +70,8 @@ When('the user navigates to the service templates listing', () => {
 
 Then('the listing table is rendered via AJAX', () => {
   // The modern listing uses cl-listing-table class and #clTableBody
-  cy.getIframeBody()
-    .find('table.cl-listing-table')
-    .should('exist');
-  cy.getIframeBody()
-    .find('#clTableBody')
-    .should('exist');
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody').should('exist');
 });
 
 Then('the table contains service template rows', () => {
@@ -101,9 +97,7 @@ When('the user types a search term in the search field', () => {
 });
 
 When('the user clicks the search button', () => {
-  cy.getIframeBody()
-    .find('#clSearchBtn')
-    .click();
+  cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
 
@@ -167,9 +161,7 @@ When('the user changes the rows per page to 10', () => {
 });
 
 Then('the listing shows at most 10 rows', () => {
-  cy.getIframeBody()
-    .find('#clTableBody tr')
-    .should('have.length.at.most', 10);
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.at.most', 10);
 });
 
 Then('the pagination is recalculated', () => {
@@ -186,7 +178,7 @@ Then('the pagination is recalculated', () => {
 When('the locked checkbox is checked', () => {
   cy.getIframeBody()
     .find('#displayLocked')
-    .then($cb => {
+    .then(($cb) => {
       if (!$cb.is(':checked')) {
         cy.wrap($cb).click();
         cy.getIframeBody().find('#clSearchBtn').click();
@@ -204,9 +196,7 @@ Then('locked service templates are visible in the listing', () => {
 });
 
 When('the user unchecks the locked checkbox and searches', () => {
-  cy.getIframeBody()
-    .find('#displayLocked')
-    .uncheck();
+  cy.getIframeBody().find('#displayLocked').uncheck();
   cy.getIframeBody().find('#clSearchBtn').click();
   waitForAjaxRefresh();
 });
@@ -216,9 +206,11 @@ Then('locked service templates are hidden from the listing', () => {
   cy.getIframeBody()
     .find('#clTableBody tr')
     .its('length')
-    .then(countWithoutLocked => {
-      cy.get('@countWithLocked').then(countWithLocked => {
-        expect(countWithoutLocked).to.be.at.most(countWithLocked as unknown as number);
+    .then((countWithoutLocked) => {
+      cy.get('@countWithLocked').then((countWithLocked) => {
+        expect(countWithoutLocked).to.be.at.most(
+          countWithLocked as unknown as number
+        );
       });
     });
 });
@@ -262,9 +254,7 @@ When('the user selects Duplicate from the More actions dropdown', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Duplicate');
+  cy.getIframeBody().find('select[name="o1"]').select('Duplicate');
 });
 
 Then('a duplicated service template appears in the listing', () => {
@@ -288,9 +278,7 @@ When('the user selects Delete from the More actions dropdown', () => {
       'onchange',
       "javascript: { setO(this.form.elements['o1'].value); this.form.submit(); }"
     );
-  cy.getIframeBody()
-    .find('select[name="o1"]')
-    .select('Delete');
+  cy.getIframeBody().find('select[name="o1"]').select('Delete');
 });
 
 Then('the service template is removed from the listing', () => {
@@ -314,7 +302,10 @@ When('the user clicks on a service template name', () => {
 });
 
 Then('the service template edit form is displayed', () => {
-  cy.waitForElementInIframe('#main-content', 'input[name="service_description"]');
+  cy.waitForElementInIframe(
+    '#main-content',
+    'input[name="service_description"]'
+  );
   cy.getIframeBody()
     .find('input[name="service_description"]')
     .should('have.value', 'test_listing_template');

--- a/centreon/www/include/common/listing/AjaxListingHelper.php
+++ b/centreon/www/include/common/listing/AjaxListingHelper.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * Helper class for AJAX listing endpoints.
+ *
+ * Provides boilerplate: session validation, parameter parsing,
+ * Centreon autoloader registration, and JSON response helpers.
+ *
+ * Usage in an AJAX endpoint:
+ *
+ *   $helper = AjaxListingHelper::boot();
+ *   $params = $helper->getParams();
+ *   $centreon = $helper->getCentreon();  // may be null
+ *   $db = $helper->getDb();
+ *   // ... run your query ...
+ *   $helper->jsonResponse($rows, $total, $params['num'], $params['limit']);
+ */
+class AjaxListingHelper
+{
+    private CentreonDB $db;
+    private mixed $centreon;
+
+    private function __construct(CentreonDB $db, mixed $centreon)
+    {
+        $this->db = $db;
+        $this->centreon = $centreon;
+    }
+
+    /**
+     * Bootstrap the AJAX endpoint: config, session, autoloader, JSON header.
+     * Exits with appropriate HTTP error on failure.
+     */
+    public static function boot(): self
+    {
+        require_once realpath(__DIR__ . '/../../../../config/centreon.config.php');
+        require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+        require_once _CENTREON_PATH_ . '/www/class/centreonSession.class.php';
+        require_once _CENTREON_PATH_ . '/www/include/common/common-Func.php';
+        require_once _CENTREON_PATH_ . '/www/class/HtmlAnalyzer.php';
+
+        header('Content-Type: application/json');
+
+        session_start();
+
+        $db = new CentreonDB();
+
+        try {
+            if (! CentreonSession::checkSession(session_id(), $db)) {
+                self::jsonError('Unauthorized', 401);
+            }
+        } catch (\Exception $e) {
+            self::jsonError('Internal error', 500);
+        }
+
+        // Register Centreon class autoloader for session deserialization
+        require_once _CENTREON_PATH_ . '/www/class/centreon.class.php';
+        require_once _CENTREON_PATH_ . '/www/class/centreonACL.class.php';
+
+        spl_autoload_register(function ($sClass): void {
+            $fileName = lcfirst($sClass);
+            $fileNameType1 = _CENTREON_PATH_ . '/www/class/' . $fileName . '.class.php';
+            $fileNameType2 = _CENTREON_PATH_ . '/www/class/' . $fileName . '.php';
+            if (file_exists($fileNameType1)) {
+                require_once $fileNameType1;
+            } elseif (file_exists($fileNameType2)) {
+                require_once $fileNameType2;
+            }
+        });
+
+        $centreon = $_SESSION['centreon'] ?? null;
+
+        return new self($db, $centreon);
+    }
+
+    /**
+     * Get sanitized listing parameters from the request.
+     *
+     * @return array{search: string, num: int, limit: int}
+     */
+    public function getParams(): array
+    {
+        return [
+            'search' => HtmlAnalyzer::sanitizeAndRemoveTags($_GET['search'] ?? ''),
+            'num'    => filter_var($_GET['num'] ?? 0, FILTER_VALIDATE_INT) ?: 0,
+            'limit'  => filter_var($_GET['limit'] ?? 30, FILTER_VALIDATE_INT) ?: 30,
+        ];
+    }
+
+    /**
+     * Get the Centreon session object (or null if deserialization failed).
+     */
+    public function getCentreon(): mixed
+    {
+        return $this->centreon;
+    }
+
+    /**
+     * Get the Centreon session object, or exit 403 if unavailable.
+     */
+    public function requireCentreon(): mixed
+    {
+        if (! $this->centreon) {
+            self::jsonError('Forbidden', 403);
+        }
+        return $this->centreon;
+    }
+
+    /**
+     * Get the database connection.
+     */
+    public function getDb(): CentreonDB
+    {
+        return $this->db;
+    }
+
+    /**
+     * Check if the current user is admin.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->centreon ? (bool) $this->centreon->user->admin : false;
+    }
+
+    /**
+     * Get the ACL object for the current user.
+     */
+    public function getAcl(): ?CentreonACL
+    {
+        return $this->centreon ? $this->centreon->user->access : null;
+    }
+
+    /**
+     * Require write access on a given topology page. Exits 403 if read-only or no access.
+     * Admins always pass.
+     *
+     * @param int $pageId The topology page number (e.g. 60101 for hosts, 60201 for servicegroups)
+     */
+    public function requireWriteAccess(int $pageId): void
+    {
+        if ($this->isAdmin()) {
+            return;
+        }
+        $acl = $this->getAcl();
+        if (! $acl || $acl->page($pageId) !== 1) {
+            self::jsonError('Write access denied', 403);
+        }
+    }
+
+    /**
+     * Validate and consume a CSRF token from POST. Exits 403 on failure.
+     * Returns a fresh token for the next request.
+     */
+    public function validateCsrfToken(): string
+    {
+        $token = $_POST['centreon_token'] ?? null;
+
+        if ($token === null || ! in_array($token, $_SESSION['x-centreon-token'] ?? [], true)) {
+            self::jsonError('Invalid CSRF token', 403);
+        }
+
+        $key = array_search($token, $_SESSION['x-centreon-token'], true);
+        unset($_SESSION['x-centreon-token'][$key], $_SESSION['x-centreon-token-generated-at'][$token]);
+
+        return createCSRFToken();
+    }
+
+    /**
+     * Log a toggle action (enable/disable) to the audit log.
+     * Uses direct SQL to avoid dependencies on CentreonLogAction.
+     *
+     * @param string $objectType Object type (e.g. 'servicegroup', 'host', 'contact')
+     * @param int $objectId Object ID
+     * @param string $objectName Object name for display
+     * @param string $actionType Action type ('enable' or 'disable')
+     */
+    public function logToggleAction(string $objectType, int $objectId, string $objectName, string $actionType): void
+    {
+        try {
+            $pearDBO = new CentreonDB('centstorage');
+
+            // Check if audit log is enabled
+            $optResult = $pearDBO->query("SELECT audit_log_option FROM `config` LIMIT 1");
+            $auditOpt = $optResult->fetchColumn();
+            if ($auditOpt != '1') {
+                return;
+            }
+
+            $userId = $this->centreon ? $this->centreon->user->get_id() : 0;
+
+            $stmt = $pearDBO->prepare(
+                "INSERT INTO `log_action` (action_log_date, object_type, object_id, object_name, action_type, log_contact_id)"
+                . " VALUES (:ts, :obj_type, :obj_id, :obj_name, :action, :uid)"
+            );
+            $stmt->bindValue(':ts', time(), PDO::PARAM_INT);
+            $stmt->bindValue(':obj_type', $objectType, PDO::PARAM_STR);
+            $stmt->bindValue(':obj_id', $objectId, PDO::PARAM_INT);
+            $stmt->bindValue(':obj_name', $objectName, PDO::PARAM_STR);
+            $stmt->bindValue(':action', $actionType, PDO::PARAM_STR);
+            $stmt->bindValue(':uid', $userId, PDO::PARAM_INT);
+            $stmt->execute();
+        } catch (\Throwable $e) {
+            // Silently fail logging — don't break the toggle
+        }
+    }
+
+    /**
+     * Send a successful JSON listing response and exit.
+     */
+    public function jsonResponse(array $rows, int $total, int $num, int $limit): void
+    {
+        echo json_encode([
+            'rows'           => $rows,
+            'total'          => $total,
+            'num'            => $num,
+            'limit'          => $limit,
+            'centreon_token' => createCSRFToken(),
+        ]);
+        exit;
+    }
+
+    /**
+     * Send a JSON error response and exit.
+     */
+    public static function jsonError(string $message, int $httpCode = 400): void
+    {
+        http_response_code($httpCode);
+        echo json_encode(['error' => $message]);
+        exit;
+    }
+}

--- a/centreon/www/include/common/listing/listing.css
+++ b/centreon/www/include/common/listing/listing.css
@@ -1,0 +1,1018 @@
+/*
+ * Centreon Modern Listing Styles
+ *
+ * Shared CSS for AJAX-based configuration listing pages.
+ * Prefix: cl- (centreon-listing)
+ *
+ * Usage: Include this file in any Smarty listing template, then use
+ * the CentreonListing JS module for AJAX data loading and rendering.
+ */
+
+/* ==========================================================================
+   Layout container
+   ========================================================================== */
+
+.cl-listing-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+/* ==========================================================================
+   Actions bar (top toolbar: add button, bulk actions, search, pagination)
+   ========================================================================== */
+
+.cl-actions-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    gap: 12px;
+}
+
+.cl-actions-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+/* "More actions" dropdown in actions bar */
+.cl-actions-left select {
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    background: var(--select-background, #fff);
+    cursor: pointer;
+    line-height: 1.4;
+    height: auto;
+}
+
+/* ==========================================================================
+   Add button (blue with "+" prefix)
+   ========================================================================== */
+
+.cl-btn-add {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #fff;
+    background-color: var(--color-primary-light, #2E68AA);
+    border: none;
+    border-radius: 4px;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+    line-height: 1.4;
+    transition: background-color 0.15s ease;
+}
+
+.cl-btn-add:hover {
+    background-color: var(--color-primary-hover, #255891);
+    color: #fff;
+    text-decoration: none;
+}
+
+.cl-btn-add::before {
+    content: '+';
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 1;
+}
+
+/* ==========================================================================
+   Search bar (centered between actions and pagination)
+   ========================================================================== */
+
+.cl-search-center {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 24px;
+}
+
+.cl-search-input {
+    width: 100%;
+    max-width: 400px;
+    padding: 8px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.cl-search-input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+.cl-search-input::placeholder {
+    color: var(--color-grey-chateau, #a7a9ac);
+}
+
+/* ==========================================================================
+   Pagination (page numbers, nav arrows, limit selector, row count)
+   ========================================================================== */
+
+.cl-pagination {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.cl-pagination a,
+.cl-pagination span.cl-page-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    font-size: 13px;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.cl-pagination a {
+    color: var(--color-primary-light, #2E68AA);
+}
+
+.cl-pagination a:hover {
+    background-color: var(--color-listing-hover, #E6EDF5);
+    text-decoration: none;
+}
+
+/* Navigation arrows (first, prev, next, last) */
+.cl-pagination a.cl-page-nav img {
+    width: 14px;
+    height: 14px;
+    opacity: 0.6;
+}
+
+.cl-pagination a.cl-page-nav:hover img {
+    opacity: 1;
+}
+
+/* Current page indicator */
+.cl-pagination span.cl-page-current {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    background-color: var(--color-primary-light, #2E68AA);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+/* "X-Y of Z" label */
+.cl-pagination .cl-page-info {
+    font-size: 13px;
+    color: var(--body-color, #555);
+    padding: 0 4px;
+}
+
+/* Rows-per-page selector */
+.cl-pagination .cl-limit-select {
+    padding: 4px 8px;
+    font-size: 13px;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    background: var(--select-background, #fff);
+    cursor: pointer;
+    min-width: 50px;
+}
+
+/* ==========================================================================
+   Data table
+   ========================================================================== */
+
+.cl-listing-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    background: var(--select-background, #fff);
+    border: none;
+}
+
+/* -- Table header --------------------------------------------------------- */
+
+.cl-listing-table thead th {
+    padding: 6px 16px;
+    font-weight: 600;
+    font-size: 13px;
+    color: #fff;
+    text-align: left;
+    border-bottom: none;
+    background: #8C8C8C;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.cl-listing-table thead th.cl-col-center {
+    text-align: center;
+}
+
+.cl-listing-table thead th.cl-col-right {
+    text-align: right;
+}
+
+.cl-listing-table thead th.cl-col-picker {
+    width: 40px;
+    text-align: center;
+    padding: 6px 8px;
+    vertical-align: middle;
+}
+
+/* -- Table body rows ------------------------------------------------------ */
+
+.cl-listing-table tbody tr {
+    background: var(--select-background, #fff);
+    transition: background-color 0.15s ease;
+    cursor: pointer;
+}
+
+.cl-listing-table tbody tr:hover {
+    background-color: var(--color-listing-hover, #E6EDF5);
+}
+
+.cl-listing-table tbody td {
+    padding: 4px 16px;
+    font-size: 13px;
+    color: var(--body-color, #555);
+    border-bottom: 1px solid var(--color-divider, #E3E3E3);
+    vertical-align: middle;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 300px;
+}
+
+.cl-listing-table tbody td.cl-col-center {
+    text-align: center;
+}
+
+.cl-listing-table tbody td.cl-col-right {
+    text-align: right;
+}
+
+.cl-listing-table tbody td.cl-col-picker {
+    width: 40px;
+    text-align: center;
+    padding: 4px 8px;
+}
+
+/* -- Links inside rows ---------------------------------------------------- */
+
+.cl-listing-table tbody td a {
+    color: var(--color-primary-light, #2E68AA);
+    text-decoration: none;
+}
+
+.cl-listing-table tbody td a:hover {
+    text-decoration: underline;
+}
+
+.cl-listing-table tbody tr:hover td {
+    color: var(--color-charcoal, #444);
+}
+
+.cl-listing-table tbody tr:hover td a {
+    color: var(--color-primary-hover, #255891);
+}
+
+/* ==========================================================================
+   Options cell (actions column: toggle + duplication input)
+   ========================================================================== */
+
+.cl-options-cell {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.cl-dup-input {
+    width: 36px;
+    height: 22px;
+    text-align: center;
+    border: 1px solid var(--color-divider, #E3E3E3);
+    border-radius: 4px;
+    font-size: 11px;
+    margin: 0;
+    padding: 0 2px;
+    line-height: 20px;
+}
+
+.cl-dup-input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+    outline: none;
+}
+
+/* ==========================================================================
+   Toggle switch (iPhone style enable/disable)
+   ========================================================================== */
+
+.cl-toggle {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.cl-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.cl-toggle-slider {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    border-radius: 20px;
+    transition: background-color 0.25s ease;
+}
+
+.cl-toggle-slider::before {
+    content: '';
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: #fff;
+    border-radius: 50%;
+    transition: transform 0.25s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.cl-toggle input:checked + .cl-toggle-slider {
+    background-color: var(--color-success, #88B922);
+}
+
+.cl-toggle input:checked + .cl-toggle-slider::before {
+    transform: translateX(16px);
+}
+
+.cl-toggle input:disabled + .cl-toggle-slider {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ==========================================================================
+   Bottom bar (bulk actions + pagination)
+   ========================================================================== */
+
+.cl-bottom-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+}
+
+/* ==========================================================================
+   Checkbox alignment (header and body rows)
+   ========================================================================== */
+
+.cl-listing-table .cl-col-picker .md-checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    height: 100%;
+}
+
+.cl-listing-table .cl-col-picker .md-checkbox input[type="checkbox"] {
+    margin: 0;
+}
+
+.cl-listing-table .cl-col-picker .md-checkbox label {
+    margin: 0;
+    padding: 0;
+    min-height: auto;
+    line-height: 1;
+}
+
+/* White checkbox border on dark header */
+.cl-listing-table thead th .md-checkbox label::before {
+    border-color: #fff;
+}
+
+/* ==========================================================================
+   States: loading, empty, fade-in animation
+   ========================================================================== */
+
+.cl-loading {
+    text-align: center;
+    padding: 24px;
+    color: var(--color-grey-chateau, #a7a9ac);
+    font-size: 14px;
+}
+
+.cl-listing-table tbody {
+    transition: opacity 0.2s ease;
+}
+
+.cl-listing-table tbody.cl-fade-in {
+    animation: clFadeIn 0.25s ease;
+}
+
+@keyframes clFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* ==========================================================================
+   Sub-listing header (e.g. meta service metric listing)
+   ========================================================================== */
+
+.cl-meta-header {
+    padding: 10px 16px;
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--body-color, #555);
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 4px;
+    margin-bottom: 8px;
+}
+
+/* ==========================================================================
+   Tooltip (instant, no-delay, fixed position in body)
+   ========================================================================== */
+
+.cl-tooltip-popup {
+    position: fixed;
+    z-index: 99999;
+    background: var(--body-background, #222);
+    color: var(--body-color, #eee);
+    border: 1px solid var(--listing-border-botom-color, #555);
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+}
+
+.cl-tooltip-popup b {
+    margin-right: 4px;
+}
+
+/* ==========================================================================
+   Add button dropdown (two-level: Wizard / Advanced)
+   ========================================================================== */
+
+.cl-add-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.cl-add-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    min-width: 160px;
+    margin-top: 4px;
+    overflow: hidden;
+}
+
+.cl-add-dropdown.cl-open .cl-add-dropdown-menu {
+    display: block;
+}
+
+.cl-add-dropdown-menu a {
+    display: block;
+    padding: 8px 16px;
+    color: var(--body-color, #444);
+    text-decoration: none;
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+.cl-add-dropdown-menu a:hover {
+    background: var(--list-hover-background-color, #E6EDF5);
+    text-decoration: none;
+}
+
+/* ==========================================================================
+   Filter box (advanced search with multiple fields)
+   ========================================================================== */
+
+.cl-filter-box {
+    background: var(--body-background, #fff);
+    border: 1px solid var(--listing-border-botom-color, #E3E3E3);
+    border-radius: 6px;
+    padding: 10px 16px;
+    margin-bottom: 8px;
+}
+
+.cl-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.cl-filter-bar .cl-search-input {
+    max-width: none;
+    width: 200px;
+    height: 28px;
+    padding: 4px 8px;
+    font-size: 13px;
+}
+
+.cl-filter-bar .select2-container {
+    width: 180px !important;
+}
+
+.cl-filter-bar .select2-container .select2-selection {
+    height: 30px;
+    min-height: 30px;
+}
+
+.cl-filter-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--body-color, #555);
+    margin-right: 4px;
+}
+
+/* ==========================================================================
+   Clear button for individual select2 dropdowns
+   ========================================================================== */
+
+.cl-clear-select {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--color-danger, #FF4A4A);
+    padding: 0 2px;
+    margin-left: -2px;
+    margin-right: 4px;
+    opacity: 0.6;
+}
+
+.cl-clear-select:hover {
+    opacity: 1;
+}
+
+/* ==========================================================================
+   Monitoring status badges (real-time host/poller status)
+   ========================================================================== */
+
+.cl-mon-badge {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.cl-mon-up {
+    background: var(--color-success, #88B922);
+    box-shadow: 0 0 4px var(--color-success, #88B922);
+}
+
+.cl-mon-down {
+    background: var(--color-danger, #FF4A4A);
+    box-shadow: 0 0 4px var(--color-danger, #FF4A4A);
+}
+
+.cl-mon-unreach {
+    background: var(--color-aluminium, #818285);
+    box-shadow: 0 0 4px var(--color-aluminium, #818285);
+}
+
+.cl-mon-warning {
+    background: var(--color-warning, #FD9B27);
+    box-shadow: 0 0 4px var(--color-warning, #FD9B27);
+}
+
+.cl-mon-unknown {
+    background: var(--color-aluminium, #818285);
+    box-shadow: 0 0 4px var(--color-aluminium, #818285);
+}
+
+.cl-mon-pending {
+    background: var(--color-pending, #1EBEB3);
+    box-shadow: 0 0 4px var(--color-pending, #1EBEB3);
+}
+
+/* ==========================================================================
+   Stale last-update highlight (pollers)
+   ========================================================================== */
+
+.cl-stale {
+    background-color: #F7D507 !important;
+    color: #333 !important;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+/* ==========================================================================
+   Trap status colors
+   ========================================================================== */
+
+.cl-status-ok { color: var(--color-success, #88B922); }
+.cl-status-warning { color: var(--color-warning, #FD9B27); }
+.cl-status-critical { color: var(--color-danger, #FF4A4A); }
+.cl-status-unknown { color: var(--color-aluminium, #818285); }
+.cl-status-pending { color: var(--color-pending, #1EBEB3); }
+
+/* ==========================================================================
+   Infinite scroll wrapper (full-height flex layout)
+   ========================================================================== */
+
+.cl-scroll-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 60px);
+    overflow: hidden;
+}
+.cl-scroll-wrapper .cl-filter-box,
+.cl-scroll-wrapper .cl-actions-bar {
+    flex-shrink: 0;
+}
+.cl-scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+}
+.cl-scroll-area table {
+    width: 100%;
+}
+.cl-scroll-area .cl-listing-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--table-header-background, #6b7888);
+}
+
+/* ==========================================================================
+   Expand button (inline detail toggle: +/− in listing rows)
+   ========================================================================== */
+
+.cl-expand-btn {
+    cursor: pointer;
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    background: var(--color-divider, #e8e8e8);
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+}
+.cl-expand-btn:hover {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cl-expand-btn.open {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cl-expand-btn.disabled {
+    cursor: default;
+    opacity: 0.3;
+    pointer-events: none;
+}
+
+/* ==========================================================================
+   Inline detail row (expanded diff inside listing)
+   ========================================================================== */
+
+.cl-detail-row td {
+    padding: 0 !important;
+    background: var(--body-background, #f9f9f9);
+}
+.cl-diff-container {
+    margin: 6px 16px 10px 36px;
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: 12px;
+}
+.cl-diff-header {
+    display: flex;
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.cl-diff-header span {
+    flex: 1;
+    padding: 6px 10px;
+}
+.cl-diff-header span:first-child {
+    flex: 0 0 200px;
+}
+.cl-diff-row {
+    display: flex;
+    border-bottom: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-row:last-child {
+    border-bottom: none;
+}
+.cl-diff-row:hover {
+    background: rgba(0,0,0,0.02);
+}
+.cl-diff-field {
+    flex: 0 0 200px;
+    padding: 5px 10px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+    word-break: break-all;
+    border-right: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-before, .cl-diff-after {
+    flex: 1;
+    padding: 5px 10px;
+    word-break: break-all;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cl-diff-before {
+    background: rgba(255, 74, 74, 0.06);
+    color: #c0392b;
+    border-right: 1px solid var(--color-divider, #eee);
+}
+.cl-diff-after {
+    background: rgba(39, 174, 96, 0.06);
+    color: #27ae60;
+}
+.cl-diff-before:empty, .cl-diff-after:empty {
+    background: transparent;
+}
+.cl-diff-empty {
+    padding: 12px 16px;
+    color: #a7a9ac;
+    font-style: italic;
+    text-align: center;
+}
+.cl-diff-loading {
+    padding: 12px 16px;
+    text-align: center;
+    color: #a7a9ac;
+}
+
+/* ==========================================================================
+   Changelog detail page — Timeline layout (cld- prefix)
+   ========================================================================== */
+
+.cld-wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 16px 20px;
+}
+
+/* Header card */
+.cld-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 8px;
+    padding: 16px 24px;
+    margin-bottom: 24px;
+}
+.cld-header-info {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+.cld-header-icon {
+    width: 42px;
+    height: 42px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #3a7bbf, #2c5f8f);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 18px;
+    flex-shrink: 0;
+}
+.cld-header-text h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--list-color, #333);
+}
+.cld-header-text .cld-subtitle {
+    margin: 2px 0 0;
+    font-size: 12px;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.cld-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    border-radius: 6px;
+    background: var(--color-divider, #e8e8e8);
+    color: var(--list-color, #555);
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 500;
+    transition: background 0.15s;
+}
+.cld-back-btn:hover {
+    background: #3a7bbf;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* Timeline */
+.cld-timeline {
+    position: relative;
+    padding-left: 40px;
+}
+.cld-timeline::before {
+    content: '';
+    position: absolute;
+    left: 15px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--color-divider, #ddd);
+    border-radius: 1px;
+}
+.cld-entry {
+    position: relative;
+    margin-bottom: 16px;
+}
+.cld-entry:last-child {
+    margin-bottom: 0;
+}
+
+/* Timeline dot */
+.cld-dot {
+    position: absolute;
+    left: -33px;
+    top: 16px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 2px var(--color-divider, #ddd);
+}
+.cld-dot.dot-create  { background: #27ae60; box-shadow: 0 0 0 2px #27ae60; }
+.cld-dot.dot-change  { background: #e67e22; box-shadow: 0 0 0 2px #e67e22; }
+.cld-dot.dot-delete  { background: #e74c3c; box-shadow: 0 0 0 2px #e74c3c; }
+.cld-dot.dot-enable  { background: #27ae60; box-shadow: 0 0 0 2px #27ae60; }
+.cld-dot.dot-disable { background: #e74c3c; box-shadow: 0 0 0 2px #e74c3c; }
+
+/* Entry card */
+.cld-card {
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #ddd);
+    border-radius: 8px;
+    overflow: hidden;
+    transition: box-shadow 0.15s;
+}
+.cld-card:hover {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+.cld-card-header {
+    display: flex;
+    align-items: center;
+    padding: 12px 16px;
+    gap: 12px;
+    cursor: pointer;
+    user-select: none;
+}
+.cld-card-header:hover {
+    background: rgba(0,0,0,0.015);
+}
+.cld-card-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    background: var(--color-divider, #e8e8e8);
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+}
+.cld-card-header:hover .cld-card-toggle {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cld-card-toggle.open {
+    background: #3a7bbf;
+    color: #fff;
+}
+.cld-card-toggle.no-expand {
+    opacity: 0.2;
+    cursor: default;
+    pointer-events: none;
+}
+.cld-card-date {
+    font-size: 13px;
+    color: #888;
+    white-space: nowrap;
+    min-width: 130px;
+}
+.cld-card-badge {
+    flex-shrink: 0;
+}
+.cld-card-author {
+    font-size: 12px;
+    color: #999;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
+/* Diff panel (inside timeline cards) */
+.cld-diff-panel {
+    display: none;
+    border-top: 1px solid var(--color-divider, #eee);
+}
+.cld-diff-panel.open {
+    display: block;
+}
+.cld-diff-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.cld-diff-table th {
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 7px 12px;
+    text-align: left;
+}
+.cld-diff-table td {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--color-divider, #eee);
+    vertical-align: top;
+    word-break: break-all;
+}
+.cld-diff-table tr:last-child td {
+    border-bottom: none;
+}
+.cld-diff-table .cld-fname {
+    width: 220px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+}
+.cld-diff-table .cld-fbefore {
+    background: rgba(255, 74, 74, 0.05);
+    color: #c0392b;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cld-diff-table .cld-fafter {
+    background: rgba(39, 174, 96, 0.05);
+    color: #27ae60;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 11px;
+}
+.cld-no-changes {
+    padding: 14px 16px;
+    color: #aaa;
+    font-style: italic;
+    text-align: center;
+    font-size: 12px;
+}

--- a/centreon/www/include/common/listing/listing.js
+++ b/centreon/www/include/common/listing/listing.js
@@ -1,0 +1,639 @@
+/*
+ * CentreonListing - Reusable AJAX listing module
+ *
+ * Provides AJAX-driven data tables for Centreon configuration pages,
+ * replacing legacy Smarty server-side rendered listings.
+ *
+ * Usage:
+ *   var listing = new CentreonListing({ ... });
+ *   listing.init();
+ *
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Licensed under the Apache License, Version 2.0
+ */
+
+function CentreonListing(config) {
+
+    // =====================================================================
+    // Configuration (with defaults)
+    // =====================================================================
+
+    var cfg = {
+        // DOM element IDs
+        tableBodyId:        config.tableBodyId        || 'clTableBody',
+        paginationTopId:    config.paginationTopId    || 'clPaginationTop',
+        paginationBottomId: config.paginationBottomId || 'clPaginationBottom',
+        searchInputId:      config.searchInputId      || 'clSearchInput',
+        searchBtnId:        config.searchBtnId        || 'clSearchBtn',
+        limitInputId:       config.limitInputId       || 'limit',
+
+        // AJAX endpoints
+        ajaxListUrl:   config.ajaxListUrl   || '',
+        ajaxToggleUrl: config.ajaxToggleUrl || '',
+
+        // Page identity
+        pageId:      config.pageId      || '',
+        writeAccess: config.writeAccess || false,
+        storageKey:  config.storageKey  || 'cl_listing_limit',
+
+        // Behaviour
+        defaultLimit: config.defaultLimit || 30,
+        autoRefresh:  config.autoRefresh !== undefined ? config.autoRefresh : 30000,
+        emptyMessage: config.emptyMessage || 'No items found',
+
+        // Column definitions
+        // Each column: { id, header, align, render: function(row, listing) }
+        columns: config.columns || [],
+
+        // Row identity field (used for checkboxes, toggle, duplication)
+        rowIdField: config.rowIdField || 'id',
+
+        // Activate field name in row data (for toggle)
+        activateField: config.activateField || 'activate',
+
+        // Edit link builder: function(row) -> URL string
+        editLink: config.editLink || null,
+
+        // Options column renderer (toggle + dup input) — null to hide
+        // function(row, listing) -> HTML string
+        renderOptions: config.renderOptions || null,
+
+        // Extra GET parameters appended to every fetch request
+        extraParams: config.extraParams || {},
+
+        // Show row checkboxes (default true)
+        showCheckboxes: config.showCheckboxes !== undefined ? config.showCheckboxes : true,
+
+        // Field name in row data that indicates a locked/non-selectable row (checkbox disabled)
+        lockedField: config.lockedField || null,
+
+        // Infinite scroll mode (default false) — appends rows on scroll instead of pagination
+        infiniteScroll: config.infiniteScroll || false,
+        infiniteScrollBuffer: config.infiniteScrollBuffer || 600, // px from bottom to trigger load
+        scrollContainerId: config.scrollContainerId || null, // custom scroll container for infinite scroll
+
+        // Callbacks
+        onDataLoaded: config.onDataLoaded || null,
+    };
+
+    // =====================================================================
+    // Internal state
+    // =====================================================================
+
+    var self       = this;
+    var csrfToken  = '';
+    var firstLoad  = true;
+
+    // Restore state from sessionStorage (survives navigation, cleared on browser close)
+    var stateKey   = 'cl_state_' + cfg.storageKey;
+    var savedState = null;
+    try { savedState = JSON.parse(sessionStorage.getItem(stateKey)); } catch(e) {}
+
+    var currentNum    = (savedState && typeof savedState.num === 'number') ? savedState.num : 0;
+    var currentLimit  = parseInt(localStorage.getItem(cfg.storageKey), 10) || (savedState && savedState.limit) || cfg.defaultLimit;
+    var currentSearch = (savedState && savedState.search) || '';
+
+    // Infinite scroll state
+    var isLoadingMore  = false;
+    var allLoaded      = false;
+    var totalLoaded    = 0;
+
+    // =====================================================================
+    // Public: HTML escape utility
+    // =====================================================================
+
+    this.escape = function (str) {
+        if (!str) return '';
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    };
+
+    // =====================================================================
+    // Public: get current CSRF token
+    // =====================================================================
+
+    this.getCsrfToken = function () {
+        return csrfToken;
+    };
+
+    this.setCsrfToken = function (token) {
+        csrfToken = token;
+    };
+
+    // =====================================================================
+    // Public: get current state
+    // =====================================================================
+
+    this.getState = function () {
+        return { num: currentNum, limit: currentLimit, search: currentSearch };
+    };
+
+    // =====================================================================
+    // Internal: save / restore checked row checkboxes
+    // =====================================================================
+
+    function getCheckedIds() {
+        var ids = [];
+        jQuery('#' + cfg.tableBodyId + ' .cl-col-picker input[type=checkbox]:checked').each(function () {
+            var name = jQuery(this).attr('name');
+            if (name) ids.push(name);
+        });
+        return ids;
+    }
+
+    function restoreCheckedIds(ids) {
+        for (var i = 0; i < ids.length; i++) {
+            jQuery('#' + cfg.tableBodyId + ' input[name="' + ids[i] + '"]').prop('checked', true);
+        }
+    }
+
+    // =====================================================================
+    // Public: fetch data from the AJAX listing endpoint
+    //   silent = true  → no loading indicator, no fade (used by auto-refresh)
+    //   silent = false → fade-in animation on success
+    // =====================================================================
+
+    this.fetch = function (num, limit, search, silent) {
+        var isAppend = cfg.infiniteScroll && num > 0 && !firstLoad;
+
+        currentNum    = num;
+        currentLimit  = limit;
+        currentSearch = search;
+
+        // Persist state to sessionStorage (including extra filter params + select2 labels)
+        try {
+            var extra = typeof cfg.extraParams === 'function' ? cfg.extraParams() : cfg.extraParams;
+            var labels = {};
+            if (extra) {
+                jQuery.each(extra, function(key, val) {
+                    if (val) {
+                        var el = jQuery('#' + key);
+                        if (el.length && el.is('select')) {
+                            labels[key] = el.find('option:selected').text() || val;
+                        }
+                    }
+                });
+            }
+            sessionStorage.setItem(stateKey, JSON.stringify({ num: num, limit: limit, search: search, extra: extra || {}, labels: labels }));
+        } catch(e) {}
+
+        var checkedIds = getCheckedIds();
+
+        if (firstLoad) {
+            jQuery('#' + cfg.tableBodyId).html(
+                '<tr><td colspan="99" class="cl-loading">Loading...</td></tr>'
+            );
+        }
+
+        if (isAppend) {
+            isLoadingMore = true;
+            // Show loading indicator at bottom
+            jQuery('#' + cfg.tableBodyId).find('.cl-infinite-loader').remove();
+            jQuery('#' + cfg.tableBodyId).append(
+                '<tr class="cl-infinite-loader"><td colspan="99" style="text-align:center;padding:12px;color:#a7a9ac;">Loading more...</td></tr>'
+            );
+        }
+
+        jQuery.ajax({
+            url: cfg.ajaxListUrl,
+            type: 'GET',
+            dataType: 'json',
+            data: jQuery.extend({ search: search, num: num, limit: limit }, typeof cfg.extraParams === 'function' ? cfg.extraParams() : cfg.extraParams),
+            success: function (data) {
+                csrfToken = data.centreon_token || '';
+                var tbody = jQuery('#' + cfg.tableBodyId);
+
+                if (cfg.infiniteScroll && isAppend) {
+                    // Remove loader row
+                    tbody.find('.cl-infinite-loader').remove();
+                    // Append new rows
+                    self.appendRows(data.rows);
+                    totalLoaded += data.rows.length;
+                    allLoaded = totalLoaded >= data.total;
+                    isLoadingMore = false;
+                    // Update info
+                    self.renderScrollInfo(totalLoaded, data.total);
+                } else {
+                    tbody.removeClass('cl-fade-in');
+                    self.renderRows(data.rows);
+                    if (cfg.infiniteScroll) {
+                        totalLoaded = data.rows.length;
+                        allLoaded = totalLoaded >= data.total;
+                        isLoadingMore = false;
+                        self.renderScrollInfo(totalLoaded, data.total);
+                    } else {
+                        self.renderPagination(data.total, data.num, data.limit);
+                    }
+                    restoreCheckedIds(checkedIds);
+                    jQuery('#' + cfg.limitInputId).val(data.limit);
+                    if (!silent) {
+                        void tbody[0].offsetWidth;
+                        tbody.addClass('cl-fade-in');
+                    }
+                }
+                firstLoad = false;
+                // Reset bulk action dropdowns to default
+                jQuery('select[name="o1"], select[name="o2"]').prop('selectedIndex', 0);
+                if (cfg.onDataLoaded) cfg.onDataLoaded(data);
+            },
+            error: function () {
+                isLoadingMore = false;
+                jQuery('#' + cfg.tableBodyId).find('.cl-infinite-loader').remove();
+                if (firstLoad) {
+                    jQuery('#' + cfg.tableBodyId).html(
+                        '<tr><td colspan="99" style="text-align:center;padding:24px;color:#FF4A4A;">Error loading data</td></tr>'
+                    );
+                }
+            }
+        });
+    };
+
+    // =====================================================================
+    // Public: render table body rows from data
+    // =====================================================================
+
+    this.renderRows = function (rows) {
+        // Allow custom renderRows from config
+        if (typeof cfg.renderRows === 'function') {
+            cfg.renderRows.call(self, rows);
+            return;
+        }
+
+        var tbody = jQuery('#' + cfg.tableBodyId);
+        tbody.empty();
+
+        if (!rows || rows.length === 0) {
+            tbody.html('<tr><td colspan="99" style="text-align:center;padding:24px;color:#a7a9ac;">' +
+                self.escape(cfg.emptyMessage) + '</td></tr>');
+            return;
+        }
+
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var rowId = row[cfg.rowIdField];
+
+            // Checkbox cell (optional)
+            var isLocked = cfg.lockedField && row[cfg.lockedField];
+            var tr = '<tr>';
+            if (cfg.showCheckboxes) {
+                var disabledAttr = isLocked ? ' disabled' : '';
+                tr += '<td class="cl-col-picker">' +
+                    '<div class="md-checkbox md-checkbox-inline">' +
+                        '<input type="checkbox" id="select_' + rowId + '" name="select[' + rowId + ']" value="1"' + disabledAttr + ' />' +
+                        '<label class="empty-label" for="select_' + rowId + '"></label>' +
+                    '</div>' +
+                '</td>';
+            }
+
+            // Data columns
+            for (var c = 0; c < cfg.columns.length; c++) {
+                var col = cfg.columns[c];
+                var align = col.align ? ' class="cl-col-' + col.align + '"' : '';
+                var cellHtml = col.render ? col.render(row, self) : self.escape(row[col.id] || '');
+                tr += '<td' + align + '>' + cellHtml + '</td>';
+            }
+
+            // Options column (always rendered; if read-only, toggle is disabled and dup input hidden)
+            if (cfg.renderOptions) {
+                var optHtml = cfg.renderOptions(row, self, cfg.writeAccess);
+                if (!cfg.writeAccess) {
+                    // Disable toggles and hide dup inputs for read-only users
+                    optHtml = optHtml.replace(/onchange="[^"]*"/g, '').replace(/<input[^>]*cl-dup-input[^>]*>/g, '');
+                    optHtml = optHtml.replace(/<input type="checkbox"/g, '<input type="checkbox" disabled');
+                }
+                tr += '<td class="cl-col-right"><div class="cl-options-cell">' + optHtml + '</div></td>';
+            }
+
+            tr += '</tr>';
+            tbody.append(tr);
+        }
+    };
+
+    // =====================================================================
+    // Public: append rows (infinite scroll mode — adds to existing tbody)
+    // =====================================================================
+
+    this.appendRows = function (rows) {
+        if (!rows || rows.length === 0) return;
+
+        var tbody = jQuery('#' + cfg.tableBodyId);
+        for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var rowId = row[cfg.rowIdField];
+            var isLocked = cfg.lockedField && row[cfg.lockedField];
+
+            var tr = '<tr>';
+            if (cfg.showCheckboxes) {
+                var disabledAttr = isLocked ? ' disabled' : '';
+                tr += '<td class="cl-col-picker">' +
+                    '<div class="md-checkbox md-checkbox-inline">' +
+                        '<input type="checkbox" id="select_' + rowId + '" name="select[' + rowId + ']" value="1"' + disabledAttr + ' />' +
+                        '<label class="empty-label" for="select_' + rowId + '"></label>' +
+                    '</div>' +
+                '</td>';
+            }
+
+            for (var c = 0; c < cfg.columns.length; c++) {
+                var col = cfg.columns[c];
+                var align = col.align ? ' class="cl-col-' + col.align + '"' : '';
+                var cellHtml = col.render ? col.render(row, self) : self.escape(row[col.id] || '');
+                tr += '<td' + align + '>' + cellHtml + '</td>';
+            }
+
+            if (cfg.renderOptions) {
+                var optHtml = cfg.renderOptions(row, self, cfg.writeAccess);
+                if (!cfg.writeAccess) {
+                    optHtml = optHtml.replace(/onchange="[^"]*"/g, '').replace(/<input[^>]*cl-dup-input[^>]*>/g, '');
+                    optHtml = optHtml.replace(/<input type="checkbox"/g, '<input type="checkbox" disabled');
+                }
+                tr += '<td class="cl-col-right"><div class="cl-options-cell">' + optHtml + '</div></td>';
+            }
+
+            tr += '</tr>';
+            tbody.append(tr);
+        }
+    };
+
+    // =====================================================================
+    // Public: render scroll info (infinite scroll mode)
+    // =====================================================================
+
+    this.renderScrollInfo = function (loaded, total) {
+        var html = '<span class="cl-page-info">' + loaded + ' / ' + total + '</span>';
+        if (!allLoaded) {
+            html += '<span style="color:#a7a9ac;margin-left:8px;font-size:11px;">Scroll for more</span>';
+        }
+        jQuery('#' + cfg.paginationTopId).html(html);
+        jQuery('#' + cfg.paginationBottomId).html(html);
+    };
+
+    // =====================================================================
+    // Public: reset infinite scroll (used on filter change)
+    // =====================================================================
+
+    this.resetScroll = function () {
+        totalLoaded = 0;
+        allLoaded = false;
+        isLoadingMore = false;
+        currentNum = 0;
+        self.fetch(0, currentLimit, currentSearch);
+    };
+
+    // =====================================================================
+    // Public: render pagination controls
+    // =====================================================================
+
+    this.renderPagination = function (total, num, limit) {
+        var totalPages = Math.ceil(total / limit);
+        if (totalPages < 1) totalPages = 1;
+
+        var startRow = total > 0 ? num * limit + 1 : 0;
+        var endRow   = Math.min((num + 1) * limit, total);
+        var info     = startRow + '-' + endRow + ' of ' + total;
+
+        var html = '';
+
+        // First / Previous
+        if (num > 0) {
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(0);return false;">'
+                + '<img src="./img/icons/first_rewind.png" title="First page" /></a>';
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (num - 1) + ');return false;">'
+                + '<img src="./img/icons/rewind.png" title="Previous page" /></a>';
+        }
+
+        // Page numbers
+        var startPage = Math.max(0, num - 5);
+        var endPage   = Math.min(totalPages - 1, num + 5);
+        for (var i = startPage; i <= endPage; i++) {
+            if (i === num) {
+                html += '<span class="cl-page-current">' + (i + 1) + '</span>';
+            } else {
+                html += '<a href="#" class="cl-page-num" onclick="' + instanceName() + '.goToPage(' + i + ');return false;">'
+                    + (i + 1) + '</a>';
+            }
+        }
+
+        // Next / Last
+        if (num < totalPages - 1) {
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (num + 1) + ');return false;">'
+                + '<img src="./img/icons/fast_forward.png" title="Next page" /></a>';
+            html += '<a href="#" class="cl-page-nav" onclick="' + instanceName() + '.goToPage(' + (totalPages - 1) + ');return false;">'
+                + '<img src="./img/icons/end_forward.png" title="Last page" /></a>';
+        }
+
+        // Rows-per-page selector
+        html += ' <select class="cl-limit-select" onchange="' + instanceName() + '.changeLimit(this.value);">';
+        var limits = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+        for (var j = 0; j < limits.length; j++) {
+            var sel = limits[j] === limit ? ' selected' : '';
+            html += '<option value="' + limits[j] + '"' + sel + '>' + limits[j] + '</option>';
+        }
+        html += '</select>';
+
+        // Row count info
+        html += '<span class="cl-page-info">' + info + '</span>';
+
+        jQuery('#' + cfg.paginationTopId).html(html);
+        jQuery('#' + cfg.paginationBottomId).html(html);
+    };
+
+    // =====================================================================
+    // Public: navigation helpers
+    // =====================================================================
+
+    this.goToPage = function (num) {
+        self.fetch(num, currentLimit, currentSearch);
+    };
+
+    this.changeLimit = function (limit) {
+        var newLimit = parseInt(limit, 10);
+        localStorage.setItem(cfg.storageKey, newLimit);
+        self.fetch(0, newLimit, currentSearch); // reset to page 0 on limit change
+    };
+
+    // =====================================================================
+    // Public: toggle activation (enable/disable via AJAX)
+    // =====================================================================
+
+    this.toggleActivation = function (toggle) {
+        if (!cfg.ajaxToggleUrl) return;
+
+        var rowId    = jQuery(toggle).data('row-id');
+        var isChecked = toggle.checked;
+        var action   = isChecked ? 's' : 'u';
+
+        toggle.disabled = true;
+
+        jQuery.ajax({
+            url: cfg.ajaxToggleUrl,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                id: rowId,
+                action: action,
+                centreon_token: csrfToken
+            },
+            success: function (response) {
+                if (response.centreon_token) {
+                    csrfToken = response.centreon_token;
+                }
+                toggle.disabled = false;
+            },
+            error: function () {
+                toggle.checked = !isChecked;
+                toggle.disabled = false;
+            }
+        });
+    };
+
+    // =====================================================================
+    // Public: select / deselect all row checkboxes
+    // =====================================================================
+
+    this.checkUncheckAll = function (masterCheckbox) {
+        var table = jQuery(masterCheckbox).closest('table');
+        table.find('tbody .cl-col-picker input[type=checkbox]').each(function () {
+            jQuery(this).prop('checked', masterCheckbox.checked);
+        });
+    };
+
+    // =====================================================================
+    // Public: initialise (first load, bind events, auto-refresh)
+    // =====================================================================
+
+    this.init = function () {
+        // Restore search value from session state (overrides Smarty default if different)
+        if (currentSearch) {
+            jQuery('#' + cfg.searchInputId).val(currentSearch);
+        } else {
+            currentSearch = jQuery('#' + cfg.searchInputId).val() || '';
+        }
+
+        // Restore extra filter params (select2 dropdowns) from session state
+        if (savedState && savedState.extra) {
+            var labels = savedState.labels || {};
+            jQuery.each(savedState.extra, function(key, val) {
+                if (val) {
+                    var el = jQuery('#' + key);
+                    if (el.length && el.is('select')) {
+                        var text = labels[key] || val;
+                        if (!el.find('option[value="' + val + '"]').length) {
+                            el.append(new Option(text, val, true, true));
+                        } else {
+                            el.val(val);
+                        }
+                        el.trigger('change');
+                    }
+                }
+            });
+        }
+
+        // Search button (resets to page 0; in infinite scroll mode, resets scroll state)
+        jQuery('#' + cfg.searchBtnId).on('click', function () {
+            currentSearch = jQuery('#' + cfg.searchInputId).val();
+            if (cfg.infiniteScroll) {
+                self.resetScroll();
+            } else {
+                self.fetch(0, currentLimit, currentSearch);
+            }
+        });
+
+        // Search on Enter key
+        jQuery('#' + cfg.searchInputId).on('keypress', function (e) {
+            if (e.which === 13) {
+                e.preventDefault();
+                jQuery('#' + cfg.searchBtnId).click();
+            }
+        });
+
+        // In infinite scroll mode, always start at page 0 and use a larger batch size
+        if (cfg.infiniteScroll) {
+            currentNum = 0;
+            if (currentLimit < 50) currentLimit = 50;
+        }
+
+        // Initial data load (restore page from session)
+        self.fetch(currentNum, currentLimit, currentSearch);
+
+        // Infinite scroll: listen for scroll on the specified container or window
+        if (cfg.infiniteScroll) {
+            var scrollParent;
+            if (cfg.scrollContainerId) {
+                scrollParent = jQuery('#' + cfg.scrollContainerId);
+            } else {
+                scrollParent = jQuery('#main-content');
+                if (!scrollParent.length) scrollParent = jQuery(window);
+            }
+
+            scrollParent.on('scroll', function () {
+                if (isLoadingMore || allLoaded) return;
+
+                var scrollTop, scrollHeight, clientHeight;
+                if (scrollParent.is(jQuery(window))) {
+                    scrollTop = jQuery(window).scrollTop();
+                    scrollHeight = jQuery(document).height();
+                    clientHeight = jQuery(window).height();
+                } else {
+                    scrollTop = scrollParent.scrollTop();
+                    scrollHeight = scrollParent[0].scrollHeight;
+                    clientHeight = scrollParent[0].clientHeight;
+                }
+
+                if (scrollTop + clientHeight >= scrollHeight - cfg.infiniteScrollBuffer) {
+                    currentNum++;
+                    self.fetch(currentNum, currentLimit, currentSearch, true);
+                }
+            });
+        }
+
+        // Auto-refresh (disabled in infinite scroll mode to avoid resetting the list)
+        if (cfg.autoRefresh > 0 && !cfg.infiniteScroll) {
+            setInterval(function () {
+                self.fetch(currentNum, currentLimit, currentSearch, true);
+            }, cfg.autoRefresh);
+        }
+    };
+
+    // =====================================================================
+    // Internal: resolve the global variable name for onclick handlers
+    // =====================================================================
+
+    var _instanceName = config.instanceName || null;
+
+    function instanceName() {
+        if (_instanceName) return _instanceName;
+        // Fallback: search window properties
+        for (var key in window) {
+            if (window[key] === self) {
+                _instanceName = key;
+                return key;
+            }
+        }
+        return 'this';
+    }
+}
+
+// ==========================================================================
+// Global instant tooltip for [data-cl-tooltip] elements
+// Positioned fixed in body — no overflow clipping, no delay
+// Usage: <span data-cl-tooltip="PID: 123<br>Uptime: 2d">ⓘ</span>
+// ==========================================================================
+(function () {
+    var tip = null;
+    jQuery(document).on('mouseenter', '[data-cl-tooltip]', function () {
+        var content = jQuery(this).attr('data-cl-tooltip');
+        if (!content) return;
+        tip = jQuery('<div class="cl-tooltip-popup">' + content + '</div>');
+        jQuery('body').append(tip);
+        var rect = this.getBoundingClientRect();
+        var top = rect.top - tip.outerHeight() - 6;
+        if (top < 0) top = rect.bottom + 6;
+        tip.css({
+            top: top + 'px',
+            left: (rect.left + rect.width / 2 - tip.outerWidth() / 2) + 'px'
+        });
+    }).on('mouseleave', '[data-cl-tooltip]', function () {
+        if (tip) { tip.remove(); tip = null; }
+    });
+})();

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -110,6 +110,10 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
     <link href="./include/common/javascript/jquery/plugins/colorbox/colorbox.css" rel="stylesheet" type="text/css"/>
     <link href="./include/common/javascript/jquery/plugins/qtip/jquery-qtip.css" rel="stylesheet" type="text/css"/>
 
+    <!-- Modern listing styles and JS module -->
+    <link href="./include/common/listing/listing.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css" />
+    <script type="text/javascript" src="./include/common/listing/listing.js<?php echo $versionParam; ?>"></script>
+
     <!-- graph css -->
     <link href="./include/common/javascript/charts/c3.min.css" type="text/css" rel="stylesheet" />
     <link href="./include/views/graphs/javascript/centreon-status-chart.css" type="text/css" rel="stylesheet" />

--- a/centreon/www/include/views/graphTemplates/ajaxGraphTemplatesListing.php
+++ b/centreon/www/include/views/graphTemplates/ajaxGraphTemplatesListing.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB = $helper->getDb();
+$params = $helper->getParams();
+
+$search = $params['search'];
+$num = $params['num'];
+$limit = $params['limit'];
+
+$cond = '';
+$bind = [];
+if ($search !== '') {
+    $cond = ' WHERE name LIKE :search';
+    $bind[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS graph_id, name, vertical_label, base, split_component '
+    . 'FROM giv_graphs_template' . $cond . ' ORDER BY name LIMIT :offset, :limit'
+);
+foreach ($bind as $key => $value) {
+    $statement->bindValue($key, $value, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($graph = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id' => (int) $graph['graph_id'],
+        'name' => $graph['name'],
+        'desc' => $graph['vertical_label'],
+        'base' => $graph['base'],
+        'split' => ((int) $graph['split_component']) ? _('Yes') : _('No'),
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/views/graphTemplates/listGraphTemplates.ihtml
+++ b/centreon/www/include/views/graphTemplates/listGraphTemplates.ihtml
@@ -1,62 +1,135 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch (e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Graph template{/t}</h4></td>
-        </tr>
-        <tr>
-            <td>
-                <input type="text" name="searchGT" value="{$searchGT}" class="mr-1">{$form.Search.html}
-            </td>
-        </tr>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
+    <h1 class="cl-page-title">{t}Graph templates{/t}</h1>
+    <hr class="cl-title-sep">
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$gtPage}&o=a', '{t}Add a graph template{/t}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_base}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_split_component}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft">{$elemArr[elem].RowMenu_desc}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_base}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_split_component}</td>
-            <td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
-                {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchGT" value="{$searchGT}" placeholder="{t}Name{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="gtListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th class="cl-col-center">{$headerMenu_base}</th>
+                    <th class="cl-col-center">{$headerMenu_split_component}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="6" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>  
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
+{literal}
+<script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    gtListing.fetch(gtListing.getState().num, gtListing.getState().limit, gtListing.getState().search, true);
+}
+(function () {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function (e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function (e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function () {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
+
+var gtListing = new CentreonListing({
+    instanceName: 'gtListing',
+    ajaxListUrl:  './include/views/graphTemplates/ajaxGraphTemplatesListing.php',
+    pageId:       {/literal}'{$gtPage}'{literal},
+    writeAccess:  {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit: {/literal}{$defaultLimit}{literal},
+    storageKey:   'graphtemplate_listing_limit',
+    emptyMessage: 'No graph templates found',
+    rowIdField:   'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var editUrl = 'main.get.php?p={/literal}{$gtPage}{literal}&o=c&graph_id=' + row.id;
+            var ptitle = '{/literal}{t}Modify a graph template{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(ptitle)+'\'); return false;">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'desc' },
+        { id:'base', align:'center' },
+        { id:'split', align:'center' }
+    ],
+    renderOptions: function(row, l) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+gtListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/views/graphTemplates/listGraphTemplates.ihtml
+++ b/centreon/www/include/views/graphTemplates/listGraphTemplates.ihtml
@@ -70,42 +70,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    gtListing.fetch(gtListing.getState().num, gtListing.getState().limit, gtListing.getState().search, true);
-}
-(function () {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function (e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function (e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function () {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var gtListing = new CentreonListing({
     instanceName: 'gtListing',
@@ -131,5 +95,6 @@ var gtListing = new CentreonListing({
     }
 });
 gtListing.init();
+CentreonForm.initSidePanel(gtListing);
 </script>
 {/literal}

--- a/centreon/www/include/views/graphTemplates/listGraphTemplates.php
+++ b/centreon/www/include/views/graphTemplates/listGraphTemplates.php
@@ -24,128 +24,57 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$SearchTool = null;
-$queryValues = [];
-$search = null;
-
-if (isset($_POST['searchGT'])) {
-    $search = $_POST['searchGT'];
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($_GET['searchGT'])) {
-    $search = $_GET['searchGT'];
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if ($search) {
-    $SearchTool = ' WHERE name LIKE :search';
-    $queryValues['search'] = '%' . $search . '%';
-}
-
-$rq = 'SELECT SQL_CALC_FOUND_ROWS graph_id, name, default_tpl1, vertical_label, base, split_component FROM '
-    . 'giv_graphs_template gg ' . $SearchTool . ' ORDER BY name LIMIT ' . $num * $limit . ', ' . $limit;
-$stmt = $pearDB->prepare($rq);
-foreach ($queryValues as $key => $value) {
-    $stmt->bindValue(':' . $key, $value, PDO::PARAM_STR);
-}
-
-$stmt->execute();
-
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// start header menu
+// Access level
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
+// Column headers
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_desc', _('Description'));
 $tpl->assign('headerMenu_split_component', _('Split Components'));
 $tpl->assign('headerMenu_base', _('Base'));
-$tpl->assign('headerMenu_options', _('Options'));
 
-// List
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-// Different style between each lines
-$style = 'one';
+$tpl->assign('gtPage', $p);
 
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a mutlidimensionnal Array we put in $tpl
-$elemArr = [];
-for ($i = 0; $graph = $stmt->fetch(); $i++) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $graph['graph_id'] . ']');
-    $moptions = '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $graph['graph_id'] . "]' />";
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $graph['name'], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&graph_id=' . $graph['graph_id'], 'RowMenu_desc' => $graph['vertical_label'], 'RowMenu_base' => $graph['base'], 'RowMenu_split_component' => $graph['split_component'] ? _('Yes') : _('No'), 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
+// Restore search from history
+$search = '';
+if (isset($_POST['searchGT'])) {
+    $search = $_POST['searchGT'];
+} elseif (isset($centreon->historySearch[$url])) {
+    $search = $centreon->historySearch[$url];
 }
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('searchGT', htmlentities($search ?? '', ENT_QUOTES));
 
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
+// Default limit
+$dbResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-// Toolbar select
+// Form (bulk actions + search submit)
+$form = new HTML_QuickFormCustom('form', 'POST', '?p=' . $p);
+$form->addElement('submit', 'Search', _('Search'), ['class' => 'btc bt_success']);
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </SCRIPT>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
-$attrs1 = ['onchange' => 'javascript: '
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$form->setDefaults(['o1' => null]);
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-
 $attrs = ['onchange' => 'javascript: '
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o2' => null]);
+    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('" . _('Do you confirm the duplication ?') . "')) {"
+    . " setO(this.form.elements['o1'].value); submit();} "
+    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('" . _('Do you confirm the deletion ?') . "')) {"
+    . " setO(this.form.elements['o1'].value); submit();} "];
+$form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+$form->setDefaults(['o1' => null]);
+$form->getElement('o1')->setValue(null);
 
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
-
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 $tpl->assign('limit', $limit);
-$tpl->assign('searchGT', htmlentities($search));
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary

Modernize the **Graph templates** listing (*Monitoring > Performance > Graph
templates*), which had been missed by the listing modernization effort. It was
a legacy server-rendered table; this PR rebuilds it on the shared
**CentreonListing** AJAX framework, consistent with the other modernized
listings.

> Stacked on `feature/configuration-legacy-listing-shared-library` (the AJAX
> listing framework); the diff only shows the Graph templates files.
> The side panel relies on the form assets (form.js/form.css) loaded globally.

## What changed
- New `ajaxGraphTemplatesListing.php` endpoint (queries `giv_graphs_template`,
  returns JSON via `AjaxListingHelper`).
- Rebuilt `listGraphTemplates.ihtml` with the modern layout: object title,
  thin separator, inline search, **Actions** column, no bottom bar, and
  **Add / edit opening in the side panel**.
- `listGraphTemplates.php` now only assigns the view data (access level,
  headers, default limit, single `o1` bulk action Duplicate/Delete) — the row
  data is served by the AJAX endpoint.
- No activation toggle (graph templates have no enabled/disabled state).

## How to test
1. Go to **Monitoring > Performance > Graph templates**.
2. The list loads via AJAX; search and paginate.
3. Click **Add** or a row — the form opens in the side panel; on save/close the
   list refreshes.
4. Select rows and use **More actions > Duplicate / Delete**.
