### PR TITLE
test(e2e): web: use hyphenated database names in custom DB name (dev-24.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Web-server-configuration/03-custom-db-name/index.ts
+++ b/centreon/tests/e2e/features/Web-server-configuration/03-custom-db-name/index.ts
@@ -1,8 +1,8 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { INTERCEPTORS } from 'e2e/fixtures/shared/constants/interceptors';
 
-const dbConfiguration = 'quality_centreon_config';
-const dbStorage = 'quality_centreon_storage';
+const dbConfiguration = 'quality-centreon_config';
+const dbStorage = 'quality-centreon_storage';
 
 before(() => {
   cy.startContainers({ dbConfiguration, dbStorage });


### PR DESCRIPTION
Fixes: [MON-205444](https://centreon.atlassian.net/browse/MON-205444)

Backport of #11083 to `dev-24.10.x`.

## Description

Adapt the *Custom DB Name* E2E feature so the databases use a **hyphenated** name (`quality-centreon_config` / `quality-centreon_storage`), reproducing the Centreon Cloud naming pattern (e.g. `staging_shiny-raccoon_storage`).

With the previous underscore-only names, the test could not catch [MON-205354](https://centreon.atlassian.net/browse/MON-205354): a too-strict qualified table-name validation in the ORM (`ConnectionTrait::batchInsert`) rejected database names containing a `-`. A hyphen is required to exercise that regression.

> Note: unlike the `develop` / `dev-25.10.x` backport, this branch has no `register_pollers_background` entrypoint, so only the E2E feature is changed here.

## Scope

E2E test only. No product code change.

[MON-205444]: https://centreon.atlassian.net/browse/MON-205444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-205354]: https://centreon.atlassian.net/browse/MON-205354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ