### PR TITLE
ci(awie): enrich Xray tests reported from e2e CI

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -427,9 +427,29 @@ jobs:
           push: true
           tags: ${{ steps.docker_tags.outputs.tags }}
 
+  xray-prepare-test-plan:
+    name: xray-prepare-test-plan
+    needs: [get-environment, changes]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.changes.outputs.trigger_e2e_testing == 'true' &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      (needs.get-environment.outputs.stability == 'testing' || needs.get-environment.outputs.is_nightly == 'true') &&
+      github.event.pull_request.head.repo.fork != true
+    uses: ./.github/workflows/xray-prepare-test-plan.yml
+    with:
+      major_version: ${{ needs.get-environment.outputs.major_version }}
+      minor_version: ${{ needs.get-environment.outputs.minor_version }}
+      module_name: centreon-awie
+    secrets:
+      XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
+      XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
+
   e2e-test:
     needs:
-      [get-environment, changes, dockerize]
+      [get-environment, changes, dockerize, xray-prepare-test-plan]
     if: |
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -448,6 +468,7 @@ jobs:
     with:
       name: e2e
       module_name: centreon-awie
+      jira_component_name: centreon-awie
       image_name: centreon-awie
       database_image: bitnamilegacy/${{ matrix.database }}
       os: ${{ matrix.operating_system }}
@@ -462,6 +483,8 @@ jobs:
       dependencies_lock_file: centreon-awie/tests/e2e/pnpm-lock.yaml
       is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+      jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
+      xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -471,6 +471,7 @@ jobs:
       jira_component_name: centreon-awie
       image_name: centreon-awie
       database_image: bitnamilegacy/${{ matrix.database }}
+      database_name: ${{ matrix.database }}
       os: ${{ matrix.operating_system }}
       features_path: tests/e2e/features
       major_version: ${{ needs.get-environment.outputs.major_version }}


### PR DESCRIPTION
Migrates the AWIE e2e pipeline to the Xray Test Plan flow so that Test cases reported from CI are enriched automatically (component, labels, transition to Resolved).

AWIE was still on the legacy flow: it did not run `xray-prepare-test-plan` nor pass `jira_test_plan_key`, so the `xray-api-import-results` job was always **skipped** — nothing was pushed to Xray and no `centreon-awie` Test case was ever enriched by the CI.

This adds the `xray-prepare-test-plan` job (`module_name: centreon-awie`) and passes `jira_test_plan_key`, `xray_test_plan_issue_id` and `jira_component_name: centreon-awie` to the reusable e2e workflow, mirroring `web.yml`.

To be backported to `dev-25.10.x` and `dev-24.10.x` (both still on the legacy flow).

Fixes: [MON-205508](https://centreon.atlassian.net/browse/MON-205508)

[MON-205508]: https://centreon.atlassian.net/browse/MON-205508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ