### PR TITLE
fix(media): stop deleting directories on bulk image delete [MON-204663]

### DIFF
--- a/centreon/www/include/options/media/images/DB-Func.php
+++ b/centreon/www/include/options/media/images/DB-Func.php
@@ -337,58 +337,6 @@ function insertDirectory($dir_alias, $dir_comment = '')
     return '';
 }
 
-function deleteMultDirectory($dirs = [])
-{
-    foreach (array_keys($dirs) as $selector) {
-        $id = explode('-', $selector);
-        if (count($id) != 1) {
-            continue;
-        }
-        if (! testDirectoryIsEmpty((int) $id[0])) {
-            continue;
-        }
-        deleteDirectory($id[0]);
-    }
-}
-
-function deleteDirectory($directoryId)
-{
-    global $pearDB;
-    $mediadir = './img/media/';
-    $directoryId = (int) $directoryId;
-
-    // Purge images of the directory
-    $statement1 = $pearDB->prepare('SELECT img_img_id FROM view_img_dir_relation WHERE dir_dir_parent_id = :directoryId');
-    $statement1->bindValue(':directoryId', $directoryId, PDO::PARAM_INT);
-    $statement1->execute();
-    while ($img = $statement1->fetch()) {
-        deleteImg($img['img_img_id']);
-    }
-    $statement1->closeCursor();
-
-    // Delete directory
-    $statement2 = $pearDB->prepare('SELECT dir_alias FROM view_img_dir WHERE dir_id = :directoryId');
-    $statement2->bindValue(':directoryId', $directoryId, PDO::PARAM_INT);
-    $statement2->execute();
-    $dirAlias = $statement2->fetch();
-    $statement2->closeCursor();
-
-    $safeDirAlias = basename($dirAlias['dir_alias']);
-    $filenames = scandir($mediadir . $safeDirAlias);
-    foreach ($filenames as $fileName) {
-        if (is_file($mediadir . $safeDirAlias . '/' . $fileName)) {
-            unlink($mediadir . $safeDirAlias . '/' . $fileName);
-        }
-    }
-    rmdir($mediadir . $safeDirAlias);
-
-    if (! is_dir($mediadir . $safeDirAlias)) {
-        $statement3 = $pearDB->prepare('DELETE FROM view_img_dir WHERE dir_id = :directoryId');
-        $statement3->bindValue(':directoryId', $directoryId, PDO::PARAM_INT);
-        $statement3->execute();
-    }
-}
-
 function updateDirectory($dir_id, $dir_alias, $dir_comment = '')
 {
     if (! $dir_id) {

--- a/centreon/www/include/options/media/images/DB-Func.php
+++ b/centreon/www/include/options/media/images/DB-Func.php
@@ -509,7 +509,8 @@ function isCorrectMIMEType(array $file): bool
         'zip' => 'application/zip',
         'gzip' => 'application/x-gzip',
     ];
-    $fileExtension = end(explode('.', $file['name']));
+    $explodedFilename = explode('.', $file['name']);
+    $fileExtension = end($explodedFilename);
     if (! array_key_exists($fileExtension, $mimeTypeFileExtensionConcordance)) {
         return false;
     }
@@ -702,7 +703,8 @@ function isValidMIMETypeFromArchive(
     ];
 
     foreach ($files as $file) {
-        $fileExtension = end(explode('.', $file));
+        $explodedFilename = explode('.', $file);
+        $fileExtension = end($explodedFilename);
         if (! array_key_exists($fileExtension, $mimeTypeFileExtensionConcordance)) {
             return false;
         }

--- a/centreon/www/include/options/media/images/DB-Func.php
+++ b/centreon/www/include/options/media/images/DB-Func.php
@@ -344,6 +344,9 @@ function deleteMultDirectory($dirs = [])
         if (count($id) != 1) {
             continue;
         }
+        if (! testDirectoryIsEmpty((int) $id[0])) {
+            continue;
+        }
         deleteDirectory($id[0]);
     }
 }

--- a/centreon/www/include/options/media/images/images.php
+++ b/centreon/www/include/options/media/images/images.php
@@ -71,7 +71,6 @@ switch ($o) {
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
             if (! in_array(false, $selectIds)) {
-                deleteMultDirectory($selectIds);
                 deleteMultImg($selectIds);
             }
         } else {

--- a/centreon/www/include/options/media/images/images.php
+++ b/centreon/www/include/options/media/images/images.php
@@ -71,8 +71,8 @@ switch ($o) {
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
             if (! in_array(false, $selectIds)) {
-                deleteMultImg($selectIds);
                 deleteMultDirectory($selectIds);
+                deleteMultImg($selectIds);
             }
         } else {
             unvalidFormMessage();


### PR DESCRIPTION
## Description

Fixes: [MON-204663](https://centreon.atlassian.net/browse/MON-204663)

The bulk **Delete** on *Administration → Parameters → Images* deleted whole
directories — every image and physical file on disk — instead of only the
selected images, ignoring the active search filter and causing data loss.

Root cause: the delete action ran both `deleteMultImg()` and
`deleteMultDirectory()` on the same selection. Because *"select all"* (and
ticking a directory) also selects the directory checkbox, `deleteMultDirectory()`
cascaded to `deleteDirectory()`, wiping the whole folder (DB rows via
`view_img_dir_relation`, then `scandir` + `unlink` + `rmdir`).

### Changes
- The bulk Delete no longer removes directories **at all** — not even empty ones
  (refinement decision). Only the selected images are deleted.
- `images.php`: drop the `deleteMultDirectory()` call; the action now runs only
  `deleteMultImg()`.
- `DB-Func.php`: remove the now-unused `deleteMultDirectory()` and
  `deleteDirectory()` helpers (the cascade that caused the data loss).
- Drive-by: fix two `end(explode(...))` calls that passed `explode()`'s return
  value straight to `end()` ("Only variables should be passed by reference" on
  modern PHP).

### Resulting behaviour
- Filtered or unfiltered *select all* + Delete → only the selected images are
  removed; the directory and any other images are preserved (DB + disk).
- Directories are never removed through this action.

## Test plan
- [x] Reproduced on a 24.10 dev environment: filter `alpha` → *select all* →
      Delete wiped the whole directory (filtered **and** unfiltered images + the
      folder itself).
- [x] After the fix, only the selected images are deleted; the directory and its
      other images remain (DB + disk).
- [x] `php -l` clean on both files.


[MON-204663]: https://centreon.atlassian.net/browse/MON-204663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ