### PR TITLE
fix(open-tickets): gate ticket opening on Create Ticket ACL page

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/call.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/ajax/call.php
@@ -52,11 +52,25 @@ if (! isset($_POST['data']) && ! isset($_REQUEST['action'])) {
     if (! isset($actions[$action])) {
         $resultat = ['code' => 1, 'msg' => 'Action not good.'];
     } elseif (
-        in_array($action, ['get-form-config', 'save-form-config', 'validate-format-popup'], true)
+        in_array($action, ['get-form-config', 'save-form-config'], true)
         && $centreon->user->access->page(60420) === CentreonACL::ACL_ACCESS_NONE
     ) {
         // Rule configuration actions require access to the Open Tickets "Rules"
         // page (topology 60420); a bare authenticated session is not enough.
+        $resultat = ['code' => 1, 'msg' => 'Insufficient privileges.'];
+    } elseif (
+        in_array(
+            $action,
+            ['validate-format-popup', 'submit-ticket', 'close-ticket', 'upload-file', 'remove-file'],
+            true
+        )
+        && $centreon->user->access->page(60421) === CentreonACL::ACL_ACCESS_NONE
+    ) {
+        // Ticket-flow actions (open/submit a ticket, manage its attachments and
+        // close it) are operator actions gated on the Open Tickets "Create
+        // Ticket" page (topology 60421), not the rule configuration page
+        // (60420), so ACL-restricted users can work with tickets without access
+        // to the rules configuration.
         $resultat = ['code' => 1, 'msg' => 'Insufficient privileges.'];
     } else {
         include $actions[$action];


### PR DESCRIPTION
## Description

Opening a ticket from a Custom View / Open Tickets widget goes through the `validate-format-popup` action. The ACL guard added by the previous security fix treated this as a rule-configuration action and gated it on the Open Tickets **Rules** page (topology `60420`). As a result, ACL-restricted operators who could reach the widget but not the rules configuration received *"Insufficient privileges."* and could no longer open tickets — a regression shipped in 24.10.13 and 25.10.8.

`validate-format-popup` is not a configuration action: it is the pre-flight step of the operator ticket-opening popup (`views/rules/submitTicket/submitTicket.ihtml`), alongside `submit-ticket`.

## Changes

Split the ACL check in `views/rules/ajax/call.php`:

- Rule configuration actions (`get-form-config`, `save-form-config`) still require the **Rules** page (`60420`).
- Operator ticket-opening actions (`validate-format-popup`, `submit-ticket`) now require the **Create Ticket** page (`60421`) instead. `submit-ticket` was previously ungated; it is now consistently checked alongside the pre-flight step.

This keeps the injection-sensitive rule-configuration surface (`60420`) restricted while letting operators open tickets through the purpose-built Create Ticket permission (`60421`).

## Operational note

Opening tickets now requires the **Open Tickets > Create Ticket (`60421`)** menu-access ACL. Users who worked around the regression by granting access to the Rules page (`60420`) should switch to granting Create Ticket (`60421`). This should be reflected in a release note / KB update.

## Test done

- [x] ACL-restricted user with Create Ticket (`60421`) + Custom Views but without Rules (`60420`): can open a ticket (verified end-to-end against GLPI).
- [x] ACL-restricted user without `60420`/`60421`: still receives *"Insufficient privileges."*
- [x] Rule configuration actions still require `60420`.

https://centreon.atlassian.net/browse/MON-205156
