### PR TITLE
feat(views): modern AJAX listing for graph curves

### DIFF
--- a/centreon/www/include/views/componentTemplates/ajaxComponentTemplatesListing.php
+++ b/centreon/www/include/views/componentTemplates/ajaxComponentTemplatesListing.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB = $helper->getDb();
+$params = $helper->getParams();
+
+$search = $params['search'];
+$num = $params['num'];
+$limit = $params['limit'];
+
+$cond = '';
+$bind = [];
+if ($search !== '') {
+    $cond = ' WHERE gct.name LIKE :search';
+    $bind[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS gct.compo_id, gct.name, gct.ds_name, gct.ds_legend, gct.ds_stack, '
+    . 'gct.ds_order, gct.ds_transparency, gct.ds_tickness, gct.ds_filled, gct.ds_color_line, '
+    . 'gct.ds_color_area, h.host_name '
+    . 'FROM giv_components_template gct LEFT JOIN host h ON h.host_id = gct.host_id'
+    . $cond . ' ORDER BY h.host_name, gct.name LIMIT :offset, :limit'
+);
+foreach ($bind as $key => $value) {
+    $statement->bindValue($key, $value, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($c = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $rows[] = [
+        'id' => (int) $c['compo_id'],
+        'name' => $c['name'],
+        'host' => $c['host_name'] ?: _('Global'),
+        'ds_name' => $c['ds_name'],
+        'legend' => $c['ds_legend'],
+        'stacked' => ((int) $c['ds_stack']) ? _('Yes') : _('No'),
+        'order' => $c['ds_order'],
+        'transparency' => $c['ds_transparency'],
+        'thickness' => $c['ds_tickness'],
+        'filling' => ((int) $c['ds_filled']) ? _('Yes') : _('No'),
+        'colorLine' => $c['ds_color_line'],
+        'colorArea' => $c['ds_color_area'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/views/componentTemplates/listComponentTemplates.ihtml
+++ b/centreon/www/include/views/componentTemplates/listComponentTemplates.ihtml
@@ -1,79 +1,157 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch (e) {}
+}
+</script>
+{/literal}
+
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-      <tbody>
-        <tr>
-          <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-          <td><h4>{t}Curve{/t}</h4></td>
-        </tr>
-        <tr>
-          <td><input type="text" name="searchCurve" value="{$searchCurve}" class="mr-1">{$form.Search.html}</td>
-        </tr>
-      </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
+    <h1 class="cl-page-title">{t}Curves{/t}</h1>
+    <p class="cl-page-desc">{t}Define reusable curve (data source) templates for your performance graphs.{/t}</p>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$curvePage}&o=a', '{t}Add a curve{/t}'); return false;">{$msg.addT}</a>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>    
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchCurve" value="{$searchCurve}" class="cl-search-simple" placeholder="{t}Search curves{/t}" autocomplete="off">
                 </div>
-            </td>
-            <td></td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_desc}</td>
-            <td class="ListColHeaderLeft">{$headerMenu_legend}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_stack}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_order}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_Transp}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_tickness}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_fill}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td align="center" width='30'>          
-                <table>
-                    <tr>
-                    <td width="10" height="10" bgcolor="{$elemArr[elem].RowMenu_clrLine}"></td>
-                    <td width="10" height="10" bgcolor="{$elemArr[elem].RowMenu_clrArea}"></td>
-                    </tr>
-                </table>
-            </td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft">{$elemArr[elem].RowMenu_desc}</td>
-            <td class="ListColLeft">{$elemArr[elem].RowMenu_legend}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_stack}</td>
-            <td class="ListColCenter">{if $elemArr[elem].RowMenu_order}{$elemArr[elem].RowMenu_order}{else}-{/if}</td>
-            <td class="ListColRight">{if $elemArr[elem].RowMenu_transp}{$elemArr[elem].RowMenu_transp}&nbsp;%&nbsp;&nbsp;{else}-&nbsp;&nbsp;{/if}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_tickness}&nbsp;px&nbsp;</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_fill}</td>
-            <td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
-                {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="curveListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th class="cl-col-center">{$headerMenu_color}</th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_host}</th>
+                    <th>{$headerMenu_desc}</th>
+                    <th>{$headerMenu_legend}</th>
+                    <th class="cl-col-center">{$headerMenu_stack}</th>
+                    <th class="cl-col-center">{$headerMenu_order}</th>
+                    <th class="cl-col-center">{$headerMenu_Transp}</th>
+                    <th class="cl-col-center">{$headerMenu_tickness}</th>
+                    <th class="cl-col-center">{$headerMenu_fill}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="12" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>  
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
+{literal}
+<script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    curveListing.fetch(curveListing.getState().num, curveListing.getState().limit, curveListing.getState().search, true);
+}
+(function () {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function (e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function (e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function () {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
+
+var curveListing = new CentreonListing({
+    instanceName: 'curveListing',
+    ajaxListUrl:  './include/views/componentTemplates/ajaxComponentTemplatesListing.php',
+    pageId:       {/literal}'{$curvePage}'{literal},
+    writeAccess:  {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit: {/literal}{$defaultLimit}{literal},
+    storageKey:   'curve_listing_limit',
+    emptyMessage: 'No curves found',
+    liveSearch:   true,
+    rowIdField:   'id',
+    columns: [
+        { id:'color', align:'center', render: function(row, l) {
+            var line = l.escape(row.colorLine || 'transparent');
+            var area = l.escape(row.colorArea || 'transparent');
+            return '<span style="display:inline-flex;gap:2px;">'
+                + '<span style="width:12px;height:12px;border:1px solid #ccc;background:'+line+';"></span>'
+                + '<span style="width:12px;height:12px;border:1px solid #ccc;background:'+area+';"></span></span>';
+        }},
+        { id:'name', render: function(row, l) {
+            var editUrl = 'main.get.php?p={/literal}{$curvePage}{literal}&o=c&compo_id=' + row.id;
+            var ptitle = '{/literal}{t}Modify a curve{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(ptitle)+'\'); return false;">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'host' },
+        { id:'ds_name' },
+        { id:'legend' },
+        { id:'stacked', align:'center' },
+        { id:'order', align:'center', render: function(row) { return row.order ? row.order : '-'; } },
+        { id:'transparency', align:'center', render: function(row) { return row.transparency ? row.transparency + ' %' : '-'; } },
+        { id:'thickness', align:'center', render: function(row) { return (row.thickness || 0) + ' px'; } },
+        { id:'filling', align:'center' }
+    ],
+    renderOptions: function(row, l) {
+        return '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+curveListing.init();
+</script>
+{/literal}

--- a/centreon/www/include/views/componentTemplates/listComponentTemplates.ihtml
+++ b/centreon/www/include/views/componentTemplates/listComponentTemplates.ihtml
@@ -79,42 +79,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    curveListing.fetch(curveListing.getState().num, curveListing.getState().limit, curveListing.getState().search, true);
-}
-(function () {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function (e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function (e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function () {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var curveListing = new CentreonListing({
     instanceName: 'curveListing',
@@ -153,5 +117,6 @@ var curveListing = new CentreonListing({
     }
 });
 curveListing.init();
+CentreonForm.initSidePanel(curveListing);
 </script>
 {/literal}

--- a/centreon/www/include/views/componentTemplates/listComponentTemplates.php
+++ b/centreon/www/include/views/componentTemplates/listComponentTemplates.php
@@ -25,49 +25,17 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-$SearchTool = null;
-$queryValues = [];
-$search = null;
-if (isset($_POST['searchCurve'])) {
-    $search = $_POST['searchCurve'];
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($_GET['search'])) {
-    $search = $_GET['search'];
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if ($search != null) {
-    $SearchTool = ' WHERE name LIKE :search';
-    $queryValues['search'] = '%' . $search . '%';
-    $ClWh1 = 'AND host_id IS NULL';
-    $ClWh2 = 'AND gct.host_id = h.host_id';
-} else {
-    $ClWh1 = 'WHERE host_id IS NULL';
-    $ClWh2 = 'WHERE gct.host_id = h.host_id';
-}
-$query = '( SELECT SQL_CALC_FOUND_ROWS compo_id, NULL as host_name, host_id, service_id, name, ds_stack, ds_order, '
-    . 'ds_name, ds_color_line, ds_color_area, ds_filled, ds_legend, default_tpl1, ds_tickness, ds_transparency '
-    . "FROM giv_components_template {$SearchTool} {$ClWh1} ) UNION ( SELECT compo_id, host_name, gct.host_id, "
-    . 'gct.service_id, name, ds_stack, ds_order, ds_name, ds_color_line, ds_color_area, ds_filled, ds_legend, '
-    . "default_tpl1, ds_tickness, ds_transparency FROM giv_components_template AS gct, host AS h {$SearchTool} {$ClWh2} ) "
-    . 'ORDER BY host_name, name LIMIT ' . $num * $limit . ', ' . $limit;
-$stmt = $pearDB->prepare($query);
-
-foreach ($queryValues as $key => $value) {
-    $stmt->bindValue(':' . $key, $value, PDO::PARAM_STR);
-}
-$stmt->execute();
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
-
-include './include/common/checkPagination.php';
-
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
 
-// start header menu
+// Access level
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
+// Column headers
+$tpl->assign('headerMenu_color', _('Color'));
 $tpl->assign('headerMenu_name', _('Name'));
+$tpl->assign('headerMenu_host', _('Host'));
 $tpl->assign('headerMenu_desc', _('Data Source Name'));
 $tpl->assign('headerMenu_legend', _('Legend'));
 $tpl->assign('headerMenu_stack', _('Stacked'));
@@ -75,90 +43,45 @@ $tpl->assign('headerMenu_order', _('Order'));
 $tpl->assign('headerMenu_Transp', _('Transparency'));
 $tpl->assign('headerMenu_tickness', _('Thickness'));
 $tpl->assign('headerMenu_fill', _('Filling'));
-$tpl->assign('headerMenu_options', _('Options'));
 
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$tpl->assign('curvePage', $p);
 
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a multidimensionnal Array we put in $tpl
-$yesOrNo = [null => _('No'), 0 => _('No'), 1 => _('Yes')];
-$elemArr = [];
-for ($i = 0; $compo = $stmt->fetch(); $i++) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $compo['compo_id'] . ']');
-    $moptions = '&nbsp;<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $compo['compo_id'] . "]' />";
-
-    $query = "SELECT h.host_name FROM giv_components_template AS gct, host AS h WHERE gct.host_id = '"
-        . $compo['host_id'] . "' AND gct.host_id = h.host_id";
-    $titles = $pearDB->query($query);
-    $title = $titles->rowCount() ? $titles->fetchRow() : ['host_name' => 'Global'];
-    $titles->closeCursor();
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'title' => $title['host_name'], 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $compo['name'], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&compo_id=' . $compo['compo_id'], 'RowMenu_desc' => $compo['ds_name'], 'RowMenu_legend' => $compo['ds_legend'], 'RowMenu_stack' => $yesOrNo[$compo['ds_stack']], 'RowMenu_order' => $compo['ds_order'], 'RowMenu_transp' => $compo['ds_transparency'], 'RowMenu_clrLine' => $compo['ds_color_line'], 'RowMenu_clrArea' => $compo['ds_color_area'], 'RowMenu_fill' => $yesOrNo[$compo['ds_filled']], 'RowMenu_tickness' => $compo['ds_tickness'], 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
+// Restore search from history
+$search = '';
+if (isset($_POST['searchCurve'])) {
+    $search = $_POST['searchCurve'];
+} elseif (isset($centreon->historySearch[$url])) {
+    $search = $centreon->historySearch[$url];
 }
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('searchCurve', htmlentities($search ?? '', ENT_QUOTES));
 
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
+// Default limit
+$dbResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-// Toolbar select
+// Form (bulk actions + search submit)
+$form = new HTML_QuickFormCustom('form', 'POST', '?p=' . $p);
+$form->addElement('submit', 'Search', _('Search'), ['class' => 'btc bt_success']);
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </script>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
-$attrs1 = ['onchange' => 'javascript: '
-    . "if (this.form.elements['o1'].selectedIndex === 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex === 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "this.form.elements['o1'].selectedIndex = 0;"
-    . ''];
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-
 $attrs = ['onchange' => 'javascript: '
-    . "if (this.form.elements['o2'].selectedIndex === 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex === 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "this.form.elements['o2'].selectedIndex = 0;"
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
+    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('" . _('Do you confirm the duplication ?') . "')) {"
+    . " setO(this.form.elements['o1'].value); submit();} "
+    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('" . _('Do you confirm the deletion ?') . "')) {"
+    . " setO(this.form.elements['o1'].value); submit();} "];
+$form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+$form->setDefaults(['o1' => null]);
+$form->getElement('o1')->setValue(null);
 
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 $tpl->assign('limit', $limit);
-$tpl->assign('searchCurve', htmlentities($search));
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary
Modernizes the **Graph > Curves** listing (curve / data source templates) by moving it from the legacy Smarty table to the CentreonListing AJAX framework.

## Changes
- **ajaxComponentTemplatesListing.php** (new): AJAX endpoint over `giv_components_template` (left-joined with `host` for the Global/host label). Returns name, host, data source name, legend, stacked, order, transparency, thickness, filling and line/area colors, with server-side search and pagination.
- **listComponentTemplates.ihtml**: standard listing toolbar (right-aligned live search, chevron pagination, breadcrumb + page description), color swatches per curve, name opens the edit form in a slide-in side panel, Duplicate/Delete bulk actions.
- **listComponentTemplates.php**: modern template variables (access level, column headers, page id, search restore, default limit from `maxViewConfiguration`, bulk-action form).

## Notes
Display-only refactor: no DB schema or backend logic change. The router `componentTemplates.php` is unchanged and still handles add/modify/watch/duplicate/delete.