### PR TITLE
test(api): cover /monitoring/servers realtime JOIN

### DIFF
--- a/centreon/tests/api/web-api-workspace/collections/Real_Time_Monitoring_Server/Administrator profile/GET -monitoring-servers - List monitoring servers - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Real_Time_Monitoring_Server/Administrator profile/GET -monitoring-servers - List monitoring servers - HTTP 200.bru
@@ -20,6 +20,12 @@ tests {
     expect(body).to.have.property("result").that.is.an("array");
     expect(body).to.have.property("meta").that.is.an("object");
   });
+
+  test("Realtime poller matched on nagios_server.uid is returned.", function () {
+    const body = res.getBody();
+    const seededPoller = body.result.find((server) => server.name === "QA-realtime-poller");
+    expect(seededPoller, "seeded realtime poller must be listed").to.not.be.undefined;
+  });
 }
 
 settings {

--- a/centreon/tests/api/web-api-workspace/collections/Real_Time_Monitoring_Server/setup-web.sh
+++ b/centreon/tests/api/web-api-workspace/collections/Real_Time_Monitoring_Server/setup-web.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Specific setup for the Real_Time_Monitoring_Server collection.
+#
+# GET /monitoring/servers joins centreon_storage.instances to
+# centreon.nagios_server. Since the instance_id migration to a Snowflake UID,
+# the matching key is nagios_server.uid (NOT nagios_server.id): Broker writes
+# nagios_server.uid into instances.instance_id. A regression where the JOIN
+# uses nagios_server.id silently returns an empty list.
+#
+# A fresh CI platform has no realtime instances row, so the endpoint would
+# return an empty array either way and the tests could not tell a broken JOIN
+# from a healthy-but-empty platform. We seed a dedicated poller whose
+# instances.instance_id equals its nagios_server.uid and differs from its
+# nagios_server.id, so the poller is returned only when the JOIN resolves on
+# uid. This does not impact other collections: each bruno-test job runs in its
+# own ephemeral Docker container.
+#
+# mysql connects to the "db" service host, as in the other fixture scripts.
+
+set -euo pipefail
+
+# JS-safe value (below 2^53) so Bruno can parse the returned id without losing
+# precision, while staying well above any auto-increment nagios_server.id.
+POLLER_UID=900000001
+
+# Seed a dedicated poller for the Real_Time_Monitoring_Server collection.
+echo "Seeding realtime poller (uid=${POLLER_UID}) for /monitoring/servers regression coverage"
+mysql -hdb -uroot -pcentreon -e "
+  DELETE FROM centreon_storage.instances WHERE instance_id = ${POLLER_UID};
+  DELETE FROM centreon.nagios_server WHERE uid = ${POLLER_UID};
+  INSERT INTO centreon.nagios_server (name, localhost, ns_activate, ssh_port, uid)
+    VALUES ('QA-realtime-poller', '0', '1', 22, ${POLLER_UID});
+  INSERT INTO centreon_storage.instances (instance_id, name, running, last_alive, deleted)
+    VALUES (${POLLER_UID}, 'QA-realtime-poller', 1, UNIX_TIMESTAMP(), 0);
+"
+
+echo "Real_Time_Monitoring_Server setup-web.sh: done."


### PR DESCRIPTION
## Description

Adds an API regression guard on `GET /monitoring/servers` (realtime monitoring servers).

The existing Bruno tests only asserted HTTP 200 and that `result` is an array. Because the broken JOIN returned an empty array with a 200 status, they passed both before and after the fix and never caught the regression.

The `Real_Time_Monitoring_Server` collection now ships a `setup-web.sh` that seeds a poller whose `centreon_storage.instances.instance_id` equals its `nagios_server.uid` and differs from its `nagios_server.id`. The Administrator test asserts that poller is listed — which only happens when the JOIN resolves on `nagios_server.uid`. The seed runs in the collection's own ephemeral container, so it does not affect other collections.

Out of scope (no Bruno coverage): top counter, CLAPI `INSTANCE SHOW`, timezone inheritance, CMA certificates, encryption-ready, non-admin ACL path. An E2E follow-up is tracked in [MON-205005](https://centreon.atlassian.net/browse/MON-205005).

Fixes: [MON-204995](https://centreon.atlassian.net/browse/MON-204995)
Related bug: [MON-204870](https://centreon.atlassian.net/browse/MON-204870)


[MON-205005]: https://centreon.atlassian.net/browse/MON-205005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-204995]: https://centreon.atlassian.net/browse/MON-204995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ