### PR TITLE
fix(clapi): prevent user creation with empty email

### DIFF
--- a/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
@@ -91,7 +91,7 @@ class DbReadUserRepository extends AbstractRepositoryDRB implements ReadUserRepo
         // Search
         $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
         $request .= $searchRequest !== null ? $searchRequest . ' AND ' : ' WHERE ';
-        $request .= 'contact_register = 1';
+        $request .= "contact_register = 1 AND contact_email IS NOT NULL AND contact_email <> ''";
 
         // Sort
         $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
@@ -154,7 +154,8 @@ class DbReadUserRepository extends AbstractRepositoryDRB implements ReadUserRepo
         $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
         $request .= $searchRequest !== null ? $searchRequest . ' AND ' : ' WHERE ';
         $request .= 'cg.contactgroup_cg_id IN (SELECT contactgroup_cg_id FROM `:db`.contactgroup_contact_relation '
-            . 'WHERE contact_contact_id = :contactId) AND contact_register = 1';
+            . 'WHERE contact_contact_id = :contactId) AND contact_register = 1'
+            . " AND contact_email IS NOT NULL AND contact_email <> ''";
 
         // Sort
         $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();

--- a/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
+++ b/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
@@ -83,6 +83,8 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
         $concatenator->defineWhere(
             <<<'SQL'
                 WHERE contact.contact_register = '1'
+                    AND contact.contact_email IS NOT NULL
+                    AND contact.contact_email <> ''
                 SQL
         );
 
@@ -147,6 +149,8 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
                 INNER JOIN `:db`.`acl_group_contacts_relations` acl_c_rel
                     ON acl_c_rel.contact_contact_id = contact.contact_id
                 WHERE contact.contact_register = '1'
+                    AND contact.contact_email IS NOT NULL
+                    AND contact.contact_email <> ''
                     AND acl_c_rel.acl_group_id IN ({$subRequest})
                 UNION
                 SELECT /* Finds users belonging to associated contact groups in ACL group rules */
@@ -160,6 +164,8 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
                 INNER JOIN `:db`.`acl_group_contactgroups_relations` acl_cg_rel
                     ON acl_cg_rel.cg_cg_id = c_cg_rel.contactgroup_cg_id
                 WHERE contact.contact_register = '1'
+                    AND contact.contact_email IS NOT NULL
+                    AND contact.contact_email <> ''
                     AND acl_cg_rel.acl_group_id IN ({$subRequest})
                 UNION
                 SELECT /* Finds users belonging to the same contact groups as the user */
@@ -177,6 +183,8 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
                 WHERE c_cg_rel.contact_contact_id  = :user_id
                     AND contact.contact_register = '1'
                     AND contact2.contact_register = '1'
+                    AND contact2.contact_email IS NOT NULL
+                    AND contact2.contact_email <> ''
                 GROUP BY contact2.contact_id
             ) as contact
             SQL;

--- a/centreon/www/class/centreon-clapi/centreonContact.class.php
+++ b/centreon/www/class/centreon-clapi/centreonContact.class.php
@@ -68,6 +68,7 @@ class CentreonContact extends CentreonObject
     public const UNKNOWN_TIMEZONE = 'Invalid timezone';
     public const CONTACT_LOCATION = 'timezone';
     public const UNKNOWN_NOTIFICATION_OPTIONS = 'Invalid notifications options';
+    public const EMAIL_CANNOT_BE_EMPTY = 'Contact email cannot be empty';
 
     /** @var string[] */
     public static $aDepends = ['CONTACTTPL', 'CMD', 'TP'];
@@ -324,6 +325,13 @@ class CentreonContact extends CentreonObject
             }
 
             if ($regularParam == true) {
+                if (
+                    $this->register === 1
+                    && $params[1] === 'contact_email'
+                    && trim((string) $params[2]) === ''
+                ) {
+                    throw new CentreonClapiException(static::EMAIL_CANNOT_BE_EMPTY);
+                }
                 $updateParams = [$params[1] => $params[2]];
                 $updateParams['objectId'] = $objectId;
 
@@ -455,12 +463,17 @@ class CentreonContact extends CentreonObject
      *
      * @param array<int,mixed> $params
      *
+     * @throws CentreonClapiException
      * @throws PDOException
      */
     protected function initUserInformation(array $params): void
     {
         $this->addParams['contact_name'] = $this->checkIllegalChar($params[static::ORDER_NAME]);
-        $this->addParams['contact_email'] = $params[static::ORDER_MAIL];
+        $email = trim((string) ($params[static::ORDER_MAIL] ?? ''));
+        if ((int) $this->register === 1 && $email === '') {
+            throw new CentreonClapiException(static::EMAIL_CANNOT_BE_EMPTY);
+        }
+        $this->addParams['contact_email'] = $email;
     }
 
     /**


### PR DESCRIPTION
## Description

The CLAPI `CONTACT ADD` command accepted an empty email address, and the resulting broken row propagated to the user-list read path. Once such a row existed, `Administration → Authentication` returned HTTP 500 (`Error while searching for users`) because the `User` domain model asserts a non-empty email.

This PR fixes both sides of the problem: prevent new empty-email rows via CLAPI, and stop the read endpoint from crashing on any pre-existing bad rows.

[MON-157748](https://centreon.atlassian.net/browse/MON-157748)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master


[MON-157748]: https://centreon.atlassian.net/browse/MON-157748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ