### PR TITLE
test(e2e): backfill Xray test tags for untagged scenarios

### DIFF
--- a/centreon-awie/tests/e2e/features/Import-export/01-import-export-pages.feature
+++ b/centreon-awie/tests/e2e/features/Import-export/01-import-export-pages.feature
@@ -6,10 +6,12 @@ Feature: AWIE configuration export and import
   Background:
     Given a super administrator is logged in
 
+  @MON-205084
   Scenario: contacts are exported as a downloadable archive
     When the user exports the contacts from the AWIE export page
     Then an export archive is generated
 
+  @MON-205083
   Scenario: the import page is ready to receive an archive
     When the user opens the AWIE import page
     Then the import form accepts a zip archive

--- a/centreon/tests/e2e/features/Commands/01-commands-configuration.feature
+++ b/centreon/tests/e2e/features/Commands/01-commands-configuration.feature
@@ -51,6 +51,7 @@ Feature: Configuration of a command
     Then Arguments of this command are displayed for the service
     And the admin user can configure those arguments on the service form
 
+  @MON-205041
   Scenario: Displaying the number of services using a check command
     Given a check command is configured
     And a service is configured
@@ -59,6 +60,7 @@ Feature: Configuration of a command
     And the admin user saves the configuration
     Then the "Used by services" column for the check command is updated accordingly
 
+  @MON-205040
   Scenario: Displaying the number of hosts using a check command
     Given a check command is configured
     And a host is configured

--- a/centreon/tests/e2e/features/Downtime/01-realtime-dst-transitions.feature
+++ b/centreon/tests/e2e/features/Downtime/01-realtime-dst-transitions.feature
@@ -8,18 +8,22 @@ Feature: Realtime downtime around DST transitions
     Given a user logged in with the Europe/Paris timezone
     And a passive service is monitored
 
+  @MON-205045
   Scenario: realtime downtime over a full spring-forward day lasts 23h
     When a realtime downtime covering the whole spring-forward day is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205044
   Scenario: realtime downtime over a full fall-back day lasts 25h
     When a realtime downtime covering the whole fall-back day is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205043
   Scenario: realtime downtime starting on a non-existent spring-forward time is clamped
     When a realtime downtime starting at the non-existent spring-forward time is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205042
   Scenario: realtime downtime fully inside the spring-forward gap is not scheduled
     When a realtime downtime fully inside the spring-forward gap is applied
     Then the downtime is not scheduled

--- a/centreon/tests/e2e/features/Downtime/02-recurrent-dst-transitions.feature
+++ b/centreon/tests/e2e/features/Downtime/02-recurrent-dst-transitions.feature
@@ -11,44 +11,54 @@ Feature: Recurrent downtime around DST transitions
 
   # Spring forward — clocks jump 02:00 -> 03:00, so 02:00-03:00 does not exist (23h day)
 
+  @MON-205055
   Scenario: recurrent downtime starting on a non-existent spring-forward time is clamped
     When a recurrent downtime starting at the non-existent spring-forward time is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205054
   Scenario: recurrent downtime ending on a non-existent spring-forward time is clamped
     When a recurrent downtime ending at the non-existent spring-forward time is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205053
   Scenario: recurrent downtime fully inside the spring-forward gap is not scheduled
     When a recurrent downtime fully inside the spring-forward gap is applied
     Then the downtime is not scheduled
 
+  @MON-205052
   Scenario: recurrent downtime over a full spring-forward day lasts 23h
     When a recurrent downtime covering the whole spring-forward day is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205051
   Scenario: recurrent downtime on the day after the spring-forward transition lasts 24h
     When a recurrent downtime covering the day after the spring-forward transition is applied
     Then the scheduled downtime matches the expected start, end and duration
 
   # Fall back — clocks go 03:00 -> 02:00, so 02:00-03:00 happens twice (25h day)
 
+  @MON-205050
   Scenario: recurrent downtime starting in the repeated fall-back hour is scheduled as entered
     When a recurrent downtime starting in the repeated fall-back hour is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205049
   Scenario: recurrent downtime ending in the repeated fall-back hour is scheduled as entered
     When a recurrent downtime ending in the repeated fall-back hour is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205048
   Scenario: recurrent downtime fully inside the repeated fall-back hour is scheduled
     When a recurrent downtime fully inside the repeated fall-back hour is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205047
   Scenario: recurrent downtime over a full fall-back day lasts 25h
     When a recurrent downtime covering the whole fall-back day is applied
     Then the scheduled downtime matches the expected start, end and duration
 
+  @MON-205046
   Scenario: recurrent downtime on the day after the fall-back transition lasts 24h
     When a recurrent downtime covering the day after the fall-back transition is applied
     Then the scheduled downtime matches the expected start, end and duration

--- a/centreon/tests/e2e/features/Downtime/03-recurrent-downtime-host.feature
+++ b/centreon/tests/e2e/features/Downtime/03-recurrent-downtime-host.feature
@@ -8,6 +8,7 @@ Feature: Recurrent downtime on a host
   Background:
     Given a user logged in with the Europe/Paris timezone
 
+  @MON-205056
   Scenario: a recurrent downtime on a host is scheduled
     When a recurrent downtime on a host is applied
     Then a host downtime is scheduled

--- a/centreon/tests/e2e/features/Downtime/04-downtime-start-and-stop.feature
+++ b/centreon/tests/e2e/features/Downtime/04-downtime-start-and-stop.feature
@@ -8,11 +8,13 @@ Feature: Service downtime start and stop
   Background:
     Given a passive service is monitored
 
+  @MON-205058
   Scenario: a fixed downtime becomes active during its time window
     Given a fixed downtime is scheduled on the service for the next minutes
     When the downtime start time is reached
     Then the service downtime is active
 
+  @MON-205057
   Scenario: a fixed downtime ends when its time window is over
     Given a fixed downtime is scheduled on the service for the next minutes
     And the service downtime is active

--- a/centreon/tests/e2e/features/Migration-scripts/01-command.feature
+++ b/centreon/tests/e2e/features/Migration-scripts/01-command.feature
@@ -9,11 +9,13 @@ Feature: Migration of commands from a source platform to a target platform
     And another non-admin user has the necessary rights to manage commands
     And the non-admin user has access to both the source and target platforms
 
+  @MON-205069
   Scenario: Command creation on the source platform
     Given a non-admin user logged in on the source platform
     When the user creates a new command
     Then the command is created and listed on the source platform
 
+  @MON-205068
   Scenario: Execution of the migration script with the complete command
     Given an admin user logged in on the source platform on the terminal
     When the user runs the following command in the terminal:
@@ -22,6 +24,7 @@ Feature: Migration of commands from a source platform to a target platform
     """
     Then a command line is displayed asking for the API token of the target platform
 
+  @MON-205067
   Scenario: Successful execution of the migration script
     Given an admin user who has entered the correct command line
     And the command line asking for the API token of the target platform is displayed
@@ -29,6 +32,7 @@ Feature: Migration of commands from a source platform to a target platform
     Then the migration script is executed without errors
     And the same command as in the source platform is created and displayed in the command listing
 
+  @MON-205066
   Scenario: Wrong token entered
     Given an admin user who has entered the correct command line
     And the command line asking for the API token of the target platform is displayed
@@ -36,6 +40,7 @@ Feature: Migration of commands from a source platform to a target platform
     Then the migration script is not executed
     And an error is displayed
 
+  @MON-205065
   Scenario: Execution of the migration script without the target platform IP
     Given an admin user logged in the terminal of the source platform
     When the user runs the following command in the terminal :
@@ -45,18 +50,21 @@ Feature: Migration of commands from a source platform to a target platform
     Then the migration script is not executed
     And a "missing URL" error is displayed
 
+  @MON-205064
   Scenario: Comparing command details between platforms
     Given a non-admin user logged in on the source and target platforms
     And the original and migrated commands are displayed
     When the user compares the commands parameters
     Then the parameters are identical on both platforms
 
+  @MON-205063
   Scenario: Editing the command on the target platform
     Given a non-admin user logged in on the target platform
     And the migrated command is displayed
     When the user updates the command
     Then the command is successfully updated
 
+  @MON-205062
   Scenario: Comparing monitoring information of services based on the command
     Given a non-admin user logged in on the source and target platforms
     When the user creates a service based on the command of each platform
@@ -64,6 +72,7 @@ Feature: Migration of commands from a source platform to a target platform
     And runs a check on each platform
     Then the services must have the same output on both platforms
 
+  @MON-205061
   Scenario: Validating monitoring graph on the target platform
     Given a non-admin user logged in on the target platform
     And a monitored service based on the command
@@ -71,11 +80,13 @@ Feature: Migration of commands from a source platform to a target platform
     Then a graph is created with the service data
     And its information is correct
 
+  @MON-205060
   Scenario: Deleting the command on the target platform
     Given a non-admin user logged in on the target platform
     When the user deletes the command
     Then the command is deleted and no longer displayed
 
+  @MON-205059
   Scenario: Re-execution of the migration script
     Given an admin user who successfully executed the migration script once
     When the user executes the migration script a second time

--- a/centreon/tests/e2e/features/Migration-scripts/02-media.feature
+++ b/centreon/tests/e2e/features/Migration-scripts/02-media.feature
@@ -9,11 +9,13 @@ Feature: Migration of medias from a source platform to a target platform
     And another non-admin user has the necessary rights to manage medias
     And the non-admin user has access to both the source and target platforms
 
+  @MON-205079
   Scenario: Medias creation on the source platform
     Given a non-admin user logged in on the source platform
     When the user adds a new media
     Then the media is added and listed on the source platform
 
+  @MON-205077
   Scenario: Execution of the migration script with the complete command
     Given an admin user logged in on the source platform on the terminal
     When the user runs the following command in the terminal:
@@ -22,6 +24,7 @@ Feature: Migration of medias from a source platform to a target platform
     """
     Then the user is asked for the API token of the target platform
 
+  @MON-205076
   Scenario: Successful execution of the migration script
     Given an admin user who has entered the correct command line
     And the user is asked for the API token of the target platform
@@ -29,6 +32,7 @@ Feature: Migration of medias from a source platform to a target platform
     Then the migration script is executed without errors
     And the same media as in the source platform is added and displayed in the media listing
 
+  @MON-205075
   Scenario: Incorrect token entered
     Given an admin user who has entered the correct command line
     And the user is asked for the API token of the target platform
@@ -36,6 +40,7 @@ Feature: Migration of medias from a source platform to a target platform
     Then the migration script is not executed
     And an error is displayed
 
+  @MON-205074
   Scenario: Execution of the migration script without the target platform IP
     Given an admin user logged in on the terminal of the source platform
     When the user runs the following command in the terminal:
@@ -45,23 +50,27 @@ Feature: Migration of medias from a source platform to a target platform
     Then the migration script does not succeed
     And a "missing URL" error is displayed
 
+  @MON-205073
   Scenario: Comparing media details between platforms
     Given a non-admin user logged in on the source and target platforms
     And the original and migrated medias are displayed
     When the user compares the medias parameters
     Then the parameters are identical on both platforms
 
+  @MON-205072
   Scenario: Editing the media on the target platform after migration
     Given a non-admin user logged in on the target platform
     And the migrated media is displayed
     When the user updates the media
     Then the media is successfully updated
 
+  @MON-205071
   Scenario: Deleting the media on the target platform after migration
     Given a non-admin user logged in on the target platform
     When the user deletes the media
     Then the media is deleted and no longer displayed
 
+  @MON-205070
   Scenario: Re-execution of the migration script
     Given an admin user who successfully executed the migration script once
     When the user executes the migration script a second time

--- a/centreon/tests/e2e/features/Services-configuration/07-meta-service-configuration.feature
+++ b/centreon/tests/e2e/features/Services-configuration/07-meta-service-configuration.feature
@@ -22,6 +22,7 @@ Feature: Edit a meta service
     When the user deletes a meta service
     Then the deleted meta service is not displayed in the list
 
+  @MON-205080
   Scenario: Filter the configuration services list by service type
     When the configuration services list is requested for each selection filter
     Then services and meta services are returned according to the selected filter

--- a/centreon/tests/e2e/features/Time-Period/01-time-period-configuration.feature
+++ b/centreon/tests/e2e/features/Time-Period/01-time-period-configuration.feature
@@ -8,12 +8,14 @@ Feature: Time period Configuration
 
   @MON-162178
   # jours à exclure : 1er janvier, 1er mai, 14 juillet, 25 décembre
+  @MON-205082
   Scenario: Time period excluding holidays
     When a user creates a time period with separated holidays dates excluded
     Then all properties of my time period are saved
 
   @MON-162179
   # période à exclure : du 1er au 31 août
+  @MON-205081
   Scenario: Time period excluding a range of dates
     When a user creates a time period with a range of dates to exclude
     Then all properties of my time period are saved with the exclusions


### PR DESCRIPTION
Fixes: [MON-205038](https://centreon.atlassian.net/browse/MON-205038)

Backfills the Xray Test tags for e2e scenarios that were left **untagged** since the Xray / GHA communication refactor. Each previously untagged scenario now carries its `@MON-xxxx` tag, so its execution results can be mapped and reported to Xray.

### Scope (OSS repo)
- **44** scenarios tagged across 10 feature files: core e2e (`centreon/tests/e2e/features`, 42) + `centreon-awie` (2).
- Tags were generated by the `xray-provision-tests` action (real run), which created the corresponding Xray Cucumber Tests (MON-205036, MON-205079 → MON-205084, …).
- Modules (`centreon-modules`, ~15 orphans) will be handled in a **separate PR** in that repo.

### Notes
- Pure tag additions — no test logic changed.
- The created Xray Tests carry **no component yet**; component/labels/test-type are applied later by the enrich step.

[MON-205038]: https://centreon.atlassian.net/browse/MON-205038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ