### PR TITLE
refactor(docker): extractor trim + single COPY, drop hardcoded per-file trap paths

### DIFF
--- a/.github/docker/centreon-centreontrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-centreontrapd/trixie/Dockerfile
@@ -83,6 +83,11 @@ rm -f /usr/share/centreon/bin/centreontrapdforward \
       /lib/systemd/system/centreontrapd.service \
       /etc/default/centreontrapd \
       /etc/logrotate.d/centreontrapd
+# dpkg backs up the pre-transaction /var/lib/dpkg/status to status-old before writing the new
+# one — a rollback safety net that's dead weight in an immutable image (never read unless
+# recovering a broken dpkg transaction, which won't happen here). Safe to drop: dpkg -l/-s
+# only read /var/lib/dpkg/status, not status-old.
+rm -f /var/lib/dpkg/status-old
 EOF
 
 # Create directory structure

--- a/.github/docker/centreon-centreontrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-centreontrapd/trixie/Dockerfile
@@ -19,10 +19,14 @@ done
 # systemd/sysconfig/logrotate files (inert here: no systemd, logs go to stdout) so the runtime
 # stage only ever copies a directory containing what it actually needs, rather than us having
 # to name individual files to include.
+# /extracted/lib is dropped entirely (not just the .service file inside it): on trixie /lib is
+# a symlink to /usr/lib (merged-usr), but dpkg-deb -x recreates the .deb's declared /lib/...
+# path as a REAL directory — broad-copying that below would replace the /lib symlink with a
+# real (near-empty) dir and break dynamic linking for anything resolved through /lib/*.
 rm -f /extracted/usr/share/centreon/bin/centreontrapdforward \
-      /extracted/lib/systemd/system/centreontrapd.service \
       /extracted/etc/default/centreontrapd \
       /extracted/etc/logrotate.d/centreontrapd
+rm -rf /extracted/lib
 echo "=== Extracted binaries (trimmed) ==="
 ls -lah /extracted/usr/share/centreon/bin/ || true
 echo "=== Extracted Perl modules ==="

--- a/.github/docker/centreon-centreontrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-centreontrapd/trixie/Dockerfile
@@ -76,6 +76,13 @@ RUN --mount=type=bind,source=packages-centreon,target=/packages \
     bash -e <<EOF
 cd /packages
 dpkg -i --force-depends centreon-trap*.deb centreon-perl-libs*.deb
+# centreon-trap.deb also ships centreontrapdforward (this image only runs centreontrapd) and
+# systemd/logrotate/sysconfig files that are inert here (no systemd, logs go to stdout) —
+# drop them in this same layer so they never end up in the image.
+rm -f /usr/share/centreon/bin/centreontrapdforward \
+      /lib/systemd/system/centreontrapd.service \
+      /etc/default/centreontrapd \
+      /etc/logrotate.d/centreontrapd
 EOF
 
 # Create directory structure

--- a/.github/docker/centreon-centreontrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-centreontrapd/trixie/Dockerfile
@@ -3,8 +3,36 @@
 ARG USE_SOURCE_TRAPD=false
 
 #############################################
-# Stage 1: Centreon Perl libs selector
-# USE_SOURCE_TRAPD=false → installed from .deb directly in the runtime stage (production default)
+# Stage 1: Extract files from .deb packages
+#############################################
+FROM debian:13-slim AS extractor
+
+RUN --mount=type=bind,source=packages-centreon,target=/packages \
+    bash -e <<EOF
+mkdir -p /extracted
+cd /packages
+for deb in centreon-trap*.deb centreon-perl-libs*.deb; do
+    echo "Extracting \$deb..."
+    dpkg-deb -x "\$deb" /extracted/
+done
+# This image only runs centreontrapd — trim the sibling centreontrapdforward binary and the
+# systemd/sysconfig/logrotate files (inert here: no systemd, logs go to stdout) so the runtime
+# stage only ever copies a directory containing what it actually needs, rather than us having
+# to name individual files to include.
+rm -f /extracted/usr/share/centreon/bin/centreontrapdforward \
+      /extracted/lib/systemd/system/centreontrapd.service \
+      /extracted/etc/default/centreontrapd \
+      /extracted/etc/logrotate.d/centreontrapd
+echo "=== Extracted binaries (trimmed) ==="
+ls -lah /extracted/usr/share/centreon/bin/ || true
+echo "=== Extracted Perl modules ==="
+ls -lah /extracted/usr/share/perl5/ || true
+EOF
+
+#############################################
+# Stage 1b/1c: Centreon Perl libs selector
+# USE_SOURCE_TRAPD=false → perl modules already come from the broad COPY --from=extractor below
+#                          (this branch is an empty no-op merge)
 # USE_SOURCE_TRAPD=true  → copy from local repo source (dev/testing), overriding the .deb install
 #############################################
 FROM debian:13-slim AS centreon-perl-false
@@ -67,29 +95,6 @@ apt-get clean
 rm -rf /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/*
 EOF
 
-# Install centreon-trap and centreon-perl-libs .deb packages directly: dpkg places every file
-# at the path the package declares, so we don't hand-maintain COPY paths that mirror the
-# package's internal layout. --force-depends skips the package's own Depends (snmpd,
-# snmptrapd, librrds-perl, libgd-perl, ...) which are unused here — real runtime deps are the
-# explicit apt-get install list above, same as before.
-RUN --mount=type=bind,source=packages-centreon,target=/packages \
-    bash -e <<EOF
-cd /packages
-dpkg -i --force-depends centreon-trap*.deb centreon-perl-libs*.deb
-# centreon-trap.deb also ships centreontrapdforward (this image only runs centreontrapd) and
-# systemd/logrotate/sysconfig files that are inert here (no systemd, logs go to stdout) —
-# drop them in this same layer so they never end up in the image.
-rm -f /usr/share/centreon/bin/centreontrapdforward \
-      /lib/systemd/system/centreontrapd.service \
-      /etc/default/centreontrapd \
-      /etc/logrotate.d/centreontrapd
-# dpkg backs up the pre-transaction /var/lib/dpkg/status to status-old before writing the new
-# one — a rollback safety net that's dead weight in an immutable image (never read unless
-# recovering a broken dpkg transaction, which won't happen here). Safe to drop: dpkg -l/-s
-# only read /var/lib/dpkg/status, not status-old.
-rm -f /var/lib/dpkg/status-old
-EOF
-
 # Create directory structure
 RUN bash -e <<EOF
 mkdir -p /var/spool/centreontrapd \
@@ -112,7 +117,13 @@ chown centreon-engine:centreon-engine /var/lib/centreon-engine/rw
 chmod 0775 /var/lib/centreon-engine/rw
 EOF
 
-# Copy Perl modules from selected source
+# Copy everything the extractor kept (already trimmed to just what this image needs) in one
+# shot, instead of naming individual destination paths — a file added anywhere under /extracted
+# by a future packaging change lands here automatically, no Dockerfile update required.
+COPY --from=extractor --link /extracted/ /
+
+# Override with local dev source when USE_SOURCE_TRAPD=true; a no-op empty merge otherwise
+# (perl modules already arrived via the COPY above).
 COPY --from=centreon-perl-selected --link /centreon-modules/ /usr/share/perl5/centreon/
 
 # Copy entrypoint scripts

--- a/.github/docker/centreon-centreontrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-centreontrapd/trixie/Dockerfile
@@ -99,7 +99,16 @@ apt-get clean
 rm -rf /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/*
 EOF
 
-# Create directory structure
+# Copy everything the extractor kept (already trimmed to just what this image needs) in one
+# shot, instead of naming individual destination paths — a file added anywhere under /extracted
+# by a future packaging change lands here automatically, no Dockerfile update required.
+COPY --from=extractor --link /extracted/ /
+
+# Create directory structure. Must run AFTER the COPY above: centreon-trap.deb also declares
+# /var/spool/centreontrapd and /etc/snmp/centreon_traps, and COPY of a directory that already
+# exists at the destination overwrites that destination directory's own ownership/mode with
+# whatever the source has (verified: this is not just a merge of contents) — so doing this
+# chown/chmod before the COPY would get silently clobbered back to the .deb's root-owned dirs.
 RUN bash -e <<EOF
 mkdir -p /var/spool/centreontrapd \
          /etc/snmp/centreon_traps \
@@ -120,11 +129,6 @@ chmod 0755 /var/lib/centreon-engine
 chown centreon-engine:centreon-engine /var/lib/centreon-engine/rw
 chmod 0775 /var/lib/centreon-engine/rw
 EOF
-
-# Copy everything the extractor kept (already trimmed to just what this image needs) in one
-# shot, instead of naming individual destination paths — a file added anywhere under /extracted
-# by a future packaging change lands here automatically, no Dockerfile update required.
-COPY --from=extractor --link /extracted/ /
 
 # Override with local dev source when USE_SOURCE_TRAPD=true; a no-op empty merge otherwise
 # (perl modules already arrived via the COPY above).

--- a/.github/docker/centreon-centreontrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-centreontrapd/trixie/Dockerfile
@@ -3,45 +3,12 @@
 ARG USE_SOURCE_TRAPD=false
 
 #############################################
-# Stage 1: Extract files from .deb packages
+# Stage 1: Centreon Perl libs selector
+# USE_SOURCE_TRAPD=false → installed from .deb directly in the runtime stage (production default)
+# USE_SOURCE_TRAPD=true  → copy from local repo source (dev/testing), overriding the .deb install
 #############################################
-FROM debian:13-slim AS extractor
-
-# Configure APT for optimal container usage
-COPY <<EOF /etc/apt/apt.conf.d/99custom
-Acquire::Retries "10";
-Acquire::https::Timeout "300";
-Acquire::http::Timeout "300";
-APT::Install-Recommends "false";
-APT::Install-Suggests "false";
-EOF
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    bash -e <<EOF
-apt-get update
-apt-get install -y --no-install-recommends dpkg
-EOF
-
-RUN --mount=type=bind,source=packages-centreon,target=/packages \
-    mkdir -p /extracted && \
-    cd /packages && \
-    for deb in centreon-trap*.deb centreon-perl-libs*.deb; do \
-        echo "Extracting $deb..."; \
-        dpkg-deb -x "$deb" /extracted/; \
-    done && \
-    echo "=== Extracted binaries ===" && \
-    ls -lah /extracted/usr/share/centreon/bin/ || true && \
-    echo "=== Extracted Perl modules ===" && \
-    ls -lah /extracted/usr/share/perl5/ || true
-
-#############################################
-# Stage 1b/1c: Centreon Perl libs selector
-# USE_SOURCE_TRAPD=false → extract from .deb (production default)
-# USE_SOURCE_TRAPD=true  → copy from local repo source (dev/testing)
-#############################################
-FROM scratch AS centreon-perl-false
-COPY --from=extractor --link /extracted/usr/share/perl5/centreon /centreon-modules/
+FROM debian:13-slim AS centreon-perl-false
+RUN mkdir -p /centreon-modules
 
 FROM scratch AS centreon-perl-true
 COPY centreon-collect/perl-libs/lib/centreon/ /centreon-modules/
@@ -100,6 +67,17 @@ apt-get clean
 rm -rf /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/*
 EOF
 
+# Install centreon-trap and centreon-perl-libs .deb packages directly: dpkg places every file
+# at the path the package declares, so we don't hand-maintain COPY paths that mirror the
+# package's internal layout. --force-depends skips the package's own Depends (snmpd,
+# snmptrapd, librrds-perl, libgd-perl, ...) which are unused here — real runtime deps are the
+# explicit apt-get install list above, same as before.
+RUN --mount=type=bind,source=packages-centreon,target=/packages \
+    bash -e <<EOF
+cd /packages
+dpkg -i --force-depends centreon-trap*.deb centreon-perl-libs*.deb
+EOF
+
 # Create directory structure
 RUN bash -e <<EOF
 mkdir -p /var/spool/centreontrapd \
@@ -124,9 +102,6 @@ EOF
 
 # Copy Perl modules from selected source
 COPY --from=centreon-perl-selected --link /centreon-modules/ /usr/share/perl5/centreon/
-
-# Copy centreontrapd binary from extractor
-COPY --from=extractor --link --chmod=755 /extracted/usr/share/centreon/bin/centreontrapd /usr/share/centreon/bin/centreontrapd
 
 # Copy entrypoint scripts
 COPY --link --chmod=755 .github/docker/centreon-centreontrapd/trixie/entrypoint /usr/local/lib/centreon-centreontrapd/

--- a/.github/docker/centreon-snmptrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-snmptrapd/trixie/Dockerfile
@@ -3,8 +3,36 @@
 ARG USE_SOURCE_TRAPD=false
 
 #############################################
-# Stage 1: Centreon Perl libs selector
-# USE_SOURCE_TRAPD=false → installed from .deb directly in the runtime stage (production default)
+# Stage 1: Extract files from .deb packages
+#############################################
+FROM debian:13-slim AS extractor
+
+RUN --mount=type=bind,source=packages-centreon,target=/packages \
+    bash -e <<EOF
+mkdir -p /extracted
+cd /packages
+for deb in centreon-trap*.deb centreon-perl-libs*.deb; do
+    echo "Extracting \$deb..."
+    dpkg-deb -x "\$deb" /extracted/
+done
+# This image only runs centreontrapdforward — trim the sibling centreontrapd binary and the
+# systemd/sysconfig/logrotate files (inert here: no systemd, logs go to stdout) so the runtime
+# stage only ever copies a directory containing what it actually needs, rather than us having
+# to name individual files to include.
+rm -f /extracted/usr/share/centreon/bin/centreontrapd \
+      /extracted/lib/systemd/system/centreontrapd.service \
+      /extracted/etc/default/centreontrapd \
+      /extracted/etc/logrotate.d/centreontrapd
+echo "=== Extracted binaries (trimmed) ==="
+ls -lah /extracted/usr/share/centreon/bin/ || true
+echo "=== Extracted Perl modules ==="
+ls -lah /extracted/usr/share/perl5/ || true
+EOF
+
+#############################################
+# Stage 1b/1c: Centreon Perl libs selector
+# USE_SOURCE_TRAPD=false → perl modules already come from the broad COPY --from=extractor below
+#                          (this branch is an empty no-op merge)
 # USE_SOURCE_TRAPD=true  → copy from local repo source (dev/testing), overriding the .deb install
 #############################################
 FROM debian:13-slim AS centreon-perl-false
@@ -54,29 +82,6 @@ groupadd -g 900 centreon
 useradd -u 900 -g centreon -m -r -d /var/spool/centreon -s /bin/bash centreon
 EOF
 
-# Install centreon-trap and centreon-perl-libs .deb packages directly: dpkg places every file
-# at the path the package declares, so we don't hand-maintain COPY paths that mirror the
-# package's internal layout. --force-depends skips the package's own Depends (snmpd,
-# snmptrapd, librrds-perl, libgd-perl, ...) which are unused here — real runtime deps are the
-# explicit apt-get install list above/below, same as before.
-RUN --mount=type=bind,source=packages-centreon,target=/packages \
-    bash -e <<EOF
-cd /packages
-dpkg -i --force-depends centreon-trap*.deb centreon-perl-libs*.deb
-# centreon-trap.deb also ships centreontrapd (this image only runs centreontrapdforward) and
-# systemd/logrotate/sysconfig files that are inert here (no systemd, logs go to stdout) —
-# drop them in this same layer so they never end up in the image.
-rm -f /usr/share/centreon/bin/centreontrapd \
-      /lib/systemd/system/centreontrapd.service \
-      /etc/default/centreontrapd \
-      /etc/logrotate.d/centreontrapd
-# dpkg backs up the pre-transaction /var/lib/dpkg/status to status-old before writing the new
-# one — a rollback safety net that's dead weight in an immutable image (never read unless
-# recovering a broken dpkg transaction, which won't happen here). Safe to drop: dpkg -l/-s
-# only read /var/lib/dpkg/status, not status-old.
-rm -f /var/lib/dpkg/status-old
-EOF
-
 # Create directory structure
 RUN bash -e <<EOF
 mkdir -p /var/spool/centreontrapd \
@@ -91,7 +96,13 @@ chown -R centreon:centreon /etc/snmp
 chmod 0755 /var/spool/centreon
 EOF
 
-# Copy Perl modules from selected source
+# Copy everything the extractor kept (already trimmed to just what this image needs) in one
+# shot, instead of naming individual destination paths — a file added anywhere under /extracted
+# by a future packaging change lands here automatically, no Dockerfile update required.
+COPY --from=extractor --link /extracted/ /
+
+# Override with local dev source when USE_SOURCE_TRAPD=true; a no-op empty merge otherwise
+# (perl modules already arrived via the COPY above).
 COPY --from=centreon-perl-selected --link /centreon-modules/ /usr/share/perl5/centreon/
 
 # Copy entrypoint scripts

--- a/.github/docker/centreon-snmptrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-snmptrapd/trixie/Dockerfile
@@ -3,45 +3,12 @@
 ARG USE_SOURCE_TRAPD=false
 
 #############################################
-# Stage 1: Extract files from .deb packages
+# Stage 1: Centreon Perl libs selector
+# USE_SOURCE_TRAPD=false → installed from .deb directly in the runtime stage (production default)
+# USE_SOURCE_TRAPD=true  → copy from local repo source (dev/testing), overriding the .deb install
 #############################################
-FROM debian:13-slim AS extractor
-
-# Configure APT for optimal container usage
-COPY <<EOF /etc/apt/apt.conf.d/99custom
-Acquire::Retries "10";
-Acquire::https::Timeout "300";
-Acquire::http::Timeout "300";
-APT::Install-Recommends "false";
-APT::Install-Suggests "false";
-EOF
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    bash -e <<EOF
-apt-get update
-apt-get install -y --no-install-recommends dpkg
-EOF
-
-RUN --mount=type=bind,source=packages-centreon,target=/packages \
-    mkdir -p /extracted && \
-    cd /packages && \
-    for deb in centreon-trap*.deb centreon-perl-libs*.deb; do \
-        echo "Extracting $deb..."; \
-        dpkg-deb -x "$deb" /extracted/; \
-    done && \
-    echo "=== Extracted binaries ===" && \
-    ls -lah /extracted/usr/share/centreon/bin/ || true && \
-    echo "=== Extracted Perl modules ===" && \
-    ls -lah /extracted/usr/share/perl5/ || true
-
-#############################################
-# Stage 1b/1c: Centreon Perl libs selector
-# USE_SOURCE_TRAPD=false → extract from .deb (production default)
-# USE_SOURCE_TRAPD=true  → copy from local repo source (dev/testing)
-#############################################
-FROM scratch AS centreon-perl-false
-COPY --from=extractor --link /extracted/usr/share/perl5/centreon /centreon-modules/
+FROM debian:13-slim AS centreon-perl-false
+RUN mkdir -p /centreon-modules
 
 FROM scratch AS centreon-perl-true
 COPY centreon-collect/perl-libs/lib/centreon/ /centreon-modules/
@@ -87,6 +54,17 @@ groupadd -g 900 centreon
 useradd -u 900 -g centreon -m -r -d /var/spool/centreon -s /bin/bash centreon
 EOF
 
+# Install centreon-trap and centreon-perl-libs .deb packages directly: dpkg places every file
+# at the path the package declares, so we don't hand-maintain COPY paths that mirror the
+# package's internal layout. --force-depends skips the package's own Depends (snmpd,
+# snmptrapd, librrds-perl, libgd-perl, ...) which are unused here — real runtime deps are the
+# explicit apt-get install list above/below, same as before.
+RUN --mount=type=bind,source=packages-centreon,target=/packages \
+    bash -e <<EOF
+cd /packages
+dpkg -i --force-depends centreon-trap*.deb centreon-perl-libs*.deb
+EOF
+
 # Create directory structure
 RUN bash -e <<EOF
 mkdir -p /var/spool/centreontrapd \
@@ -103,9 +81,6 @@ EOF
 
 # Copy Perl modules from selected source
 COPY --from=centreon-perl-selected --link /centreon-modules/ /usr/share/perl5/centreon/
-
-# Copy centreontrapdforward binary from extractor
-COPY --from=extractor --link --chmod=755 /extracted/usr/share/centreon/bin/centreontrapdforward /usr/share/centreon/bin/centreontrapdforward
 
 # Copy entrypoint scripts
 COPY --link --chmod=755 .github/docker/centreon-snmptrapd/trixie/entrypoint /usr/local/lib/centreon-snmptrapd/

--- a/.github/docker/centreon-snmptrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-snmptrapd/trixie/Dockerfile
@@ -19,10 +19,14 @@ done
 # systemd/sysconfig/logrotate files (inert here: no systemd, logs go to stdout) so the runtime
 # stage only ever copies a directory containing what it actually needs, rather than us having
 # to name individual files to include.
+# /extracted/lib is dropped entirely (not just the .service file inside it): on trixie /lib is
+# a symlink to /usr/lib (merged-usr), but dpkg-deb -x recreates the .deb's declared /lib/...
+# path as a REAL directory — broad-copying that below would replace the /lib symlink with a
+# real (near-empty) dir and break dynamic linking for anything resolved through /lib/*.
 rm -f /extracted/usr/share/centreon/bin/centreontrapd \
-      /extracted/lib/systemd/system/centreontrapd.service \
       /extracted/etc/default/centreontrapd \
       /extracted/etc/logrotate.d/centreontrapd
+rm -rf /extracted/lib
 echo "=== Extracted binaries (trimmed) ==="
 ls -lah /extracted/usr/share/centreon/bin/ || true
 echo "=== Extracted Perl modules ==="

--- a/.github/docker/centreon-snmptrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-snmptrapd/trixie/Dockerfile
@@ -70,6 +70,11 @@ rm -f /usr/share/centreon/bin/centreontrapd \
       /lib/systemd/system/centreontrapd.service \
       /etc/default/centreontrapd \
       /etc/logrotate.d/centreontrapd
+# dpkg backs up the pre-transaction /var/lib/dpkg/status to status-old before writing the new
+# one — a rollback safety net that's dead weight in an immutable image (never read unless
+# recovering a broken dpkg transaction, which won't happen here). Safe to drop: dpkg -l/-s
+# only read /var/lib/dpkg/status, not status-old.
+rm -f /var/lib/dpkg/status-old
 EOF
 
 # Create directory structure

--- a/.github/docker/centreon-snmptrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-snmptrapd/trixie/Dockerfile
@@ -63,6 +63,13 @@ RUN --mount=type=bind,source=packages-centreon,target=/packages \
     bash -e <<EOF
 cd /packages
 dpkg -i --force-depends centreon-trap*.deb centreon-perl-libs*.deb
+# centreon-trap.deb also ships centreontrapd (this image only runs centreontrapdforward) and
+# systemd/logrotate/sysconfig files that are inert here (no systemd, logs go to stdout) —
+# drop them in this same layer so they never end up in the image.
+rm -f /usr/share/centreon/bin/centreontrapd \
+      /lib/systemd/system/centreontrapd.service \
+      /etc/default/centreontrapd \
+      /etc/logrotate.d/centreontrapd
 EOF
 
 # Create directory structure

--- a/.github/docker/centreon-snmptrapd/trixie/Dockerfile
+++ b/.github/docker/centreon-snmptrapd/trixie/Dockerfile
@@ -86,7 +86,16 @@ groupadd -g 900 centreon
 useradd -u 900 -g centreon -m -r -d /var/spool/centreon -s /bin/bash centreon
 EOF
 
-# Create directory structure
+# Copy everything the extractor kept (already trimmed to just what this image needs) in one
+# shot, instead of naming individual destination paths — a file added anywhere under /extracted
+# by a future packaging change lands here automatically, no Dockerfile update required.
+COPY --from=extractor --link /extracted/ /
+
+# Create directory structure. Must run AFTER the COPY above: centreon-trap.deb also declares
+# /var/spool/centreontrapd and /etc/snmp/centreon_traps, and COPY of a directory that already
+# exists at the destination overwrites that destination directory's own ownership/mode with
+# whatever the source has (verified: this is not just a merge of contents) — so doing this
+# chown/chmod before the COPY would get silently clobbered back to the .deb's root-owned dirs.
 RUN bash -e <<EOF
 mkdir -p /var/spool/centreontrapd \
          /etc/snmp \
@@ -99,11 +108,6 @@ chown centreon:centreon /var/spool/centreontrapd /etc/centreon /var/log/centreon
 chown -R centreon:centreon /etc/snmp
 chmod 0755 /var/spool/centreon
 EOF
-
-# Copy everything the extractor kept (already trimmed to just what this image needs) in one
-# shot, instead of naming individual destination paths — a file added anywhere under /extracted
-# by a future packaging change lands here automatically, no Dockerfile update required.
-COPY --from=extractor --link /extracted/ /
 
 # Override with local dev source when USE_SOURCE_TRAPD=true; a no-op empty merge otherwise
 # (perl modules already arrived via the COPY above).


### PR DESCRIPTION
## Summary

Both `centreon-snmptrapd` and `centreon-centreontrapd` (trixie) Dockerfiles used an `extractor` stage (`dpkg-deb -x`) followed by `COPY --from=extractor /extracted/usr/share/centreon/bin/<exact-binary-name> ...` — a hardcoded destination path that mirrors the `.deb`'s internal layout and has to be kept in sync by hand if that layout ever changes.

**Final approach** (this PR went through several iterations — see commit history/review discussion — weighing it against the `centreon-broker`/`centreon-engine` reference Dockerfiles and a `dpkg -i`-based alternative):

- Keep the `extractor` stage (`dpkg-deb -x`, consistent with the broker/engine reference pattern), but **trim what we don't want inside the extractor** (the unused sibling trap binary, plus the systemd unit/sysconfig/logrotate files, which are inert in both images since neither runs systemd).
- Replace the per-file `COPY` in the runtime stage with **one `COPY --from=extractor /extracted/ /`**. A future file added anywhere under `/extracted` by a packaging change now lands in the image automatically — the Dockerfile only maintains a short, stable *exclude* list (in the extractor), not an ever-growing *include* list of exact paths.
- The `USE_SOURCE_TRAPD` dev-override selector is preserved: its `false` branch is now an empty stage (perl modules arrive via the broad extractor `COPY`), its `true` branch still overrides with local `centreon-collect` source for local testing.

### Two bugs found and fixed while validating the broad-COPY approach

1. **`/lib` symlink clobbered → broke arm64 builds under QEMU (caught by CI).** `centreon-trap.deb` declares its systemd unit at `/lib/systemd/system/centreontrapd.service` (pre-merged-usr path). `dpkg-deb -x` recreates `/extracted/lib` as a **real directory**, and broad-copying it replaced the runtime image's `/lib -> usr/lib` symlink (merged-usr, standard on trixie) with that near-empty real directory — breaking dynamic linking for anything resolved through `/lib/*`. Silent on native amd64 (didn't trip anything at build time) but fatal under QEMU (`qemu-aarch64: Could not open '/lib/ld-linux-aarch64.so.1'`), which is exactly what failed in CI. Fix: `rm -rf /extracted/lib` entirely in the extractor (not just the `.service` file). Reproduced the failure locally with `buildx --platform linux/arm64`, confirmed the fix resolves it, and confirmed `/lib` is still a proper symlink post-build.
2. **Directory ownership/mode silently clobbered.** `centreon-trap.deb` also declares `/var/spool/centreontrapd` and `/etc/snmp/centreon_traps`. `COPY` of a directory that already exists at the destination overwrites *that destination directory's own* ownership/mode with the source's — not just a content merge (verified empirically). With the directory-structure `chown`/`chmod` `RUN` block running *before* the broad extractor `COPY`, the correct `centreon:centreon` ownership and the `1777` sticky bit on the spool dir were being silently reset back to the `.deb`'s `root:root`/`0755` right after — which would have broken trap forwarding at runtime (the process runs as the non-root `centreon` user and needs write access to the spool dir). Fix: moved the `mkdir`/`chown`/`chmod` block to *after* the extractor `COPY` in both Dockerfiles. Reverified with a full rebuild that all shared directories end up with correct final ownership/mode.

### Alternatives considered and why they were rejected
- **`apt-get install <deb>` / plain `dpkg -i`** (the `centreon-web` pattern): would force-install the package's own `Depends` (`snmpd`, `snmptrapd`, `librrds-perl`, `libgd-perl`, ...) which aren't used by `centreontrapd`/`centreontrapdforward` — real bloat for these deliberately slim images.
- **`dpkg -i --force-depends` directly in the runtime stage** (an earlier version of this PR): solves the hardcoded-path problem and adds `dpkg -l`/SBOM visibility, but costs ~0.07% image size for dpkg's own database bookkeeping, and still requires either enumerating unwanted files to `rm -f` per image or accepting them as dead weight.
- **`dpkg -i --root=/staging` inside a separate extractor stage**: would create an *isolated* dpkg database under `/staging/var/lib/dpkg`; copying that over the runtime stage's real `/var/lib/dpkg` would clobber its knowledge of the base image's own packages — not safe to broad-copy.
- The final approach knowingly trades away `dpkg -l`/SBOM visibility (these 3 packages won't show up in scanners) for simplicity, consistency with the existing broker/engine convention, and zero measured size cost.

## Measured image size impact

Built `develop` and this branch locally against identical representative `.deb` packages, `--no-cache --provenance=false --sbom=false`:

| Image | develop | this branch | delta |
|---|---|---|---|
| centreon-snmptrapd | 46,104,247 B | 46,103,527 B | **-720 B (-0.0016%)** |
| centreon-centreontrapd | 47,041,731 B | 47,041,191 B | **-540 B (-0.0011%)** |

Essentially size-neutral (within build-to-build noise).

## Test plan
- [x] `docker build --check` passes with no warnings on both Dockerfiles
- [x] Built both Dockerfiles (this branch vs. `develop`) locally against identical representative `.deb` packages — both build successfully
- [x] Reproduced the arm64/QEMU `/lib` failure locally with `buildx --platform linux/arm64`, confirmed the fix resolves it, confirmed `/lib` is still a symlink post-build
- [x] Confirmed via `stat` that `/var/spool/centreontrapd`, `/etc/snmp(/centreon_traps)`, `/etc/centreon`, `/var/log/centreon`, `/var/lib/centreon-engine(/rw)` all have correct final owner/mode after the reorder fix
- [x] Confirmed each image contains only its own binary (no sibling dead code), full Perl module tree present
- [x] Measured size delta — effectively neutral
- [ ] CI `docker-trapd.yml` workflow (re-running after these fixes): package build → dockerize → boot-test → config-wiring-test, on both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)