### PR TITLE
fix(nagios): latest changes due to instance_id column migration to snowflake uid 64bits

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
@@ -368,8 +368,8 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
         $qb = $this->realTimeConnection->createQueryBuilder();
         $qb->select('i.cma_certificate_sha AS certificate_sha', 'i.cma_certificate_cn  AS certificate_cn')
             ->from('instances', 'i')
-            ->where('i.instance_id = :poller_id')
-            ->setParameter('poller_id', $poller->id()->value);
+            ->where('i.instance_id = :poller_uid')
+            ->setParameter('poller_uid', $poller->uid->value);
 
         $row = $qb->executeQuery()->fetchAssociative() ?: [];
         $certSha = ($row['certificate_sha'] ?? '') !== '' ? $row['certificate_sha'] : null;

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
@@ -170,7 +170,7 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
             }
         );
 
-        $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.id');
+        $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.uid');
         $whereCondition = false;
 
         // Search
@@ -190,7 +190,7 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
                 $instanceIds[] = $key;
                 $collector->addValue($key, $instanceId, \PDO::PARAM_INT);
             }
-            $request .= 'instances.instance_id IN (' . implode(', ', $instanceIds) . ')';
+            $request .= 'nagios_server.id IN (' . implode(', ', $instanceIds) . ')';
         }
 
         $request .= ($whereCondition ? ' AND ' : ' WHERE ') . 'instances.deleted = 0 AND nagios_server.ns_activate = 1';

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
@@ -385,9 +385,10 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
         $statement = $this->db->prepare($this->translateDbName(
             <<<'SQL'
                 SELECT 1
-                FROM `:dbstg`.`instances`
-                WHERE instance_id = :monitoringServerId
-                    AND is_encryption_ready = 1
+                FROM `:dbstg`.`instances` i
+                INNER JOIN `:db`.`nagios_server` ns ON ns.uid = i.instance_id
+                WHERE ns.id = :monitoringServerId
+                    AND i.is_encryption_ready = 1
                 SQL
         ));
         $statement->bindValue(':monitoringServerId', $monitoringServerId, \PDO::PARAM_INT);

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
@@ -126,7 +126,7 @@ class DbWriteMonitoringServerRepository extends AbstractRepositoryRDB implements
             <<<'SQL'
                 UPDATE `:db`.nagios_server ns
                     INNER JOIN `:dbstg`.instances i
-                    ON ns.id = i.instance_id
+                    ON ns.uid = i.instance_id
                 SET ns.is_encryption_ready = i.is_encryption_ready
                 SQL
         ));

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
@@ -204,10 +204,15 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
     private function insertInstance(int $pollerId, ?string $certificateSha, ?string $certificateCn): void
     {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        // instances.instance_id holds the Snowflake UID (nagios_server.uid), not the poller config id.
+        $instanceId = (int) $connection->fetchOne('SELECT uid FROM nagios_server WHERE id = ?', [$pollerId]);
+
         /** @var Connection $realtimeConnection */
         $realtimeConnection = self::getContainer()->get('doctrine.dbal.realtime_connection');
         $realtimeConnection->insert('instances', [
-            'instance_id' => $pollerId,
+            'instance_id' => $instanceId,
             'name' => 'test-instance-' . $pollerId,
             'cma_certificate_sha' => $certificateSha,
             'cma_certificate_cn' => $certificateCn,

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
@@ -207,7 +207,8 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
         /** @var Connection $connection */
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
         // instances.instance_id holds the Snowflake UID (nagios_server.uid), not the poller config id.
-        $instanceId = (int) $connection->fetchOne('SELECT uid FROM nagios_server WHERE id = ?', [$pollerId]);
+        $uid = $connection->fetchOne('SELECT uid FROM nagios_server WHERE id = ?', [$pollerId]);
+        $instanceId = is_numeric($uid) ? (int) $uid : 0;
 
         /** @var Connection $realtimeConnection */
         $realtimeConnection = self::getContainer()->get('doctrine.dbal.realtime_connection');

--- a/centreon/www/api/class/centreon_monitoring_poller.class.php
+++ b/centreon/www/api/class/centreon_monitoring_poller.class.php
@@ -59,8 +59,19 @@ class CentreonMonitoringPoller extends CentreonConfigurationObjects
 
         if (! $centreon->user->admin) {
             $acl = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
-            $queryPoller .= 'AND instances.instance_id IN ('
-                . $acl->getPollerString('ID', $this->pearDBMonitoring) . ') ';
+            // getPollerString('ID') returns nagios_server.id (config) values; translate them
+            // to the Snowflake UIDs (nagios_server.uid) that match instances.instance_id.
+            $aclPollerIds = $acl->getPollerString('ID', $this->pearDBMonitoring);
+            $uids = [];
+            if ($aclPollerIds !== '') {
+                $uidResult = $this->pearDB->query(
+                    'SELECT uid FROM nagios_server WHERE id IN (' . $aclPollerIds . ')'
+                );
+                while ($uidRow = $uidResult->fetchRow()) {
+                    $uids[] = $uidRow['uid'];
+                }
+            }
+            $queryPoller .= 'AND instances.instance_id IN (' . ($uids === [] ? '0' : implode(',', $uids)) . ') ';
         }
 
         $queryPoller .= ' ORDER BY name ';

--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -603,7 +603,7 @@ class CentreonTopCounter extends CentreonWebService
     {
         // Get the list of configured pollers
         $listPoller = [];
-        $query = 'SELECT id, name, last_restart, updated FROM nagios_server WHERE ns_activate = "1"';
+        $query = 'SELECT id, name, uid, last_restart, updated FROM nagios_server WHERE ns_activate = "1"';
 
         // Add ACL
         $aclPoller = $this->centreon->user->access->getPollerString('id');
@@ -624,7 +624,7 @@ class CentreonTopCounter extends CentreonWebService
             return [];
         }
         while ($row = $res->fetch()) {
-            $listPoller[$row['id']] = ['id' => $row['id'], 'name' => $row['name'], 'lastRestart' => $row['last_restart'], 'updated' => $row['updated']];
+            $listPoller[$row['id']] = ['id' => $row['id'], 'name' => $row['name'], 'uid' => $row['uid'], 'lastRestart' => $row['last_restart'], 'updated' => $row['updated']];
         }
 
         return $listPoller;
@@ -639,14 +639,21 @@ class CentreonTopCounter extends CentreonWebService
     protected function pollersStatusList()
     {
         $listPoller = [];
+        // Map instances.instance_id (Snowflake UID stored in nagios_server.uid) to the poller config id.
+        $uidToId = [];
         $listConfPoller = $this->pollersList();
         foreach ($listConfPoller as $poller) {
             $listPoller[$poller['id']] = ['id' => $poller['id'], 'name' => $poller['name'], 'stability' => 0, 'database' => ['state' => 0, 'time' => null], 'latency' => ['state' => 0, 'time' => null]];
+            $uidToId[$poller['uid']] = $poller['id'];
+        }
+
+        if ($uidToId === []) {
+            return $listPoller;
         }
 
         // Get status of pollers
         $query = 'SELECT 1 AS REALTIME, instance_id, last_alive, running FROM instances
-            WHERE deleted = 0 AND instance_id IN (' . implode(', ', array_keys($listPoller)) . ')';
+            WHERE deleted = 0 AND instance_id IN (' . implode(', ', array_keys($uidToId)) . ')';
 
         try {
             $res = $this->pearDBMonitoring->query($query);
@@ -655,18 +662,19 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         while ($row = $res->fetch()) {
+            $pollerId = $uidToId[$row['instance_id']];
             // Test if poller running and activity
             if (time() - $row['last_alive'] >= $this->timeUnit * 10) {
-                $listPoller[$row['instance_id']]['stability'] = 2;
-                $listPoller[$row['instance_id']]['database']['state'] = 2;
-                $listPoller[$row['instance_id']]['database']['time'] = time() - $row['last_alive'];
+                $listPoller[$pollerId]['stability'] = 2;
+                $listPoller[$pollerId]['database']['state'] = 2;
+                $listPoller[$pollerId]['database']['time'] = time() - $row['last_alive'];
             } elseif (time() - $row['last_alive'] >= $this->timeUnit * 5) {
-                $listPoller[$row['instance_id']]['stability'] = 1;
-                $listPoller[$row['instance_id']]['database']['state'] = 1;
-                $listPoller[$row['instance_id']]['database']['time'] = time() - $row['last_alive'];
+                $listPoller[$pollerId]['stability'] = 1;
+                $listPoller[$pollerId]['database']['state'] = 1;
+                $listPoller[$pollerId]['database']['time'] = time() - $row['last_alive'];
             }
             if ($row['running'] == 0) {
-                $listPoller[$row['instance_id']]['stability'] = 2;
+                $listPoller[$pollerId]['stability'] = 2;
             }
         }
         // Get latency
@@ -676,7 +684,7 @@ class CentreonTopCounter extends CentreonWebService
                 AND n.stat_key = "Average"
                 AND n.instance_id = i.instance_id
                 AND i.deleted = 0
-                AND i.instance_id IN (' . implode(', ', array_keys($listPoller)) . ')';
+                AND i.instance_id IN (' . implode(', ', array_keys($uidToId)) . ')';
 
         try {
             $res = $this->pearDBMonitoring->query($query);
@@ -685,12 +693,13 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         while ($row = $res->fetch()) {
+            $pollerId = $uidToId[$row['instance_id']];
             if ($row['stat_value'] >= 120) {
-                $listPoller[$row['instance_id']]['latency']['state'] = 2;
-                $listPoller[$row['instance_id']]['latency']['time'] = $row['stat_value'];
+                $listPoller[$pollerId]['latency']['state'] = 2;
+                $listPoller[$pollerId]['latency']['time'] = $row['stat_value'];
             } elseif ($row['stat_value'] >= 60) {
-                $listPoller[$row['instance_id']]['latency']['state'] = 1;
-                $listPoller[$row['instance_id']]['latency']['time'] = $row['stat_value'];
+                $listPoller[$pollerId]['latency']['state'] = 1;
+                $listPoller[$pollerId]['latency']['time'] = $row['stat_value'];
             }
         }
 

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -730,11 +730,22 @@ class CentreonConfigPoller
      */
     public function getPollerState()
     {
+        // instances.instance_id (centreon_storage) holds the Snowflake UID stored in
+        // nagios_server.uid; map it back to the poller config id so callers can look up
+        // the state by nagios_server.id.
+        $uidToId = [];
+        $nagiosResult = $this->DB->query('SELECT id, uid FROM nagios_server');
+        while ($row = $nagiosResult->fetchRow()) {
+            $uidToId[$row['uid']] = $row['id'];
+        }
+
         $pollerState = [];
-        $dbResult = $this->DBC->query('SELECT instance_id, running, name FROM instances');
+        $dbResult = $this->DBC->query('SELECT instance_id, running FROM instances');
 
         while ($row = $dbResult->fetchRow()) {
-            $pollerState[$row['instance_id']] = $row['running'];
+            if (isset($uidToId[$row['instance_id']])) {
+                $pollerState[$uidToId[$row['instance_id']]] = $row['running'];
+            }
         }
 
         return $pollerState;

--- a/centreon/www/class/centreonGMT.class.php
+++ b/centreon/www/class/centreonGMT.class.php
@@ -522,7 +522,9 @@ class CentreonGMT
             return $this->pollerLocations;
         }
 
-        $query = 'SELECT ns.id, t.timezone_name '
+        // Key by nagios_server.uid: pollerLocations is matched against hosts.instance_id
+        // (centreon_storage), which now holds the Snowflake UID, not nagios_server.id.
+        $query = 'SELECT ns.uid, t.timezone_name '
             . 'FROM cfg_nagios cfgn, nagios_server ns, timezone t '
             . 'WHERE cfgn.nagios_activate = "1" '
             . 'AND cfgn.nagios_server_id = ns.id '
@@ -530,7 +532,7 @@ class CentreonGMT
         try {
             $res = CentreonDBInstance::getDbCentreonInstance()->query($query);
             while ($row = $res->fetchRow()) {
-                $this->pollerLocations[$row['id']] = $row['timezone_name'];
+                $this->pollerLocations[$row['uid']] = $row['timezone_name'];
             }
         } catch (Exception $e) {
             // Nothing to do


### PR DESCRIPTION
## Issue

`centreon_storage.instances.instance_id` was migrated to a **BIGINT Snowflake UID** (MON-200819 / #10389), while `centreon.nagios_server.id` remains a small auto-increment. The value that now matches `instances.instance_id` lives in the new **`nagios_server.uid`** column (`BIGINT UNSIGNED NOT NULL`).

As a result, **every place that matched a config poller id (`nagios_server.id`) against a `centreon_storage` `instance_id`** silently returned nothing. The starting point was the join in `RealTimeMonitoringServerRepositoryRDB.php` (`ON instances.instance_id = nagios_server.id`), whose visible impact was the top counter never reporting pollers in error. An audit of the whole codebase surfaced 7 other occurrences of the same class of bug.

Scoping rule used during the audit:

- Joins **entirely within `centreon_storage`** (`hosts.instance_id = instances.instance_id`, `resources.poller_id = instances.instance_id`, `nagios_stats.instance_id = instances.instance_id`, …) are **correct** — Broker writes the Snowflake to all storage tables.
- Config-DB `instance_id` columns that are FKs to `nagios_server.id` (e.g. `cfg_resource_instance_relations`) are **correct** — they stay on the small id.
- Only **config-id ↔ storage-snowflake** crossings are bugs.

## What has been done

The correct key everywhere is `nagios_server.uid = instances.instance_id`.

| File | Symptom | Fix |
|------|---------|-----|
| `src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php` | `JOIN ... ON instances.instance_id = nagios_server.id`; non-admin `findByIds` filtered `instance_id IN (config ids)` | Join on `nagios_server.uid`; filter non-admin ids on `nagios_server.id` |
| `www/api/class/centreon_topcounter.class.php` (`pollersStatusList`) | Poller status list keyed by config id but queried/re-indexed by Snowflake → top counter never reported pollers in error | Select `nagios_server.uid`, map `uid → config id`, query `instances`/`nagios_stats` by `uid` |
| `src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php` | `updateAllEncryptionReadyFromRealtime`: `ON ns.id = i.instance_id` | `ON ns.uid = i.instance_id` |
| `src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php` | `isEncryptionReady`: `instances WHERE instance_id = :monitoringServerId` (a config id) | Join `instances` to `nagios_server` on `uid`, filter by `ns.id` |
| `src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php` | `loadCmaCertificates` queried realtime `instances` with `$poller->id()` | Bind `$poller->uid` |
| `www/class/centreonGMT.class.php` | `pollerLocations` keyed by `ns.id`, looked up by `hosts.instance_id` → host timezones never inherited from poller | Key `pollerLocations` by `ns.uid` |
| `www/class/centreon-clapi/centreon.Config.Poller.class.php` | `getPollerState` keyed by Snowflake, consumer looked up by config id → CLAPI `INSTANCE SHOW` always showed `ns_status = '-'` | Map Snowflake → config id via `nagios_server.uid` |
| `www/api/class/centreon_monitoring_poller.class.php` | Non-admin poller select2 filtered `instance_id IN (config ACL ids)` → empty list for non-admins | Translate ACL config ids → UIDs (also fixed a latent `IN ()` crash on empty ACL) |

**Left unchanged on purpose:** `www/class/centreonExternalCommand.class.php::getPollerID()` returns `hosts.instance_id` (now the Snowflake) as the external-command routing id. Gorgone maintains a `server_id ↔ uid` mapping and resolves either identifier, so no change is required here.

## How to validate

Run against an environment with **at least one poller/remote in addition to the Central** (so `nagios_server.id` and `nagios_server.uid` differ and mismatches actually manifest).

1. **Top counter** — stop a poller (`systemctl stop centengine`) or force high latency; the top-right poller indicator must turn warning/critical and list the affected poller (stayed green before). Covers `centreon_topcounter` + `RealTimeMonitoringServerRepositoryRDB`.
2. **Poller monitoring list** — as a non-admin user with an ACL restricted to some pollers, the poller select2 filter must list the accessible pollers (was empty). Covers `centreon_monitoring_poller`.
3. **Poller encryption-ready** — with a poller advertising `is_encryption_ready = 1` in `centreon_storage.instances`, confirm the flag propagates to `nagios_server.is_encryption_ready` and the check returns `true`. Covers the two `MonitoringServer` repositories.
4. **CMA certificates** — open a poller configured with CMA; its certificate CN/SHA must be displayed (was empty). Covers `DbalPollerRepository::loadCmaCertificates`.
5. **Poller timezone inheritance** — set a timezone on a poller, leave a host on that poller without its own timezone; date rendering for that host must use the poller timezone. Covers `centreonGMT`.
6. **CLAPI** — `centreon -u admin -p ... -o INSTANCE -a show`: the `ns_status` column must reflect the real running state (`0`/`1`) instead of always `-`. Covers `centreon.Config.Poller::getPollerState`.

SQL sanity check (should return one row per running poller, not empty):

```sql
SELECT ns.id, ns.name, ns.uid, i.running, i.last_alive
FROM centreon.nagios_server ns
JOIN centreon_storage.instances i ON i.instance_id = ns.uid
WHERE i.deleted = 0;
```
