### PR TITLE
fix(web): harden dynamic value rendering in legacy pages

### DIFF
--- a/centreon/www/include/configuration/configKnowledge/display-services.php
+++ b/centreon/www/include/configuration/configKnowledge/display-services.php
@@ -32,16 +32,14 @@ if (! isset($limit) || (int) $limit < 0) {
     $limit = $centreon->optGen['maxViewConfiguration'];
 }
 
-$allowedOrders = ['ASC' => 'ASC', 'DESC' => 'DESC'];
-$allowedOrderColumns = ['host_name' => 'host_name', 'service_description' => 'service_description'];
-
-$order = 'ASC';
-$orderBy = 'host_name';
-
-if (! empty($_POST['order']) && ! empty($_POST['orderby'])) {
-    $order = $allowedOrders[$_POST['order']] ?? 'ASC';
-    $orderBy = $allowedOrderColumns[$_POST['orderby']] ?? 'host_name';
-}
+$order = match (is_string($_POST['order'] ?? null) ? strtoupper($_POST['order']) : '') {
+    'DESC' => 'DESC',
+    default => 'ASC',
+};
+$orderBy = match (is_string($_POST['orderby'] ?? null) ? $_POST['orderby'] : '') {
+    'service_description' => 'service_description',
+    default => 'host_name',
+};
 
 require_once './include/common/autoNumLimit.php';
 

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -254,9 +254,12 @@ while ($topology_js = $DBRESULT->fetch()) {
                 $obis .= '_pb';
             }
             if (isset($_GET['acknowledge'])) {
-                $obis .= '_ack_' . htmlspecialchars($_GET['acknowledge'], ENT_QUOTES, 'UTF-8');
+                $obis .= '_ack_' . $_GET['acknowledge'];
             }
-            echo "\tsetTimeout('initM({$tM}, \"{$obis}\")', 0);";
+            echo "\tsetTimeout(function () { initM("
+                . (int) $tM . ", "
+                . json_encode($obis, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP)
+                . "); }, 0);";
         }
     } elseif ($topology_js['init']) {
         echo 'if (typeof ' . $topology_js['init'] . " == 'function') {";

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -257,9 +257,9 @@ while ($topology_js = $DBRESULT->fetch()) {
                 $obis .= '_ack_' . $_GET['acknowledge'];
             }
             echo "\tsetTimeout(function () { initM("
-                . (int) $tM . ", "
+                . (int) $tM . ', '
                 . json_encode($obis, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP)
-                . "); }, 0);";
+                . '); }, 0);';
         }
     } elseif ($topology_js['init']) {
         echo 'if (typeof ' . $topology_js['init'] . " == 'function') {";

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -253,8 +253,12 @@ while ($topology_js = $DBRESULT->fetch()) {
             if (isset($_GET['problem'])) {
                 $obis .= '_pb';
             }
-            if (isset($_GET['acknowledge'])) {
-                $obis .= '_ack_' . $_GET['acknowledge'];
+            if (
+                isset($_GET['acknowledge'])
+                && is_scalar($_GET['acknowledge'])
+                && in_array((string) $_GET['acknowledge'], ['0', '1'], true)
+            ) {
+                $obis .= '_ack_' . (string) $_GET['acknowledge'];
             }
             echo "\tsetTimeout(function () { initM("
                 . (int) $tM . ', '

--- a/centreon/www/include/home/customViews/widgetParam.html
+++ b/centreon/www/include/home/customViews/widgetParam.html
@@ -113,10 +113,18 @@
             data: {data: triggerValue},
             success: function (response) {
                 var xmlDoc = (typeof response === 'string') ? jQuery.parseXML(response) : response;
-                jQuery("[name=param_" + targetId + "]").find('option').remove().end();
+                var targetSelect = document.querySelector('[name="param_' + targetId + '"]');
+                if (targetSelect === null) {
+                    return;
+                }
+                targetSelect.options.length = 0;
                 jQuery(xmlDoc).find('option').each(function () {
-                    jQuery("[name=param_" + targetId + "]").append(new Option(jQuery(this).find('label').text(),
-                        triggerValue + '-' + jQuery(this).find('id').text(), true, true));
+                    var option = document.createElement('option');
+                    option.textContent = jQuery(this).find('label').text();
+                    option.value = triggerValue + '-' + jQuery(this).find('id').text();
+                    option.selected = true;
+                    option.defaultSelected = true;
+                    targetSelect.add(option);
                 });
             }
         });


### PR DESCRIPTION
Fixes: [MON-205634](https://centreon.atlassian.net/browse/MON-205634)

## Summary

Defense-in-depth hardening of three legacy Centreon Web files flagged by the Aikido static scanner. All three were triaged in previous ticket as false positives / optional hardening (input already sanitised upstream or allowlisted). This PR applies that optional hardening so the findings are cleared and the output paths are safe by construction. No functional behaviour change.

- **`centreon/www/include/core/header/htmlHeader.php`** — encode the topology object with `json_encode(…, JSON_HEX_*)` inside a closure, cast the reload timer to `int`, drop the string form of `setTimeout` (implicit eval).
- **`centreon/www/include/home/customViews/widgetParam.html`** — rebuild the widget trigger's target `<select>` with native DOM (`createElement` + `textContent`/`value` + `select.add()`) instead of `jQuery().append(new Option(…))`.
- **`centreon/www/include/configuration/configKnowledge/display-services.php`** — resolve the KB-services `ORDER BY` column and direction through `match` expressions returning hardcoded literals.

## How to test

### 1. Monitoring auto-reload (`htmlHeader.php`)
- Go to **Monitoring → Status Details → Services Grid** (also *Services by Hostgroup*, *Services by Servicegroup*, *Hostgroups Summary*).
- The grid loads and auto-refreshes (recurring `serviceGridXML.php` calls in the Network tab), no console error.
- View source, end of `<head>`: the inline script is `setTimeout(function () { initM(<ms>, "svcOV_pb"); }, 0);` (closure + JSON-encoded string), not the old `setTimeout('initM(...)', 0)`.
- Neutralisation: reload with `&o=svcOV"-alert(1)-"` → the value is emitted escaped inside the JS string literal; no `alert`, no console error.

### 2. Custom-view widget trigger (`widgetParam.html`)
- **Home → Custom Views**, add a **Graph Monitoring** (or **Single Metric**) widget, open its configuration (gear icon).
- Under **Resource**, change the **Host** select → the **Service** select clears and repopulates (POST to `loadServiceFromHost.php`); options carry the right label and `hostId-serviceId` value; no console error.
- Change host again → the previous options are replaced (no accumulation). Save → the selection persists.

### 3. KB services sort (`display-services.php`)
- Requires a configured Knowledge Base (wiki URL). Go to **Configuration → Knowledge Base → Services**.
- Default sort is Host Name ASC; clicking the **Hosts** / **Services** column headers changes the sort column and toggles ASC/DESC correctly.
- Neutralisation: replay the list POST with a crafted `orderby`/`order` (e.g. `orderby=service_id; DROP …`, `order=xxx`, or `orderby[]=x`) → the sort falls back to the defaults (`host_name` / `ASC`), no SQL error.


[MON-205634]: https://centreon.atlassian.net/browse/MON-205634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ