### PR TITLE
fix(security): enforce ACL when editing a meta service metric

### DIFF
--- a/centreon/www/include/configuration/configObject/meta_service/metaService.php
+++ b/centreon/www/include/configuration/configObject/meta_service/metaService.php
@@ -69,6 +69,19 @@ if (isset($ret) && is_array($ret) && $ret['topology_page'] != '' && $p != $ret['
     $p = $ret['topology_page'];
 }
 
+// Metric edit/duplicate/delete requests carry msr_id, not meta_id. Resolve the
+// owning meta service id so the ACL check below cannot be bypassed and the
+// listing links keep the right context.
+if (! $meta_id && $msr_id) {
+    $metaLookup = $pearDB->prepare('SELECT meta_id FROM meta_service_relation WHERE msr_id = :msr_id');
+    $metaLookup->bindValue(':msr_id', $msr_id, PDO::PARAM_INT);
+    $metaLookup->execute();
+    $metaRow = $metaLookup->fetch();
+    if ($metaRow !== false) {
+        $meta_id = (int) $metaRow['meta_id'];
+    }
+}
+
 $acl = new CentreonACL($oreon->user->get_id(), $oreon->user->admin);
 $aclDbName = $acl->getNameDBAcl();
 $metaStr = $acl->getMetaServiceString();


### PR DESCRIPTION
## Description

Fix a broken access control on the meta service metric actions.

When editing, duplicating or deleting a meta service metric, the request only carries the metric relation id (`msr_id`), not the meta service id (`meta_id`). The ACL guard in `metaService.php` only runs when `meta_id` is present, so it was **skipped** for those actions — a non-admin user could operate on metrics of meta services outside their ACL scope by passing an arbitrary `msr_id`.

## Fix

Resolve the owning `meta_id` from `msr_id` (via `meta_service_relation`) **before** the ACL check, so the authorization guard also applies to metric edit / duplicate / delete.

## How to test

1. As a non-admin user restricted to a subset of meta services, try to reach `main.php?p=<meta page>&o=cs&msr_id=<id of a metric from a meta service outside your scope>`.
2. Before: the form opens. After: access is denied ("You are not allowed to access this meta service").