### PR TITLE
fix(logging): tolerate deprecation write failures

### DIFF
--- a/centreon/config/packages/monolog.yaml
+++ b/centreon/config/packages/monolog.yaml
@@ -70,11 +70,19 @@ when@dev:
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!console"]
                 formatter: monolog.formatter.line
+            # Never let a failing deprecation write break the request; fall back to error_log if the primary handler throws.
             deprecation:
-                type: rotating_file
+                type: fallbackgroup
                 channels: [deprecation]
+                members: [deprecation_file, deprecation_error_log]
+            deprecation_file:
+                type: rotating_file
                 path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
                 max_files: 14
+                level: debug
+                formatter: monolog.formatter.line
+            deprecation_error_log:
+                type: error_log
                 level: debug
                 formatter: monolog.formatter.line
             authentication:
@@ -137,10 +145,17 @@ when@prod:
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!deprecation"]
                 formatter: monolog.formatter.line
+            # Never let a failing deprecation write break the request; fall back to error_log if the primary handler throws.
             deprecation:
-                type: stream
+                type: fallbackgroup
                 channels: [deprecation]
+                members: [deprecation_file, deprecation_error_log]
+            deprecation_file:
+                type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+                formatter: monolog.formatter.line
+            deprecation_error_log:
+                type: error_log
                 formatter: monolog.formatter.line
             authentication:
                 type: stream

--- a/centreon/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
@@ -90,7 +90,11 @@ class MonitoringServerService implements MonitoringServerServiceInterface
             return $this->monitoringServerRepository->findServer($monitoringServerId);
         } catch (\Exception $ex) {
             throw new MonitoringServerException(
-                'Error when searching for a monitoring server (' . $monitoringServerId . ')',
+                sprintf(
+                    'Error when searching for a monitoring server (%d): %s',
+                    $monitoringServerId,
+                    $ex->getMessage()
+                ),
                 0,
                 $ex
             );


### PR DESCRIPTION
## Description

Wrap the Monolog deprecation channel handler in a `fallbackgroup` so that if the primary file writer throws, records fall through to PHP's error_log instead of the exception propagating up.

On dev-24.10.x, `prod.deprecations.log` is owned apache:apache 644 but Gorgone-invoked scripts run as centreon and cannot append. Symfony 6.4 forwards @-suppressed deprecations to Monolog anyway (Symfony 7+ respects the suppression), so any CLI-emitted deprecation throws UnexpectedValueException. That exception cascades up and gets rewrapped by MonitoringServerService::findServer() as the misleading "Error when searching for a monitoring server (X)", silently killing the autodiscovery import flow.

Also include the previous exception's message in the wrapper thrown by findServer() so this class of failure surfaces the real cause instead of hiding behind a fake message.

[MON-205135](https://centreon.atlassian.net/browse/MON-205135)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-205135]: https://centreon.atlassian.net/browse/MON-205135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ