### PR TITLE
fix(host): Fix error when listing hosts but with ACL restricting pollers

### DIFF
--- a/centreon/www/include/configuration/configObject/host/listHost.php
+++ b/centreon/www/include/configuration/configObject/host/listHost.php
@@ -169,6 +169,7 @@ $tab_relation = [];
 $tab_relation_id = [];
 $dbResult = $pearDB->query(
     'SELECT nhr.host_host_id, nhr.nagios_server_id FROM ns_host_relation nhr'
+    . ($aclPollerString != "''" ? ' ' . $acl->queryBuilder('WHERE', 'nhr.nagios_server_id', $aclPollerString) : '')
 );
 while ($relation = $dbResult->fetch()) {
     $tab_relation[$relation['host_host_id']] = $nagios_server[$relation['nagios_server_id']];


### PR DESCRIPTION
## Description

**Fixes** #[MON-203155](https://centreon.atlassian.net/browse/MON-203155)

Backport of #8675 to `24.10`

When a user is subject to poller restrictions via ACL, the query on `ns_host_relation` was not filtered by the allowed pollers, so relations pointing to pollers the user cannot see generated a flood of `Undefined array key` warnings in the PHP logs. The fix applies the same ACL poller filter to the `ns_host_relation` query.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master


[MON-203155]: https://centreon.atlassian.net/browse/MON-203155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ