### PR TITLE
fix(severity): deduplicate severities granted by multiple ACL rules

### DIFF
--- a/centreon/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
+++ b/centreon/src/Core/Severity/RealTime/Infrastructure/Repository/DbReadSeverityRepository.php
@@ -172,9 +172,9 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
                 return $this->findAllByTypeId($typeId);
             }
 
-            $severitiesAcls = <<<'SQL'
-                INNER JOIN `:db`.acl_resources_sc_relations arsr
-                    ON s.id = arsr.sc_id
+            $severitiesAclSubRequest = <<<'SQL'
+                SELECT arsr.sc_id
+                FROM `:db`.acl_resources_sc_relations arsr
                 INNER JOIN `:db`.acl_resources res
                     ON arsr.acl_res_id = res.acl_res_id
                 INNER JOIN `:db`.acl_res_group_relations argr
@@ -190,9 +190,9 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
                 return $this->findAllByTypeId($typeId);
             }
 
-            $severitiesAcls = <<<'SQL'
-                INNER JOIN `:db`.acl_resources_hc_relations arhr
-                    ON s.id = arhr.hc_id
+            $severitiesAclSubRequest = <<<'SQL'
+                SELECT arhr.hc_id
+                FROM `:db`.acl_resources_hc_relations arhr
                 INNER JOIN `:db`.acl_resources res
                     ON arhr.acl_res_id = res.acl_res_id
                 INNER JOIN `:db`.acl_res_group_relations argr
@@ -202,7 +202,7 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
                 SQL;
         }
 
-        $request = <<<SQL
+        $request = <<<'SQL'
             SELECT SQL_CALC_FOUND_ROWS
                 1 AS REALTIME,
                 severity_id,
@@ -222,7 +222,6 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
                 ON imgdr.img_img_id = img.img_id
             INNER JOIN `:db`.view_img_dir imgd
                 ON imgd.dir_id = imgdr.dir_dir_parent_id
-            {$severitiesAcls}
             SQL;
 
         $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
@@ -232,7 +231,8 @@ class DbReadSeverityRepository extends AbstractRepositoryDRB implements ReadSeve
         foreach ($accessGroupIds as $key => $id) {
             $bindValues[":access_group_id_{$key}"] = $id;
         }
-        $request .= ' AND ag.acl_group_id IN (' . implode(', ', array_keys($bindValues)) . ')';
+        $request .= ' AND s.id IN (' . $severitiesAclSubRequest
+            . ' WHERE ag.acl_group_id IN (' . implode(', ', array_keys($bindValues)) . '))';
 
         // Handle sort
         $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();


### PR DESCRIPTION
## Summary

Backport of #11036 to `dev-25.10.x`.

- The realtime severity endpoints (`GET /monitoring/severities/host` and `/service`), used by the dashboard resource-table widget, returned each severity once per ACL "Resource Access" rule that granted it. Duplicating a Resource Access rule listed the same host/service severity several times and inflated `meta.total`.
- Root cause: the ACL-restricted branch of `DbReadSeverityRepository::findAllByTypeIdAndAccessGroups()` filtered severities through a chain of `INNER JOIN` on the ACL tables without `DISTINCT`/`GROUP BY`, so a severity was emitted once per matching `acl_resources` row.
- Fix: replace the ACL `INNER JOIN` chain with an existence filter (`s.id IN (SELECT ...)`) on both branches (host `hc_id`, service `sc_id`). Nothing from the ACL tables is selected, so this removes the row multiplication at the source and keeps `SQL_CALC_FOUND_ROWS` / `meta.total` correct. The non-restricted path (`findAllByTypeId()`) is unchanged.

Fixes: [MON-205258](https://centreon.atlassian.net/browse/MON-205258)

## Test plan

- [ ] As a non-admin user restricted by two ACL Resource Access rules that both grant the same host severity, `GET /monitoring/severities/host` returns the severity once with `meta.total` = 1 (same for `/service`).
- [ ] The dashboard resource-table widget lists each severity once.
- [ ] An admin, and a non-admin without severity ACL restriction, still see all their severities.


[MON-205258]: https://centreon.atlassian.net/browse/MON-205258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ