### PR TITLE
test(api): Web: add poller configuration tests

### DIFF
--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
@@ -1,0 +1,29 @@
+meta {
+  name: GET /logout - Logout administrator - HTTP 200
+  type: http
+  seq: 12
+}
+
+get {
+  url: {{baseUrlWeb}}/logout
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("Logout is successful", function () {
+    const body = res.getBody();
+    expect(body).to.be.an("object");
+    bru.deleteEnvVar("authToken");
+    bru.deleteEnvVar("cleanupToken");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Get command by poller id - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Get command by poller id - HTTP 200.bru
@@ -1,0 +1,29 @@
+meta {
+  name: GET /pollers/installation-command - Get command by poller id - HTTP 200
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrlWeb}}/configuration/pollers/installation-command/{{CreatedPollerId}}
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("A curl installation command is returned", function () {
+    const body = res.getBody();
+    expect(body.installation_command).to.be.a("string");
+    expect(body.installation_command).to.include("curl -fsSL");
+    expect(body.installation_command).to.include("/poller/install.sh");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Non-existent poller - HTTP 404.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Non-existent poller - HTTP 404.bru
@@ -1,0 +1,20 @@
+meta {
+  name: GET /pollers/installation-command - Non-existent poller - HTTP 404
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrlWeb}}/configuration/pollers/installation-command/999999
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 404
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Target token by name - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Target token by name - HTTP 200.bru
@@ -1,0 +1,28 @@
+meta {
+  name: GET /pollers/installation-command - Target token by name - HTTP 200
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrlWeb}}/configuration/pollers/installation-command/{{CreatedPollerId}}?token-name={{PollerTokenName}}
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("Command targets the requested token", function () {
+    const body = res.getBody();
+    expect(body.installation_command).to.be.a("string");
+    expect(body.installation_command).to.include("--poller_token");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Unknown token name - HTTP 404.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -pollers-installation-command - Unknown token name - HTTP 404.bru
@@ -1,0 +1,20 @@
+meta {
+  name: GET /pollers/installation-command - Unknown token name - HTTP 404
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrlWeb}}/configuration/pollers/installation-command/{{CreatedPollerId}}?token-name={{UnknownPollerTokenName}}
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 404
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created Docker poller - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created Docker poller - HTTP 200.bru
@@ -1,0 +1,34 @@
+meta {
+  name: POST /clapi - Delete created Docker poller - HTTP 200
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{baseUriCentreonCLAPI}}
+  body: json
+  auth: none
+}
+
+headers {
+  centreon-auth-token: {{cleanupToken}}
+}
+
+body:json {
+  {
+    "action": "del",
+    "object": "INSTANCE",
+    "values": "{{PollerNameDocker}}"
+  }
+}
+
+tests {
+  test("Created Docker poller is cleaned up (avoids breaking export conf)", function () {
+    expect(res.status).to.be.oneOf([200, 404]);
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created VM poller - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created VM poller - HTTP 200.bru
@@ -1,0 +1,35 @@
+meta {
+  name: POST /clapi - Delete created VM poller - HTTP 200
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{baseUriCentreonCLAPI}}
+  body: json
+  auth: none
+}
+
+headers {
+  centreon-auth-token: {{cleanupToken}}
+}
+
+body:json {
+  {
+    "action": "del",
+    "object": "INSTANCE",
+    "values": "{{PollerName}}"
+  }
+}
+
+tests {
+  test("Created VM poller is cleaned up (avoids breaking export conf)", function () {
+    expect(res.status).to.be.oneOf([200, 404]);
+    bru.deleteEnvVar("CreatedPollerId");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -login - Authenticate as administrator - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -login - Authenticate as administrator - HTTP 200.bru
@@ -1,0 +1,39 @@
+meta {
+  name: POST /login - Authenticate as administrator - HTTP 200
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrlWeb}}/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "security": {
+      "credentials": {
+        "login": "{{user_administrator_login}}",
+        "password": "{{user_administrator_password}}"
+      }
+    }
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("Authentication returns a token", function () {
+    const body = res.getBody();
+    bru.setGlobalEnvVar("authToken", body.security.token);
+    expect(body.security.token).to.be.a("string");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -login - Authenticate as super-admin for cleanup - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -login - Authenticate as super-admin for cleanup - HTTP 200.bru
@@ -1,0 +1,39 @@
+meta {
+  name: POST /login - Authenticate as super-admin for cleanup - HTTP 200
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrlWeb}}/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "security": {
+      "credentials": {
+        "login": "{{api_login}}",
+        "password": "{{api_password}}"
+      }
+    }
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("Super-admin token is stored for poller cleanup (CLAPI INSTANCE requires super-admin)", function () {
+    const body = res.getBody();
+    expect(body.security.token).to.be.a("string");
+    bru.setEnvVar("cleanupToken", body.security.token);
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create Docker poller returns installation command - HTTP 201.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create Docker poller returns installation command - HTTP 201.bru
@@ -1,0 +1,40 @@
+meta {
+  name: POST /pollers - Create Docker poller returns installation command - HTTP 201
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/pollers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "{{PollerNameDocker}}",
+    "address": "{{PollerAddress}}",
+    "poller_type": "docker",
+    "poller_token_name": "{{PollerTokenName}}"
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+tests {
+  test("Docker poller is created and returns a non-null installation command", function () {
+    const body = res.getBody();
+    expect(body.name).to.eql(bru.getEnvVar("PollerNameDocker"));
+    expect(body.poller_type).to.eql("docker");
+    expect(body.installation_command).to.be.a("string");
+    expect(body.installation_command).to.include("curl -fsSL");
+    expect(body.installation_command).to.include("--type docker");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create VM poller returns installation command - HTTP 201.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create VM poller returns installation command - HTTP 201.bru
@@ -1,0 +1,43 @@
+meta {
+  name: POST /pollers - Create VM poller returns installation command - HTTP 201
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/pollers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "{{PollerName}}",
+    "address": "{{PollerAddress}}",
+    "poller_type": "vm",
+    "poller_token_name": "{{PollerTokenName}}"
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+tests {
+  test("VM poller is created and returns a non-null installation command", function () {
+    const body = res.getBody();
+    if (body.id) {
+      bru.setEnvVar("CreatedPollerId", body.id);
+    }
+    expect(body.name).to.eql(bru.getEnvVar("PollerName"));
+    expect(body.poller_type).to.eql("vm");
+    expect(body.installation_command).to.be.a("string");
+    expect(body.installation_command).to.include("curl -fsSL");
+    expect(body.installation_command).to.include("--type vm");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Unknown poller token name - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Unknown poller token name - HTTP 400.bru
@@ -1,0 +1,29 @@
+meta {
+  name: POST /pollers - Unknown poller token name - HTTP 400
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/pollers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "poller-bruno-unknown-token",
+    "address": "1.2.3.6",
+    "poller_type": "vm",
+    "poller_token_name": "{{UnknownPollerTokenName}}"
+  }
+}
+
+assert {
+  res.status: eq 400
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/folder.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Administrator profile
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/GET -logout - Logout unprivileged user - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/GET -logout - Logout unprivileged user - HTTP 200.bru
@@ -1,0 +1,28 @@
+meta {
+  name: GET /logout - Logout unprivileged user - HTTP 200
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrlWeb}}/logout
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("Logout is successful", function () {
+    const body = res.getBody();
+    expect(body).to.be.an("object");
+    bru.deleteEnvVar("authToken");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/GET -pollers-installation-command - Access denied - HTTP 403.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/GET -pollers-installation-command - Access denied - HTTP 403.bru
@@ -1,0 +1,20 @@
+meta {
+  name: GET /pollers/installation-command - Access denied - HTTP 403
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrlWeb}}/configuration/pollers/installation-command/1
+  body: none
+  auth: inherit
+}
+
+assert {
+  res.status: eq 403
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/POST -login - Authenticate as unprivileged user - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/POST -login - Authenticate as unprivileged user - HTTP 200.bru
@@ -1,0 +1,39 @@
+meta {
+  name: POST /login - Authenticate as unprivileged user - HTTP 200
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrlWeb}}/login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "security": {
+      "credentials": {
+        "login": "{{user_unprivileged_login}}",
+        "password": "{{user_unprivileged_password}}"
+      }
+    }
+  }
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("Authentication returns a token", function () {
+    const body = res.getBody();
+    bru.setGlobalEnvVar("authToken", body.security.token);
+    expect(body.security.token).to.be.a("string");
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/POST -pollers - Access denied - HTTP 403.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/POST -pollers - Access denied - HTTP 403.bru
@@ -1,0 +1,29 @@
+meta {
+  name: POST /pollers - Access denied - HTTP 403
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/pollers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "poller-bruno-forbidden",
+    "address": "1.2.3.7",
+    "poller_type": "vm",
+    "poller_token_name": "{{PollerTokenName}}"
+  }
+}
+
+assert {
+  res.status: eq 403
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/folder.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Unprivileged Profile
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/bruno.json
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/bruno.json
@@ -1,0 +1,1 @@
+{ "version": "1", "name": "Poller_Configuration", "type": "collection", "ignore": ["node_modules", ".git"] }

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/collection.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/collection.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Poller_Configuration
+}
+
+auth {
+  mode: apikey
+}
+
+auth:apikey {
+  key: X-AUTH-TOKEN
+  value: {{authToken}}
+  placement: header
+}
+
+docs {
+  # Poller Configuration
+
+  Functional API tests for the poller configuration endpoints
+  (`POST /configuration/pollers` and
+  `GET /configuration/pollers/installation-command/{id}`).
+
+  ## Prerequisites
+
+  - **A valid poller token named `poller-default`** (type `poller`, not
+    revoked, not expired) must exist. This token is seeded by the base
+    Centreon installation (`insertBaseConf.php`), so it is present on any
+    standard platform — the tests reference it via the `PollerTokenName`
+    collection variable and do not create it.
+  - The `create_edit_poller_cfg` ACL action must be granted to the
+    administrator test profile. This is provided by the API test dataset
+    (`fixtures/imports/permissions/aclactionperms.csv`) and requires an
+    ACL reload to take effect.
+
+  ## Profiles
+
+  - **Administrator profile** — `user_administrator` (non-super-admin,
+    authorized through the `create_edit_poller_cfg` ACL): create VM and
+    Docker pollers, retrieve installation commands, and cover the
+    404 / 400 error cases. Created pollers are cleaned up through a
+    dedicated super-admin session because CLAPI `INSTANCE` deletion
+    requires a super-administrator.
+  - **Unprivileged Profile** — a user without the ACL: every poller
+    endpoint is denied (403).
+}

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/environments/poller-configuration-collection-environment.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/environments/poller-configuration-collection-environment.bru
@@ -1,0 +1,7 @@
+vars {
+  PollerName: poller-bruno-test
+  PollerNameDocker: poller-bruno-test-docker
+  PollerAddress: 1.2.3.5
+  PollerTokenName: poller-default
+  UnknownPollerTokenName: this-token-does-not-exist
+}

--- a/centreon/tests/api/web-api-workspace/fixtures/imports/permissions/aclactionperms.csv
+++ b/centreon/tests/api/web-api-workspace/fixtures/imports/permissions/aclactionperms.csv
@@ -41,6 +41,7 @@ ACLACTION;GRANT;customer_admin_action;global_host_obsess;
 ACLACTION;GRANT;customer_admin_action;global_perf_data;
 ACLACTION;GRANT;customer_admin_action;generate_cfg;
 ACLACTION;GRANT;customer_admin_action;delete_poller_cfg;
+ACLACTION;GRANT;customer_admin_action;create_edit_poller_cfg;
 ACLACTION;GRANT;customer_admin_action;generate_trap;
 ACLACTION;GRANT;customer_admin_action;manage_tokens;
 ACLACTION;GRANT;customer_admin_action;manage_check_commands;

--- a/centreon/tests/api/web-api-workspace/workspace.yml
+++ b/centreon/tests/api/web-api-workspace/workspace.yml
@@ -106,6 +106,8 @@ collections:
     path: "collections/Resources_By_Parent_Monitoring"
   - name: "Monitoring_Server_Configuration"
     path: "collections/Monitoring_Server_Configuration"
+  - name: "Poller_Configuration"
+    path: "collections/Poller_Configuration"
   - name: "Monitoring_Timeline"
     path: "collections/Monitoring_Timeline"
   - name: "Comment"


### PR DESCRIPTION
## Description

Adds a Bruno functional API test collection (`Poller_Configuration`) covering the poller configuration endpoints used for VM/Docker poller installation.

**Administrator profile** (`user_administrator`, a non-super-admin authorized through the `create_edit_poller_cfg` ACL action under test):
- `POST /configuration/pollers` — create VM poller → 201 with a non-null `installation_command` (`--type vm`)
- `POST /configuration/pollers` — create Docker poller → 201 (`--type docker`)
- `GET /configuration/pollers/installation-command/{id}` → 200
- same GET with `?token-name=` → 200
- same GET with an unknown token name → 404
- same GET with a non-existent poller id → 404
- `POST /configuration/pollers` with an unknown token name → 400
- created pollers are cleaned up via a dedicated super-admin session (CLAPI `INSTANCE` deletion requires a super-administrator)

**Unprivileged profile**: `GET` and `POST` denied → 403.

Also grants the `create_edit_poller_cfg` ACL action to the API test dataset (`aclactionperms.csv`) and registers the collection in `workspace.yml`.

### Notes

- The positive tests rely on the base-install poller token `poller-default` (seeded by `insertBaseConf.php`); this prerequisite is documented in the collection docs.
- The admin positive path deliberately runs as an ACL-authorized non-admin (not a super-admin) to exercise the ACL action under test; the super-admin session is used only for CLAPI cleanup.

Fixes: [MON-204576](https://centreon.atlassian.net/browse/MON-204576)


[MON-204576]: https://centreon.atlassian.net/browse/MON-204576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ