### PR TITLE
chore(docker): open poller ports by default

### DIFF
--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     env_file:
       - .env
     image: "${WEB_IMAGE:-docker.centreon.com/centreon/centreon-web-alma9:develop}"
-    ports: ["4000:80"]
+    ports: ["4000:80", "5669:5669", "8086:8086"]
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Expose the poller-facing ports on the always-on `web` (central) service of the develop dev environment, so a dockerized poller ("poller in container" feature) can reach the central by default, without enabling any compose profile:

- `5669:5669` — Centreon Broker BBDO input (the poller's broker output connects to the central `cbd`)
- `8086:8086` — central communication port used by the poller's gorgone in PULLWSS mode, matching `CENTRAL_PORT` in the poller container `.env`

The existing `4000:80` HTTP mapping is kept.

Fixes: [MON-205173](https://centreon.atlassian.net/browse/MON-205173)
Part of the "Pollers in container" epic: [MON-192897](https://centreon.atlassian.net/browse/MON-192897)

[MON-205173]: https://centreon.atlassian.net/browse/MON-205173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-192897]: https://centreon.atlassian.net/browse/MON-192897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ