### PR TITLE
enh(ci): xray: make import/enrich resilient to transient errors

### DIFF
--- a/.github/actions/xray-api-auth/auth.sh
+++ b/.github/actions/xray-api-auth/auth.sh
@@ -4,32 +4,40 @@ set -euo pipefail
 CLIENT_ID="$1"
 CLIENT_SECRET="$2"
 
-response=$(curl -s -w "\n%{http_code}" -X POST \
-  -H "Content-Type: application/json" \
-  --data "{
-    \"client_id\": \"${CLIENT_ID}\",
-    \"client_secret\": \"${CLIENT_SECRET}\"
-  }" \
-  https://xray.cloud.getxray.app/api/v1/authenticate)
+MAX_RETRIES=5
+RETRY_DELAY=2
 
-http_code=$(tail -n1 <<<"$response")
-body=$(sed '$d' <<<"$response")
+attempt=0
+while :; do
+  response=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    --data "{
+      \"client_id\": \"${CLIENT_ID}\",
+      \"client_secret\": \"${CLIENT_SECRET}\"
+    }" \
+    https://xray.cloud.getxray.app/api/v1/authenticate || true)
 
-# Surface HTTP code and raw body on failure (diagnostics go to stderr, token to stdout).
-if [[ "$http_code" != "200" ]]; then
+  http_code=$(tail -n1 <<<"$response")
+  body=$(sed '$d' <<<"$response")
+  [[ -z "$http_code" ]] && http_code="000"
+  token=$(tr -d '"' <<<"$body")
+
+  # Success: HTTP 200 with a non-empty token.
+  if [[ "$http_code" == "200" && -n "$token" && "$token" != "null" ]]; then
+    echo "$token"
+    exit 0
+  fi
+
+  # Retry transient failures only: network error (000), 429, 5xx, or an empty token on 200.
+  if [[ "$attempt" -lt "$MAX_RETRIES" && ( "$http_code" == "000" || "$http_code" == "429" || "$http_code" -ge 500 || ( "$http_code" == "200" && ( -z "$token" || "$token" == "null" ) ) ) ]]; then
+    echo "Xray auth transient failure (HTTP $http_code), retry $((attempt + 1))/$MAX_RETRIES in ${RETRY_DELAY}s" >&2
+    attempt=$((attempt + 1))
+    sleep "$RETRY_DELAY"
+    continue
+  fi
+
+  # Permanent failure (e.g. 4xx bad credentials) or retries exhausted.
   echo "Xray authentication failed: HTTP $http_code" >&2
   echo "$body" >&2
   exit 1
-fi
-
-# Xray returns the token as a JSON string: "token"
-token=$(tr -d '"' <<<"$body")
-
-if [[ -z "$token" || "$token" == "null" ]]; then
-  echo "Xray authentication failed: empty token in response" >&2
-  echo "$body" >&2
-  exit 1
-fi
-
-# Output the token on stdout to be captured by the calling script
-echo "$token"
+done

--- a/.github/actions/xray-enrich-tests/enrich-tests.js
+++ b/.github/actions/xray-enrich-tests/enrich-tests.js
@@ -65,17 +65,55 @@ for (const [variableName, variableValue] of Object.entries({
 
 const jiraAuthorizationHeader = `Basic ${Buffer.from(`${JIRA_USER_EMAIL}:${JIRA_TOKEN}`).toString("base64")}`;
 
+const MAX_HTTP_RETRIES = 5;
+const RETRY_DELAY_MS = 2000;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Backoff before retrying a transient failure. `status` is null on a network error.
+// Return the delay in ms, or null to stop retrying.
+function retryDelayMs(attempt, status) {
+  if (attempt >= MAX_HTTP_RETRIES) return null;
+  const isTransient = status === null || status === 429 || status >= 500;
+  if (!isTransient) return null;
+  return RETRY_DELAY_MS;
+}
+
+// Fetch with retry/backoff on transient failures (policy in retryDelayMs).
+async function fetchWithRetry(operation, label) {
+  for (let attempt = 0; ; attempt++) {
+    let response = null;
+    let networkError = null;
+    try {
+      response = await operation();
+      if (response.ok) return response;
+    } catch (error) {
+      networkError = error;
+    }
+    const delay = retryDelayMs(attempt, networkError ? null : response.status);
+    if (delay == null) {
+      if (networkError) throw networkError;
+      return response;
+    }
+    console.log(`  ${label}: transient failure, retry #${attempt + 1} in ${delay}ms`);
+    await sleep(delay);
+  }
+}
+
 // Jira REST call -> { ok, status, body } where body is parsed JSON or raw text.
 async function callJiraRest(httpMethod, endpointPath, requestPayload) {
-  const response = await fetch(`${JIRA_REST_BASE_URL}${endpointPath}`, {
-    method: httpMethod,
-    headers: {
-      Authorization: jiraAuthorizationHeader,
-      Accept: "application/json",
-      ...(requestPayload ? { "Content-Type": "application/json" } : {}),
-    },
-    ...(requestPayload ? { body: JSON.stringify(requestPayload) } : {}),
-  });
+  const response = await fetchWithRetry(
+    () =>
+      fetch(`${JIRA_REST_BASE_URL}${endpointPath}`, {
+        method: httpMethod,
+        headers: {
+          Authorization: jiraAuthorizationHeader,
+          Accept: "application/json",
+          ...(requestPayload ? { "Content-Type": "application/json" } : {}),
+        },
+        ...(requestPayload ? { body: JSON.stringify(requestPayload) } : {}),
+      }),
+    `${httpMethod} ${endpointPath}`,
+  );
   const responseText = await response.text();
   let parsedBody;
   try {
@@ -94,14 +132,18 @@ function loadGraphqlOperation(operationName) {
 
 // Xray GraphQL call -> parsed JSON. Throws on a GraphQL-level error array.
 async function callXrayGraphql(graphqlQuery, queryVariables) {
-  const response = await fetch(XRAY_GRAPHQL_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${XRAY_TOKEN}`,
-    },
-    body: JSON.stringify({ query: graphqlQuery, variables: queryVariables }),
-  });
+  const response = await fetchWithRetry(
+    () =>
+      fetch(XRAY_GRAPHQL_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${XRAY_TOKEN}`,
+        },
+        body: JSON.stringify({ query: graphqlQuery, variables: queryVariables }),
+      }),
+    "Xray GraphQL",
+  );
   const responseJson = await response.json();
   if (responseJson.errors && responseJson.errors.length > 0) {
     throw new Error(`Xray GraphQL error: ${JSON.stringify(responseJson.errors)}`);
@@ -337,30 +379,37 @@ async function main() {
       continue;
     }
     console.log(`::group::Enrich ${issueKey} (${issueId})`);
-
-    // 1. Xray Test Type (set + verify + retry once)
-    if (TEST_TYPE) {
-      await setTestTypeWithRetry(issueId, issueKey, TEST_TYPE);
-    }
-
-    // 2. Component and labels (Jira)
-    if (COMPONENT || LABELS) {
-      const fieldsUpdatePayload = buildFieldsUpdatePayload(COMPONENT, LABELS);
-      const { ok, status, body } = await callJiraRest("PUT", `/issue/${issueKey}`, fieldsUpdatePayload);
-      if (ok) {
-        console.log("  component/labels updated");
-      } else {
-        console.log(`WARNING: failed to update fields for ${issueKey} (HTTP ${status}): ${JSON.stringify(body)}`);
-        failureCount++;
+    // Isolate each test: a failure here is logged and counted, never aborts the batch.
+    let testFailed = false;
+    try {
+      // 1. Xray Test Type (set + verify + retry once)
+      if (TEST_TYPE) {
+        await setTestTypeWithRetry(issueId, issueKey, TEST_TYPE);
       }
+
+      // 2. Component and labels (Jira)
+      if (COMPONENT || LABELS) {
+        const fieldsUpdatePayload = buildFieldsUpdatePayload(COMPONENT, LABELS);
+        const { ok, status, body } = await callJiraRest("PUT", `/issue/${issueKey}`, fieldsUpdatePayload);
+        if (ok) {
+          console.log("  component/labels updated");
+        } else {
+          console.log(`WARNING: failed to update fields for ${issueKey} (HTTP ${status}): ${JSON.stringify(body)}`);
+          testFailed = true;
+        }
+      }
+
+      // 3. Resolve: walk the known Test chain to a done status.
+      if (RESOLVE === "true") {
+        const finalStatus = await driveToResolved(issueKey, TEST_RESOLVE_TRANSITION_IDS);
+        console.log(`  final status: ${finalStatus?.id} - ${finalStatus?.name}`);
+      }
+    } catch (error) {
+      console.log(`WARNING: enrichment error for ${issueKey}: ${error.message} — will be retried on a re-run`);
+      testFailed = true;
     }
 
-    // 3. Resolve: walk the known Test chain to a done status.
-    if (RESOLVE === "true") {
-      const finalStatus = await driveToResolved(issueKey, TEST_RESOLVE_TRANSITION_IDS);
-      console.log(`  final status: ${finalStatus?.id} - ${finalStatus?.name}`);
-    }
-
+    if (testFailed) failureCount++;
     console.log("::endgroup::");
   }
 
@@ -376,13 +425,14 @@ async function main() {
     console.log("::endgroup::");
   }
 
+  const enrichedCount = tests.length - skippedCount - failureCount;
+  console.log(
+    `Enrichment done: ${enrichedCount} enriched, ${skippedCount} already up-to-date, ${failureCount} left un-enriched.`,
+  );
   if (failureCount > 0) {
-    console.error(`Enrichment finished with ${failureCount} failure(s).`);
+    console.error(`${failureCount} test(s) left un-enriched — re-run the job to finish (it resumes idempotently).`);
     process.exit(1);
   }
-  console.log(
-    `Enrichment done: ${tests.length - skippedCount} enriched, ${skippedCount} already up-to-date (skipped).`,
-  );
 }
 
 main().catch((error) => {

--- a/.github/workflows/xray-api-import-results.yml
+++ b/.github/workflows/xray-api-import-results.yml
@@ -150,22 +150,38 @@ jobs:
 
           echo "Importing $results_file ($RESULT_FORMAT) with Jira fields parameters into Xray..."
 
-          response=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
-            -H "Authorization: Bearer ${{ steps.generate-xray-token.outputs.xray_token }}" \
-            -F "results=@$results_file" \
-            -F "info=@issueJiraFields.json" \
-            "$import_endpoint")
+          # Retry the import on transient failures (network, 429, 5xx) except 504 (may duplicate the Test Execution).
+          max_retries=5
+          retry_delay=2
+          attempt=0
+          while :; do
+            response=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+              -H "Authorization: Bearer ${{ steps.generate-xray-token.outputs.xray_token }}" \
+              -F "results=@$results_file" \
+              -F "info=@issueJiraFields.json" \
+              "$import_endpoint" || true)
 
-          http_code=$(echo "$response" | sed -n 's/.*HTTP_CODE://p')
-          body=$(echo "$response" | sed 's/HTTP_CODE:.*//')
+            http_code=$(echo "$response" | sed -n 's/.*HTTP_CODE://p')
+            body=$(echo "$response" | sed 's/HTTP_CODE:.*//')
+            [ -z "$http_code" ] && http_code="000"
 
-          echo "HTTP code: $http_code"
-          echo "Response: $body"
+            echo "HTTP code: $http_code"
+            echo "Response: $body"
 
-          if [ "$http_code" -ne 200 ]; then
+            if [ "$http_code" -eq 200 ]; then
+              break
+            fi
+
+            if [ "$attempt" -lt "$max_retries" ] && { [ "$http_code" = "000" ] || [ "$http_code" = "429" ] || { [ "$http_code" -ge 500 ] && [ "$http_code" != "504" ]; }; }; then
+              echo "Transient import failure (HTTP $http_code), retry $((attempt + 1))/$max_retries in ${retry_delay}s"
+              attempt=$((attempt + 1))
+              sleep "$retry_delay"
+              continue
+            fi
+
             echo "ERROR: Import failed for $results_file with Jira fields parameters into Xray"
             exit 1
-          fi
+          done
 
           test_execution_key=$(jq -r '.key // empty' <<<"$body")
           echo "Created/updated Test Execution: $test_execution_key"


### PR DESCRIPTION
Backport of #10965 to `dev-24.10.x`.

Makes the Xray import + enrich resilient to transient errors on large batches.

- `xray-enrich-tests/enrich-tests.js`: `fetchWithRetry` retries transient failures (network error, 429, 5xx) with a fixed 2s delay, up to 5 times, in `callJiraRest` and `callXrayGraphql`. Each test's enrichment is wrapped in try/catch so a single failure is logged and counted instead of aborting the whole batch; the final report gives the enriched / skipped / un-enriched counts (a re-run resumes idempotently to finish the rest).
- `xray-api-auth/auth.sh`: retries the token request on network error / 429 / 5xx / empty token (2s x 5); a 4xx stays a permanent failure.
- `xray-api-import-results.yml`: the import `curl` retries on network error / 429 / 5xx (e.g. the 504 gateway timeout observed in nightly).

Refs: MON-204886