### PR TITLE
enh(poller): update installation command token format and add cloud flag

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/InstallationCommandResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/InstallationCommandResource.php
@@ -68,7 +68,7 @@ final class InstallationCommandResource
     public function __construct(
         #[ApiProperty(
             description: 'Poller Installation Command',
-            openapiContext: ['example' => 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
+            openapiContext: ['example' => 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
         )]
         #[Sensitive]
         public string $installationCommand,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
@@ -68,7 +68,7 @@ final class PollerResource
         public string $gorgoneCommunicationType,
 
         #[ApiProperty(
-            openapiContext: ['example' => 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
+            openapiContext: ['example' => 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
         )]
         #[Sensitive]
         public string $installationCommand = '',

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -103,6 +103,7 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
             $token,
             $appSecret,
             $salt,
+            $this->isCloudPlatform,
         );
 
         $resource = $this->transformer->transform($model);

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
@@ -31,6 +31,7 @@ use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\InstallationCommandResource;
 use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Shared\Domain\Repository\EngineSecretsRepository;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
@@ -42,6 +43,8 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
         private PollerRepository $pollerRepository,
         private PollerTokenRepository $pollerTokenRepository,
         private EngineSecretsRepository $engineSecretsRepository,
+        #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
+        private bool $isCloudPlatform = false,
     ) {
     }
 
@@ -65,6 +68,7 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
             $token,
             $this->engineSecretsRepository->getAppSecret(),
             $this->engineSecretsRepository->getSalt(),
+            $this->isCloudPlatform,
         );
 
         return new InstallationCommandResource(

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -34,20 +34,21 @@ final readonly class PollerInstallationCommandFactory
         private PollerToken $pollerToken,
         #[Sensitive] private string $appSecret,
         #[Sensitive] private string $salt,
+        private bool $isCloudPlatform = false,
         private string $centralUrl = '<CENTRAL_URL>',
     ) {
     }
 
     public function generate(): string
     {
-        // TODO to update with final path when available
         // Only `name` is escaped with escapeshellarg(): it is the sole free-form,
         // user-provided value. The other parameters are controlled and cannot carry
-        // shell metacharacters: pollerToken is hex (bin2hex), uid is an int, pollerType
-        // is an enum, appSecret/salt are engine-generated, and centralUrl comes from config.
-        return sprintf(
-            'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
+        // shell metacharacters: pollerToken name+value are hex (bin2hex), uid is an int,
+        // pollerType is an enum, appSecret/salt are engine-generated, and centralUrl comes from config.
+        $command = sprintf(
+            'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
             $this->centralUrl,
+            $this->pollerToken->name,
             $this->pollerToken->value,
             $this->poller->uid->value,
             escapeshellarg($this->poller->name->value),
@@ -56,5 +57,11 @@ final readonly class PollerInstallationCommandFactory
             $this->appSecret,
             $this->salt,
         );
+
+        if ($this->isCloudPlatform) {
+            $command .= ' --cloud';
+        }
+
+        return $command;
     }
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
@@ -87,7 +87,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL https://<CENTRAL_URL>/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type %s --central_url <CENTRAL_URL> --appsecret test-app-secret --salt test-salt',
+            'curl -fsSL https://<CENTRAL_URL>/poller/install.sh | bash -s -- --poller_token test-token-default:%s --uid %s --name %s --type %s --central_url <CENTRAL_URL> --appsecret test-app-secret --salt test-salt',
             $tokenValue,
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
@@ -108,7 +108,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL https://<CENTRAL_URL>/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type %s --central_url <CENTRAL_URL> --appsecret test-app-secret --salt test-salt',
+            'curl -fsSL https://<CENTRAL_URL>/poller/install.sh | bash -s -- --poller_token named-token:%s --uid %s --name %s --type %s --central_url <CENTRAL_URL> --appsecret test-app-secret --salt test-salt',
             $namedTokenValue,
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
@@ -77,7 +77,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             centralUrl: self::CENTRAL_URL,
         );
 
-        self::assertStringContainsString('--poller_token ' . self::POLLER_TOKEN, $factory->generate());
+        self::assertStringContainsString('--poller_token test-token:' . self::POLLER_TOKEN, $factory->generate());
     }
 
     public function testGenerateCommandContainsPollerUid(): void
@@ -182,7 +182,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         );
 
         $expected = sprintf(
-            'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type vm --central_url %s --appsecret %s --salt %s',
+            'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token test-token:%s --uid %s --name %s --type vm --central_url %s --appsecret %s --salt %s',
             self::CENTRAL_URL,
             self::POLLER_TOKEN,
             self::POLLER_UID,
@@ -193,6 +193,34 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         );
 
         self::assertSame($expected, $factory->generate());
+    }
+
+    public function testGenerateCommandContainsCloudFlagWhenCloudPlatform(): void
+    {
+        $factory = new PollerInstallationCommandFactory(
+            poller: $this->createPoller(PollerTypeEnum::VM),
+            pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
+            appSecret: self::APP_SECRET,
+            salt: self::SALT,
+            isCloudPlatform: true,
+            centralUrl: self::CENTRAL_URL,
+        );
+
+        self::assertStringEndsWith('--cloud', $factory->generate());
+    }
+
+    public function testGenerateCommandDoesNotContainCloudFlagWhenOnPremise(): void
+    {
+        $factory = new PollerInstallationCommandFactory(
+            poller: $this->createPoller(PollerTypeEnum::VM),
+            pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
+            appSecret: self::APP_SECRET,
+            salt: self::SALT,
+            isCloudPlatform: false,
+            centralUrl: self::CENTRAL_URL,
+        );
+
+        self::assertStringNotContainsString('--cloud', $factory->generate());
     }
 
     private function createPoller(PollerTypeEnum $type): Poller


### PR DESCRIPTION
## Description

Update the poller installation command with two changes:

1. **Token format**: Changed from `--poller_token <value>` to `--poller_token <name>:<value>` to include both the token name and value in the command.
2. **Cloud flag**: Added `--cloud` flag that is appended to the installation command when the platform is identified as cloud (via `IS_CLOUD_PLATFORM` environment variable).

**Fixes** MON-205359

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Create a poller via the API and retrieve its installation command.
2. Verify the `--poller_token` flag now uses the `<name>:<value>` format instead of just `<value>`.
3. Set the `IS_CLOUD_PLATFORM` environment variable to a truthy value and retrieve the installation command again.
4. Verify the `--cloud` flag is appended to the command.
5. Unset or set `IS_CLOUD_PLATFORM` to a falsy value and verify the `--cloud` flag is absent.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).