### PR TITLE
fix(clapi): preserve pre-hashed passwords on PHP 8.4

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonContact.class.php
+++ b/centreon/www/class/centreon-clapi/centreonContact.class.php
@@ -282,7 +282,7 @@ class CentreonContact extends CentreonObject
                     $params[2] = $completeLanguage;
                 } elseif ($params[1] === 'password') {
                     $params[1] = 'passwd';
-                    if (password_needs_rehash($params[2], CentreonAuth::PASSWORD_HASH_ALGORITHM)) {
+                    if (! $this->isPasswordAlreadyHashed((string) $params[2])) {
                         $contact = new \CentreonContact($this->db);
                         try {
                             $contact->respectPasswordPolicyOrFail($params[2], $objectId);
@@ -472,7 +472,7 @@ class CentreonContact extends CentreonObject
      */
     protected function initPassword(array $params): void
     {
-        if (password_needs_rehash($params[static::ORDER_PASS], CentreonAuth::PASSWORD_HASH_ALGORITHM)) {
+        if (! $this->isPasswordAlreadyHashed((string) $params[static::ORDER_PASS])) {
             $contact = new \CentreonContact($this->db);
             try {
                 $contact->respectPasswordPolicyOrFail($params[static::ORDER_PASS], null);
@@ -581,6 +581,24 @@ class CentreonContact extends CentreonObject
         foreach ($cmdIds as $cmdId) {
             $relObj->insert($contactId, $cmdId);
         }
+    }
+
+    /**
+     * Whether the value is already a hash (e.g. from a CLAPI export) rather than plaintext.
+     *
+     * Not password_needs_rehash(): it also flags a valid hash whose cost differs from the
+     * current default, which would hash the value twice and break authentication.
+     *
+     * @param string $password
+     *
+     * @return bool
+     */
+    private function isPasswordAlreadyHashed(string $password): bool
+    {
+        // password_get_info() returns a null algorithm for plaintext.
+        $algorithm = password_get_info($password)['algo'];
+
+        return $algorithm !== null && $algorithm !== 0;
     }
 
     /**


### PR DESCRIPTION
Fixes: [MON-205521](https://centreon.atlassian.net/browse/MON-205521)

## Description

Replaying a CLAPI export of a **local** contact stored a password that no longer matched the real one on PHP 8.4, so the affected user could no longer log in — neither through the UI nor through CLAPI. It worked on 25.10 (PHP 8.2) and broke on the develop line (PHP 8.4).

PHP 8.4 raised the default bcrypt cost from 10 to 12. The CLAPI import path used `password_needs_rehash()` to tell plaintext apart from an already-hashed value, but that function also flags a *valid* hash whose cost differs from the current default. As a result a cost-10 hash coming from a PHP 8.2 platform (`<= 25.10`) was hashed a **second time** and no longer verified against the real password.

The fix detects an already-hashed value with `password_get_info()` instead, at both the `CONTACT;ADD` and `CONTACT;setparam ...;password` paths. A precomputed hash is now stored verbatim regardless of its cost, while plaintext is still hashed exactly once.

## Behavior

| Input | Before (PHP 8.4) | After |
|---|---|---|
| plaintext | hashed once | hashed once |
| bcrypt cost 10 (e.g. a 25.10 export) | re-hashed → login broken | stored verbatim → login OK |
| bcrypt cost 12 | stored verbatim | stored verbatim |
| legacy `md5__…` | hashed | hashed |

## Remediation for already-affected platforms

Contacts already imported via CLAPI on a 26.x platform have an incorrect stored hash. Reset their password via the UI (hashed correctly at the current cost), or re-run `CONTACT;setparam ...;password;<plaintext>` after this fix.


[MON-205521]: https://centreon.atlassian.net/browse/MON-205521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ