### PR TITLE
fix(db): allow hyphens in database names for tables & columns

### DIFF
--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -160,7 +160,7 @@ trait ConnectionTrait
                 throw ConnectionException::batchInsertQueryBadUsage('Table name must not be empty');
             }
             $bareTableName = str_replace('`', '', $tableName);
-            if (preg_match('/^[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)?$/', $bareTableName) !== 1) {
+            if (preg_match('/^[\w$][\w$-]*(\.[\w$][\w$-]*)?$/', $bareTableName) !== 1) {
                 throw ConnectionException::batchInsertQueryBadUsage("Invalid table name: {$tableName}");
             }
             if ($columns === []) {
@@ -168,7 +168,7 @@ trait ConnectionTrait
             }
             foreach ($columns as $column) {
                 $bareColumn = str_replace('`', '', $column);
-                if (preg_match('/^[a-zA-Z_]\w*$/', $bareColumn) !== 1) {
+                if (preg_match('/^[\w$][\w$-]*$/', $bareColumn) !== 1) {
                     throw ConnectionException::batchInsertQueryBadUsage("Invalid column name: {$column}");
                 }
             }

--- a/centreon/src/Centreon/Domain/Repository/Traits/CheckListOfIdsTrait.php
+++ b/centreon/src/Centreon/Domain/Repository/Traits/CheckListOfIdsTrait.php
@@ -38,7 +38,7 @@ trait CheckListOfIdsTrait
         string $tableName,
         string $columnNameOfIdentificator,
     ): bool {
-        if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName) !== 1) {
+        if (preg_match('/^[a-zA-Z0-9_$][a-zA-Z0-9_$-]*$/', $tableName) !== 1) {
             throw new \InvalidArgumentException("Invalid table name: {$tableName}");
         }
         if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $columnNameOfIdentificator) !== 1) {


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/11095

Cloud database names can contain hyphens (e.g. `staging_shiny-raccoon_storage`), which were rejected by the regex validation in `batchInsert()` and `checkListOfIdsTrait()`. Updated the regexes to accept `-` and `$` characters in table and column names.

**Fixes** MON-205383

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

Deploy on a Cloud environment with a database name containing hyphens and verify that batch insert operations and ID list checks work correctly.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).