### PR TITLE
fix(graph): Debug curve thickness not rendering in interactive graphs

### DIFF
--- a/centreon/www/include/views/graphs/javascript/centreon-graph.js
+++ b/centreon/www/include/views/graphs/javascript/centreon-graph.js
@@ -17,6 +17,7 @@
       unit: parseInterval[2]
     };
     this.ids = {};
+    this.tickness = {};
     this.toggleAction = 'hide';
 
     if ($elem.attr('id') === undefined) {
@@ -230,6 +231,9 @@
         regions: self.buildRegions(data),
         legend: {
           show: false
+        },
+        onrendered: function () {
+          self.applyLineThickness();
         }
       });
 
@@ -324,6 +328,7 @@
       for (i = 0; i < dataRaw.metrics.length; i++) {
         name = 'data' + (i + 1);
         this.ids[dataRaw.metrics[i].legend] = name;
+        this.tickness[name] = Number(dataRaw.metrics[i].ds_data.ds_tickness) || 1;
         column = dataRaw.metrics[i].data;
         column.unshift(name);
         data.columns.push(column);
@@ -399,6 +404,18 @@
         data: data,
         axis: axis
       };
+    },
+    /**
+     * Apply each curve's configured thickness to its rendered line/area path.
+     * c3.js has no built-in per-series line-width option, so the value captured
+     * in this.tickness (from ds_data.ds_tickness) is applied as an inline style
+     * after each render, which takes precedence over the default c3 CSS rule.
+     */
+    applyLineThickness: function () {
+      var self = this;
+      Object.keys(this.tickness).forEach(function (name) {
+        self.$elem.find('.c3-line-' + name).css('stroke-width', self.tickness[name] + 'px');
+      });
     },
     /**
      * Build data for status graph


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Investigation report</h2><p>The curve thickness configured from <strong>Performances &gt; Curves</strong> is correctly saved and used by PNG exports, but it is ignored by the interactive graph displayed in <strong>Performances &gt; Graphs</strong>.</p><h2>Root cause</h2><p>The <strong>Performances &gt; Graphs</strong> page uses the legacy <strong>jQuery + C3.js</strong> graph implementation.</p><p>The topology is registered in <code inline="">insertTopology.sql</code>:</p><pre><code class="language-sql">INSERT INTO `topology` (...)
VALUES (
  139,
  'Graphs',
  204,
  20401,
  10,
  40,
  './include/views/graphs/graphs.php',
  ...
);
</code></pre><p>The page loads:</p><pre><code class="language-text">www/include/views/graphs/javascript/centreon-graph.js
</code></pre><p>The frontend retrieves graph data through:</p><pre><code class="language-text">object=centreon_metric
action=metricsDataByService
type=ng
</code></pre><p>This request is handled by:</p><pre><code class="language-text">CentreonMetric::serviceDatasNg()
</code></pre><p>in:</p><pre><code class="language-text">centreon_metric.class.php:706
</code></pre><p>The method instantiates <code inline="">CentreonGraphNg</code> and returns the result of <code inline="">getGraph()</code> directly, without an additional presenter or filtering layer.</p><h3>Backend behavior</h3><p>The backend correctly retrieves and returns the thickness value.</p><p><code inline="">CentreonGraphNg::getDsData()</code> executes:</p><pre><code class="language-php">SELECT * FROM giv_components_template
</code></pre><p>and stores the complete database row in:</p><pre><code class="language-php">$metric['ds_data']
</code></pre><p>As a result, the JSON response received by the browser contains:</p><pre><code class="language-json">{
  "ds_data": {
    "ds_tickness": 3
  }
}
</code></pre><p>The graph refresh action also retrieves fresh data correctly. There is no cache or persistence issue in the backend flow.</p><h3>Frontend behavior</h3><p>The value is lost in <code inline="">buildMetricData()</code> inside <code inline="">centreon-graph.js</code>.</p><p>The current implementation only reads the fill mode and line color:</p><pre><code class="language-js">data.types[name] =
  dataRaw.metrics[i].ds_data.ds_filled == 1 ? 'area' : 'line';

data.colors[name] =
  dataRaw.metrics[i].ds_data.ds_color_line;
</code></pre><p>The function never reads:</p><pre><code class="language-text">ds_tickness
thickness
lineWidth
strokeWidth
</code></pre><p>Therefore, no thickness information is passed to C3.js, and all curves use the default line width.</p><p>C3's stylesheet also defines a global width:</p><pre><code class="language-css">.c3-line {
  stroke-width: 1px;
}

.c3-line,
.c3-target.c3-focused path.c3-step {
  stroke-width: 2px;
}
</code></pre><p>Because C3.js does not provide a native numeric line-width option per series, the configured thickness must be applied directly to the generated SVG paths.</p><h2>Why PNG export works</h2><p>PNG export follows a separate rendering flow:</p><pre><code class="language-text">generateImage.php
  → CentreonGraph
  → RRDtool
</code></pre><p>The exporter retrieves <code inline="">ds_tickness</code> from the database and adds it directly to the RRDtool command:</p><pre><code class="language-php">$arg =
  'LINE'
  . $tm['ds_tickness']
  . ':'
  . $this-&gt;vname[$tm['metric']];
</code></pre><p>This produces commands such as:</p><pre><code class="language-text">LINE1:...
LINE2:...
LINE3:...
</code></pre><p>RRDtool supports the width directly, so the exported image correctly reflects the configured value.</p><h2>Evidence summary</h2>
Stage | File / location | Uses ds_tickness
-- | -- | --
Curve configuration field | formComponentTemplate.php:187 | Yes
Save query | DB-Func.php:397 | Yes
Database column | giv_components_template.ds_tickness | Yes
Interactive graph data query | centreonGraphNg.class.php:780 | Yes
Interactive graph JSON construction | centreonGraphNg.class.php:1035 | Yes
AJAX endpoint | centreon_metric.class.php:706 | Yes
C3 data preparation | centreon-graph.js:342-343 | No
C3 chart generation | centreon-graph.js:201 | No
C3 stylesheet | c3.min.css | Hardcoded width
PNG data query | centreonGraph.class.php:611 | Yes
PNG RRDtool command | centreonGraph.class.php:920 | Yes

<h2>Database column typo</h2><p>The database column is named:</p><pre><code class="language-text">ds_tickness
</code></pre><p>instead of:</p><pre><code class="language-text">ds_thickness
</code></pre><p>This typo is not the cause of the reported issue.</p><p>The legacy name is used consistently across:</p><ul><li><p>The administration form</p></li><li><p>SQL queries</p></li><li><p>PDO bindings</p></li><li><p>PHP arrays</p></li><li><p>The interactive graph JSON response</p></li><li><p>The PNG export implementation</p></li></ul><p>The interactive renderer ignores the field entirely, regardless of its spelling.</p><p>Renaming the database column would not fix the issue and is not recommended as part of this change.</p><h2>Recommended fix</h2><p>Apply the smallest possible change in:</p><pre><code class="language-text">www/include/views/graphs/javascript/centreon-graph.js
</code></pre><h3>1. Store the configured width per metric</h3><p>Inside <code inline="">buildMetricData()</code>, create a map associating each C3 series identifier with its configured thickness.</p><p>Example:</p><pre><code class="language-js">this.lineWidths[name] =
  Number(dataRaw.metrics[i].ds_data.ds_tickness) || 1;
</code></pre><p>The fallback to <code inline="">1</code> preserves the current behavior for:</p><ul><li><p>Existing curves without a configured value</p></li><li><p>Missing values</p></li><li><p>Invalid values</p></li><li><p>String values such as <code inline="">"3"</code></p></li></ul><p>The map must use the same sanitized series identifier used by C3.js.</p><h3>2. Apply the width after C3 renders</h3><p>Add an <code inline="">onrendered</code> callback to the existing <code inline="">c3.generate()</code> configuration.</p><p>Inside the callback, apply an inline <code inline="">stroke-width</code> style to each generated series path:</p><pre><code class="language-js">onrendered: () =&gt; {
  Object.entries(this.lineWidths).forEach(([id, width]) =&gt; {
    d3.selectAll(`.c3-line-${id}`).style('stroke-width', `${width}px`);
  });
}
</code></pre><p>The exact selector must be verified against the identifiers generated by the existing graph implementation.</p><p>Using an inline style ensures the configured value overrides:</p><pre><code class="language-css">.c3-line {
  stroke-width: 1px;
}
</code></pre><p>No global CSS modification should be necessary.</p><h3>3. Reapply the width after graph updates</h3><p>The width must be reapplied after:</p><ul><li><p>Initial graph rendering</p></li><li><p>Refresh</p></li><li><p>Period changes</p></li><li><p>Zoom changes</p></li><li><p>Calls to <code inline="">chart.load()</code></p></li></ul><p>Using C3's <code inline="">onrendered</code> callback should naturally cover these cases because C3 calls it again after rendering updates.</p><p>No backend cache invalidation or additional API request should be required.</p><h2>Proposed scope</h2><p>This fix should remain limited to the legacy graph implementation used by:</p><pre><code class="language-text">Performances &gt; Graphs
</code></pre><p>No changes are required in:</p><ul><li><p>The database schema</p></li><li><p><code inline="">CentreonGraphNg</code></p></li><li><p><code inline="">CentreonMetric</code></p></li><li><p>The PNG exporter</p></li><li><p>The React graph implementations</p></li></ul><p>The PNG and interactive graph implementations should continue reading the same database value independently because they use different rendering technologies:</p><ul><li><p>RRDtool uses <code inline="">LINE{width}</code></p></li><li><p>C3.js uses SVG <code inline="">stroke-width</code></p></li></ul><h2>Testing strategy</h2><h3>Frontend unit test</h3><p>Add coverage around the thickness mapping logic.</p><p>Given two metrics:</p><pre><code class="language-json">[
  {
    "name": "metric-1",
    "ds_data": {
      "ds_tickness": 1
    }
  },
  {
    "name": "metric-2",
    "ds_data": {
      "ds_tickness": 3
    }
  }
]
</code></pre><p>Verify that the generated SVG paths receive:</p><pre><code class="language-text">metric-1 → stroke-width: 1px
metric-2 → stroke-width: 3px
</code></pre><p>Also verify the default behavior when <code inline="">ds_tickness</code> is missing or invalid.</p><h3>Regression test</h3><p>Display two curves in the same graph:</p><ul><li><p>Curve A with thickness <code inline="">1</code></p></li><li><p>Curve B with thickness <code inline="">3</code></p></li></ul><p>Verify that they are rendered with visibly different widths.</p><h3>Refresh test</h3><ol><li><p>Open a graph.</p></li><li><p>Change the curve thickness from the Curves configuration page.</p></li><li><p>Return to the graph.</p></li><li><p>Click refresh without performing a complete browser reload.</p></li><li><p>Verify that the updated width is applied.</p></li></ol><h3>Backend regression test</h3><p>Verify that the response returned by:</p><pre><code class="language-text">CentreonMetric::serviceDatasNg()
</code></pre><p>continues to expose:</p><pre><code class="language-text">ds_data.ds_tickness
</code></pre><p>for both:</p><ul><li><p>A curve-specific configuration</p></li><li><p>The default template fallback</p></li></ul><h2>Secondary findings</h2><p>Two other graph implementations also ignore or override the configured thickness, but they do not affect the reported <strong>Performances &gt; Graphs</strong> page.</p><h3>Resource Details graph tab</h3><pre><code class="language-text">Resources/Details/tabs/Graph/ChartGraph.tsx
</code></pre><p>The modern <code inline="">@centreon/ui</code> <code inline="">LineChart</code> supports:</p><pre><code class="language-text">lineStyle.lineWidth
</code></pre><p>but the current implementation hardcodes:</p><pre><code class="language-tsx">lineStyle={{ lineWidth: 1 }}
</code></pre><p>The related presenter also omits <code inline="">ds_tickness</code> from its output.</p><h3>Host graph / performance widget</h3><pre><code class="language-text">Resources/Graph/Performance/Lines/RegularLine.tsx
</code></pre><p>The component calculates <code inline="">strokeWidth</code> from metric-name rules and highlighting state rather than using the configured curve thickness.</p><p>These implementations share the same general problem but should be handled in separate tickets to keep this fix focused.</p></body></html><!--EndFragment-->
</body>
</html>