### PR TITLE
fix(open-tickets): escape Dropzone option values to prevent DOM XSS [MON-204477]

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
@@ -26,7 +26,7 @@
  */
 
 (function() {
-  var Dropzone, Emitter, ExifRestore, camelize, contentLoaded, detectVerticalSquash, drawImageIOSFix, noop, without,
+  var Dropzone, Emitter, ExifRestore, camelize, contentLoaded, detectVerticalSquash, drawImageIOSFix, escapeHtml, noop, without,
     slice = [].slice,
     extend1 = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
@@ -301,7 +301,7 @@
             node.innerHTML = this.filesize(file.size);
           }
           if (this.options.addRemoveLinks) {
-            file._removeLink = Dropzone.createElement("<a class=\"dz-remove\" href=\"javascript:undefined;\" data-dz-remove>" + this.options.dictRemoveFile + "</a>");
+            file._removeLink = Dropzone.createElement("<a class=\"dz-remove\" href=\"javascript:undefined;\" data-dz-remove>" + escapeHtml(this.options.dictRemoveFile) + "</a>");
             file.previewElement.appendChild(file._removeLink);
           }
           removeFileEvent = (function(_this) {
@@ -576,7 +576,7 @@
         this.element.setAttribute("enctype", "multipart/form-data");
       }
       if (this.element.classList.contains("dropzone") && !this.element.querySelector(".dz-message")) {
-        this.element.appendChild(Dropzone.createElement("<div class=\"dz-default dz-message\"><span>" + this.options.dictDefaultMessage + "</span></div>"));
+        this.element.appendChild(Dropzone.createElement("<div class=\"dz-default dz-message\"><span>" + escapeHtml(this.options.dictDefaultMessage) + "</span></div>"));
       }
       if (this.clickableElements.length) {
         setupHiddenFileInput = (function(_this) {
@@ -774,12 +774,12 @@
       }
       fieldsString = "<div class=\"dz-fallback\">";
       if (this.options.dictFallbackText) {
-        fieldsString += "<p>" + this.options.dictFallbackText + "</p>";
+        fieldsString += "<p>" + escapeHtml(this.options.dictFallbackText) + "</p>";
       }
-      fieldsString += "<input type=\"file\" name=\"" + (this._getParamName(0)) + "\" " + (this.options.uploadMultiple ? 'multiple="multiple"' : void 0) + " /><input type=\"submit\" value=\"Upload!\"></div>";
+      fieldsString += "<input type=\"file\" name=\"" + escapeHtml(this._getParamName(0)) + "\" " + (this.options.uploadMultiple ? 'multiple="multiple"' : void 0) + " /><input type=\"submit\" value=\"Upload!\"></div>";
       fields = Dropzone.createElement(fieldsString);
       if (this.element.tagName !== "FORM") {
-        form = Dropzone.createElement("<form action=\"" + this.options.url + "\" enctype=\"multipart/form-data\" method=\"" + this.options.method + "\"></form>");
+        form = Dropzone.createElement("<form action=\"" + escapeHtml(this.options.url) + "\" enctype=\"multipart/form-data\" method=\"" + escapeHtml(this.options.method) + "\"></form>");
         form.appendChild(fields);
       } else {
         this.element.setAttribute("enctype", "multipart/form-data");
@@ -1654,6 +1654,18 @@
   camelize = function(str) {
     return str.replace(/[\-_](\w)/g, function(match) {
       return match.charAt(1).toUpperCase();
+    });
+  };
+
+  escapeHtml = function(str) {
+    return String(str).replace(/[&<>"']/g, function(char) {
+      return {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[char];
     });
   };
 


### PR DESCRIPTION
## Summary

Security-scanner findings for HTML/JS/TS in Centreon Web: DOM-based XSS (CWE-79) in a widget template and a bundled library, and path-traversal/file-inclusion (CWE-23) in Cypress test tooling. Each finding was re-verified against `develop`, per-file, as a genuine target / scanner false positive / already fixed elsewhere.

## Claude Analysis

### `centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js` — genuine defect, fixed in this PR

`Dropzone.createElement()` assigns its string argument directly to `div.innerHTML`. Several call sites concatenate option/dictionary-derived strings (`dictDefaultMessage`, `dictRemoveFile`, `dictFallbackText`, `paramName`, `url`, `method`) into that markup without escaping, so HTML metacharacters in those values would be parsed into the DOM rather than rendered as text.

In the current Open Tickets integration, the only dynamic value reaching this sink (`options.url`, built from a PHP `uniqid()`-generated `uniqId`) isn't attacker-controlled, so it wasn't practically exploitable today — but the sink pattern itself is a real DOM-XSS class in a vendored library and is worth closing defensively.

**Fix:** added a local `escapeHtml()` helper and applied it at the interpolation points listed above (`dropzone.js` lines ~304, 579, 776-782). Left `previewTemplate` (line 290) untouched — it's a full developer-configured HTML template used as designed, and the values substituted into it (`file.name`, `file.size`) already go through `textContent`/numeric formatting, not raw concatenation.

**Verification:** loaded the actual patched file in `jsdom` and exercised it end-to-end:
- Benign default message, the real production URL (`...?action=upload-file&uniqId=...`, including `&`), and remove-link text all render identically to before (no regression).
- Payloads like `"><img src=x onerror=alert(1)>` and `"><script>alert(2)</script>` injected into `dictDefaultMessage` / `dictRemoveFile` / `options.url` no longer produce injected `<img>`/`<script>` DOM nodes (checked by inspecting the DOM tree, not string output).

### `centreon/www/include/home/customViews/widgetParam.html` — already fixed on `develop`

Scanner flagged `jQuery(response).find('option')` as a DOM-XSS sink. Already fixed by MON-200903 (commit `0dd2189293`, #10802): the AJAX call uses `dataType: "xml"` and the handler now does `jQuery.parseXML(response)` before `.find()`, with values extracted via `.text()`/`new Option()` (property assignment, not an HTML sink). No further change needed; this branch already contains that fix.

### `centreon/packages/js-config/cypress/e2e/tasks.ts` / `centreon/packages/js-config/cypress/component/configuration.js` — already fixed on `develop`

Path-traversal findings in Cypress Node-side test tooling (`readCsvFile`, `clearDownloadsFolder`, retries-file path) — test-only, no production runtime exposure. Already fixed by MON-200903 (commit `0dd2189293`, #10802) with `path.resolve()` + base-dir containment checks. No further change needed; this branch already contains that fix.

## Fix priorities (for reference)

- **MEDIUM** → fixed here: `dropzone.js` `Dropzone.createElement()` innerHTML sink.
- **LOW / already fixed**: Cypress path handling (MON-200903).
- **None (false positive) / already fixed**: `widgetParam.html` (MON-200903).

## Test plan

- [ ] Enable "Allow file attachments" on an Open Tickets rule/widget, open the ticket popup, confirm the default "Drop files here to upload" message, drag-and-drop upload, and the "Remove file" link all render and behave as before.
- [x] `node --check` on the modified file passes.
- [x] jsdom end-to-end test on the patched file: benign values render unchanged; injected `"><img src=x onerror=alert(1)>` / `"><script>alert(2)</script>` payloads in `dictDefaultMessage`, `dictRemoveFile`, and `options.url` no longer create `<img>`/`<script>` DOM nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)