### PR TITLE
fix(resources): stop double base URI prefix in resource details links

### DIFF
--- a/centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -93,7 +93,7 @@ class MonitoringResourceController extends AbstractController
 
         return $this->buildListingUri([
             'details' => json_encode([
-                'resourcesDetailsEndpoint' => $this->getBaseUri() . $this->generateResourceDetailsEndpoint($parameters, 'host'),
+                'resourcesDetailsEndpoint' => $this->generateResourceDetailsEndpoint($parameters, 'host'),
                 'type' => ResourceEntity::TYPE_HOST,
                 'id' => $hostId,
                 'tab' => $tab,
@@ -139,7 +139,7 @@ class MonitoringResourceController extends AbstractController
 
         return $this->buildListingUri([
             'details' => json_encode([
-                'resourcesDetailsEndpoint' => $this->getBaseUri() . $this->generateResourceDetailsEndpoint($parameters, 'service'),
+                'resourcesDetailsEndpoint' => $this->generateResourceDetailsEndpoint($parameters, 'service'),
                 'id' => $serviceId,
                 'tab' => $tab,
                 'uuid' => 'h' . $hostId . '-s' . $serviceId,
@@ -227,7 +227,7 @@ class MonitoringResourceController extends AbstractController
             'details' => json_encode([
                 'id' => $resourceId,
                 'tab' => self::TAB_DETAILS_NAME,
-                'resourcesDetailsEndpoint' => $this->getBaseUri() . $this->generateResourceDetailsEndpoint($parameters, $resourceType),
+                'resourcesDetailsEndpoint' => $this->generateResourceDetailsEndpoint($parameters, $resourceType),
             ]),
         ]);
     }


### PR DESCRIPTION
## Summary

Resource detail links built for legacy monitoring pages and Custom Views
widgets (host / service / meta-service) were prefixed with the application
base URI **twice**: once manually via `getBaseUri()` in
`MonitoringResourceController`, and once by the API `Router`, which already
includes it now that the base URI is resolved from the current request in
every context (including legacy `Kernel::createForWeb()` boots).

The resulting endpoint (`/centreon/centreon/api/latest/monitoring/resources/...`)
made the Resource Status details request fail, so clicking a resource opened
the page **without** the detail panel and showed "Oops, something went wrong".

This removes the redundant `getBaseUri()` prefix in the three
`MonitoringResourceController` builders so the details endpoint is generated
once, by the `Router`.

## Jira

Fixes: [MON-204800](https://centreon.atlassian.net/browse/MON-204800)

## Test plan

- [ ] In your profile, disable **Use deprecated monitoring pages**
- [ ] Click a resource from a host/service-monitoring Custom Views widget, from Monitoring > Downtimes, or from a status listing
- [ ] The Resource Status detail panel opens with no "Oops" error
- [ ] The details request targets `/centreon/api/latest/monitoring/resources/...` (single `/centreon` prefix)


[MON-204800]: https://centreon.atlassian.net/browse/MON-204800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ