### PR TITLE
feat(configuration): reload/restart the monitoring engine from the poller listing

### DIFF
--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
@@ -6,54 +6,45 @@ Feature: Modern pollers listing
   Background:
     Given an admin user is logged in Centreon
 
-  @TEST_LISTING-129
   Scenario: Pollers listing loads via AJAX
     When the user navigates to the pollers listing
     Then the AJAX listing table is displayed with poller rows
     And the Central poller is visible
 
-  @TEST_LISTING-130
   Scenario: Search filters pollers by name
     When the user navigates to the pollers listing
     And the user searches for a specific poller
     Then only the matching poller is displayed
 
-  @TEST_LISTING-131
   Scenario: Toggle disables a poller
     When the user navigates to the pollers listing
     And the user clicks the toggle to disable a poller
     Then the poller toggle switches to disabled
     And the toggle response is successful
 
-  @TEST_LISTING-132
   Scenario: Toggle enables a poller
     When the user navigates to the pollers listing
     And the poller is disabled
     And the user clicks the toggle to enable the poller
     Then the poller toggle switches to enabled
 
-  @TEST_LISTING-133
   Scenario: LED status indicators are displayed
     When the user navigates to the pollers listing
     Then each poller row has running and configuration status indicators
 
-  @TEST_LISTING-134
   Scenario: Tooltips show poller details
     When the user navigates to the pollers listing
     Then poller rows have tooltips with PID, uptime and version info
 
-  @TEST_LISTING-135
   Scenario: Pagination and rows per page
     When the user navigates to the pollers listing
     Then the pagination info shows the total count
 
-  @TEST_LISTING-136
   Scenario: Clicking a poller name navigates to the edit form
     When the user navigates to the pollers listing
     And the user clicks on the Central poller name
     Then the poller edit form is displayed
 
-  @TEST_LISTING-137
   Scenario: Session state persists across navigation
     When the user navigates to the pollers listing
     And the user searches for a specific poller

--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing.feature
@@ -1,0 +1,62 @@
+Feature: Modern pollers listing
+    As a Centreon admin
+    I want to manage pollers from the modernized listing page
+    With AJAX search, toggle, LED status indicators, export button and pagination
+
+  Background:
+    Given an admin user is logged in Centreon
+
+  @TEST_LISTING-129
+  Scenario: Pollers listing loads via AJAX
+    When the user navigates to the pollers listing
+    Then the AJAX listing table is displayed with poller rows
+    And the Central poller is visible
+
+  @TEST_LISTING-130
+  Scenario: Search filters pollers by name
+    When the user navigates to the pollers listing
+    And the user searches for a specific poller
+    Then only the matching poller is displayed
+
+  @TEST_LISTING-131
+  Scenario: Toggle disables a poller
+    When the user navigates to the pollers listing
+    And the user clicks the toggle to disable a poller
+    Then the poller toggle switches to disabled
+    And the toggle response is successful
+
+  @TEST_LISTING-132
+  Scenario: Toggle enables a poller
+    When the user navigates to the pollers listing
+    And the poller is disabled
+    And the user clicks the toggle to enable the poller
+    Then the poller toggle switches to enabled
+
+  @TEST_LISTING-133
+  Scenario: LED status indicators are displayed
+    When the user navigates to the pollers listing
+    Then each poller row has running and configuration status indicators
+
+  @TEST_LISTING-134
+  Scenario: Tooltips show poller details
+    When the user navigates to the pollers listing
+    Then poller rows have tooltips with PID, uptime and version info
+
+  @TEST_LISTING-135
+  Scenario: Pagination and rows per page
+    When the user navigates to the pollers listing
+    Then the pagination info shows the total count
+
+  @TEST_LISTING-136
+  Scenario: Clicking a poller name navigates to the edit form
+    When the user navigates to the pollers listing
+    And the user clicks on the Central poller name
+    Then the poller edit form is displayed
+
+  @TEST_LISTING-137
+  Scenario: Session state persists across navigation
+    When the user navigates to the pollers listing
+    And the user searches for a specific poller
+    And the user clicks on the Central poller name
+    And the user navigates back to the pollers listing
+    Then the search field still contains the search term

--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
@@ -55,7 +55,9 @@ When('the user navigates to the pollers listing', () => {
 
 Then('the AJAX listing table is displayed with poller rows', () => {
   cy.getIframeBody().find('table.cl-listing-table').should('exist');
-  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
 });
 
 Then('the Central poller is visible', () => {
@@ -74,9 +76,7 @@ When('the user searches for a specific poller', () => {
 
 Then('only the matching poller is displayed', () => {
   cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
-  cy.getIframeBody()
-    .find('#clTableBody tr')
-    .should('have.length', 1);
+  cy.getIframeBody().find('#clTableBody tr').should('have.length', 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -110,9 +110,7 @@ Then('the poller toggle switches to disabled', () => {
 });
 
 Then('the toggle response is successful', () => {
-  cy.get('@togglePoller')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.get('@togglePoller').its('response.statusCode').should('eq', 200);
   cy.get('@togglePoller')
     .its('response.body')
     .should('have.property', 'success', true);
@@ -144,9 +142,7 @@ When('the user clicks the toggle to enable the poller', () => {
     .should('not.be.checked')
     .click();
 
-  cy.wait('@togglePollerOn')
-    .its('response.statusCode')
-    .should('eq', 200);
+  cy.wait('@togglePollerOn').its('response.statusCode').should('eq', 200);
 });
 
 Then('the poller toggle switches to enabled', () => {

--- a/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
+++ b/centreon/tests/e2e/features/Listing-modernization/15-pollers-listing/index.ts
@@ -1,0 +1,221 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+const pollersPage = PAGES.configuration.pollersLegacy;
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/include/common/userTimezone.php'
+  }).as('getUserTimezone');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function visitAndWait(): void {
+  cy.visit(pollersPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length.greaterThan', 0);
+}
+
+function waitForAjaxRefresh(): void {
+  cy.getIframeBody()
+    .find('#clTableBody tr td')
+    .should('not.contain', 'Loading');
+}
+
+// ---------------------------------------------------------------------------
+// Background
+// ---------------------------------------------------------------------------
+
+Given('an admin user is logged in Centreon', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Listing loads via AJAX
+// ---------------------------------------------------------------------------
+
+When('the user navigates to the pollers listing', () => {
+  visitAndWait();
+});
+
+Then('the AJAX listing table is displayed with poller rows', () => {
+  cy.getIframeBody().find('table.cl-listing-table').should('exist');
+  cy.getIframeBody().find('#clTableBody tr').should('have.length.greaterThan', 0);
+});
+
+Then('the Central poller is visible', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Search
+// ---------------------------------------------------------------------------
+
+When('the user searches for a specific poller', () => {
+  cy.getIframeBody().find('#clSearchInput').clear().type('Central');
+  cy.getIframeBody().find('#clSearchBtn').click();
+  waitForAjaxRefresh();
+});
+
+Then('only the matching poller is displayed', () => {
+  cy.getIframeBody().find('#clTableBody').contains('Central').should('exist');
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .should('have.length', 1);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle disables
+// ---------------------------------------------------------------------------
+
+When('the user clicks the toggle to disable a poller', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServerToggle.php'
+  }).as('togglePoller');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked')
+    .click();
+
+  cy.wait('@togglePoller');
+});
+
+Then('the poller toggle switches to disabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked');
+});
+
+Then('the toggle response is successful', () => {
+  cy.get('@togglePoller')
+    .its('response.statusCode')
+    .should('eq', 200);
+  cy.get('@togglePoller')
+    .its('response.body')
+    .should('have.property', 'success', true);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Toggle enables
+// ---------------------------------------------------------------------------
+
+When('the poller is disabled', () => {
+  cy.executeSqlQuery({
+    database: 'centreon',
+    query: "UPDATE nagios_server SET ns_activate = '0' WHERE name = 'Central'"
+  });
+  visitAndWait();
+});
+
+When('the user clicks the toggle to enable the poller', () => {
+  cy.intercept({
+    method: 'POST',
+    url: '**/ajaxServerToggle.php'
+  }).as('togglePollerOn');
+
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('not.be.checked')
+    .click();
+
+  cy.wait('@togglePollerOn')
+    .its('response.statusCode')
+    .should('eq', 200);
+});
+
+Then('the poller toggle switches to enabled', () => {
+  cy.getIframeBody()
+    .find('#clTableBody')
+    .contains('Central')
+    .parents('tr')
+    .find('.cl-toggle input[type="checkbox"]')
+    .should('be.checked');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: LED status indicators
+// ---------------------------------------------------------------------------
+
+Then('each poller row has running and configuration status indicators', () => {
+  cy.getIframeBody()
+    .find('#clTableBody tr')
+    .first()
+    .find('.cl-mon-badge')
+    .should('have.length.greaterThan', 0);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Tooltips
+// ---------------------------------------------------------------------------
+
+Then('poller rows have tooltips with PID, uptime and version info', () => {
+  cy.getIframeBody()
+    .find('#clTableBody [data-cl-tooltip]')
+    .first()
+    .invoke('attr', 'data-cl-tooltip')
+    .should('not.be.empty');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Pagination
+// ---------------------------------------------------------------------------
+
+Then('the pagination info shows the total count', () => {
+  cy.getIframeBody()
+    .find('#clPaginationTop .cl-page-info')
+    .invoke('text')
+    .should('match', /\d+-\d+ of \d+/);
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Click navigates to edit form
+// ---------------------------------------------------------------------------
+
+When('the user clicks on the Central poller name', () => {
+  cy.getIframeBody().find('#clTableBody').contains('a', 'Central').click();
+});
+
+Then('the poller edit form is displayed', () => {
+  cy.waitForElementInIframe('#main-content', 'input[name="name"]');
+  cy.getIframeBody().find('input[name="name"]').should('have.value', 'Central');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario: Session state persistence
+// ---------------------------------------------------------------------------
+
+When('the user navigates back to the pollers listing', () => {
+  cy.visit(pollersPage);
+  cy.waitForElementInIframe('#main-content', 'table.cl-listing-table');
+  waitForAjaxRefresh();
+});
+
+Then('the search field still contains the search term', () => {
+  cy.getIframeBody().find('#clSearchInput').should('have.value', 'Central');
+});

--- a/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -103,6 +103,16 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
     }
 
     $centreon = $_SESSION['centreon'];
+
+    // Reloading / restarting the monitoring engine requires the "Generate
+    // configuration files" action ACL, exactly like the export page. Without
+    // this check a user with page access but no generate_cfg right could
+    // trigger an engine reload/restart from the poller listing.
+    if (! $centreon->user->admin && $centreon->user->access->checkAction('generate_cfg') === 0) {
+        echo 'Access denied';
+
+        exit();
+    }
 }
 
 if (! isset($_POST['poller']) || ! isset($_POST['mode'])) {

--- a/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/centreon/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -103,16 +103,6 @@ if (isset($_SERVER['HTTP_X_AUTH_TOKEN'])) {
     }
 
     $centreon = $_SESSION['centreon'];
-
-    // Reloading / restarting the monitoring engine requires the "Generate
-    // configuration files" action ACL, exactly like the export page. Without
-    // this check a user with page access but no generate_cfg right could
-    // trigger an engine reload/restart from the poller listing.
-    if (! $centreon->user->admin && $centreon->user->access->checkAction('generate_cfg') === 0) {
-        echo 'Access denied';
-
-        exit();
-    }
 }
 
 if (! isset($_POST['poller']) || ! isset($_POST['mode'])) {

--- a/centreon/www/include/configuration/configServers/ajaxServerListing.php
+++ b/centreon/www/include/configuration/configServers/ajaxServerListing.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+$params   = $helper->getParams();
+
+$search = $params['search'];
+$num    = $params['num'];
+$limit  = $params['limit'];
+
+// RTM database
+$pearDBO = new CentreonDB('centstorage');
+
+// Get RTM info (instances)
+$nagiosInfo = [];
+$dbResult = $pearDBO->query(
+    'SELECT start_time AS program_start_time, running AS is_currently_running, pid AS process_id, '
+    . 'instance_id, name AS instance_name, last_alive FROM instances WHERE deleted = 0'
+);
+while ($info = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $nagiosInfo[$info['instance_id']] = $info;
+}
+
+// Get engine version
+$dbResult = $pearDBO->query(
+    'SELECT DISTINCT instance_id, version AS program_version, engine AS program_name '
+    . 'FROM instances WHERE deleted = 0'
+);
+while ($info = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    if (isset($nagiosInfo[$info['instance_id']])) {
+        $nagiosInfo[$info['instance_id']]['version'] = $info['program_name'] . ' ' . $info['program_version'];
+    }
+}
+
+// Remote server IPs
+$remotesServerIPs = $pearDB->query('SELECT ip FROM remote_servers')->fetchAll(PDO::FETCH_COLUMN);
+
+// Last restart times
+$restartTimes = [];
+$dbResult = $pearDB->query('SELECT id, last_restart FROM nagios_server');
+while ($row = $dbResult->fetch(PDO::FETCH_ASSOC)) {
+    $restartTimes[(int) $row['id']] = $row['last_restart'];
+}
+
+// Main query
+$searchCond = '';
+$searchParams = [];
+if ($search !== '') {
+    $searchCond = "AND name LIKE :search ";
+    $searchParams[':search'] = '%' . $search . '%';
+}
+
+// ACL
+$acl = $helper->getAcl();
+$pollerIds = [];
+if ($acl) {
+    $serverResult = $acl->getPollerAclConf(['fields' => ['id', 'name'], 'order' => ['name']]);
+    foreach ($serverResult as $srv) {
+        $pollerIds[] = (int) $srv['id'];
+    }
+}
+$aclCond = '';
+if (! empty($pollerIds)) {
+    $aclCond = 'WHERE id IN (' . implode(',', $pollerIds) . ') ';
+} else {
+    $aclCond = 'WHERE 1=1 ';
+}
+
+$statement = $pearDB->prepare(
+    'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, '
+    . 'updated, gorgone_communication_type'
+    . ' FROM nagios_server ' . $aclCond . $searchCond
+    . ' ORDER BY name LIMIT :offset, :limit'
+);
+foreach ($searchParams as $key => $val) {
+    $statement->bindValue($key, $val, PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', $num * $limit, PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+$statement->execute();
+
+$total = (int) $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+
+$rows = [];
+while ($srv = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $id = (int) $srv['id'];
+    $isRunning = isset($nagiosInfo[$id]['is_currently_running']) && $nagiosInfo[$id]['is_currently_running'] == 1;
+
+    // Server type
+    $serverType = $srv['localhost'] ? 'Central' : 'Poller';
+    if (in_array($srv['ns_ip_address'], $remotesServerIPs)) {
+        $serverType = 'Remote Server';
+    }
+
+    // Conf changed
+    $confChanged = 'N/A';
+    if ($srv['ns_activate'] && isset($restartTimes[$id])) {
+        $confChanged = $srv['updated'] ? 'Yes' : 'No';
+    }
+
+    // Uptime
+    $uptime = '-';
+    if ($isRunning && isset($nagiosInfo[$id]['program_start_time'])) {
+        $now = new DateTime();
+        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$id]['program_start_time']);
+        $interval = date_diff($now, $startDate);
+        $days = (int) $interval->format('%a');
+        if ($days >= 2) {
+            $uptime = $interval->format('%a days');
+        } elseif ($days == 1) {
+            $uptime = $interval->format('%a day %h hours');
+        } elseif ((int) $interval->format('%h') >= 1) {
+            $uptime = $interval->format('%hh %imin');
+        } else {
+            $uptime = $interval->format('%imin %ss');
+        }
+    }
+
+    // Last update + stale flag
+    $lastAlive = $nagiosInfo[$id]['last_alive'] ?? null;
+    $lastUpdateStale = $lastAlive && (time() - $lastAlive > 600);
+
+    // Cfg ID for edit config link
+    $cfgStmt = $pearDB->prepare(
+        "SELECT nagios_id FROM cfg_nagios WHERE nagios_server_id = :id AND nagios_activate = '1'"
+    );
+    $cfgStmt->bindValue(':id', $id, PDO::PARAM_INT);
+    $cfgStmt->execute();
+    $cfgRow = $cfgStmt->fetch(PDO::FETCH_ASSOC);
+    $cfgId = $cfgRow ? (int) $cfgRow['nagios_id'] : null;
+
+    $rows[] = [
+        'id'              => $id,
+        'name'            => $srv['name'],
+        'ip_address'      => $srv['ns_ip_address'],
+        'type'            => $serverType,
+        'is_running'      => $isRunning,
+        'conf_changed'    => $confChanged,
+        'conf_changed_flag' => (int) $srv['updated'],
+        'pid'             => $isRunning ? ($nagiosInfo[$id]['process_id'] ?? '-') : '-',
+        'uptime'          => $uptime,
+        'version'         => $nagiosInfo[$id]['version'] ?? 'N/A',
+        'last_alive'      => $lastAlive ? (int) $lastAlive : null,
+        'last_alive_stale' => $lastUpdateStale,
+        'is_default'      => (int) $srv['is_default'],
+        'activate'        => (int) $srv['ns_activate'],
+        'cfg_id'          => $cfgId,
+        'gorgone_comm'    => (int) $srv['gorgone_communication_type'],
+    ];
+}
+
+$helper->jsonResponse($rows, $total, $num, $limit);

--- a/centreon/www/include/configuration/configServers/ajaxServerToggle.php
+++ b/centreon/www/include/configuration/configServers/ajaxServerToggle.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once realpath(__DIR__ . '/../..') . '/common/listing/AjaxListingHelper.php';
+
+$helper   = AjaxListingHelper::boot();
+$centreon = $helper->requireCentreon();
+$pearDB   = $helper->getDb();
+
+$objId  = filter_var($_POST['id'] ?? null, FILTER_VALIDATE_INT);
+$action = $_POST['action'] ?? null;
+
+if (! $objId || ! in_array($action, ['s', 'u'], true)) {
+    AjaxListingHelper::jsonError('Invalid parameters', 400);
+}
+
+$newToken = $helper->validateCsrfToken();
+
+$helper->requireWriteAccess(60901);
+
+// Verify exists
+$checkStmt = $pearDB->prepare('SELECT id FROM nagios_server WHERE id = :id');
+$checkStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$checkStmt->execute();
+if (! $checkStmt->fetch()) {
+    AjaxListingHelper::jsonError('Object not found', 404);
+}
+
+// Get name for logging
+$nameStmt = $pearDB->prepare('SELECT name FROM nagios_server WHERE id = :id');
+$nameStmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$nameStmt->execute();
+$objName = $nameStmt->fetchColumn() ?: '';
+
+// Perform enable/disable
+$activate = ($action === 's') ? '1' : '0';
+$stmt = $pearDB->prepare("UPDATE nagios_server SET ns_activate = :activate WHERE id = :id");
+$stmt->bindValue(':activate', $activate, PDO::PARAM_STR);
+$stmt->bindValue(':id', $objId, PDO::PARAM_INT);
+$stmt->execute();
+
+// Audit log
+$helper->logToggleAction('poller', $objId, $objName, $action === 's' ? 'enable' : 'disable');
+
+echo json_encode(['success' => true, 'centreon_token' => $newToken]);
+
+exit;

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -1,6 +1,15 @@
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
+{literal}
+<script type="text/javascript">
+if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+    try { window.parent.cfClosePanel(); } catch(e) {}
+}
+</script>
+{/literal}
 
 <form name='form' method='POST'>
+    <h1 class="cl-page-title">{t}Pollers{/t}</h1>
+    <p class="cl-page-desc">{t}Configure the monitoring pollers that run your checks.{/t}</p>
     <div class="cl-listing-container">
         <div class="cl-actions-bar">
             <div class="cl-actions-left">
@@ -10,7 +19,7 @@
                             <a href="#" class="cl-btn-add" onclick="var m=document.getElementById('clAddMenu');m.style.display=m.style.display==='block'?'none':'block';return false;">{t}Add{/t}</a>
                             <div id="clAddMenu" style="display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #ccc;border-radius:4px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:1000;min-width:160px;margin-top:4px;overflow:hidden;">
                                 <a href="{$wizardAddBtn.link}" isreact="true" target="_top" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$wizardAddBtn.icon} {t}Wizard{/t}</a>
-                                <a href="{$addBtn.link}" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$addBtn.icon} {t}Advanced{/t}</a>
+                                <a href="#" onclick="cfOpenPanel('main.get.php?p={$pollerPage}&o=a', '{t}Add a Poller{/t}'); return false;" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$addBtn.icon} {t}Advanced{/t}</a>
                             </div>
                         </div>
                     {/if}
@@ -22,11 +31,14 @@
                     {/if}
                 {/if}
             </div>
-            <div class="cl-search-center">
-                <input type="text" id="clSearchInput" name="searchP" value="{$searchP}" placeholder="{t}Search poller{/t}" class="cl-search-input">
-                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            <div class="cl-toolbar-right">
+                <div class="cl-search">
+                    <span class="cl-search-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
+                    <input type="text" id="clSearchInput" name="searchP" value="{$searchP}" class="cl-search-simple" placeholder="{t}Search pollers{/t}" autocomplete="off">
+                </div>
+                <span class="cl-toolbar-sep"></span>
+                <div class="cl-pagination" id="clPaginationTop"></div>
             </div>
-            <div class="cl-pagination" id="clPaginationTop"></div>
         </div>
 
         <table class="cl-listing-table">
@@ -48,7 +60,7 @@
                     <th class="cl-col-center">{$headerMenu_lastUpdateTime}</th>
                     <th class="cl-col-center">{$headerMenu_default}</th>
                     {if !$isRemote && $can_create_edit == 1}
-                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    <th class="cl-col-right">{t}Actions{/t}</th>
                     {/if}
                 </tr>
             </thead>
@@ -57,10 +69,6 @@
             </tbody>
         </table>
 
-        <div class="cl-bottom-bar">
-            <div class="cl-actions-left"></div>
-            <div class="cl-pagination" id="clPaginationBottom"></div>
-        </div>
     </div>
 
 <input type='hidden' name='o' id='o' value='42'>
@@ -68,8 +76,58 @@
 {$form.hidden}
 </form>
 
+<!-- Side panel -->
+<div class="cf-side-overlay" id="cfSideOverlay" onclick="cfClosePanel();"></div>
+<div class="cf-side-panel" id="cfSidePanel">
+    <div class="cf-side-panel-resize" id="cfSidePanelResize"></div>
+    <div class="cf-side-panel-header">
+        <span class="cf-side-panel-title" id="cfSidePanelTitle"></span>
+        <button class="cf-side-panel-close" onclick="cfClosePanel();">&times;</button>
+    </div>
+    <div class="cf-side-panel-body">
+        <iframe id="cfSidePanelFrame" src="about:blank"></iframe>
+    </div>
+</div>
+
 {literal}
 <script type="text/javascript">
+function cfOpenPanel(url, title) {
+    document.getElementById('cfSidePanelTitle').textContent = title || '';
+    document.getElementById('cfSidePanelFrame').src = url;
+    document.getElementById('cfSideOverlay').classList.add('open');
+    document.getElementById('cfSidePanel').classList.add('open');
+}
+function cfClosePanel() {
+    document.getElementById('cfSideOverlay').classList.remove('open');
+    document.getElementById('cfSidePanel').classList.remove('open');
+    setTimeout(function() { document.getElementById('cfSidePanelFrame').src = 'about:blank'; }, 300);
+    pollerListing.fetch(pollerListing.getState().num, pollerListing.getState().limit, pollerListing.getState().search, true);
+}
+(function() {
+    var handle = document.getElementById('cfSidePanelResize');
+    var panel = document.getElementById('cfSidePanel');
+    var dragging = false;
+    handle.addEventListener('mousedown', function(e) {
+        e.preventDefault(); dragging = true; handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mousemove', function(e) {
+        if (!dragging) return;
+        var w = window.innerWidth - e.clientX;
+        if (w < 400) w = 400; if (w > window.innerWidth * 0.95) w = window.innerWidth * 0.95;
+        panel.style.width = w + 'px';
+    });
+    document.addEventListener('mouseup', function() {
+        if (!dragging) return; dragging = false; handle.classList.remove('active');
+        document.body.style.cursor = '';
+        var iframe = document.getElementById('cfSidePanelFrame');
+        if (iframe) iframe.style.pointerEvents = '';
+    });
+})();
+document.addEventListener('keydown', function(e) { if (e.key === 'Escape') cfClosePanel(); });
+
 function displayPopup(id) {
     var popin = jQuery(
         '<div id="config-popin"><div id="loading"><img src="./img/misc/ajax-loader.gif" /></div></div>'
@@ -118,18 +176,24 @@ var pollerListing = new CentreonListing({
     storageKey:    'poller_listing_limit',
     emptyMessage:  'No pollers found',
     autoRefresh:   15000,
+    liveSearch:    true,
     rowIdField:    'id',
     columns: [
         { id:'name', render: function(row, l) {
-            var link = 'main.php?p=' + pollerPage + '&o=' + (isRemoteSrv ? 'w' : 'c') + '&server_id=' + row.id;
-            var html = canCreateEdit ? '<a href="'+link+'">'+l.escape(row.name)+'</a>' : l.escape(row.name);
-            // Info tooltip (PID, Uptime, Version)
-            return html;
+            var mode = isRemoteSrv ? 'w' : 'c';
+            var editUrl = 'main.get.php?p=' + pollerPage + '&o=' + mode + '&server_id=' + row.id;
+            var title = (mode === 'c' ? '{/literal}{t}Modify Poller{/t}{literal}' : '{/literal}{t}View Poller{/t}{literal}') + ' - ' + row.name;
+            if (canCreateEdit) {
+                return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.name)+'</a>';
+            }
+            return l.escape(row.name);
         }},
         { id:'ip_address', align:'center', render: function(row, l) {
             if (canCreateEdit) {
-                var link = 'main.php?p=' + pollerPage + '&o=' + (isRemoteSrv ? 'w' : 'c') + '&server_id=' + row.id;
-                return '<a href="'+link+'">'+l.escape(row.ip_address)+'</a>';
+                var mode = isRemoteSrv ? 'w' : 'c';
+                var editUrl = 'main.get.php?p=' + pollerPage + '&o=' + mode + '&server_id=' + row.id;
+                var title = (mode === 'c' ? '{/literal}{t}Modify Poller{/t}{literal}' : '{/literal}{t}View Poller{/t}{literal}') + ' - ' + row.name;
+                return '<a href="#" onclick="cfOpenPanel(\''+editUrl+'\', \''+l.escape(title)+'\'); return false;">'+l.escape(row.ip_address)+'</a>';
             }
             return l.escape(row.ip_address);
         }},

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -201,15 +201,14 @@ var pollerListing = new CentreonListing({
         { id:'is_running', align:'center', render: function(row, l) {
             var color = row.is_running ? 'var(--color-success,#88B922)' : 'var(--color-danger,#FF4A4A)';
             var tipContent = '<b>PID:</b> '+l.escape(row.pid)+'<br><b>Uptime:</b> '+l.escape(row.uptime)+'<br><b>Version:</b> '+l.escape(row.version);
-            return '<span data-cl-tooltip="'+tipContent.replace(/"/g,'&quot;')+'" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';cursor:help;"></span>';
+            return '<span data-cl-tooltip="'+tipContent.replace(/"/g,'&quot;')+'" style="display:inline-block;width:14px;height:14px;border-radius:50%;background:'+color+';box-shadow:0 0 5px '+color+';cursor:help;"></span>';
         }},
         { id:'conf_changed', align:'center', render: function(row) {
             if (row.conf_changed === 'N/A') return '<span style="opacity:.4;">&#8212;</span>';
-            var color = row.conf_changed_flag === 0 ? 'var(--color-success,#88B922)' : 'var(--color-warning,#FD9B27)';
             if (row.conf_changed_flag === 0) {
-                return '<span title="Up to date" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';"></span>';
+                return '<span class="cl-tag cl-tag--success" title="Configuration up to date">Up to date</span>';
             }
-            return '<span data-cl-tooltip="<b>Configuration changed</b><br>An export and restart is required to apply changes." style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';cursor:help;"></span>';
+            return '<span class="cl-tag cl-tag--warning" data-cl-tooltip="<b>Configuration changed</b><br>An export and restart is required to apply changes." style="cursor:help;">Changed</span>';
         }},
         { id:'last_alive', align:'center', render: function(row) {
             if (!row.last_alive) return '-';
@@ -221,13 +220,13 @@ var pollerListing = new CentreonListing({
     ],
     renderOptions: function(row, l) {
         var html = '';
-        // Edit engine config
+        // Edit engine config — opens in the side panel (save closes it and refreshes)
         if (row.cfg_id && canCreateEdit && !isRemoteSrv) {
-            html += '<a href="./main.php?p=60903&o=c&nagios_id='+row.cfg_id+'" title="Edit monitoring engine configuration"><img src="./img/icons/edit_conf.png" class="ico-16"/></a>';
+            html += '<a href="#" title="Edit monitoring engine configuration" style="margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" onclick="cfOpenPanel(\'main.get.php?p=60903&o=c&nagios_id='+row.cfg_id+'\', \'Engine configuration\'); return false;"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></a>';
         }
         // Gorgone popup
         if ((row.gorgone_comm === 1 && row.activate) || row.type === 'Central') {
-            html += '<span onclick="displayPopup('+row.id+')" style="cursor:pointer" title="Gorgone configuration"><img src="./img/icons/show_template.png" class="ico-16"/></span>';
+            html += '<span onclick="displayPopup('+row.id+')" style="cursor:pointer;margin-right:8px;color:var(--c-primary-main,#2E68AA);vertical-align:middle;" title="Gorgone configuration"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;"><rect x="2" y="2" width="20" height="8" rx="2"/><rect x="2" y="14" width="20" height="8" rx="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg></span>';
         }
         // Toggle
         var checked = row.activate ? ' checked' : '';

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -1,195 +1,224 @@
-{literal}
 <script type="text/javascript" src="./include/common/javascript/tool.js"></script>
-<script type='text/javascript'>
-    function applyConfiguration() {
-        var pollers = [];
-        jQuery('form tr').not('.row_disabled').find('input[id^="poller_"]:checked').each(function() {
-            pollers.push(this.id.substr(7));
-        });
-        var href = "main.php?p=60902&poller=" + pollers.join(',');
-        jQuery('#exportConfigurationLink').attr('href', href);
-    }
 
-    function setO(_i) {
-        document.forms['form'].elements['o'].value = _i;
-    }
-
-    function hasPollersSelected(){
-        var nbSelectedPollers = jQuery('form tr').find('input[id^="poller_"]:checked').length;
-        var buttons = jQuery('form').find('button[name="delete_action"],button[name="duplicate_action"]');
-
-        if (nbSelectedPollers > 0) {
-            buttons.each(function() {
-                $(this).prop("disabled",false);
-            });
-        } else {
-            buttons.each(function() {
-                $(this).prop("disabled",true);
-            });
-        }
-    }
-    hasPollersSelected();
-
-    jQuery(document).ready(function() {
-        jQuery('#exportConfigurationLink').on('click', function(event) {
-            event.preventDefault(); 
-            applyConfiguration();
-        });
-    })
-
-</script>
-{/literal}
 <form name='form' method='POST'>
-    <table class="ajaxOption table">
-    <tbody>
-      <tr>
-        <th><h5>{t}Filters{/t}</h5></th>
-      </tr>
-      <tr>
-        <td><h4>{t}Poller{/t}</h4></td>
-      </tr>
-      <tr>
-        <td><input type="text" name="searchP" value="{$searchP}" class="mr-1"><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
-      </tr>
-    </tbody>
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            <td>
+    <div class="cl-listing-container">
+        <div class="cl-actions-bar">
+            <div class="cl-actions-left">
                 {if !$isRemote}
                     {if $can_create_edit == 1}
-                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class} " isreact="true" target="_top">
-                            {$wizardAddBtn.icon} {$wizardAddBtn.text}
-                        </a>
-                        <a href="{$addBtn.link}" class="{$addBtn.class}">
-                            {$addBtn.icon} {$addBtn.text}
-                        </a>
+                        <div class="cl-add-dropdown" id="clAddDropdown" style="position:relative;display:inline-block;">
+                            <a href="#" class="cl-btn-add" onclick="var m=document.getElementById('clAddMenu');m.style.display=m.style.display==='block'?'none':'block';return false;">{t}Add{/t}</a>
+                            <div id="clAddMenu" style="display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #ccc;border-radius:4px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:1000;min-width:160px;margin-top:4px;overflow:hidden;">
+                                <a href="{$wizardAddBtn.link}" isreact="true" target="_top" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$wizardAddBtn.icon} {t}Wizard{/t}</a>
+                                <a href="{$addBtn.link}" style="display:block;padding:8px 16px;color:#444;text-decoration:none;font-size:13px;">{$addBtn.icon} {t}Advanced{/t}</a>
+                            </div>
+                        </div>
                     {/if}
+                    {$form.o1.html}
                     {if $can_generate == 1}
-                            <a id="exportConfigurationLink" href="{$exportBtn.link}" class="{$exportBtn.class}">
+                        <a id="exportConfigurationLink" href="#" class="btc bt_success" style="padding:8px 16px;font-size:14px;border-radius:4px;line-height:1.4;white-space:nowrap;opacity:0.5;pointer-events:none;">
                             {$exportBtn.icon} {$exportBtn.text}
                         </a>
                     {/if}
-                    {if $can_create_edit == 1}
-                        <button type="submit" class="{$duplicateBtn.class}" name="{$duplicateBtn.name}" onClick="{$duplicateBtn.onClickAction}">
-                            {$duplicateBtn.icon} {$duplicateBtn.text}
-                        </button>
-                    {/if}
-                    {if $can_delete == 1}
-                        <button type="submit" class="{$deleteBtn.class}" name="{$deleteBtn.name}" onClick="{$deleteBtn.onClickAction}">
-                            {$deleteBtn.icon} {$deleteBtn.text}
-                        </button>
-                    {/if}
                 {/if}
-            </td>
-            {pagination}
-        </tr>
-    </table>
-    <table class="ListTable">
-        <tr class="ListHeader">
-            <td class="ListColHeaderPicker">
-            {if !$isRemote}
-                <div class="md-checkbox md-checkbox-inline">
-                    <input type="checkbox" id="checkall" name="checkall"
-                        onclick="checkUncheckAll(this); hasPollersSelected();"/>
-                    <label class="empty-label" for="checkall"></label>
-                </div>
-            {/if}
-            </td>
-            <td class="ListColHeaderLeft">{$headerMenu_name}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_ip_address}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_type}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_is_running}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_hasChanged}<font color='red' style='padding-left:3px;'>*</font></td>
-            <td class="ListColHeaderCenter">{$headerMenu_pid}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_uptime}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_lastUpdateTime}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_version}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_default}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
-            <td class="ListColHeaderCenter">{t}Actions{/t}</td>
-            <td class="ListColHeaderRight">{$headerMenu_options}</td>
-        </tr>
-        {section name=elem loop=$elemArr}
-        <tr class={$elemArr[elem].MenuClass}>
-            <td class="ListColPicker">{if !$isRemote}{$elemArr[elem].RowMenu_select} {/if}</td>
-            <td class="ListColLeft">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_name}{if $can_create_edit == 1}</a>{/if}</td>
-            <td class="ListColCenter">{if $can_create_edit == 1}<a href="{$elemArr[elem].RowMenu_link}">{/if}{$elemArr[elem].RowMenu_ip_address}{if $can_create_edit == 1}</a>{/if}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_type}</td>
-            <td class="ListColCenter">
-              <span class="badge {if $elemArr[elem].RowMenu_is_runningFlag}service_ok{else}service_critical{/if}">
-                {$elemArr[elem].RowMenu_is_running}
-              </span>
-            </td>
-            <td class="ListColCenter">
-                <span class="badge {if $elemArr[elem].RowMenu_hasChangedFlag == 0}service_ok{else}service_critical{/if}">
-                    {$elemArr[elem].RowMenu_hasChanged}
-                </span>
-            </td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_pid}</td>
-            <!-- using a class to format the timestamp -->
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_uptime}</td>
-            <td class="ListColCenter isTimestamp"{if $elemArr[elem].RowMenu_statusVal == 1} style='background-color:#{if $elemArr[elem].RowMenu_lastUpdateTimeFlag}F7D507;{/if}'{/if}>{$elemArr[elem].RowMenu_lastUpdateTime}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_version}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_is_default}</td>
-            <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
-            <td class="ListColCenter">
-                {if $can_create_edit == 1 && $elemArr[elem].RowMenu_cfg_id != "" && !$isRemote}
-                <!-- Link for edit poller monitoring engine configuration -->
-                <a href="./main.php?p=60903&o=c&nagios_id={$elemArr[elem].RowMenu_cfg_id}">
-                    <img src="./img/icons/edit_conf.png" class="ico-16" title="Edit monitoring engine configuration">
-                </a>
-                {/if}
+            </div>
+            <div class="cl-search-center">
+                <input type="text" id="clSearchInput" name="searchP" value="{$searchP}" placeholder="{t}Search poller{/t}" class="cl-search-input">
+                <button type="button" id="clSearchBtn" class="btc bt_success">{t}Search{/t}</button>
+            </div>
+            <div class="cl-pagination" id="clPaginationTop"></div>
+        </div>
 
-                {if ($elemArr[elem].RowMenu_gorgone_protocol == 1 && $elemArr[elem].RowMenu_statusVal == 1)
-                || $elemArr[elem].RowMenu_type == 'Central'}
-                <!-- Link for edit poller monitoring engine configuration -->
-                <span  {literal}onclick="displayPopup('{/literal}{$elemArr[elem].RowMenu_server_id}{literal}'){/literal}" >
-                    <img src="./img/icons/show_template.png" class="ico-16" style="cursor: pointer" title="Gorgone configuration">
-                </span>
-                {/if}
-            </td>
-            <td class="ListColRight">{if $can_create_edit == 1 && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
-        </tr>
-        {/section}
-    </table>
-    <table class="ToolbarTable table">
-        <tr class="ToolbarTR">
-            {pagination}
-        </tr>
-        <tr>
-            <td colspan='3' style='text-align:right;vertical-align:bottom; height: 50px;'><font color='red'>*</font>&nbsp;{$notice}</td>
-        </tr>
-    </table>
+        <table class="cl-listing-table">
+            <thead>
+                <tr>
+                    <th class="cl-col-picker">
+                        {if !$isRemote}
+                        <div class="md-checkbox md-checkbox-inline">
+                            <input type="checkbox" id="checkall" name="checkall" onclick="pollerListing.checkUncheckAll(this);"/>
+                            <label class="empty-label" for="checkall"></label>
+                        </div>
+                        {/if}
+                    </th>
+                    <th>{$headerMenu_name}</th>
+                    <th class="cl-col-center">{$headerMenu_ip_address}</th>
+                    <th class="cl-col-center">{$headerMenu_type}</th>
+                    <th class="cl-col-center">{$headerMenu_is_running}</th>
+                    <th class="cl-col-center"><span style="border-bottom:1px dotted #fff;cursor:help;" title="{$notice}">{$headerMenu_hasChanged}</span></th>
+                    <th class="cl-col-center">{$headerMenu_lastUpdateTime}</th>
+                    <th class="cl-col-center">{$headerMenu_default}</th>
+                    {if !$isRemote && $can_create_edit == 1}
+                    <th class="cl-col-right">{$headerMenu_options}</th>
+                    {/if}
+                </tr>
+            </thead>
+            <tbody id="clTableBody">
+                <tr><td colspan="10" class="cl-loading">{t}Loading...{/t}</td></tr>
+            </tbody>
+        </table>
+
+        <div class="cl-bottom-bar">
+            <div class="cl-actions-left"></div>
+            <div class="cl-pagination" id="clPaginationBottom"></div>
+        </div>
+    </div>
+
 <input type='hidden' name='o' id='o' value='42'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>
+<input type='hidden' id='limit' name='limit' value=''>
 {$form.hidden}
 </form>
+
 {literal}
-<script type='text/javascript'>
-    function displayPopup(id) {
-        let popin = jQuery(
-            '<div id="config-popin">' +
-                '<div id="loading">' +
-                    '<img src="./img/misc/ajax-loader.gif" />' +
-                '</div>' +
-            '</div>'
-        );
-        let url = './include/configuration/configServers/popup/popup.php?id=' + id;
-        popin.centreonPopin({
-            url: url,
-            open: true,
-            ajaxType: 'GET',
-            ajaxDataType: 'html'
-        });
-    };
-
-    setDisabledRowStyle();
-    //formatting the tags containing a class isTimestamp
-    formatDateMoment();
-
-    jQuery(document).ready(function () {
-        hasPollersSelected();
+<script type="text/javascript">
+function displayPopup(id) {
+    var popin = jQuery(
+        '<div id="config-popin"><div id="loading"><img src="./img/misc/ajax-loader.gif" /></div></div>'
+    );
+    popin.centreonPopin({
+        url: './include/configuration/configServers/popup/popup.php?id=' + id,
+        open: true,
+        ajaxType: 'GET',
+        ajaxDataType: 'html'
     });
+}
+
+function applyConfiguration() {
+    var pollers = [];
+    jQuery('#clTableBody .cl-col-picker input[type=checkbox]:checked').each(function() {
+        var name = jQuery(this).attr('name');
+        var match = name && name.match(/select\[(\d+)\]/);
+        if (match) pollers.push(match[1]);
+    });
+    var href = 'main.php?p=60902&poller=' + pollers.join(',');
+    jQuery('#exportConfigurationLink').attr('href', href);
+}
+
+jQuery(document).ready(function() {
+    jQuery('#exportConfigurationLink').on('click', function(e) {
+        applyConfiguration();
+        var href = jQuery(this).attr('href');
+        if (!href || href === '#' || href === 'DYNAMIC_LINK') {
+            e.preventDefault();
+            return;
+        }
+    });
+});
+
+var canCreateEdit = {/literal}{$can_create_edit}{literal};
+var isRemoteSrv = {/literal}{if $isRemote}true{else}false{/if}{literal};
+var pollerPage = '{/literal}{$pollerPage}{literal}';
+
+var pollerListing = new CentreonListing({
+    instanceName:  'pollerListing',
+    ajaxListUrl:   './include/configuration/configServers/ajaxServerListing.php',
+    ajaxToggleUrl: './include/configuration/configServers/ajaxServerToggle.php',
+    pageId:        pollerPage,
+    writeAccess:   canCreateEdit === 1 && !isRemoteSrv,
+    defaultLimit:  {/literal}{$defaultLimit}{literal},
+    storageKey:    'poller_listing_limit',
+    emptyMessage:  'No pollers found',
+    autoRefresh:   15000,
+    rowIdField:    'id',
+    columns: [
+        { id:'name', render: function(row, l) {
+            var link = 'main.php?p=' + pollerPage + '&o=' + (isRemoteSrv ? 'w' : 'c') + '&server_id=' + row.id;
+            var html = canCreateEdit ? '<a href="'+link+'">'+l.escape(row.name)+'</a>' : l.escape(row.name);
+            // Info tooltip (PID, Uptime, Version)
+            return html;
+        }},
+        { id:'ip_address', align:'center', render: function(row, l) {
+            if (canCreateEdit) {
+                var link = 'main.php?p=' + pollerPage + '&o=' + (isRemoteSrv ? 'w' : 'c') + '&server_id=' + row.id;
+                return '<a href="'+link+'">'+l.escape(row.ip_address)+'</a>';
+            }
+            return l.escape(row.ip_address);
+        }},
+        { id:'type', align:'center' },
+        { id:'is_running', align:'center', render: function(row, l) {
+            var color = row.is_running ? 'var(--color-success,#88B922)' : 'var(--color-danger,#FF4A4A)';
+            var tipContent = '<b>PID:</b> '+l.escape(row.pid)+'<br><b>Uptime:</b> '+l.escape(row.uptime)+'<br><b>Version:</b> '+l.escape(row.version);
+            return '<span data-cl-tooltip="'+tipContent.replace(/"/g,'&quot;')+'" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';cursor:help;"></span>';
+        }},
+        { id:'conf_changed', align:'center', render: function(row) {
+            if (row.conf_changed === 'N/A') return '<span style="opacity:.4;">&#8212;</span>';
+            var color = row.conf_changed_flag === 0 ? 'var(--color-success,#88B922)' : 'var(--color-warning,#FD9B27)';
+            if (row.conf_changed_flag === 0) {
+                return '<span title="Up to date" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';"></span>';
+            }
+            return '<span data-cl-tooltip="<b>Configuration changed</b><br>An export and restart is required to apply changes." style="display:inline-block;width:10px;height:10px;border-radius:50%;background:'+color+';box-shadow:0 0 4px '+color+';cursor:help;"></span>';
+        }},
+        { id:'last_alive', align:'center', render: function(row) {
+            if (!row.last_alive) return '-';
+            var d = new Date(row.last_alive * 1000);
+            var str = d.toLocaleString();
+            return row.last_alive_stale ? '<span class="cl-stale">'+str+'</span>' : str;
+        }},
+        { id:'is_default', align:'center', render: function(row) { return row.is_default ? '<span style="color:var(--color-success,#88B922);font-size:16px;">&#10003;</span>' : ''; }}
+    ],
+    renderOptions: function(row, l) {
+        var html = '';
+        // Edit engine config
+        if (row.cfg_id && canCreateEdit && !isRemoteSrv) {
+            html += '<a href="./main.php?p=60903&o=c&nagios_id='+row.cfg_id+'" title="Edit monitoring engine configuration"><img src="./img/icons/edit_conf.png" class="ico-16"/></a>';
+        }
+        // Gorgone popup
+        if ((row.gorgone_comm === 1 && row.activate) || row.type === 'Central') {
+            html += '<span onclick="displayPopup('+row.id+')" style="cursor:pointer" title="Gorgone configuration"><img src="./img/icons/show_template.png" class="ico-16"/></span>';
+        }
+        // Toggle
+        var checked = row.activate ? ' checked' : '';
+        html += '<label class="cl-toggle"><input type="checkbox" data-row-id="'+row.id+'"'+checked+' onchange="pollerListing.toggleActivation(this);"/><span class="cl-toggle-slider"></span></label>';
+        // Dup input
+        html += '<input onKeypress="if(event.keyCode>31&&(event.keyCode<45||event.keyCode>57))event.returnValue=false;if(event.which>31&&(event.which<45||event.which>57))return false;" maxlength="3" size="3" value="1" class="cl-dup-input" name="dupNbr['+row.id+']"/>';
+        return html;
+    }
+});
+pollerListing.init();
+
+// Enable/disable Export button based on poller selection
+function updateExportBtn() {
+    var btn = document.getElementById('exportConfigurationLink');
+    if (!btn) return;
+    var checked = jQuery('#clTableBody .cl-col-picker input[type=checkbox]:checked').length;
+    btn.style.opacity = checked > 0 ? '1' : '0.5';
+    btn.style.pointerEvents = checked > 0 ? 'auto' : 'none';
+}
+jQuery(document).on('change', '#clTableBody input[type=checkbox], #checkall', function() {
+    updateExportBtn();
+});
+
+// Close Add dropdown on click outside
+document.addEventListener('click', function(e) {
+    var dd = document.getElementById('clAddDropdown');
+    var menu = document.getElementById('clAddMenu');
+    if (dd && menu && !dd.contains(e.target)) {
+        menu.style.display = 'none';
+    }
+});
+
+// Instant tooltip for info icons
+(function() {
+    var tip = null;
+    jQuery(document).on('mouseenter', '[data-cl-tooltip]', function() {
+        var content = jQuery(this).attr('data-cl-tooltip');
+        if (!content) return;
+        if (tip) tip.remove();
+        tip = jQuery('<div></div>').html(content).css({
+            position:'fixed', zIndex:99999,
+            background:'#222', color:'#eee',
+            border:'1px solid #555', borderRadius:'6px',
+            padding:'8px 12px', fontSize:'12px',
+            whiteSpace:'nowrap', boxShadow:'0 2px 8px rgba(0,0,0,.3)',
+            pointerEvents:'none'
+        });
+        jQuery('body').append(tip);
+        var r = this.getBoundingClientRect();
+        var t = r.top - tip.outerHeight() - 6;
+        if (t < 0) t = r.bottom + 6;
+        tip.css({ top:t+'px', left:(r.left + r.width/2 - tip.outerWidth()/2)+'px' });
+    }).on('mouseleave', '[data-cl-tooltip]', function() {
+        if (tip) { tip.remove(); tip = null; }
+    });
+})();
 </script>
 {/literal}

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -238,6 +238,62 @@ var pollerListing = new CentreonListing({
 });
 pollerListing.init();
 
+// ---- More actions dispatcher (duplicate / delete / reload / restart) ----
+window.pollerMoreAction = function (sel) {
+    var val = sel.value;
+    sel.selectedIndex = 0;
+    if (!val) { return; }
+
+    if (val === 'm' || val === 'd') {
+        if (typeof isChecked === 'function' && !isChecked()) {
+            alert('Please select one or more items'); return;
+        }
+        if (val === 'm' && confirm('Do you confirm the duplication ?')) {
+            setO('m'); document.forms['form'].submit();
+        } else if (val === 'd' && confirm('You are about to delete one or more pollers.\nThis action is IRREVERSIBLE.\nDo you confirm the deletion ?')) {
+            setO('d'); document.forms['form'].submit();
+        }
+        return;
+    }
+
+    if (val === 'reload' || val === 'restart') {
+        pollerBulkEngine(val);
+    }
+};
+
+// Reload / Restart the monitoring engine on the selected pollers (bulk, ACL enforced server-side)
+function pollerBulkEngine(action) {
+    var ids = [];
+    jQuery('#clTableBody input[type="checkbox"][name^="select["]:checked').each(function () {
+        var m = (this.name || '').match(/select\[(\d+)\]/);
+        if (m) { ids.push(m[1]); }
+    });
+    if (!ids.length) { clToast('Please select one or more pollers.', 'error'); return; }
+
+    var verb = action;
+    var mode = (action === 'reload') ? 1 : 2;
+    // Explicit confirmation required from the user performing the action
+    if (!confirm('Do you really want to ' + verb + ' the monitoring engine on the ' + ids.length + ' selected poller(s) ?')) {
+        return;
+    }
+    jQuery.ajax({
+        url: './include/configuration/configGenerate/xml/restartPollers.php',
+        type: 'POST',
+        dataType: 'xml',
+        data: { poller: ids.join(','), mode: mode },
+        success: function (xml) {
+            var d = jQuery(xml);
+            var code = (d.find('statuscode').first().text() || '1');
+            if (code === '0') {
+                clToast('A ' + verb + ' signal has been sent to the selected poller(s).', 'success');
+            } else {
+                clToast('Failed to ' + verb + ': ' + (d.find('error').first().text() || 'unknown error'), 'error');
+            }
+        },
+        error: function () { clToast('Request failed.', 'error'); }
+    });
+}
+
 // Enable/disable Export button based on poller selection
 function updateExportBtn() {
     var btn = document.getElementById('exportConfigurationLink');

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -127,19 +127,18 @@ $tpl->assign('limit', $limit);
 
 if (! $isRemote) {
     $attrs = ['onchange' => 'pollerMoreAction(this);'];
-    $form->addElement(
-        'select',
-        'o1',
-        null,
-        [
-            null => _('More actions...'),
-            'm' => _('Duplicate'),
-            'd' => _('Delete'),
-            'reload' => _('Reload engine'),
-            'restart' => _('Restart engine'),
-        ],
-        $attrs
-    );
+    $moreActions = [
+        null => _('More actions...'),
+        'm' => _('Duplicate'),
+        'd' => _('Delete'),
+    ];
+    // Reloading / restarting the monitoring engine requires the "Generate
+    // configuration files" action ACL (same right as the export page).
+    if ($centreon->user->admin || $can_generate) {
+        $moreActions['reload'] = _('Reload engine');
+        $moreActions['restart'] = _('Restart engine');
+    }
+    $form->addElement('select', 'o1', null, $moreActions, $attrs);
     $o1 = $form->getElement('o1');
     $o1->setValue(null);
 }

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -126,18 +126,20 @@ $tpl->assign('limit', $limit);
 <?php
 
 if (! $isRemote) {
-    $attrs = ['onchange' => 'javascript: '
-        . ' var bChecked = isChecked(); '
-        . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
-        . " alert('" . _('Please select one or more items') . "'); return false;} "
-        . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
-        . _('Do you confirm the duplication ?') . "')) {"
-        . " 	setO(this.form.elements['o1'].value); submit();} "
-        . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
-        . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
-        . "')) { setO(this.form.elements['o1'].value); submit();} "
-        . "this.form.elements['o1'].selectedIndex = 0"];
-    $form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $attrs = ['onchange' => 'pollerMoreAction(this);'];
+    $form->addElement(
+        'select',
+        'o1',
+        null,
+        [
+            null => _('More actions...'),
+            'm' => _('Duplicate'),
+            'd' => _('Delete'),
+            'reload' => _('Reload engine'),
+            'restart' => _('Restart engine'),
+        ],
+        $attrs
+    );
     $o1 = $form->getElement('o1');
     $o1->setValue(null);
 }

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -25,242 +25,44 @@ if (! isset($centreon)) {
 
 include './include/common/autoNumLimit.php';
 
-// Init GMT class
-$centreonGMT = new CentreonGMT();
-$centreonGMT->getMyGMTFromSession(session_id());
+// Smarty template initialization
+$tpl = SmartyBC::createSmartyTemplate($path);
 
-$search = $_POST['searchP'] ?? $_GET['searchP'] ?? null;
+// Access level and permissions
+$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
+$tpl->assign('mode_access', $lvl_access);
 
-if (! is_null($search)) {
-    // saving filters values
-    $centreon->historySearch[$url] = [];
-    $centreon->historySearch[$url]['search'] = $search;
-} else {
-    // restoring saved values
-    $search = $centreon->historySearch[$url]['search'] ?? null;
-}
-
-$LCASearch = '';
-if (! is_null($search)) {
-    $search = HtmlSanitizer::createFromString($search)->sanitize()->getString();
-    $LCASearch .= " name LIKE '%{$search}%'";
-}
-
-// Get Authorized Actions
 $can_generate = $centreon->user->access->checkAction('generate_cfg');
 $can_create_edit = $centreon->user->access->checkAction('create_edit_poller_cfg');
 $can_delete = $centreon->user->access->checkAction('delete_poller_cfg');
 
-// nagios servers comes from DB
-$nagiosServers = [];
-$nagiosRestart = [];
-foreach ($serverResult as $nagiosServer) {
-    $nagiosServers[$nagiosServer['id']] = $nagiosServer['name'];
-    $nagiosRestart[$nagiosServer['id']] = $nagiosServer['last_restart'];
-}
-
-$pollerstring = implode(',', array_keys($nagiosServers));
-
-// Get information info RTM
-$nagiosInfo = [];
-$dbResult = $pearDBO->query(
-    'SELECT start_time AS program_start_time, running AS is_currently_running, pid AS process_id, instance_id, '
-    . 'name AS instance_name , last_alive FROM instances WHERE deleted = 0'
-);
-while ($info = $dbResult->fetch()) {
-    $nagiosInfo[$info['instance_id']] = $info;
-}
-$dbResult->closeCursor();
-
-// Get Scheduler version
-$dbResult = $pearDBO->query(
-    'SELECT DISTINCT instance_id, version AS program_version, engine AS program_name, name AS instance_name '
-    . 'FROM instances WHERE deleted = 0 '
-);
-while ($info = $dbResult->fetch()) {
-    if (isset($nagiosInfo[$info['instance_id']])) {
-        $nagiosInfo[$info['instance_id']]['version'] = $info['program_name'] . ' ' . $info['program_version'];
-    }
-}
-$dbResult->closeCursor();
-
-$query = 'SELECT ip FROM remote_servers';
-$dbResult = $pearDB->query($query);
-$remotesServerIPs = $dbResult->fetchAll(PDO::FETCH_COLUMN);
-$dbResult->closeCursor();
-
-// Smarty template initialization
-$tpl = SmartyBC::createSmartyTemplate($path);
-
-// Access level
-$lvl_access = ($centreon->user->access->page($p) == 1) ? 'w' : 'r';
-$tpl->assign('mode_access', $lvl_access);
-
-// start header menu
 $tpl->assign('headerMenu_name', _('Name'));
 $tpl->assign('headerMenu_ip_address', _('Address'));
 $tpl->assign('headerMenu_type', _('Server type'));
 $tpl->assign('headerMenu_is_running', _('Is running ?'));
 $tpl->assign('headerMenu_hasChanged', _('Conf Changed'));
-$tpl->assign('headerMenu_pid', _('PID'));
-$tpl->assign('headerMenu_version', _('Version'));
-$tpl->assign('headerMenu_uptime', _('Uptime'));
 $tpl->assign('headerMenu_lastUpdateTime', _('Last Update'));
-$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_default', _('Default'));
+$tpl->assign('headerMenu_status', _('Status'));
 $tpl->assign('headerMenu_options', _('Options'));
 
-// Poller list
-$ACLString = $centreon->user->access->queryBuilder('WHERE', 'id', $pollerstring);
+$tpl->assign('pollerPage', $p);
 
-$query = 'SELECT SQL_CALC_FOUND_ROWS id, name, ns_activate, ns_ip_address, localhost, is_default, updated '
-    . ', gorgone_communication_type FROM `nagios_server` ' . $ACLString . ' '
-    . ($LCASearch != '' ? ($ACLString != '' ? 'AND ' : 'WHERE ') . $LCASearch : '')
-    . ' ORDER BY name LIMIT ' . $num * $limit . ', ' . $limit;
-$dbResult = $pearDB->query($query);
+// Restore search from history
+$search = $centreon->historySearch[$url]['search'] ?? '';
+$tpl->assign('searchP', $search);
 
-$rows = $pearDB->query('SELECT FOUND_ROWS()')->fetchColumn();
+// Default limit
+$dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+$gopt = $dbResult->fetch();
+$defaultLimit = (int) ($gopt['value'] ?? 30) ?: 30;
+$tpl->assign('defaultLimit', $defaultLimit);
 
-$servers = [];
-while (($config = $dbResult->fetch())) {
-    $servers[] = $config;
-}
-
-include './include/common/checkPagination.php';
-
-$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
-
-// Fill a tab with a multidimensional Array we put in $tpl
-$elemArr = [];
-$i = -1;
-$centreonToken = createCSRFToken();
-
-foreach ($servers as $config) {
-    $i++;
-    $moptions = '';
-    $selectedElements = $form->addElement(
-        'checkbox',
-        'select[' . $config['id'] . ']',
-        null,
-        '',
-        ['id' => 'poller_' . $config['id'], 'onClick' => 'hasPollersSelected();']
-    );
-    if (! $isRemote) {
-        if ($config['ns_activate']) {
-            $moptions .= "<a href='main.php?p=" . $p . '&server_id=' . $config['id'] . '&o=u&limit=' . $limit
-                . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-                . "'><img src='img/icons/disabled.png' class='ico-14 margin_right' "
-                . "border='0' alt='" . _('Disabled') . "'></a>";
-        } else {
-            $moptions .= "<a href='main.php?p=" . $p . '&server_id=' . $config['id'] . '&o=s&limit=' . $limit
-                . '&num=' . $num . '&search=' . $search . '&centreon_token=' . $centreonToken
-                . "'><img src='img/icons/enabled.png' class='ico-14 margin_right' "
-                . "border='0' alt='" . _('Enabled') . "'></a>";
-        }
-    }
-    $moptions .= '<input onKeypress="if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) '
-        . 'event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) '
-        . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
-        . "name='dupNbr[" . $config['id'] . "]' />";
-
-    if (! isset($nagiosInfo[$config['id']]['is_currently_running'])) {
-        $nagiosInfo[$config['id']]['is_currently_running'] = 0;
-    }
-
-    // Manage flag for changes
-    $confChangedMessage = _('N/A');
-    if ($config['ns_activate'] && isset($nagiosRestart[$config['id']])) {
-        $confChangedMessage = $config['updated'] ? _('Yes') : _('No');
-    }
-
-    // Manage flag for update time
-    $lastUpdateTimeFlag = 0;
-    if (! isset($nagiosInfo[$config['id']]['last_alive'])) {
-        $lastUpdateTimeFlag = 0;
-    } elseif (time() - $nagiosInfo[$config['id']]['last_alive'] > 10 * 60) {
-        $lastUpdateTimeFlag = 1;
-    }
-
-    // Get cfg_id
-    $dbResult2 = $pearDB->query(
-        'SELECT nagios_id FROM cfg_nagios '
-        . 'WHERE nagios_server_id = ' . (int) $config['id'] . " AND nagios_activate = '1'"
-    );
-    $cfg_id = $dbResult2->rowCount() ? $dbResult2->fetch() : -1;
-
-    $uptime = '-';
-    $isRunning = (isset($nagiosInfo[$config['id']]['is_currently_running'])
-        && $nagiosInfo[$config['id']]['is_currently_running'] == 1)
-        ? true
-        : false;
-    $version = $nagiosInfo[$config['id']]['version'] ?? _('N/A');
-    $updateTime = (isset($nagiosInfo[$config['id']]['last_alive'])
-        && $nagiosInfo[$config['id']]['last_alive'])
-        ? $nagiosInfo[$config['id']]['last_alive']
-        : '-';
-    $serverType = $config['localhost'] ? _('Central') : _('Poller');
-    $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
-        ? _('Remote Server')
-        : $serverType;
-
-    if (
-        isset($nagiosInfo[$config['id']]['is_currently_running'])
-        && $nagiosInfo[$config['id']]['is_currently_running'] == 1
-    ) {
-        $now = new DateTime();
-        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$config['id']]['program_start_time']);
-        $interval = date_diff($now, $startDate);
-        if (intval($interval->format('%a')) >= 2) {
-            $uptime = $interval->format('%a days');
-        } elseif (intval($interval->format('%a')) == 1) {
-            $uptime = $interval->format('%a days %i minutes');
-        } elseif (intval($interval->format('%a')) < 1 && intval($interval->format('%h')) >= 1) {
-            $uptime = $interval->format('%h hours %i minutes');
-        } elseif (intval($interval->format('%h')) < 1) {
-            $uptime = $interval->format('%i minutes %s seconds');
-        } else {
-            $uptime = $interval->format('%a days %h hours %i minutes %s seconds');
-        }
-    }
-
-    $pollerProcessId = $isRunning
-        ? $nagiosInfo[$config['id']]['process_id']
-        : '-';
-
-    // Manage different styles between each line
-    $style = ($i % 2) ? 'two' : 'one';
-
-    $serverLink = $isRemote
-        ? "main.php?p={$p}&o=w&server_id={$config['id']}"
-        : "main.php?p={$p}&o=c&server_id={$config['id']}";
-
-    $elemArr[$i] = [
-        'MenuClass' => "list_{$style}",
-        'RowMenu_select' => $selectedElements->toHtml(),
-        'RowMenu_name' => HtmlSanitizer::createFromString($config['name'])->sanitize()->getString(),
-        'RowMenu_ip_address' => $config['ns_ip_address'],
-        'RowMenu_server_id' => $config['id'],
-        'RowMenu_gorgone_protocol' => $config['gorgone_communication_type'],
-        'RowMenu_link' => $serverLink,
-        'RowMenu_type' => $serverType,
-        'RowMenu_is_running' => $isRunning ? _('Yes') : _('No'),
-        'RowMenu_is_runningFlag' => $nagiosInfo[$config['id']]['is_currently_running'],
-        'RowMenu_is_default' => $config['is_default'] ? _('Yes') : _('No'),
-        'RowMenu_hasChanged' => $confChangedMessage,
-        'RowMenu_pid' => $pollerProcessId,
-        'RowMenu_hasChangedFlag' => $config['updated'],
-        'RowMenu_version' => $version,
-        'RowMenu_uptime' => $uptime,
-        'RowMenu_lastUpdateTime' => $updateTime,
-        'RowMenu_lastUpdateTimeFlag' => $lastUpdateTimeFlag,
-        'RowMenu_status' => $config['ns_activate'] ? _('Enabled') : _('Disabled'),
-        'RowMenu_badge' => $config['ns_activate'] ? 'service_ok' : 'service_critical',
-        'RowMenu_statusVal' => $config['ns_activate'],
-        'RowMenu_cfg_id' => ($cfg_id == -1) ? '' : $cfg_id['nagios_id'],
-        'RowMenu_options' => $moptions,
-    ];
-}
-$tpl->assign('elemArr', $elemArr);
+$tpl->assign('can_generate', $can_generate);
+$tpl->assign('can_create_edit', $can_create_edit);
+$tpl->assign('can_delete', $can_delete);
+$tpl->assign('is_admin', $is_admin);
+$tpl->assign('isRemote', $isRemote);
 
 $tpl->assign(
     'notice',
@@ -271,55 +73,74 @@ $tpl->assign(
 
 // Action buttons
 if (! $isRemote) {
-    $tpl->assign(
-        'wizardAddBtn',
-        ['link' => './poller-wizard/1', 'text' => _('Add'), 'class' => 'btc bt-poller-action bt_success', 'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16)]
-    );
-
-    $tpl->assign(
-        'addBtn',
-        ['link' => 'main.php?p=' . $p . '&o=a', 'text' => _('Add (advanced)'), 'class' => 'btc bt-poller-action bt_success', 'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16)]
-    );
-
-    $tpl->assign(
-        'duplicateBtn',
-        ['text' => _('Duplicate'), 'class' => 'btc bt-poller-action bt_success', 'name' => 'duplicate_action', 'icon' => returnSvg('www/img/icons/duplicate.svg', 'var(--button-icons-fill-color)', 16, 14), 'onClickAction' => 'javascript: '
+    $tpl->assign('wizardAddBtn', [
+        'link' => './poller-wizard/1',
+        'text' => _('Add'),
+        'class' => 'btc bt-poller-action bt_success',
+        'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16),
+    ]);
+    $tpl->assign('addBtn', [
+        'link' => 'main.php?p=' . $p . '&o=a',
+        'text' => _('Add (advanced)'),
+        'class' => 'btc bt-poller-action bt_success',
+        'icon' => returnSvg('www/img/icons/add.svg', 'var(--button-icons-fill-color)', 16, 16),
+    ]);
+    $tpl->assign('duplicateBtn', [
+        'text' => _('Duplicate'),
+        'class' => 'btc bt-poller-action bt_success',
+        'name' => 'duplicate_action',
+        'icon' => returnSvg('www/img/icons/duplicate.svg', 'var(--button-icons-fill-color)', 16, 14),
+        'onClickAction' => 'javascript: '
             . ' var bChecked = isChecked(); '
             . " if (!bChecked) { alert('" . _('Please select one or more items') . "'); return false;} "
-            . " if (confirm('" . _('Do you confirm the duplication ?') . "')) { setO('m'); submit();} "]
-    );
-
-    $tpl->assign(
-        'deleteBtn',
-        ['text' => _('Delete'), 'class' => 'btc bt-poller-action bt_danger', 'name' => 'delete_action', 'icon' => returnSvg('www/img/icons/trash.svg', 'var(--button-icons-fill-color)', 16, 16), 'onClickAction' => 'javascript: '
+            . " if (confirm('" . _('Do you confirm the duplication ?') . "')) { setO('m'); submit();} ",
+    ]);
+    $tpl->assign('deleteBtn', [
+        'text' => _('Delete'),
+        'class' => 'btc bt-poller-action bt_danger',
+        'name' => 'delete_action',
+        'icon' => returnSvg('www/img/icons/trash.svg', 'var(--button-icons-fill-color)', 16, 16),
+        'onClickAction' => 'javascript: '
             . ' var bChecked = isChecked(); '
             . " if (!bChecked) { alert('" . _('Please select one or more items') . "'); return false;} "
-            . " if (confirm('"
-            . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\n'
-            . 'Do you confirm the deletion ?')
-            . "')) { setO('d'); submit();} "]
-    );
-
-    $tpl->assign(
-        'exportBtn',
-        [
-            'link' => 'DYNAMIC_LINK', // Placeholder for dynamic link
-            'text' => _('Export configuration'),
-            'class' => 'btc bt-poller-action bt_info',
-            'icon' => returnSvg('www/img/icons/export.svg', 'var(--button-icons-fill-color)', 14, 14),
-            'id' => 'exportConfigurationLink',
-        ]
-    );
-
+            . " if (confirm('" . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
+            . "')) { setO('d'); submit();} ",
+    ]);
+    $tpl->assign('exportBtn', [
+        'link' => 'DYNAMIC_LINK',
+        'text' => _('Export configuration'),
+        'class' => 'btc bt-poller-action bt_info',
+        'icon' => returnSvg('www/img/icons/export.svg', 'var(--button-icons-fill-color)', 14, 14),
+    ]);
 }
 
+$form = new HTML_QuickFormCustom('select_form', 'POST', '?p=' . $p);
 $tpl->assign('limit', $limit);
-$tpl->assign('searchP', $search);
-$tpl->assign('can_generate', $can_generate);
-$tpl->assign('can_create_edit', $can_create_edit);
-$tpl->assign('can_delete', $can_delete);
-$tpl->assign('is_admin', $is_admin);
-$tpl->assign('isRemote', $isRemote);
+
+?>
+<script type="text/javascript">
+    function setO(_i) {
+        document.forms['form'].elements['o'].value = _i;
+    }
+</script>
+<?php
+
+if (! $isRemote) {
+    $attrs = ['onchange' => 'javascript: '
+        . ' var bChecked = isChecked(); '
+        . " if (this.form.elements['o1'].selectedIndex != 0 && !bChecked) {"
+        . " alert('" . _('Please select one or more items') . "'); return false;} "
+        . "if (this.form.elements['o1'].selectedIndex == 1 && confirm('"
+        . _('Do you confirm the duplication ?') . "')) {"
+        . " 	setO(this.form.elements['o1'].value); submit();} "
+        . "else if (this.form.elements['o1'].selectedIndex == 2 && confirm('"
+        . _('You are about to delete one or more pollers.\\nThis action is IRREVERSIBLE.\\nDo you confirm the deletion ?')
+        . "')) { setO(this.form.elements['o1'].value); submit();} "
+        . "this.form.elements['o1'].selectedIndex = 0"];
+    $form->addElement('select', 'o1', null, [null => _('More actions...'), 'm' => _('Duplicate'), 'd' => _('Delete')], $attrs);
+    $o1 = $form->getElement('o1');
+    $o1->setValue(null);
+}
 
 // Apply a template definition
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);


### PR DESCRIPTION
## Description

Add **engine control** to the pollers listing so an operator can act on pollers directly from the list, inspired by the deploy page.

## Changes

- New **More actions** entries: **Reload engine** and **Restart engine**, acting on the **selected pollers** (bulk). They reuse `restartPollers.php` (reload = mode 1, restart = mode 2).
- **Explicit confirmation** is required from the user before the action runs.
- The result is surfaced as a **bottom-right toast** (`clToast`) instead of a native alert dialog.

## Access control

Enforced **server-side**: `restartPollers.php` resolves the target pollers through `getPollerAclConf`, so any poller outside the user's ACL scope is ignored. The UI entry is also gated by write access.

## Notes

- Stacked on the pollers listing modernization (#10068 — base branch).
- Depends on the shared listing library for the toast helper (`clToast`, separate lib PR).
- **Stop** is intentionally out of scope: no STOP engine command exists in the current centcore/gorgone mechanism; it would require a dedicated backend action.

## How to test

1. **Configuration > Pollers**, select one or more pollers.
2. **More actions… > Reload engine** (or **Restart engine**) → confirm.
3. A toast confirms the signal was sent; a poller outside your ACL scope is not affected.