### PR TITLE
fix(service): block mass change creating duplicate service descriptions on a host

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -365,7 +365,7 @@ function checkServiceMassiveChangeExistence(array $fields): array|bool
     $targetHosts = is_array($fields['service_hPars'] ?? null) ? $fields['service_hPars'] : [];
     $targetHostGroups = is_array($fields['service_hgPars'] ?? null) ? $fields['service_hgPars'] : [];
 
-    if (! count($targetHosts) && ! count($targetHostGroups)) {
+    if ($targetHosts === [] && $targetHostGroups === []) {
         return true;
     }
 

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -347,6 +347,153 @@ function testServiceExistence($name = null, $hPars = [], $hgPars = [], $returnId
 }
 
 /**
+ * Form rule for the service "Mass Change": forbids moving one or several services onto a
+ * host (or hostgroup) that already holds another service with the same description, and also
+ * catches the case where two selected services sharing the same description are moved onto the
+ * same host/hostgroup within the same mass change.
+ *
+ * @param array $fields submitted form values
+ *
+ * @return array|bool true when valid, otherwise an [elementName => errorMessage] array
+ */
+function checkServiceMassiveChangeExistence(array $fields): array|bool
+{
+    if (empty($fields['select'])) {
+        return true;
+    }
+
+    $targetHosts = is_array($fields['service_hPars'] ?? null) ? $fields['service_hPars'] : [];
+    $targetHostGroups = is_array($fields['service_hgPars'] ?? null) ? $fields['service_hgPars'] : [];
+
+    if (! count($targetHosts) && ! count($targetHostGroups)) {
+        return true;
+    }
+
+    $serviceIds = array_filter(array_map('intval', explode(',', (string) $fields['select'])));
+
+    // Descriptions already claimed on each target relation within this mass change,
+    // so two selected services with the same description cannot land on the same host.
+    $seenOnHost = [];
+    $seenOnHostGroup = [];
+
+    foreach ($serviceIds as $serviceId) {
+        $description = getServiceDescriptionById($serviceId);
+        if ($description === null) {
+            continue;
+        }
+
+        foreach ($targetHosts as $hostId) {
+            $hostId = (int) $hostId;
+            if (
+                serviceDescriptionExistsOnHost($description, $hostId, $serviceId)
+                || isset($seenOnHost[$hostId][$description])
+            ) {
+                return ['service_hPars' => _(
+                    'One or more of the selected services cannot be moved: '
+                    . 'a service with the same description already exists on the target host(s).'
+                )];
+            }
+            $seenOnHost[$hostId][$description] = true;
+        }
+
+        foreach ($targetHostGroups as $hostGroupId) {
+            $hostGroupId = (int) $hostGroupId;
+            if (
+                serviceDescriptionExistsOnHostGroup($description, $hostGroupId, $serviceId)
+                || isset($seenOnHostGroup[$hostGroupId][$description])
+            ) {
+                return ['service_hgPars' => _(
+                    'One or more of the selected services cannot be moved: '
+                    . 'a service with the same description already exists on the target host group(s).'
+                )];
+            }
+            $seenOnHostGroup[$hostGroupId][$description] = true;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @param int $serviceId
+ *
+ * @return string|null the service description, or null when the service does not exist
+ */
+function getServiceDescriptionById(int $serviceId): ?string
+{
+    global $pearDB;
+
+    $statement = $pearDB->prepare(
+        'SELECT service_description FROM service WHERE service_id = :service_id'
+    );
+    $statement->bindValue(':service_id', $serviceId, PDO::PARAM_INT);
+    $statement->execute();
+    $description = $statement->fetchColumn();
+
+    return $description === false ? null : $description;
+}
+
+/**
+ * @param string $description
+ * @param int $hostId
+ * @param int $excludeServiceId service to exclude from the lookup (the one being moved)
+ *
+ * @return bool true when another service with the same description is already linked to the host
+ */
+function serviceDescriptionExistsOnHost(string $description, int $hostId, int $excludeServiceId): bool
+{
+    global $pearDB;
+
+    $statement = $pearDB->prepare(
+        <<<'SQL'
+            SELECT 1
+            FROM service
+            INNER JOIN host_service_relation hsr
+                ON hsr.service_service_id = service.service_id
+            WHERE hsr.host_host_id = :host_id
+                AND service.service_description = :service_description
+                AND service.service_id != :service_id
+            SQL
+    );
+    $statement->bindValue(':host_id', $hostId, PDO::PARAM_INT);
+    $statement->bindValue(':service_description', $description, PDO::PARAM_STR);
+    $statement->bindValue(':service_id', $excludeServiceId, PDO::PARAM_INT);
+    $statement->execute();
+
+    return (bool) $statement->fetchColumn();
+}
+
+/**
+ * @param string $description
+ * @param int $hostGroupId
+ * @param int $excludeServiceId service to exclude from the lookup (the one being moved)
+ *
+ * @return bool true when another service with the same description is already linked to the hostgroup
+ */
+function serviceDescriptionExistsOnHostGroup(string $description, int $hostGroupId, int $excludeServiceId): bool
+{
+    global $pearDB;
+
+    $statement = $pearDB->prepare(
+        <<<'SQL'
+            SELECT 1
+            FROM service
+            INNER JOIN host_service_relation hsr
+                ON hsr.service_service_id = service.service_id
+            WHERE hsr.hostgroup_hg_id = :hostgroup_hg_id
+                AND service.service_description = :service_description
+                AND service.service_id != :service_id
+            SQL
+    );
+    $statement->bindValue(':hostgroup_hg_id', $hostGroupId, PDO::PARAM_INT);
+    $statement->bindValue(':service_description', $description, PDO::PARAM_STR);
+    $statement->bindValue(':service_id', $excludeServiceId, PDO::PARAM_INT);
+    $statement->execute();
+
+    return (bool) $statement->fetchColumn();
+}
+
+/**
  * Get service id by combination of host or hostgroup relations
  *
  * @param string $serviceDescription

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -382,8 +382,15 @@ function checkServiceMassiveChangeExistence(array $fields): array|bool
             continue;
         }
 
+        // Only newly created relations can introduce a duplicate: like the incremental
+        // mass change, skip the hosts/hostgroups the service is already linked to.
+        $currentRelations = getServiceLinkedRelations($serviceId);
+
         foreach ($targetHosts as $hostId) {
             $hostId = (int) $hostId;
+            if (isset($currentRelations['hosts'][$hostId])) {
+                continue;
+            }
             if (
                 serviceDescriptionExistsOnHost($description, $hostId, $serviceId)
                 || isset($seenOnHost[$hostId][$description])
@@ -398,6 +405,9 @@ function checkServiceMassiveChangeExistence(array $fields): array|bool
 
         foreach ($targetHostGroups as $hostGroupId) {
             $hostGroupId = (int) $hostGroupId;
+            if (isset($currentRelations['hostGroups'][$hostGroupId])) {
+                continue;
+            }
             if (
                 serviceDescriptionExistsOnHostGroup($description, $hostGroupId, $serviceId)
                 || isset($seenOnHostGroup[$hostGroupId][$description])
@@ -431,6 +441,37 @@ function getServiceDescriptionById(int $serviceId): ?string
     $description = $statement->fetchColumn();
 
     return $description === false ? null : $description;
+}
+
+/**
+ * Returns the hosts and hostgroups a service is currently linked to.
+ *
+ * @param int $serviceId
+ *
+ * @return array{hosts: array<int, true>, hostGroups: array<int, true>} id-keyed sets of current relations
+ */
+function getServiceLinkedRelations(int $serviceId): array
+{
+    global $pearDB;
+
+    $statement = $pearDB->prepare(
+        'SELECT host_host_id, hostgroup_hg_id FROM host_service_relation WHERE service_service_id = :service_id'
+    );
+    $statement->bindValue(':service_id', $serviceId, PDO::PARAM_INT);
+    $statement->execute();
+
+    $hosts = [];
+    $hostGroups = [];
+    while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        if (! empty($row['host_host_id'])) {
+            $hosts[(int) $row['host_host_id']] = true;
+        }
+        if (! empty($row['hostgroup_hg_id'])) {
+            $hostGroups[(int) $row['hostgroup_hg_id']] = true;
+        }
+    }
+
+    return ['hosts' => $hosts, 'hostGroups' => $hostGroups];
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -1078,6 +1078,9 @@ if ($o !== SERVICE_MASSIVE_CHANGE) {
     $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _('Required fields'));
 } elseif ($o === SERVICE_MASSIVE_CHANGE) {
     $from_list_menu = $form->getSubmitValue('submitMC') ? false : true;
+    // Prevent a mass change from moving a service onto a host/hostgroup that already
+    // has (or would end up with) another service sharing the same description.
+    $form->addFormRule('checkServiceMassiveChangeExistence');
 }
 
 if (isset($service['service_template_model_stm_id']) && ($service['service_template_model_stm_id'] === '')) {


### PR DESCRIPTION
## Description

Resolves [MON-160984](https://centreon.atlassian.net/browse/MON-160984).

The **Mass Change** action on services skipped all form validation, so it was possible to move several services with the same description onto a single host — something the normal add/edit flow forbids (a host cannot hold two services with the same description).

## Fix

- Register a form rule (`checkServiceMassiveChangeExistence`) on the service Mass Change form.
- The rule blocks the change and shows an error above the **Hosts** / **Host groups** field when a move would create a duplicate service description, covering both:
  - a target host/hostgroup that already holds another service with that description, and
  - two selected services sharing the same description being moved onto the same host/hostgroup in the same operation (the exact reproduction in the ticket).
- Applies to both On-Premise and Cloud (rule lives in the shared `formService.php`).

## How to test

1. Create two services with the same description on two different hosts.
2. Select both in Configuration > Services, More actions > Mass Change.
3. Set the destination to a single host and save.
4. **Expected:** the change is refused with an error message above the Hosts field. Moving services with distinct descriptions still works.

[MON-160984]: https://centreon.atlassian.net/browse/MON-160984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ