### PR TITLE
feat(views): modern AJAX listing for virtual metrics

### DIFF
--- a/centreon/www/include/views/virtualMetrics/ajaxVirtualMetricsListing.php
+++ b/centreon/www/include/views/virtualMetrics/ajaxVirtualMetricsListing.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB = $helper->getDb();
+$params = $helper->getParams();
+
+$search = $params['search'];
+$num = $params['num'];
+$limit = $params['limit'];
+
+$cond = '';
+$bind = [];
+if ($search !== '') {
+    $cond = ' WHERE vmetric_name LIKE :search';
+    $bind[':search'] = '%' . $search . '%';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS vmetric_id, vmetric_name, unit_name, rpn_function, def_type, hidden, '
+    . 'vmetric_activate, index_id FROM virtual_metrics' . $cond
+    . ' ORDER BY vmetric_name LIMIT :offset, :limit'
+);
+foreach ($bind as $key => $value) {
+    $statement->bindValue($key, $value, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$vmetrics = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+// Resolve the "host > service" label from the storage index_data table (batch)
+$indexNames = [];
+$indexIds = array_filter(array_map(static fn($v) => (int) $v['index_id'], $vmetrics));
+if ($indexIds !== []) {
+    $pearDBO = new CentreonDB('centstorage');
+    $idList = implode(',', array_unique($indexIds));
+    $idxResult = $pearDBO->query(
+        'SELECT id, host_name, service_description FROM index_data WHERE id IN (' . $idList . ')'
+    );
+    while ($idx = $idxResult->fetch(PDO::FETCH_ASSOC)) {
+        $indexNames[(int) $idx['id']] = trim(($idx['host_name'] ?? '') . ' > ' . ($idx['service_description'] ?? ''), ' >');
+    }
+}
+
+$defType = [0 => 'CDEF', 1 => 'VDEF'];
+
+$rows = [];
+foreach ($vmetrics as $vm) {
+    $rows[] = [
+        'id' => (int) $vm['vmetric_id'],
+        'name' => $vm['vmetric_name'],
+        'resource' => $indexNames[(int) $vm['index_id']] ?? '',
+        'unit' => $vm['unit_name'],
+        'rpn' => $vm['rpn_function'],
+        'deftype' => $defType[(int) $vm['def_type']] ?? '',
+        'hidden' => ((int) $vm['hidden']) ? _('Yes') : _('No'),
+        'activate' => (int) $vm['vmetric_activate'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/views/virtualMetrics/ajaxVirtualMetricsToggle.php
+++ b/centreon/www/include/views/virtualMetrics/ajaxVirtualMetricsToggle.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(20408);
+
+// Verify it exists + get name for logging
+$nameStmt = $pearDB->prepare('SELECT vmetric_name FROM virtual_metrics WHERE vmetric_id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn();
+if ($objName === false) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare('UPDATE virtual_metrics SET vmetric_activate = :activate WHERE vmetric_id = :id');
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+$helper->logToggleAction('virtual_metrics', $objId, (string) $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/views/virtualMetrics/listVirtualMetrics.ihtml
+++ b/centreon/www/include/views/virtualMetrics/listVirtualMetrics.ihtml
@@ -1,99 +1,146 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<form name='form' method='POST'>
-    <table class="ajaxOption table">
-        <tbody>
-        <tr>
-            <th><h5>{t}Filters{/t}</h5></th>
-        </tr>
-        <tr>
-            <td><h4>{t}Virtual metrics{/t}</h4></td>
-        </tr>
-        <tr>
-            <td><input type="text" name="searchVM" value="{$searchVM}" class="mr-1">{$form.Search.html}</td>
-        </tr>
-        </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
-                {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall" onclick="checkUncheckAll(this);"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            </td>
-            <td></td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter" width='60'>{$headerMenu_unit}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_rpnfunc}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_count}</td>
-            <td class="ListColHeaderCenter" width='100'>{$headerMenu_dtype}</td>
-            <td class="ListColHeaderCenter" width='100'>{$headerMenu_hidden}</td>
-            <td class="ListColHeaderCenter" width='100'>{$headerMenu_status}</td>
-            <td class="ListColHeaderRight" width='130'>{$headerMenu_options}</td>
-        </tr>
-        {assign var=title_mode value=0}
-        {section name=elem loop=$elemArr}
-        {if isset($title_value) && $elemArr[elem].title != $title_value}
-        {assign var=title_mode value=0}
-        {/if}
-        {if $elemArr[elem].title && $title_mode == 0}
-        <tr class="list_lvl_1">
-            <td class="ListColLeft" colspan="10"><b>{$elemArr[elem].title}</b></td>
-        </tr>
-        {assign var=title_mode value=1}
-        {assign var=title_value value=$elemArr[elem].title}
-        {/if}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td align="center" width="16" height="16" style="padding: 0px">
-                {if $elemArr[elem].RowMenu_ckstate == 1}
-                <img style="margin: 0px; padding-left: 4px; padding-right: 4px; padding-top: 2px;"
-                     src="./img/icons/checked.png" class="ico-14">
-                {else}
-                {if $elemArr[elem].RowMenu_ckstate == 2}
-                <img style="margin: 0px; padding-left: 4px; padding-right: 4px; padding-top: 2px;"
-                     src="./img/icons/checked.png" class='ico-16'/>
-                {else}
-                <img style="margin: 0px; padding-left: 4px; padding-right: 4px; padding-top: 2px;"
-                     src="./img/icons/deleted.png" class='ico-16'/>
-                {/if}
-                {/if}
-            </td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_unit}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_rpnfunc}</td>
-            <td class="ListColCenter">{if $elemArr[elem].RowMenu_count}{$elemArr[elem].RowMenu_count}&nbsp;&nbsp;&nbsp;{else}-&nbsp;&nbsp;{/if}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_dtype}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_hidden}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_status}</td>
-            <td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
-                {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <input type='hidden' name='o' id='o' value='42'>
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>
-    {$form.hidden}
-</form>
+
 {literal}
-<script type='text/javascript'>
-    setDisabledRowStyle();
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch (e) {}
+}
+</script>
+{/literal}
+
+<form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Virtual metrics{/t}</h1>
+    <p class="cl-page-desc">{t}Build computed metrics (RPN) derived from existing service metrics.{/t}</p>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            { if $mode_access == 'w' }
+            <div class="cl-actions-left">
+                <a href="#" class="cl-btn-add" onclick="cfOpenPanel('main.get.php?p={$vmPage}&o=a', '{t}Add a virtual metric{/t}'); return false;">{$msg.addT}</a>
+                {$form.o1.html}
+            </div>
+            { else }
+            <div class="cl-actions-left">&nbsp;</div>
+            { /if }
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchVM" value="{$searchVM}" class="cl-search-simple" placeholder="{t}Search virtual metrics{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
+            </div>
+        </div>
+
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="vmListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th>{$headerMenu_resource}</th>
+                    <th>{$headerMenu_unit}</th>
+                    <th>{$headerMenu_rpnfunc}</th>
+                    <th class="cl-col-center">{$headerMenu_dtype}</th>
+                    <th class="cl-col-center">{$headerMenu_hidden}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="8" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+<input type='hidden' name='o' id='o' value='42'>
+<input type='hidden' id='limit' name='limit' value=''>
+{$form.hidden}
+</form>
+
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
+{literal}
+<script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    vmListing.fetch(vmListing.getState().num, vmListing.getState().limit, vmListing.getState().search, true);
+}
+(function () {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function (e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function (e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function () {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
+
+var vmListing = new CentreonListing({
+    instanceName:  'vmListing',
+    ajaxListUrl:   './include/views/virtualMetrics/ajaxVirtualMetricsListing.php',
+    ajaxToggleUrl: './include/views/virtualMetrics/ajaxVirtualMetricsToggle.php',
+    pageId:        {/literal}'{$vmPage}'{literal},
+    writeAccess:   {/literal}'{$mode_access}'{literal} === 'w',
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'vmetric_listing_limit',
+    emptyMessage:  'No virtual metrics found',
+    liveSearch:    true,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var editUrl = 'main.get.php?p={/literal}{$vmPage}{literal}&o=c&vmetric_id=' + row.id;
+            var ptitle = '{/literal}{t}Modify a virtual metric{/t}{literal} - ' + row.name;
+            return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(ptitle)+'\'); return false;">'+l.escape(row.name)+'</a>';
+        }},
+        { id:'resource' },
+        { id:'unit' },
+        { id:'rpn' },
+        { id:'deftype', align:'center' },
+        { id:'hidden', align:'center' }
+    ],
+    renderOptions: function(row, l) {
+        var checked = row.activate ? ' checked' : '';
+        return '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="vmListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>' +
+            '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+    }
+});
+vmListing.init();
 </script>
 {/literal}

--- a/centreon/www/include/views/virtualMetrics/listVirtualMetrics.ihtml
+++ b/centreon/www/include/views/virtualMetrics/listVirtualMetrics.ihtml
@@ -75,42 +75,6 @@ if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
 
 {literal}
 <script type="text/javascript">
-function cfOpenPanel(url, title) {
-    document.getElementById('cfSidePanelTitle').textContent = title || '';
-    document.getElementById('cfSidePanelFrame').src = url;
-    document.getElementById('cfSideOverlay').classList.add('open');
-    document.getElementById('cfSidePanel').classList.add('open');
-}
-function cfClosePanel() {
-    document.getElementById('cfSideOverlay').classList.remove('open');
-    document.getElementById('cfSidePanel').classList.remove('open');
-    setTimeout(function () { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
-    vmListing.fetch(vmListing.getState().num, vmListing.getState().limit, vmListing.getState().search, true);
-}
-(function () {
-    var handle = document.getElementById('cfSidePanelResize');
-    var panel = document.getElementById('cfSidePanel');
-    var dragging = false;
-    handle.addEventListener('mousedown', function (e) {
-        e.preventDefault(); dragging = true; handle.classList.add('active');
-        document.body.style.cursor = 'col-resize';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = 'none';
-    });
-    document.addEventListener('mousemove', function (e) {
-        if (!dragging) return;
-        var w = window.innerWidth - e.clientX;
-        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
-        panel.style.width = w + 'px';
-    });
-    document.addEventListener('mouseup', function () {
-        if (!dragging) return; dragging = false; handle.classList.remove('active');
-        document.body.style.cursor = '';
-        var iframe = document.getElementById('cfSidePanelFrame');
-        if (iframe) iframe.style.pointerEvents = '';
-    });
-})();
-document.addEventListener('keydown', function (e) { if (e.key === 'Escape') cfClosePanel(); });
 
 var vmListing = new CentreonListing({
     instanceName:  'vmListing',
@@ -142,5 +106,6 @@ var vmListing = new CentreonListing({
     }
 });
 vmListing.init();
+CentreonForm.initSidePanel(vmListing);
 </script>
 {/literal}

--- a/centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+++ b/centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -18,221 +19,65 @@
  *
  */
 
-if (! isset($oreon)) {
+if (! isset($centreon)) {
     exit;
 }
 
-use Adaptation\Database\Connection\Collection\QueryParameters;
-use Adaptation\Database\Connection\Exception\ConnectionException;
-use Adaptation\Database\Connection\ValueObject\QueryParameter;
-
 include './include/common/autoNumLimit.php';
-
-$queryValues ??= [];
-$searchTool = '';
-$search = null;
-
-if (isset($_POST['searchVM'])) {
-    $search = htmlspecialchars($_POST['searchVM'], ENT_QUOTES, 'UTF-8');
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($_GET['searchVM'])) {
-    $search = htmlspecialchars($_GET['searchVM'], ENT_QUOTES, 'UTF-8');
-    $centreon->historySearch[$url] = $search;
-} elseif (isset($centreon->historySearch[$url])) {
-    $search = $centreon->historySearch[$url];
-}
-
-if ($search) {
-    $searchTool .= ' WHERE vmetric_name LIKE :search';
-    $queryValues['search'] = '%' . $search . '%';
-}
-
-$listResults =  [];
-$rows = 0;
-try {
-    $listResults = $pearDB->fetchAllAssociative(
-        <<<SQL
-            SELECT SQL_CALC_FOUND_ROWS *
-            FROM virtual_metrics
-            {$searchTool}
-            ORDER BY index_id, vmetric_name
-            LIMIT :offset, :limit
-            SQL,
-        new QueryParameters(array_filter([
-            QueryParameter::int('offset', $num * $limit),
-            QueryParameter::int('limit', $limit),
-            ...array_map(
-                fn ($key, $value) => QueryParameter::string($key, $value),
-                array_keys($queryValues),
-                $queryValues
-            ),
-        ]))
-    );
-    $rows = (int) $pearDB->fetchOne('SELECT FOUND_ROWS()');
-} catch (ConnectionException $e) {
-    echo 'DB Error : ' . $e->getMessage();
-}
-
-include './include/common/checkPagination.php';
 
 // Smarty template initialization
 $tpl = SmartyBC::createSmartyTemplate($path);
-// start header menu
+
+// Access level
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
+
+// Column headers
 $tpl->assign('headerMenu_name', _('Name'));
+$tpl->assign('headerMenu_resource', _('Host / Service'));
 $tpl->assign('headerMenu_unit', _('Unit'));
 $tpl->assign('headerMenu_rpnfunc', _('Function'));
-$tpl->assign('headerMenu_count', _('Data Count'));
 $tpl->assign('headerMenu_dtype', _('DEF Type'));
 $tpl->assign('headerMenu_hidden', _('Hidden'));
-$tpl->assign('headerMenu_status', _('Status'));
-$tpl->assign('headerMenu_options', _('Options'));
 
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
+$tpl->assign('vmPage', $p);
 
-// Different style between each lines
-$style = 'one';
-
-$attrBtnSuccess = ['class' => 'btc bt_success', 'onClick' => "window.history.replaceState('', '', '?p=" . $p . "');"];
-$form->addElement('submit', 'Search', _('Search'), $attrBtnSuccess);
-
-// Fill a tab with a multidimensionnal Array we put in $tpl
-$deftype = [0 => 'CDEF', 1 => 'VDEF'];
-$yesOrNo = [null => 'No', 0 => 'No', 1 => 'Yes'];
-$elemArr = [];
-$centreonToken = createCSRFToken();
-
-foreach ($listResults as $i => $vmetric) {
-    $selectedElements = $form->addElement('checkbox', 'select[' . $vmetric['vmetric_id'] . ']');
-    if ($vmetric['vmetric_activate']) {
-        $moptions = "<a href='main.php?p=" . $p . '&vmetric_id=' . $vmetric['vmetric_id'] . '&o=u&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-            . "border='0' alt='" . _('Disabled') . "'></a>";
-    } else {
-        $moptions = "<a href='main.php?p=" . $p . '&vmetric_id=' . $vmetric['vmetric_id'] . '&o=s&limit=' . $limit
-            . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-            . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-            . "border = '0' alt = '" . _('Enabled') . "' ></a > ";
-    }
-    $moptions .= ' &nbsp;<input onKeypress = "if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;'
-        . "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr["
-        . $vmetric['vmetric_id'] . "]' />";
-
-    try {
-        $indd = $pearDBO->fetchAssociative(
-            <<<'SQL'
-                SELECT id,host_id,service_id FROM index_data WHERE id = :indexId
-                SQL,
-            new QueryParameters([
-                QueryParameter::int('indexId', (int) $vmetric['index_id']),
-            ])
-        );
-    } catch (ConnectionException $e) {
-        echo 'DB Error : ' . $e->getMessage() . '<br />';
-    }
-
-    if ($indd !== false) {
-        try {
-            $hsrname = $pearDB->fetchAssociative(
-                <<<'SQL'
-                    (SELECT concat(h.host_name,' > ',s.service_description) full_name
-                    FROM host_service_relation AS hsr, host AS h, service AS s
-                    WHERE hsr.host_host_id = h.host_id
-                    AND hsr.service_service_id = s.service_id
-                    AND h.host_id = :hostId
-                    AND s.service_id = :serviceId )
-                    UNION
-                    (SELECT concat(h.host_name,' > ',s.service_description) full_name
-                    FROM host_service_relation AS hsr, host AS h, service AS s, hostgroup_relation AS hr
-                    WHERE hsr.hostgroup_hg_id = hr.hostgroup_hg_id
-                    AND hr.host_host_id = h.host_id
-                    AND hsr.service_service_id = s.service_id
-                    AND h.host_id = :hostId
-                    AND s.service_id = :serviceId )
-                    ORDER BY full_name
-                    SQL,
-                new QueryParameters([
-                    QueryParameter::int('hostId', (int) $indd['host_id']),
-                    QueryParameter::int('serviceId', (int) $indd['service_id']),
-                ])
-            );
-
-        } catch (ConnectionException $e) {
-            echo 'DB Error : ' . $e->getMessage() . '<br />';
-        }
-        if ($hsrname !== false) {
-            $hsrname['full_name'] = str_replace('#S#', '/', $hsrname['full_name']);
-            $hsrname['full_name'] = str_replace('#BS#', '\\', $hsrname['full_name']);
-        }
-    }
-
-    // ## TODO : data_count
-    $elemArr[$i] = ['MenuClass' => 'list_' . $style, 'title' => $hsrname['full_name'] ?? null, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_ckstate' => $vmetric['ck_state'], 'RowMenu_name' => $vmetric['vmetric_name'], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&vmetric_id=' . $vmetric['vmetric_id'], 'RowMenu_unit' => $vmetric['unit_name'], 'RowMenu_rpnfunc' => htmlentities($vmetric['rpn_function']), 'RowMenu_count' => '-', 'RowMenu_dtype' => $deftype[$vmetric['def_type']], 'RowMenu_hidden' => $yesOrNo[$vmetric['hidden']], 'RowMenu_status' => $vmetric['vmetric_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_options' => $moptions];
-    $style = $style != 'two' ? 'two' : 'one';
+// Restore search from history
+$search = '';
+if (isset($_POST['searchVM'])) {
+    $search = $_POST['searchVM'];
+} elseif (isset($centreon->historySearch[$url])) {
+    $search = $centreon->historySearch[$url];
 }
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('searchVM', htmlentities($search ?? '', ENT_QUOTES));
 
-// Different messages we put in the template
-$tpl->assign(
-    'msg',
-    ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add'), 'delConfirm' => _('Do you confirm the deletion ?')]
-);
+// Default limit
+$dbResult = $pearDB->query("SELECT `value` FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-// Toolbar select
+// Form (bulk actions + search submit)
+$form = new HTML_QuickFormCustom('form', 'POST', '?p=' . $p);
+$form->addElement('submit', 'Search', _('Search'), ['class' => 'btc bt_success']);
 ?>
-    <script type="text/javascript">
-        function setO(_i) {
-            document.forms['form'].elements['o'].value = _i;
-        }
-    </script>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
 <?php
-$attrs1 = ['onchange' => 'javascript: '
-    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . "else if (this.form.elements['o1'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o1'].value); submit();} "
-    . ''];
-
-$form->addElement(
-    'select',
-    'o1',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs1
-);
-
-$form->setDefaults(['o1' => null]);
-$o1 = $form->getElement('o1');
-$o1->setValue(null);
-
 $attrs = ['onchange' => 'javascript: '
-    . "if (this.form.elements['o2'].selectedIndex == 1 && confirm('"
-    . _('Do you confirm the duplication ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 2 && confirm('"
-    . _('Do you confirm the deletion ?') . "')) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . "else if (this.form.elements['o2'].selectedIndex == 3) {"
-    . " 	setO(this.form.elements['o2'].value); submit();} "
-    . ''];
-$form->addElement(
-    'select',
-    'o2',
-    null,
-    [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')],
-    $attrs
-);
-$form->setDefaults(['o2' => null]);
+    . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('" . _('Do you confirm the duplication ?') . "')) {"
+    . " setO(this.form.elements['o1'].value); submit();} "
+    . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('" . _('Do you confirm the deletion ?') . "')) {"
+    . " setO(this.form.elements['o1'].value); submit();} "];
+$form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+$form->setDefaults(['o1' => null]);
+$form->getElement('o1')->setValue(null);
 
-$o2 = $form->getElement('o2');
-$o2->setValue(null);
+$tpl->assign('msg', ['addL' => 'main.php?p=' . $p . '&o=a', 'addT' => _('Add')]);
 $tpl->assign('limit', $limit);
-$tpl->assign('searchVM', htmlentities($search));
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Summary
Modernizes the **Graph > Virtual Metrics** listing by moving it from the legacy Smarty table to the CentreonListing AJAX framework.

## Changes
- **ajaxVirtualMetricsListing.php** (new): AJAX endpoint over `virtual_metrics` (name, unit, RPN function, DEF type, hidden, activation). The **Host / Service** label is resolved from the storage `index_data` table, batched by `index_id`. Server-side search + pagination.
- **ajaxVirtualMetricsToggle.php** (new): enable/disable a virtual metric (`vmetric_activate`) with CSRF + write-access checks and audit logging.
- **listVirtualMetrics.ihtml**: standard listing toolbar (right-aligned live search, chevron pagination, breadcrumb + page description), per-row **activation toggle**, name opens the form in a slide-in side panel, Duplicate/Delete bulk actions.
- **listVirtualMetrics.php**: modern template variables (access level, column headers, page id, search restore, default limit, bulk-action form).

## Notes
Display-only refactor; no DB schema change. The router `virtualMetrics.php` is unchanged and still handles add/modify/watch/enable/disable/duplicate/delete.