### PR TITLE
test(e2e): web: use hyphenated database names in custom DB name (dev-25.10.x)

### DIFF
--- a/.github/docker/centreon-web/alma8/entrypoint/container.d/80-register_pollers_background.sh
+++ b/.github/docker/centreon-web/alma8/entrypoint/container.d/80-register_pollers_background.sh
@@ -8,7 +8,7 @@ RESTART_WAIT=60
 
 while true ; do
   sleep "$POLL_INTERVAL"
-  SQL_RESULT=$(timeout "$MYSQL_TIMEOUT" mysql -h"${MYSQL_HOST}" -uroot -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DB_CONFIGURATION:-centreon}" -e "SELECT id FROM nagios_server WHERE name NOT IN (SELECT name from ${MYSQL_DB_STORAGE:-centreon_storage}.instances)" 2>&1)
+  SQL_RESULT=$(timeout "$MYSQL_TIMEOUT" mysql -h"${MYSQL_HOST}" -uroot -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DB_CONFIGURATION:-centreon}" -e "SELECT id FROM nagios_server WHERE name NOT IN (SELECT name from `${MYSQL_DB_STORAGE:-centreon_storage}`.instances)" 2>&1)
   if [ $? -eq 124 ]; then
     echo "MySQL query timed out"
     continue

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/80-register_pollers_background.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/80-register_pollers_background.sh
@@ -8,7 +8,7 @@ RESTART_WAIT=60
 
 while true ; do
   sleep "$POLL_INTERVAL"
-  SQL_RESULT=$(timeout "$MYSQL_TIMEOUT" mysql -h"${MYSQL_HOST}" -uroot -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DB_CONFIGURATION:-centreon}" -e "SELECT id FROM nagios_server WHERE name NOT IN (SELECT name from ${MYSQL_DB_STORAGE:-centreon_storage}.instances)" 2>&1)
+  SQL_RESULT=$(timeout "$MYSQL_TIMEOUT" mysql -h"${MYSQL_HOST}" -uroot -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DB_CONFIGURATION:-centreon}" -e "SELECT id FROM nagios_server WHERE name NOT IN (SELECT name from `${MYSQL_DB_STORAGE:-centreon_storage}`.instances)" 2>&1)
   if [ $? -eq 124 ]; then
     echo "MySQL query timed out"
     continue

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/80-register_pollers_background.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/80-register_pollers_background.sh
@@ -10,7 +10,7 @@ while true ; do
   sleep "$POLL_INTERVAL"
   SQL_RESULT=$(timeout "$MYSQL_TIMEOUT" mysql -h"${MYSQL_HOST}" \
     -uroot -p"${MYSQL_ROOT_PASSWORD}" \
-    "${MYSQL_DB_CONFIGURATION:-centreon}" -e "SELECT id FROM nagios_server WHERE name NOT IN (SELECT name from ${MYSQL_DB_STORAGE:-centreon_storage}.instances)" 2>&1)
+    "${MYSQL_DB_CONFIGURATION:-centreon}" -e "SELECT id FROM nagios_server WHERE name NOT IN (SELECT name from `${MYSQL_DB_STORAGE:-centreon_storage}`.instances)" 2>&1)
   if [ $? -eq 124 ]; then
     echo "MySQL query timed out"
     continue

--- a/centreon/tests/e2e/features/Web-server-configuration/03-custom-db-name/index.ts
+++ b/centreon/tests/e2e/features/Web-server-configuration/03-custom-db-name/index.ts
@@ -1,8 +1,8 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { INTERCEPTORS } from 'fixtures/shared/constants/interceptors';
 
-const dbConfiguration = 'quality_centreon_config';
-const dbStorage = 'quality_centreon_storage';
+const dbConfiguration = 'quality-centreon_config';
+const dbStorage = 'quality-centreon_storage';
 
 before(() => {
   cy.startContainers({ dbConfiguration, dbStorage });


### PR DESCRIPTION
Fixes: [MON-205445](https://centreon.atlassian.net/browse/MON-205445)

Backport of #11083 to `dev-25.10.x`.

## Description

Adapt the *Custom DB Name* E2E feature so the databases use a **hyphenated** name (`quality-centreon_config` / `quality-centreon_storage`), reproducing the Centreon Cloud naming pattern (e.g. `staging_shiny-raccoon_storage`).

With the previous underscore-only names, the test could not catch [MON-205354](https://centreon.atlassian.net/browse/MON-205354): a too-strict qualified table-name validation in the ORM (`ConnectionTrait::batchInsert`) rejected database names containing a `-`. A hyphen is required to exercise that regression.

Also backtick-quote the storage database in the poller-registration entrypoint (`register_pollers_background`) so the container starts with a hyphenated database name instead of failing on an unquoted qualified identifier.

## Scope

E2E test + E2E docker image only. No product code change.

[MON-205445]: https://centreon.atlassian.net/browse/MON-205445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-205354]: https://centreon.atlassian.net/browse/MON-205354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ