### PR TITLE
feat(vault): add DB credentials rollback script

### DIFF
--- a/centreon/bin/revertCredentials.php
+++ b/centreon/bin/revertCredentials.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../config/centreon.config.php';
+require_once __DIR__ . '/../www/include/common/vault-functions.php';
+
+use App\Kernel;
+use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
+use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Infrastructure\FeatureFlags;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+try {
+    if (posix_getuid() !== 0) {
+        throw new Exception('This script must be run as root');
+    }
+    $kernel = Kernel::createForWeb();
+    $readVaultConfigurationRepository = $kernel->getContainer()->get(
+        ReadVaultConfigurationRepositoryInterface::class
+    );
+    $vaultConfiguration = $readVaultConfigurationRepository->find();
+
+    if ($vaultConfiguration === null) {
+        throw new Exception('No vault configured');
+    }
+
+    /** @var ReadVaultRepositoryInterface $readVaultRepository */
+    $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
+    /** @var WriteVaultRepositoryInterface $writeVaultRepository */
+    $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
+
+    revertAndUpdateDatabaseCredentials($readVaultRepository, $writeVaultRepository);
+    revertGorgoneApiCredentials($readVaultRepository, $writeVaultRepository);
+    revertApplicationCredentials();
+
+} catch (Throwable $ex) {
+    echo $ex->getMessage() . PHP_EOL;
+}
+
+/**
+ * Revert Gorgone API credentials from the vault back to the configuration file.
+ *
+ * This is handle outside of Symfony Command as this should be executed as root.
+ *
+ * @param ReadVaultRepositoryInterface $readVaultRepository
+ * @param WriteVaultRepositoryInterface $writeVaultRepository
+ *
+ * @throws Throwable
+ */
+function revertGorgoneApiCredentials(
+    ReadVaultRepositoryInterface $readVaultRepository,
+    WriteVaultRepositoryInterface $writeVaultRepository,
+): void {
+    echo 'Revert of Gorgone API credentials' . PHP_EOL;
+
+    (new Dotenv())->bootEnv('/usr/share/centreon/.env');
+    $isCloudPlatform = false;
+    if (array_key_exists('IS_CLOUD_PLATFORM', $_ENV) && $_ENV['IS_CLOUD_PLATFORM']) {
+        $isCloudPlatform = true;
+    }
+    $featuresFileContent = file_get_contents(__DIR__ . '/../config/features.json');
+    $featureFlagManager = new FeatureFlags($isCloudPlatform, $featuresFileContent);
+    if ($featureFlagManager->isEnabled('vault_gorgone')) {
+        revertGorgoneCredentialsToDb($readVaultRepository, $writeVaultRepository);
+    }
+
+    echo 'Revert of Gorgone API credentials completed' . PHP_EOL;
+}
+
+/**
+ * Execute Symfony command to revert web and modules credentials.
+ *
+ * @throws ProcessFailedException
+ */
+function revertApplicationCredentials(): void
+{
+    echo 'Revert of application credentials' . PHP_EOL;
+    $process = Process::fromShellCommandline(
+        'sudo -u apache php ' . _CENTREON_PATH_ . '/bin/console list vault:revert-credentials'
+    );
+    $process->setWorkingDirectory(_CENTREON_PATH_);
+    $process->run();
+
+    if (! $process->isSuccessful()) {
+        echo 'No application revert command available, skipping' . PHP_EOL;
+
+        return;
+    }
+
+    preg_match_all('/\S*vault:revert-credentials:\S*/', $process->getOutput(), $matches);
+    foreach ($matches[0] as $revertCommand) {
+        $process = Process::fromShellCommandline(
+            'sudo -u apache php ' . _CENTREON_PATH_ . '/bin/console ' . $revertCommand
+        );
+        $process->setWorkingDirectory(_CENTREON_PATH_);
+        $process->mustRun(function ($type, $buffer): void {
+            if ($type === Process::ERR) {
+                echo 'ERROR: ' . $buffer . PHP_EOL;
+            } else {
+                echo $buffer;
+            }
+        });
+    }
+    echo 'Revert of application credentials completed' . PHP_EOL;
+}

--- a/centreon/bin/revertCredentials.php
+++ b/centreon/bin/revertCredentials.php
@@ -23,6 +23,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../config/centreon.config.php';
 require_once __DIR__ . '/../www/include/common/vault-functions.php';
 
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
 use App\Kernel;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -51,11 +53,15 @@ try {
     /** @var WriteVaultRepositoryInterface $writeVaultRepository */
     $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
 
+    echo 'Revert of database credentials' . PHP_EOL;
     revertAndUpdateDatabaseCredentials($readVaultRepository, $writeVaultRepository);
+    echo 'Revert of database credentials completed' . PHP_EOL;
+
     revertGorgoneApiCredentials($readVaultRepository, $writeVaultRepository);
     revertApplicationCredentials();
 
 } catch (Throwable $ex) {
+    Logger::create(LogChannelEnum::WEB)->error($ex->getMessage(), ['exception' => $ex]);
     echo $ex->getMessage() . PHP_EOL;
 }
 

--- a/centreon/bin/revertCredentials.php
+++ b/centreon/bin/revertCredentials.php
@@ -19,6 +19,8 @@
  *
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../config/centreon.config.php';
 require_once __DIR__ . '/../www/include/common/vault-functions.php';

--- a/centreon/bin/revertCredentials.php
+++ b/centreon/bin/revertCredentials.php
@@ -30,9 +30,7 @@ use Adaptation\Log\Logger;
 use App\Kernel;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
-use Core\Common\Infrastructure\FeatureFlags;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
-use Symfony\Component\Dotenv\Dotenv;
+use Core\Common\Application\VaultEligibilityService;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
@@ -41,12 +39,10 @@ try {
         throw new Exception('This script must be run as root');
     }
     $kernel = Kernel::createForWeb();
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    /** @var VaultEligibilityService $vaultEligibilityService */
+    $vaultEligibilityService = $kernel->getContainer()->get(VaultEligibilityService::class);
 
-    if ($vaultConfiguration === null) {
+    if (! $vaultEligibilityService->shouldUseVault()) {
         throw new Exception('No vault configured');
     }
 
@@ -59,12 +55,18 @@ try {
     revertAndUpdateDatabaseCredentials($readVaultRepository, $writeVaultRepository);
     echo 'Revert of database credentials completed' . PHP_EOL;
 
-    revertGorgoneApiCredentials($readVaultRepository, $writeVaultRepository);
+    revertGorgoneApiCredentials(
+        $readVaultRepository,
+        $writeVaultRepository,
+        $vaultEligibilityService->shouldUseVault('vault_gorgone')
+    );
     revertApplicationCredentials();
 
 } catch (Throwable $ex) {
     Logger::create(LogChannelEnum::WEB)->error($ex->getMessage(), ['exception' => $ex]);
     echo $ex->getMessage() . PHP_EOL;
+
+    exit(1);
 }
 
 /**
@@ -74,23 +76,18 @@ try {
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
+ * @param bool $isGorgoneVaultEnabled whether the `vault_gorgone` feature flag is active for this platform
  *
  * @throws Throwable
  */
 function revertGorgoneApiCredentials(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
+    bool $isGorgoneVaultEnabled,
 ): void {
     echo 'Revert of Gorgone API credentials' . PHP_EOL;
 
-    (new Dotenv())->bootEnv('/usr/share/centreon/.env');
-    $isCloudPlatform = false;
-    if (array_key_exists('IS_CLOUD_PLATFORM', $_ENV) && $_ENV['IS_CLOUD_PLATFORM']) {
-        $isCloudPlatform = true;
-    }
-    $featuresFileContent = file_get_contents(__DIR__ . '/../config/features.json');
-    $featureFlagManager = new FeatureFlags($isCloudPlatform, $featuresFileContent);
-    if ($featureFlagManager->isEnabled('vault_gorgone')) {
+    if ($isGorgoneVaultEnabled) {
         revertGorgoneCredentialsToDb($readVaultRepository, $writeVaultRepository);
     }
 

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -200,6 +200,13 @@ contents:
       group: "root"
       mode: 0744
 
+  - src: "../bin/revertCredentials.php"
+    dst: "/usr/share/centreon/bin/revertCredentials.php"
+    file_info:
+      owner: "root"
+      group: "root"
+      mode: 0744
+
   - src: "../bin/logAnalyserBroker"
     dst: "/usr/share/centreon/bin/logAnalyserBroker"
     file_info:

--- a/centreon/www/include/common/vault-functions.php
+++ b/centreon/www/include/common/vault-functions.php
@@ -20,6 +20,7 @@
  */
 
 use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger as AdaptationLogger;
 use Centreon\Domain\Log\Logger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -1480,9 +1481,12 @@ function updateDatabaseYamlFile(array $vaultPaths): void
  * This is the reverse of {@see migrateAndUpdateDatabaseCredentials()} / {@see migrateDatabaseCredentialsToVault()}.
  * It is handled outside of a Symfony Command as this must be executed as root.
  *
- * The operation is idempotent/resumable: if the config file no longer holds a Vault path, it is a no-op.
- * The plaintext is restored to the config files *before* the Vault secret is deleted, so an interruption
- * can never lose the credentials. A Vault deletion failure is logged and tolerated.
+ * The operation is idempotent: if the config file no longer holds a Vault path, it is a no-op.
+ * The plaintext is restored to the config files *before* the Vault secret is deleted, so an
+ * interruption can never lose the credentials. The resume is not fully self-healing though: if the
+ * run is interrupted after the config is restored but before the Vault secret is deleted, a re-run
+ * short-circuits on the no-op check above and leaves the (now unused) Vault secret in place. Such an
+ * orphaned secret is tolerated, as is an outright Vault deletion failure (both are logged).
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
@@ -1495,7 +1499,7 @@ function revertAndUpdateDatabaseCredentials(
 ): void {
     $stored = retrieveDatabaseCredentialsFromConfigFile();
     if (! str_starts_with($stored['username'], VaultConfiguration::VAULT_PATH_PATTERN)) {
-        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Database credentials are not stored in Vault, nothing to revert');
+        AdaptationLogger::create(LogChannelEnum::WEB)->info('Database credentials are not stored in Vault, nothing to revert');
 
         return;
     }
@@ -1517,7 +1521,7 @@ function revertAndUpdateDatabaseCredentials(
 
     deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::DATABASE_VAULT_PATH, $stored['username']);
 
-    Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Database credentials reverted from Vault to configuration files');
+    AdaptationLogger::create(LogChannelEnum::WEB)->info('Database credentials reverted from Vault to configuration files');
 }
 
 /**
@@ -1525,12 +1529,22 @@ function revertAndUpdateDatabaseCredentials(
  *
  * Reverse of {@see updateConfigFilesWithVaultPath()}.
  *
+ * The credentials stored in Vault are the raw bytes {@see retrieveDatabaseCredentialsFromConfigFile()}
+ * captured from centreon.conf.php, i.e. still in PHP single-quote escaped form. They are decoded to
+ * their logical value once here, then each writer re-encodes them for its own file syntax. This keeps
+ * a credential containing `"`, `$`, `@` or `\` from corrupting conf.pm / the YAML files.
+ *
  * @param array{username: string, password: string} $credentials
  *
  * @throws Exception
  */
 function updateConfigFilesWithDbCredentials(array $credentials): void
 {
+    $credentials = [
+        'username' => decodeFromPhpSingleQuoted($credentials['username']),
+        'password' => decodeFromPhpSingleQuoted($credentials['password']),
+    ];
+
     $featuresFileContent = file_get_contents(__DIR__ . '/../../../config/features.json');
     $featureFlagManager = new FeatureFlags(false, $featuresFileContent);
 
@@ -1539,6 +1553,64 @@ function updateConfigFilesWithDbCredentials(array $credentials): void
         restoreCentreonConfPmFile($credentials);
         restoreDatabaseYamlFile($credentials);
     }
+}
+
+/**
+ * Decode a value captured from a PHP single-quoted literal back to its logical form.
+ *
+ * PHP single-quoted strings only recognise `\\` (backslash) and `\'` (single quote) as escapes, so
+ * this reverses exactly those two sequences. This is the inverse of {@see encodeForPhpSingleQuoted()}.
+ *
+ * @param string $value the raw bytes as captured between the single quotes in centreon.conf.php
+ *
+ * @return string the logical (unescaped) value
+ */
+function decodeFromPhpSingleQuoted(string $value): string
+{
+    return preg_replace('/\\\\([\\\\\'])/', '$1', $value);
+}
+
+/**
+ * Escape a logical value so it can be embedded in a PHP single-quoted literal (`'...'`).
+ *
+ * @param string $value the logical value
+ *
+ * @return string the escaped value (backslash and single quote prefixed with a backslash)
+ */
+function encodeForPhpSingleQuoted(string $value): string
+{
+    return addcslashes($value, "\\'");
+}
+
+/**
+ * Escape a logical value so it can be embedded in a Perl double-quoted string (`"..."`).
+ *
+ * Perl interpolates `$` and `@` and treats `\` and `"` specially inside double quotes, so all four
+ * are prefixed with a backslash. Backslash is escaped first to avoid re-escaping the ones inserted
+ * afterwards.
+ *
+ * @param string $value the logical value
+ *
+ * @return string the escaped value
+ */
+function encodeForPerlDoubleQuoted(string $value): string
+{
+    return str_replace(['\\', '"', '$', '@'], ['\\\\', '\\"', '\\$', '\\@'], $value);
+}
+
+/**
+ * Escape a logical value so it can be embedded in a YAML double-quoted scalar (`"..."`).
+ *
+ * A YAML double-quoted scalar only needs `\` and `"` escaped to stay valid. Backslash is escaped
+ * first to avoid re-escaping the one inserted for `"`.
+ *
+ * @param string $value the logical value
+ *
+ * @return string the escaped value
+ */
+function encodeForYamlDoubleQuoted(string $value): string
+{
+    return str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
 }
 
 /**
@@ -1558,12 +1630,12 @@ function restoreCentreonConfPhpFile(array $credentials): void
 
     $newContentPhp = preg_replace_callback(
         '/\$conf_centreon\[[\'\"]user[\'\"]\]\s*=\s*(.*)/',
-        static fn (): string => "\$conf_centreon['user'] = '" . $credentials['username'] . "';",
+        static fn (): string => "\$conf_centreon['user'] = '" . encodeForPhpSingleQuoted($credentials['username']) . "';",
         $content
     );
     $newContentPhp = preg_replace_callback(
         '/\$conf_centreon\[[\'\"]password[\'\"]\]\s*=\s*(.*)/',
-        static fn (): string => "\$conf_centreon['password'] = '" . $credentials['password'] . "';",
+        static fn (): string => "\$conf_centreon['password'] = '" . encodeForPhpSingleQuoted($credentials['password']) . "';",
         (string) $newContentPhp
     );
 
@@ -1586,24 +1658,27 @@ function restoreCentreonConfPmFile(array $credentials): void
         throw new Exception('Unable to retrieve content of file: ' . _CENTREON_ETC_ . '/conf.pm');
     }
 
+    $encodedUser = encodeForPerlDoubleQuoted($credentials['username']);
+    $encodedPassword = encodeForPerlDoubleQuoted($credentials['password']);
+
     $newContentPm = preg_replace_callback(
         '/"db_user"\s*=>\s*(.*)/',
-        static fn (): string => '"db_user" => "' . $credentials['username'] . '",',
+        static fn (): string => '"db_user" => "' . $encodedUser . '",',
         $content
     );
     $newContentPm = preg_replace_callback(
         '/"db_passwd"\s*=>\s*(.*)/',
-        static fn (): string => '"db_passwd" => "' . $credentials['password'] . '"',
+        static fn (): string => '"db_passwd" => "' . $encodedPassword . '"',
         (string) $newContentPm
     );
     $newContentPm = preg_replace_callback(
         '/\$mysql_user\s*=\s*(.*)/',
-        static fn (): string => '$mysql_user = "' . $credentials['username'] . '";',
+        static fn (): string => '$mysql_user = "' . $encodedUser . '";',
         (string) $newContentPm
     );
     $newContentPm = preg_replace_callback(
         '/\$mysql_passwd\s*=\s*(.*)/',
-        static fn (): string => '$mysql_passwd = "' . $credentials['password'] . '";',
+        static fn (): string => '$mysql_passwd = "' . $encodedPassword . '";',
         (string) $newContentPm
     );
 
@@ -1628,12 +1703,12 @@ function restoreDatabaseYamlFile(array $credentials): void
     }
     $newContentYaml = preg_replace_callback(
         '/username: (.*)/',
-        static fn (): string => 'username: "' . $credentials['username'] . '"',
+        static fn (): string => 'username: "' . encodeForYamlDoubleQuoted($credentials['username']) . '"',
         $content
     );
     $newContentYaml = preg_replace_callback(
         '/password: (.*)/',
-        static fn (): string => 'password: "' . $credentials['password'] . '"',
+        static fn (): string => 'password: "' . encodeForYamlDoubleQuoted($credentials['password']) . '"',
         (string) $newContentYaml
     );
 
@@ -1647,6 +1722,9 @@ function restoreDatabaseYamlFile(array $credentials): void
  * Reverse of {@see migrateGorgoneCredentialsToVault()} + {@see updateGorgoneApiFile()}. The `vault_gorgone`
  * feature-flag gating is handled by the caller (the bin orchestrator).
  *
+ * Same guarantees as {@see revertAndUpdateDatabaseCredentials()}: the config file is restored before
+ * the Vault secret is deleted, and an interruption between the two leaves a tolerated orphaned secret.
+ *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
  *
@@ -1658,7 +1736,7 @@ function revertGorgoneCredentialsToDb(
 ): void {
     $storedPassword = retrieveGorgoneApiCredentialsFromConfigFile();
     if (! str_starts_with($storedPassword, VaultConfiguration::VAULT_PATH_PATTERN)) {
-        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Gorgone API credentials are not stored in Vault, nothing to revert');
+        AdaptationLogger::create(LogChannelEnum::WEB)->info('Gorgone API credentials are not stored in Vault, nothing to revert');
 
         return;
     }
@@ -1674,7 +1752,7 @@ function revertGorgoneCredentialsToDb(
 
     deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::GORGONE_VAULT_PATH, $storedPassword);
 
-    Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Gorgone API credentials reverted from Vault to configuration file');
+    AdaptationLogger::create(LogChannelEnum::WEB)->info('Gorgone API credentials reverted from Vault to configuration file');
 }
 
 /**
@@ -1697,7 +1775,7 @@ function restoreGorgoneApiFile(string $password): void
 
     $newContentYaml = preg_replace_callback(
         '/password: (.*)/',
-        static fn (): string => 'password: "' . $password . '"',
+        static fn (): string => 'password: "' . encodeForYamlDoubleQuoted($password) . '"',
         $content
     );
 
@@ -1717,7 +1795,7 @@ function deleteVaultSecret(
     string $vaultPath,
 ): void {
     if (! preg_match('/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/', $vaultPath, $matches)) {
-        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->warning(
+        AdaptationLogger::create(LogChannelEnum::WEB)->warning(
             'Unable to extract UUID from Vault path, skipping Vault deletion',
             ['path' => $customPath]
         );
@@ -1729,12 +1807,12 @@ function deleteVaultSecret(
     try {
         $writeVaultRepository->setCustomPath($customPath);
         $writeVaultRepository->delete($uuid);
-        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info(
+        AdaptationLogger::create(LogChannelEnum::WEB)->info(
             'Secret deleted from Vault',
             ['uuid' => $uuid, 'path' => $customPath]
         );
     } catch (Throwable $ex) {
-        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->error(
+        AdaptationLogger::create(LogChannelEnum::WEB)->error(
             'Unable to delete secret from Vault, continuing',
             ['uuid' => $uuid, 'path' => $customPath, 'exception' => $ex]
         );

--- a/centreon/www/include/common/vault-functions.php
+++ b/centreon/www/include/common/vault-functions.php
@@ -20,8 +20,8 @@
  */
 
 use Adaptation\Log\Enum\LogChannelEnum;
-use Adaptation\Log\Logger as AdaptationLogger;
-use Centreon\Domain\Log\Logger;
+use Adaptation\Log\Logger;
+use Centreon\Domain\Log\Logger as DeprecatedLogger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Infrastructure\FeatureFlags;
@@ -35,7 +35,7 @@ const DEFAULT_SCHEME = 'https';
  * Get Client Token for Vault.
  *
  * @param VaultConfiguration $vaultConfiguration
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param CentreonRestHttp $httpClient
  *
  * @throws Exception
@@ -44,7 +44,7 @@ const DEFAULT_SCHEME = 'https';
  */
 function authenticateToVault(
     VaultConfiguration $vaultConfiguration,
-    Logger $logger,
+    DeprecatedLogger $logger,
     CentreonRestHttp $httpClient,
 ): string {
     try {
@@ -77,7 +77,7 @@ function authenticateToVault(
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param int $hostId
  * @param string $vaultPath
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  *
  * @throws Exception
  *
@@ -87,7 +87,7 @@ function getHostSecretsFromVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     int $hostId,
     string $vaultPath,
-    Logger $logger,
+    DeprecatedLogger $logger,
 ): array {
     try {
         return $readVaultRepository->findFromPath($vaultPath);
@@ -124,7 +124,7 @@ function updateHostTableWithVaultPath(CentreonDB $pearDB, string $hostPath, int 
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param ?string $snmpCommunity
  * @param array<int, array<string, string>> $macroPasswords
  * @param int $duplicatedHostId
@@ -135,7 +135,7 @@ function updateHostTableWithVaultPath(CentreonDB $pearDB, string $hostPath, int 
 function duplicateHostSecretsInVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     ?string $snmpCommunity,
     array $macroPasswords,
     int $duplicatedHostId,
@@ -457,7 +457,7 @@ function retrieveServiceVaultPathFromDatabase(CentreonDB $pearDB, int $serviceId
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param string|null $vaultPath
  * @param int $hostId
  * @param array<int,array<string,string>> $macros
@@ -468,7 +468,7 @@ function retrieveServiceVaultPathFromDatabase(CentreonDB $pearDB, int $serviceId
 function updateHostSecretsInVaultFromMC(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     ?string $vaultPath,
     int $hostId,
     array $macros,
@@ -549,7 +549,7 @@ function prepareHostUpdateMCPayload(?string $hostSNMPCommunity, array $macros, a
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param string|null $vaultPath
  * @param int $hostId
  * @param array $macros
@@ -560,7 +560,7 @@ function prepareHostUpdateMCPayload(?string $hostSNMPCommunity, array $macros, a
 function updateHostSecretsInVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     ?string $vaultPath,
     int $hostId,
     array $macros,
@@ -692,7 +692,7 @@ function prepareHostUpdatePayload(?string $hostSNMPCommunity, array $macros, arr
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param int $duplicatedServiceId
  * @param array<int, array<string, string> $macroPasswords
  *
@@ -701,7 +701,7 @@ function prepareHostUpdatePayload(?string $hostSNMPCommunity, array $macros, arr
 function duplicateServiceSecretsInVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     int $duplicatedServiceId,
     array $macroPasswords,
 ): void {
@@ -745,7 +745,7 @@ function duplicateServiceSecretsInVault(
  * @param int $serviceId
  * @param string $uuid
  * @param string $clientToken
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param CentreonRestHttp $httpClient
  *
  * @throws Throwable
@@ -756,7 +756,7 @@ function getServiceSecretsFromVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     int $serviceId,
     string $vaultPath,
-    Logger $logger,
+    DeprecatedLogger $logger,
 ): array {
     try {
         return $readVaultRepository->findFromPath($vaultPath);
@@ -845,7 +845,7 @@ function retrieveServiceSecretUuidFromDatabase(
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param string|null $vaultPath
  * @param int $serviceId
  * @param array<int,array{
@@ -860,7 +860,7 @@ function retrieveServiceSecretUuidFromDatabase(
 function updateServiceSecretsInVaultFromMC(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     ?string $vaultPath,
     int $serviceId,
     array $macros,
@@ -932,7 +932,7 @@ function prepareServiceUpdateMCPayload(array $macros, array $serviceSecretsFromV
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param WriteVaultRepositoryInterface $writeVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param int $serviceId
  * @param array<int,array{
  *       macroName: string,
@@ -947,7 +947,7 @@ function prepareServiceUpdateMCPayload(array $macros, array $serviceSecretsFromV
 function updateServiceSecretsInVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     ?string $vaultPath,
     int $serviceId,
     array $macros,
@@ -1499,7 +1499,7 @@ function revertAndUpdateDatabaseCredentials(
 ): void {
     $stored = retrieveDatabaseCredentialsFromConfigFile();
     if (! str_starts_with($stored['username'], VaultConfiguration::VAULT_PATH_PATTERN)) {
-        AdaptationLogger::create(LogChannelEnum::WEB)->info('Database credentials are not stored in Vault, nothing to revert');
+        Logger::create(LogChannelEnum::WEB)->info('Database credentials are not stored in Vault, nothing to revert');
 
         return;
     }
@@ -1519,9 +1519,18 @@ function revertAndUpdateDatabaseCredentials(
         'password' => $secrets[VaultConfiguration::DATABASE_PASSWORD_KEY],
     ]);
 
+    // Make sure the plaintext was actually written back before deleting the Vault secret: if the
+    // config rewrite silently no-oped (format drift), deleting the secret would lose the credentials.
+    $postCheck = retrieveDatabaseCredentialsFromConfigFile();
+    if (str_starts_with($postCheck['username'], VaultConfiguration::VAULT_PATH_PATTERN)) {
+        throw new Exception(
+            'Vault path still present in config after restore, aborting Vault deletion to prevent credential loss'
+        );
+    }
+
     deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::DATABASE_VAULT_PATH, $stored['username']);
 
-    AdaptationLogger::create(LogChannelEnum::WEB)->info('Database credentials reverted from Vault to configuration files');
+    Logger::create(LogChannelEnum::WEB)->info('Database credentials reverted from Vault to configuration files');
 }
 
 /**
@@ -1736,7 +1745,7 @@ function revertGorgoneCredentialsToDb(
 ): void {
     $storedPassword = retrieveGorgoneApiCredentialsFromConfigFile();
     if (! str_starts_with($storedPassword, VaultConfiguration::VAULT_PATH_PATTERN)) {
-        AdaptationLogger::create(LogChannelEnum::WEB)->info('Gorgone API credentials are not stored in Vault, nothing to revert');
+        Logger::create(LogChannelEnum::WEB)->info('Gorgone API credentials are not stored in Vault, nothing to revert');
 
         return;
     }
@@ -1750,9 +1759,18 @@ function revertGorgoneCredentialsToDb(
 
     restoreGorgoneApiFile($secrets[VaultConfiguration::GORGONE_PASSWORD]);
 
+    // Make sure the plaintext was actually written back before deleting the Vault secret: if the
+    // config rewrite silently no-oped (format drift), deleting the secret would lose the credentials.
+    $postCheck = retrieveGorgoneApiCredentialsFromConfigFile();
+    if (str_starts_with($postCheck, VaultConfiguration::VAULT_PATH_PATTERN)) {
+        throw new Exception(
+            'Vault path still present in Gorgone config after restore, aborting Vault deletion to prevent credential loss'
+        );
+    }
+
     deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::GORGONE_VAULT_PATH, $storedPassword);
 
-    AdaptationLogger::create(LogChannelEnum::WEB)->info('Gorgone API credentials reverted from Vault to configuration file');
+    Logger::create(LogChannelEnum::WEB)->info('Gorgone API credentials reverted from Vault to configuration file');
 }
 
 /**
@@ -1795,7 +1813,7 @@ function deleteVaultSecret(
     string $vaultPath,
 ): void {
     if (! preg_match('/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/', $vaultPath, $matches)) {
-        AdaptationLogger::create(LogChannelEnum::WEB)->warning(
+        Logger::create(LogChannelEnum::WEB)->warning(
             'Unable to extract UUID from Vault path, skipping Vault deletion',
             ['path' => $customPath]
         );
@@ -1807,12 +1825,12 @@ function deleteVaultSecret(
     try {
         $writeVaultRepository->setCustomPath($customPath);
         $writeVaultRepository->delete($uuid);
-        AdaptationLogger::create(LogChannelEnum::WEB)->info(
+        Logger::create(LogChannelEnum::WEB)->info(
             'Secret deleted from Vault',
             ['uuid' => $uuid, 'path' => $customPath]
         );
     } catch (Throwable $ex) {
-        AdaptationLogger::create(LogChannelEnum::WEB)->error(
+        Logger::create(LogChannelEnum::WEB)->error(
             'Unable to delete secret from Vault, continuing',
             ['uuid' => $uuid, 'path' => $customPath, 'exception' => $ex]
         );
@@ -1884,7 +1902,7 @@ function retrieveMultipleBrokerConfigUuidsFromDatabase(array $brokerIds): array
  * Retrieve raw value of broker config parameters from vault.
  *
  * @param ReadVaultRepositoryInterface $readVaultRepository
- * @param Logger $logger
+ * @param DeprecatedLogger $logger
  * @param string $key
  * @param string $vaultPath
  *
@@ -1894,7 +1912,7 @@ function retrieveMultipleBrokerConfigUuidsFromDatabase(array $brokerIds): array
  */
 function findBrokerConfigValueFromVault(
     ReadVaultRepositoryInterface $readVaultRepository,
-    Logger $logger,
+    DeprecatedLogger $logger,
     string $key,
     string $vaultPath,
 ): string {

--- a/centreon/www/include/common/vault-functions.php
+++ b/centreon/www/include/common/vault-functions.php
@@ -1471,6 +1471,265 @@ function updateDatabaseYamlFile(array $vaultPaths): void
         ?: throw new Exception('Unable to update file: ' . _CENTREON_ETC_ . '/config.d/10-database.yaml');
 }
 
+// DATABASE & GORGONE CREDENTIALS REVERT
+
+/**
+ * Revert database credentials from Vault back to the config files and delete the Vault secret.
+ *
+ * This is the reverse of {@see migrateAndUpdateDatabaseCredentials()} / {@see migrateDatabaseCredentialsToVault()}.
+ * It is handled outside of a Symfony Command as this must be executed as root.
+ *
+ * The operation is idempotent/resumable: if the config file no longer holds a Vault path, it is a no-op.
+ * The plaintext is restored to the config files *before* the Vault secret is deleted, so an interruption
+ * can never lose the credentials. A Vault deletion failure is logged and tolerated.
+ *
+ * @param ReadVaultRepositoryInterface $readVaultRepository
+ * @param WriteVaultRepositoryInterface $writeVaultRepository
+ *
+ * @throws Throwable
+ */
+function revertAndUpdateDatabaseCredentials(
+    ReadVaultRepositoryInterface $readVaultRepository,
+    WriteVaultRepositoryInterface $writeVaultRepository,
+): void {
+    echo 'Revert of database credentials' . PHP_EOL;
+
+    $stored = retrieveDatabaseCredentialsFromConfigFile();
+    if (! str_starts_with($stored['username'], VaultConfiguration::VAULT_PATH_PATTERN)) {
+        echo 'Database credentials are not stored in Vault, nothing to revert' . PHP_EOL;
+
+        return;
+    }
+
+    $readVaultRepository->setCustomPath(AbstractVaultRepository::DATABASE_VAULT_PATH);
+    $secrets = $readVaultRepository->findFromPath($stored['username']);
+
+    if (
+        ! array_key_exists(VaultConfiguration::DATABASE_USERNAME_KEY, $secrets)
+        || ! array_key_exists(VaultConfiguration::DATABASE_PASSWORD_KEY, $secrets)
+    ) {
+        throw new Exception('Unable to retrieve database credentials from Vault');
+    }
+
+    updateConfigFilesWithDbCredentials([
+        'username' => $secrets[VaultConfiguration::DATABASE_USERNAME_KEY],
+        'password' => $secrets[VaultConfiguration::DATABASE_PASSWORD_KEY],
+    ]);
+
+    deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::DATABASE_VAULT_PATH, $stored['username']);
+
+    echo 'Revert of database credentials completed' . PHP_EOL;
+}
+
+/**
+ * Update the different config files with the plaintext database credentials.
+ *
+ * Reverse of {@see updateConfigFilesWithVaultPath()}.
+ *
+ * @param array{username: string, password: string} $credentials
+ *
+ * @throws Exception
+ */
+function updateConfigFilesWithDbCredentials(array $credentials): void
+{
+    $featuresFileContent = file_get_contents(__DIR__ . '/../../../config/features.json');
+    $featureFlagManager = new FeatureFlags(false, $featuresFileContent);
+
+    restoreCentreonConfPhpFile($credentials);
+    if ($featureFlagManager->isEnabled('vault_broker')) {
+        restoreCentreonConfPmFile($credentials);
+        restoreDatabaseYamlFile($credentials);
+    }
+}
+
+/**
+ * Reverse of {@see updateCentreonConfPhpFile()}: write the plaintext credentials back.
+ *
+ * @param array{username: string, password: string} $credentials
+ *
+ * @throws Exception
+ */
+function restoreCentreonConfPhpFile(array $credentials): void
+{
+    if (! file_exists(_CENTREON_ETC_ . '/centreon.conf.php')
+        || ($content = file_get_contents(_CENTREON_ETC_ . '/centreon.conf.php')) === false
+    ) {
+        throw new Exception('Unable to retrieve content of file: ' . _CENTREON_ETC_ . '/centreon.conf.php');
+    }
+
+    $newContentPhp = preg_replace_callback(
+        '/\$conf_centreon\[[\'\"]user[\'\"]\]\s*=\s*(.*)/',
+        static fn (): string => "\$conf_centreon['user'] = '" . $credentials['username'] . "';",
+        $content
+    );
+    $newContentPhp = preg_replace_callback(
+        '/\$conf_centreon\[[\'\"]password[\'\"]\]\s*=\s*(.*)/',
+        static fn (): string => "\$conf_centreon['password'] = '" . $credentials['password'] . "';",
+        (string) $newContentPhp
+    );
+
+    file_put_contents(_CENTREON_ETC_ . '/centreon.conf.php', $newContentPhp)
+        ?: throw new Exception('Unable to update file: ' . _CENTREON_ETC_ . '/centreon.conf.php');
+}
+
+/**
+ * Reverse of {@see updateCentreonConfPmFile()}: write the plaintext credentials back.
+ *
+ * @param array{username: string, password: string} $credentials
+ *
+ * @throws Exception
+ */
+function restoreCentreonConfPmFile(array $credentials): void
+{
+    if (! file_exists(_CENTREON_ETC_ . '/conf.pm')
+        || ($content = file_get_contents(_CENTREON_ETC_ . '/conf.pm')) === false
+    ) {
+        throw new Exception('Unable to retrieve content of file: ' . _CENTREON_ETC_ . '/conf.pm');
+    }
+
+    $newContentPm = preg_replace_callback(
+        '/"db_user"\s*=>\s*(.*)/',
+        static fn (): string => '"db_user" => "' . $credentials['username'] . '",',
+        $content
+    );
+    $newContentPm = preg_replace_callback(
+        '/"db_passwd"\s*=>\s*(.*)/',
+        static fn (): string => '"db_passwd" => "' . $credentials['password'] . '"',
+        (string) $newContentPm
+    );
+    $newContentPm = preg_replace_callback(
+        '/\$mysql_user\s*=\s*(.*)/',
+        static fn (): string => '$mysql_user = "' . $credentials['username'] . '";',
+        (string) $newContentPm
+    );
+    $newContentPm = preg_replace_callback(
+        '/\$mysql_passwd\s*=\s*(.*)/',
+        static fn (): string => '$mysql_passwd = "' . $credentials['password'] . '";',
+        (string) $newContentPm
+    );
+
+    file_put_contents(_CENTREON_ETC_ . '/conf.pm', $newContentPm)
+        ?: throw new Exception('Unable to update file: ' . _CENTREON_ETC_ . '/conf.pm');
+}
+
+/**
+ * Reverse of {@see updateDatabaseYamlFile()}: write the plaintext credentials back.
+ *
+ * @param array{username: string, password: string} $credentials
+ *
+ * @throws Exception
+ */
+function restoreDatabaseYamlFile(array $credentials): void
+{
+    if (! file_exists(_CENTREON_ETC_ . '/config.d/10-database.yaml')
+        || ($content = file_get_contents(_CENTREON_ETC_ . '/config.d/10-database.yaml')) === false
+    ) {
+        throw new Exception('Unable to retrieve content of file: ' . _CENTREON_ETC_
+            . '/config.d/10-database.yaml');
+    }
+    $newContentYaml = preg_replace_callback(
+        '/username: (.*)/',
+        static fn (): string => 'username: "' . $credentials['username'] . '"',
+        $content
+    );
+    $newContentYaml = preg_replace_callback(
+        '/password: (.*)/',
+        static fn (): string => 'password: "' . $credentials['password'] . '"',
+        (string) $newContentYaml
+    );
+
+    file_put_contents(_CENTREON_ETC_ . '/config.d/10-database.yaml', $newContentYaml)
+        ?: throw new Exception('Unable to update file: ' . _CENTREON_ETC_ . '/config.d/10-database.yaml');
+}
+
+/**
+ * Revert Gorgone API credentials from Vault back to the config file and delete the Vault secret.
+ *
+ * Reverse of {@see migrateGorgoneCredentialsToVault()} + {@see updateGorgoneApiFile()}. The `vault_gorgone`
+ * feature-flag gating is handled by the caller (the bin orchestrator).
+ *
+ * @param ReadVaultRepositoryInterface $readVaultRepository
+ * @param WriteVaultRepositoryInterface $writeVaultRepository
+ *
+ * @throws Throwable
+ */
+function revertGorgoneCredentialsToDb(
+    ReadVaultRepositoryInterface $readVaultRepository,
+    WriteVaultRepositoryInterface $writeVaultRepository,
+): void {
+    $storedPassword = retrieveGorgoneApiCredentialsFromConfigFile();
+    if (! str_starts_with($storedPassword, VaultConfiguration::VAULT_PATH_PATTERN)) {
+        echo 'Gorgone API credentials are not stored in Vault, nothing to revert' . PHP_EOL;
+
+        return;
+    }
+
+    $readVaultRepository->setCustomPath(AbstractVaultRepository::GORGONE_VAULT_PATH);
+    $secrets = $readVaultRepository->findFromPath($storedPassword);
+
+    if (! array_key_exists(VaultConfiguration::GORGONE_PASSWORD, $secrets)) {
+        throw new Exception('Unable to retrieve Gorgone API credentials from Vault');
+    }
+
+    restoreGorgoneApiFile($secrets[VaultConfiguration::GORGONE_PASSWORD]);
+
+    deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::GORGONE_VAULT_PATH, $storedPassword);
+}
+
+/**
+ * Reverse of {@see updateGorgoneApiFile()}: write the plaintext Gorgone API password back.
+ *
+ * @param string $password the plaintext Gorgone API password
+ *
+ * @throws Exception
+ */
+function restoreGorgoneApiFile(string $password): void
+{
+    $filePath = '/etc/centreon-gorgone/config.d/31-centreon-api.yaml';
+
+    if (
+        ! file_exists($filePath)
+        || ($content = file_get_contents($filePath)) === false
+    ) {
+        throw new Exception('Unable to retrieve content of file: ' . $filePath);
+    }
+
+    $newContentYaml = preg_replace_callback(
+        '/password: (.*)/',
+        static fn (): string => 'password: "' . $password . '"',
+        $content
+    );
+
+    file_put_contents($filePath, $newContentYaml) ?: throw new Exception('Unable to update file: ' . $filePath);
+}
+
+/**
+ * Delete a secret from Vault. Deletion failures are logged and tolerated (the revert continues).
+ *
+ * @param WriteVaultRepositoryInterface $writeVaultRepository
+ * @param string $customPath one of the {@see AbstractVaultRepository} path constants
+ * @param string $vaultPath the `secret::...` reference currently stored, used to extract the UUID
+ */
+function deleteVaultSecret(
+    WriteVaultRepositoryInterface $writeVaultRepository,
+    string $customPath,
+    string $vaultPath,
+): void {
+    if (! preg_match('/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/', $vaultPath, $matches)) {
+        echo 'Unable to extract UUID from Vault path, skipping Vault deletion' . PHP_EOL;
+
+        return;
+    }
+    $uuid = $matches[2];
+
+    try {
+        $writeVaultRepository->setCustomPath($customPath);
+        $writeVaultRepository->delete($uuid);
+    } catch (Throwable $ex) {
+        echo 'Unable to delete secret from Vault, continuing: ' . $ex->getMessage() . PHP_EOL;
+    }
+}
+
 // BROKER CONFIG
 
 /**

--- a/centreon/www/include/common/vault-functions.php
+++ b/centreon/www/include/common/vault-functions.php
@@ -19,6 +19,7 @@
  *
  */
 
+use Adaptation\Log\Enum\LogChannelEnum;
 use Centreon\Domain\Log\Logger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -1492,11 +1493,9 @@ function revertAndUpdateDatabaseCredentials(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
 ): void {
-    echo 'Revert of database credentials' . PHP_EOL;
-
     $stored = retrieveDatabaseCredentialsFromConfigFile();
     if (! str_starts_with($stored['username'], VaultConfiguration::VAULT_PATH_PATTERN)) {
-        echo 'Database credentials are not stored in Vault, nothing to revert' . PHP_EOL;
+        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Database credentials are not stored in Vault, nothing to revert');
 
         return;
     }
@@ -1518,7 +1517,7 @@ function revertAndUpdateDatabaseCredentials(
 
     deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::DATABASE_VAULT_PATH, $stored['username']);
 
-    echo 'Revert of database credentials completed' . PHP_EOL;
+    Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Database credentials reverted from Vault to configuration files');
 }
 
 /**
@@ -1659,7 +1658,7 @@ function revertGorgoneCredentialsToDb(
 ): void {
     $storedPassword = retrieveGorgoneApiCredentialsFromConfigFile();
     if (! str_starts_with($storedPassword, VaultConfiguration::VAULT_PATH_PATTERN)) {
-        echo 'Gorgone API credentials are not stored in Vault, nothing to revert' . PHP_EOL;
+        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Gorgone API credentials are not stored in Vault, nothing to revert');
 
         return;
     }
@@ -1674,6 +1673,8 @@ function revertGorgoneCredentialsToDb(
     restoreGorgoneApiFile($secrets[VaultConfiguration::GORGONE_PASSWORD]);
 
     deleteVaultSecret($writeVaultRepository, AbstractVaultRepository::GORGONE_VAULT_PATH, $storedPassword);
+
+    Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info('Gorgone API credentials reverted from Vault to configuration file');
 }
 
 /**
@@ -1716,7 +1717,10 @@ function deleteVaultSecret(
     string $vaultPath,
 ): void {
     if (! preg_match('/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/', $vaultPath, $matches)) {
-        echo 'Unable to extract UUID from Vault path, skipping Vault deletion' . PHP_EOL;
+        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->warning(
+            'Unable to extract UUID from Vault path, skipping Vault deletion',
+            ['path' => $customPath]
+        );
 
         return;
     }
@@ -1725,8 +1729,15 @@ function deleteVaultSecret(
     try {
         $writeVaultRepository->setCustomPath($customPath);
         $writeVaultRepository->delete($uuid);
+        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->info(
+            'Secret deleted from Vault',
+            ['uuid' => $uuid, 'path' => $customPath]
+        );
     } catch (Throwable $ex) {
-        echo 'Unable to delete secret from Vault, continuing: ' . $ex->getMessage() . PHP_EOL;
+        Adaptation\Log\Logger::create(LogChannelEnum::WEB)->error(
+            'Unable to delete secret from Vault, continuing',
+            ['uuid' => $uuid, 'path' => $customPath, 'exception' => $ex]
+        );
     }
 }
 


### PR DESCRIPTION
Adds `bin/revertCredentials.php`, the root orchestrator that rolls credentials back out of the vault. It restores the database and Gorgone API credentials into their configuration files (deleting the vault secrets afterwards, tolerating deletion failures), and delegates application credentials to the `vault:revert-credentials:*` console commands discovered from `bin/console`.

The script is now packaged to `/usr/share/centreon/bin/revertCredentials.php`, alongside `migrateCredentials.php`, so the rollback flow is available on installed platforms.

Fixes: [MON-204553](https://centreon.atlassian.net/browse/MON-204553)

[MON-204553]: https://centreon.atlassian.net/browse/MON-204553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ