### PR TITLE
enh(clapi): handle new gorgone_communication_type values on poller creation

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonInstance.class.php
+++ b/centreon/www/class/centreon-clapi/centreonInstance.class.php
@@ -49,7 +49,7 @@ class CentreonInstance extends CentreonObject
     public const ORDER_SSH_PORT = 2;
     public const ORDER_GORGONE_PROTOCOL = 3;
     public const ORDER_GORGONE_PORT = 4;
-    public const GORGONE_COMMUNICATION = ['ZMQ' => '1', 'SSH' => '2'];
+    public const GORGONE_COMMUNICATION = ['ZMQ' => '1', 'SSH' => '2', 'PULL' => '3', 'PULLWSS' => '4'];
     public const INCORRECTIPADDRESS = 'Invalid IP address format';
 
     /** @var CentreonConfigPoller */
@@ -67,11 +67,19 @@ class CentreonInstance extends CentreonObject
     {
         parent::__construct($dependencyInjector);
         $this->object = new Centreon_Object_Instance($dependencyInjector);
+        $isCloudPlatform = filter_var(
+            $_ENV['IS_CLOUD_PLATFORM'] ?? null,
+            FILTER_VALIDATE_BOOL,
+            FILTER_NULL_ON_FAILURE
+        ) === true;
+        $defaultGorgoneCommunicationType = $isCloudPlatform
+            ? self::GORGONE_COMMUNICATION['PULLWSS']
+            : self::GORGONE_COMMUNICATION['ZMQ'];
         $this->params = [
             'localhost' => '0',
             'ns_activate' => '1',
             'ssh_port' => '22',
-            'gorgone_communication_type' => self::GORGONE_COMMUNICATION['ZMQ'],
+            'gorgone_communication_type' => $defaultGorgoneCommunicationType,
             'gorgone_port' => '5556',
             'nagios_bin' => '/usr/sbin/centengine',
             'nagiostats_bin' => '/usr/bin/centenginestats',
@@ -110,6 +118,9 @@ class CentreonInstance extends CentreonObject
         $addParams[$this->object->getUniqueLabelField()] = $params[self::ORDER_UNIQUENAME];
         $addParams['ns_ip_address'] = $params[self::ORDER_ADDRESS];
 
+        if ($params[self::ORDER_GORGONE_PROTOCOL] === '') {
+            $params[self::ORDER_GORGONE_PROTOCOL] = $this->params['gorgone_communication_type'];
+        }
         if (is_numeric($params[self::ORDER_GORGONE_PROTOCOL])) {
             $revertGorgoneCom = array_flip(self::GORGONE_COMMUNICATION);
             $params[self::ORDER_GORGONE_PROTOCOL] = $revertGorgoneCom[$params[self::ORDER_GORGONE_PROTOCOL]];


### PR DESCRIPTION
## Description

 - Accept `pull` / `pullwss` (or `3` / `4`) as valid values for `gorgone_communication_type` in `INSTANCE ADD` and `INSTANCE setparam`.
  - Introduce a cloud-aware default: cloud pollers default to `pullwss` (4), on-prem stays on `zmq` (1).
  - An empty value at the protocol position of the semicolon-separated `INSTANCE ADD` payload now falls back to that default instead of raising `Incorrect connection protocol`.

[MON-199770](https://centreon.atlassian.net/browse/MON-199770)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

  - [ ] `INSTANCE add;P1;10.30.2.50;22;ZMQ;5556`  -> backward compat, type = 1.
  - [ ] `INSTANCE add;P2;10.30.2.51;22;PULLWSS;5556`  -> type = 4.
  - [ ] `INSTANCE add;P3;10.30.2.52;22;4;5556` -> numeric input, type = 4.
  - [ ] `INSTANCE add;P4;10.30.2.53;22;;5556` on a non-cloud platform -> type = 1 (ZMQ default).
  - [ ] Same payload with `IS_CLOUD_PLATFORM=1` -> type = 4 (PullWSS default).
  - [ ] Invalid value (e.g. `FOO`) still throws `Incorrect connection protocol`.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-199770]: https://centreon.atlassian.net/browse/MON-199770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ