### PR TITLE
fix(engine): export gRPC port and listen address in centengine.cfg

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -179,6 +179,7 @@ class Engine extends AbstractObject
         'macros_filter',
         'enable_macros_filter',
         'grpc_port',
+        'rpc_listen_address',
         'log_v2_enabled',
         'log_legacy_enabled',
         'log_v2_logger',
@@ -430,6 +431,22 @@ class Engine extends AbstractObject
     }
 
     /**
+     * @param int $poller_id
+     *
+     * @return string 'vm'|'docker'
+     */
+    private function getPollerType(int $poller_id): string
+    {
+        $stmt = $this->backend_instance->db->prepare(
+            'SELECT poller_type FROM nagios_server WHERE id = :poller_id'
+        );
+        $stmt->bindParam(':poller_id', $poller_id, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchColumn() ?: 'vm';
+    }
+
+    /**
      * @param $poller_id
      *
      * @throws LogicException
@@ -479,7 +496,9 @@ class Engine extends AbstractObject
         $object['global_service_event_handler']
             = $command_instance->generateFromCommandId($object['global_service_event_handler_id']);
 
-        $object['grpc_port'] = 50000 + $poller_id;
+        $pollerType = $this->getPollerType($poller_id);
+        $object['grpc_port'] = 50155;
+        $object['rpc_listen_address'] = $pollerType === 'docker' ? '0.0.0.0' : '127.0.0.1';
         $this->generate_filename = 'centengine.DEBUG';
         $object['cfg_file'] = $this->cfg_file['debug']['cfg_file'];
         $object['resource_file'] = $this->cfg_file['debug']['resource_file'];


### PR DESCRIPTION
## Description

Export the gRPC port and listen address for Docker pollers in `centengine.cfg` during configuration generation.

- Added `rpc_listen_address` to the `$attributes_write` array in `engine.class.php`
- Added a `getPollerType()` private method that queries `nagios_server` for `poller_type` (vm or docker)
- Changed `generate()` to use a fixed `grpc_port = 50155` (was `50000 + $poller_id`) and a conditional `rpc_listen_address` (`0.0.0.0` for docker, `127.0.0.1` for vm)

**Fixes** MON-198227

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Create a poller with `poller_type = 'docker'` in the `nagios_server` table
2. Export the configuration for that poller
3. Verify in the generated `centengine.cfg` that `grpc_port=50155` and `rpc_listen_address=0.0.0.0`
4. Verify a VM poller still gets `grpc_port=50155` and `rpc_listen_address=127.0.0.1`

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).