### PR TITLE
fix(nagios): latest changes due to instance_id column migration to snowflake uid 64bits

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
@@ -368,8 +368,8 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
         $qb = $this->realTimeConnection->createQueryBuilder();
         $qb->select('i.cma_certificate_sha AS certificate_sha', 'i.cma_certificate_cn  AS certificate_cn')
             ->from('instances', 'i')
-            ->where('i.instance_id = :poller_id')
-            ->setParameter('poller_id', $poller->id()->value);
+            ->where('i.instance_id = :poller_uid')
+            ->setParameter('poller_uid', $poller->uid->value);
 
         $row = $qb->executeQuery()->fetchAssociative() ?: [];
         $certSha = ($row['certificate_sha'] ?? '') !== '' ? $row['certificate_sha'] : null;

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
@@ -170,7 +170,7 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
             }
         );
 
-        $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.id');
+        $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.uid');
         $whereCondition = false;
 
         // Search
@@ -190,7 +190,7 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
                 $instanceIds[] = $key;
                 $collector->addValue($key, $instanceId, \PDO::PARAM_INT);
             }
-            $request .= 'instances.instance_id IN (' . implode(', ', $instanceIds) . ')';
+            $request .= 'nagios_server.id IN (' . implode(', ', $instanceIds) . ')';
         }
 
         $request .= ($whereCondition ? ' AND ' : ' WHERE ') . 'instances.deleted = 0 AND nagios_server.ns_activate = 1';

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
@@ -385,9 +385,10 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
         $statement = $this->db->prepare($this->translateDbName(
             <<<'SQL'
                 SELECT 1
-                FROM `:dbstg`.`instances`
-                WHERE instance_id = :monitoringServerId
-                    AND is_encryption_ready = 1
+                FROM `:dbstg`.`instances` i
+                INNER JOIN `:db`.`nagios_server` ns ON ns.uid = i.instance_id
+                WHERE ns.id = :monitoringServerId
+                    AND i.is_encryption_ready = 1
                 SQL
         ));
         $statement->bindValue(':monitoringServerId', $monitoringServerId, \PDO::PARAM_INT);

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
@@ -126,7 +126,7 @@ class DbWriteMonitoringServerRepository extends AbstractRepositoryRDB implements
             <<<'SQL'
                 UPDATE `:db`.nagios_server ns
                     INNER JOIN `:dbstg`.instances i
-                    ON ns.id = i.instance_id
+                    ON ns.uid = i.instance_id
                 SET ns.is_encryption_ready = i.is_encryption_ready
                 SQL
         ));

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
@@ -204,10 +204,16 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
     private function insertInstance(int $pollerId, ?string $certificateSha, ?string $certificateCn): void
     {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        // instances.instance_id holds the Snowflake UID (nagios_server.uid), not the poller config id.
+        $uid = $connection->fetchOne('SELECT uid FROM nagios_server WHERE id = ?', [$pollerId]);
+        $instanceId = is_numeric($uid) ? (int) $uid : 0;
+
         /** @var Connection $realtimeConnection */
         $realtimeConnection = self::getContainer()->get('doctrine.dbal.realtime_connection');
         $realtimeConnection->insert('instances', [
-            'instance_id' => $pollerId,
+            'instance_id' => $instanceId,
             'name' => 'test-instance-' . $pollerId,
             'cma_certificate_sha' => $certificateSha,
             'cma_certificate_cn' => $certificateCn,

--- a/centreon/www/api/class/centreon_monitoring_poller.class.php
+++ b/centreon/www/api/class/centreon_monitoring_poller.class.php
@@ -59,8 +59,19 @@ class CentreonMonitoringPoller extends CentreonConfigurationObjects
 
         if (! $centreon->user->admin) {
             $acl = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
-            $queryPoller .= 'AND instances.instance_id IN ('
-                . $acl->getPollerString('ID', $this->pearDBMonitoring) . ') ';
+            // getPollerString('ID') returns nagios_server.id (config) values; translate them
+            // to the Snowflake UIDs (nagios_server.uid) that match instances.instance_id.
+            $aclPollerIds = $acl->getPollerString('ID', $this->pearDBMonitoring);
+            $uids = [];
+            if ($aclPollerIds !== '') {
+                $uidResult = $this->pearDB->query(
+                    'SELECT uid FROM nagios_server WHERE id IN (' . $aclPollerIds . ')'
+                );
+                while ($uidRow = $uidResult->fetchRow()) {
+                    $uids[] = $uidRow['uid'];
+                }
+            }
+            $queryPoller .= 'AND instances.instance_id IN (' . ($uids === [] ? '0' : implode(',', $uids)) . ') ';
         }
 
         $queryPoller .= ' ORDER BY name ';

--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -603,7 +603,7 @@ class CentreonTopCounter extends CentreonWebService
     {
         // Get the list of configured pollers
         $listPoller = [];
-        $query = 'SELECT id, name, last_restart, updated FROM nagios_server WHERE ns_activate = "1"';
+        $query = 'SELECT id, name, uid, last_restart, updated FROM nagios_server WHERE ns_activate = "1"';
 
         // Add ACL
         $aclPoller = $this->centreon->user->access->getPollerString('id');
@@ -624,7 +624,7 @@ class CentreonTopCounter extends CentreonWebService
             return [];
         }
         while ($row = $res->fetch()) {
-            $listPoller[$row['id']] = ['id' => $row['id'], 'name' => $row['name'], 'lastRestart' => $row['last_restart'], 'updated' => $row['updated']];
+            $listPoller[$row['id']] = ['id' => $row['id'], 'name' => $row['name'], 'uid' => $row['uid'], 'lastRestart' => $row['last_restart'], 'updated' => $row['updated']];
         }
 
         return $listPoller;
@@ -639,14 +639,21 @@ class CentreonTopCounter extends CentreonWebService
     protected function pollersStatusList()
     {
         $listPoller = [];
+        // Map instances.instance_id (Snowflake UID stored in nagios_server.uid) to the poller config id.
+        $uidToId = [];
         $listConfPoller = $this->pollersList();
         foreach ($listConfPoller as $poller) {
             $listPoller[$poller['id']] = ['id' => $poller['id'], 'name' => $poller['name'], 'stability' => 0, 'database' => ['state' => 0, 'time' => null], 'latency' => ['state' => 0, 'time' => null]];
+            $uidToId[$poller['uid']] = $poller['id'];
+        }
+
+        if ($uidToId === []) {
+            return $listPoller;
         }
 
         // Get status of pollers
         $query = 'SELECT 1 AS REALTIME, instance_id, last_alive, running FROM instances
-            WHERE deleted = 0 AND instance_id IN (' . implode(', ', array_keys($listPoller)) . ')';
+            WHERE deleted = 0 AND instance_id IN (' . implode(', ', array_keys($uidToId)) . ')';
 
         try {
             $res = $this->pearDBMonitoring->query($query);
@@ -655,18 +662,19 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         while ($row = $res->fetch()) {
+            $pollerId = $uidToId[$row['instance_id']];
             // Test if poller running and activity
             if (time() - $row['last_alive'] >= $this->timeUnit * 10) {
-                $listPoller[$row['instance_id']]['stability'] = 2;
-                $listPoller[$row['instance_id']]['database']['state'] = 2;
-                $listPoller[$row['instance_id']]['database']['time'] = time() - $row['last_alive'];
+                $listPoller[$pollerId]['stability'] = 2;
+                $listPoller[$pollerId]['database']['state'] = 2;
+                $listPoller[$pollerId]['database']['time'] = time() - $row['last_alive'];
             } elseif (time() - $row['last_alive'] >= $this->timeUnit * 5) {
-                $listPoller[$row['instance_id']]['stability'] = 1;
-                $listPoller[$row['instance_id']]['database']['state'] = 1;
-                $listPoller[$row['instance_id']]['database']['time'] = time() - $row['last_alive'];
+                $listPoller[$pollerId]['stability'] = 1;
+                $listPoller[$pollerId]['database']['state'] = 1;
+                $listPoller[$pollerId]['database']['time'] = time() - $row['last_alive'];
             }
             if ($row['running'] == 0) {
-                $listPoller[$row['instance_id']]['stability'] = 2;
+                $listPoller[$pollerId]['stability'] = 2;
             }
         }
         // Get latency
@@ -676,7 +684,7 @@ class CentreonTopCounter extends CentreonWebService
                 AND n.stat_key = "Average"
                 AND n.instance_id = i.instance_id
                 AND i.deleted = 0
-                AND i.instance_id IN (' . implode(', ', array_keys($listPoller)) . ')';
+                AND i.instance_id IN (' . implode(', ', array_keys($uidToId)) . ')';
 
         try {
             $res = $this->pearDBMonitoring->query($query);
@@ -685,12 +693,13 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         while ($row = $res->fetch()) {
+            $pollerId = $uidToId[$row['instance_id']];
             if ($row['stat_value'] >= 120) {
-                $listPoller[$row['instance_id']]['latency']['state'] = 2;
-                $listPoller[$row['instance_id']]['latency']['time'] = $row['stat_value'];
+                $listPoller[$pollerId]['latency']['state'] = 2;
+                $listPoller[$pollerId]['latency']['time'] = $row['stat_value'];
             } elseif ($row['stat_value'] >= 60) {
-                $listPoller[$row['instance_id']]['latency']['state'] = 1;
-                $listPoller[$row['instance_id']]['latency']['time'] = $row['stat_value'];
+                $listPoller[$pollerId]['latency']['state'] = 1;
+                $listPoller[$pollerId]['latency']['time'] = $row['stat_value'];
             }
         }
 

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -730,11 +730,22 @@ class CentreonConfigPoller
      */
     public function getPollerState()
     {
+        // instances.instance_id (centreon_storage) holds the Snowflake UID stored in
+        // nagios_server.uid; map it back to the poller config id so callers can look up
+        // the state by nagios_server.id.
+        $uidToId = [];
+        $nagiosResult = $this->DB->query('SELECT id, uid FROM nagios_server');
+        while ($row = $nagiosResult->fetchRow()) {
+            $uidToId[$row['uid']] = $row['id'];
+        }
+
         $pollerState = [];
-        $dbResult = $this->DBC->query('SELECT instance_id, running, name FROM instances');
+        $dbResult = $this->DBC->query('SELECT instance_id, running FROM instances');
 
         while ($row = $dbResult->fetchRow()) {
-            $pollerState[$row['instance_id']] = $row['running'];
+            if (isset($uidToId[$row['instance_id']])) {
+                $pollerState[$uidToId[$row['instance_id']]] = $row['running'];
+            }
         }
 
         return $pollerState;

--- a/centreon/www/class/centreonGMT.class.php
+++ b/centreon/www/class/centreonGMT.class.php
@@ -522,7 +522,9 @@ class CentreonGMT
             return $this->pollerLocations;
         }
 
-        $query = 'SELECT ns.id, t.timezone_name '
+        // Key by nagios_server.uid: pollerLocations is matched against hosts.instance_id
+        // (centreon_storage), which now holds the Snowflake UID, not nagios_server.id.
+        $query = 'SELECT ns.uid, t.timezone_name '
             . 'FROM cfg_nagios cfgn, nagios_server ns, timezone t '
             . 'WHERE cfgn.nagios_activate = "1" '
             . 'AND cfgn.nagios_server_id = ns.id '
@@ -530,7 +532,7 @@ class CentreonGMT
         try {
             $res = CentreonDBInstance::getDbCentreonInstance()->query($query);
             while ($row = $res->fetchRow()) {
-                $this->pollerLocations[$row['id']] = $row['timezone_name'];
+                $this->pollerLocations[$row['uid']] = $row['timezone_name'];
             }
         } catch (Exception $e) {
             // Nothing to do


### PR DESCRIPTION
## Description

Fix `nagios_server.uid` / `instances.instance_id` JOIN mismatches across the codebase after the Snowflake UID migration. Every place that matched a config poller id (`nagios_server.id`) against a `centreon_storage` `instance_id` was silently returning nothing. The correct key everywhere is `nagios_server.uid = instances.instance_id`.

Backport of https://github.com/centreon/centreon/pull/11017

Fixes: [MON-205023](https://centreon.atlassian.net/browse/MON-205023)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

Run against an environment with at least one poller/remote in addition to the Central (so `nagios_server.id` and `nagios_server.uid` differ).

1. **Top counter** — stop a poller; the top-right poller indicator must turn warning/critical and list the affected poller
2. **Poller monitoring list** — as a non-admin user with ACL restricted to some pollers, the poller select2 filter must list the accessible pollers
3. **CLAPI** — `centreon -u admin -p ... -o INSTANCE -a show`: the `ns_status` column must reflect the real running state

SQL sanity check:
```sql
SELECT ns.id, ns.name, ns.uid, i.running, i.last_alive
FROM centreon.nagios_server ns
JOIN centreon_storage.instances i ON i.instance_id = ns.uid
WHERE i.deleted = 0;
```

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-205023]: https://centreon.atlassian.net/browse/MON-205023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ