### PR TITLE
fix(ci): delegate Pulp repo/distribution creation to create-repos

### DIFF
--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -71,13 +71,13 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
 fi
 
 if ! pulp deb repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-  echo "[INFO] Creating deb repository $REPOSITORY_NAME"
-  pulp deb repository create --name "$REPOSITORY_NAME" >/dev/null
+  echo "::error::deb repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
+  exit 1
 fi
 
 if ! pulp deb distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-  echo "[INFO] Creating deb distribution $REPOSITORY_NAME served at $BASE_PATH"
-  pulp deb distribution create --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME" >/dev/null
+  echo "::error::deb distribution $REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering. Refusing to create it here to avoid an unguarded distribution."
+  exit 1
 fi
 
 REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -84,13 +84,13 @@ for ARCH in noarch x86_64; do
   BASE_PATH="$BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp rpm repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm repository $REPOSITORY_NAME"
-    pulp rpm repository create --name "$REPOSITORY_NAME" --retain-package-versions 1 >/dev/null
+    echo "::error::rpm repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
+    exit 1
   fi
 
   if ! pulp rpm distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm distribution $REPOSITORY_NAME served at $BASE_PATH"
-    pulp rpm distribution create --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME" >/dev/null
+    echo "::error::rpm distribution $REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering. Refusing to create it here to avoid an unguarded distribution."
+    exit 1
   fi
 
   REPOSITORY_HREF=$(pulp rpm repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -76,16 +76,13 @@ for ARCH in noarch x86_64; do
   STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm repository $STABLE_REPOSITORY_NAME"
-    # no --retain-package-versions on stable: it keeps the full version history
-    # (unlike testing/unstable which retain only the latest), matching
-    # create-rpm-repos.sh. normally create-repos pre-creates it, this is a fallback.
-    pulp rpm repository create --name "$STABLE_REPOSITORY_NAME" >/dev/null
+    echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
+    exit 1
   fi
 
   if ! pulp rpm distribution show --name "$STABLE_REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm distribution $STABLE_REPOSITORY_NAME served at $STABLE_BASE_PATH"
-    pulp rpm distribution create --name "$STABLE_REPOSITORY_NAME" --base-path "$STABLE_BASE_PATH" --repository "$STABLE_REPOSITORY_NAME" >/dev/null
+    echo "::error::stable rpm distribution $STABLE_REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting. Refusing to create it here to avoid an unguarded distribution."
+    exit 1
   fi
 
   STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -6,8 +6,14 @@ if [[ -z "$MODULE_NAME" || -z "$DISTRIB" || -z "$VERSION" || -z "$STABILITY" || 
   exit 1
 fi
 
+# parse-distrib emits the el family either generically ("el") or per version
+# ("el7"/"el8"/"el9"/"el10" on centreon-collect); normalize it to "el" so the
+# family checks below are portable across both conventions.
 case "$DISTRIB_FAMILY" in
-  el) ROOT_REPO="rpm-standard" ;;
+  el | el[0-9]*)
+    ROOT_REPO="rpm-standard"
+    DISTRIB_FAMILY="el"
+    ;;
   debian) ROOT_REPO="apt-standard" ;;
   ubuntu) ROOT_REPO="ubuntu-standard" ;;
   *)

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -49,8 +49,12 @@ runs:
           exit 1
         fi
 
+        # retry on transient GitHub OIDC token service errors (5xx/timeouts):
+        # the endpoint occasionally returns 503, and a single blip must not break
+        # the whole delivery.
         PULP_TOKEN=$(
-          curl -fsSL -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             -G --data-urlencode "audience=$AUDIENCE" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value'
         )


### PR DESCRIPTION
## Description

Delegate all Pulp repository and distribution provisioning to delivery-tooling `create-repos`, and align the shared pulp files with centreon-collect.

### Repository/distribution creation is delegated to create-repos (fail-closed)

The Pulp delivery and promote scripts no longer create repositories or distributions. They now check that the target repository and distribution exist and fail closed if either is missing:
- `.github/actions/package-delivery-pulp/deliver-rpm.sh`
- `.github/actions/package-delivery-pulp/deliver-deb.sh`
- `.github/actions/promote-to-stable-pulp/promote-rpm.sh`

(`promote-deb.sh` already behaved this way.)

This ensures every repository and distribution (including business and internal ones) is created consistently in one place, with the same options (`--retain-package-versions`, guarded business distributions), instead of being auto-created ad hoc by the delivery jobs. The same change is applied to centreon-collect (centreon-collect#3549) and centreon-modules (centreon-modules#8791), and the delivery flow was validated end to end on those repositories with these exact scripts (identical files) against the create-repos-provisioned structure.

### Alignment with centreon-collect (shared pulp files kept byte-identical)

Backport two hardenings that landed on centreon-collect:
- **`setup-pulp-cli`**: retry the GitHub OIDC token request (`curl --retry 5 --retry-delay 3 --retry-all-errors`) — the token endpoint occasionally returns a transient `503`, and a single blip must not break the whole delivery.
- **`pulp-repository-properties`**: accept the per-version el `distrib_family` (`el8`/`el9`/`el10`) emitted by centreon-collect's `parse-distrib` and normalize it to `el`, making the script portable across the three repositories.

With this, the shared pulp actions/scripts are byte-identical across centreon, centreon-collect and centreon-modules (modules additionally carries a `repository_name` input for its business repositories).

## Note

`create-repos` must be run for a major version **before** delivering or promoting it (already executed for 26.09, onprem + cloud), otherwise delivery/promote fail closed with an actionable error (non-blocking during the migration).

Refs MON-200796
