### PR TITLE
fix(myaccount): always assign expirationMessage to the profile template

### DIFF
--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -498,9 +498,7 @@ $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font
 $renderer->setErrorTemplate('<font color="red">{$error}</font><br />{$html}');
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-if (isset($expirationMessage)) {
-    $tpl->assign('expirationMessage', $expirationMessage);
-}
+$tpl->assign('expirationMessage', $expirationMessage ?? '');
 $tpl->assign('cct', $cct);
 $tpl->assign('o', $o);
 $tpl->assign('featuresFlipping', (count($features) > 0));


### PR DESCRIPTION
Linked ticket: [MON-205632](https://centreon.atlassian.net/browse/MON-205632)

## Problem

Opening **Edit profile** (MyAccount) raised a CRITICAL error and broke the page for users whose password never expires (and any user excluded from the password-expiration policy, or without a stored password-creation date):

```
Warning: Undefined array key "expirationMessage" (formMyAccount.ihtml)
```

`$expirationMessage` is only defined when a password-expiration message applies. It was assigned to the template behind `if (isset($expirationMessage))`, so when no message applied the template variable was never assigned, and the strict error handler escalated the resulting Smarty *"Undefined array key"* warning to a CRITICAL error.

## Fix

Always assign the template variable, defaulting to an empty string:

```php
$tpl->assign('expirationMessage', $expirationMessage ?? '');
```

The template guard `{if $expirationMessage}` treats `''` as falsy, so the red expiration message still renders only when there is a real message — no behavior change on that path.

## Test done

- CDE (develop), log in as **admin** → profile icon → **Edit profile**: page loads with no error, no CRITICAL in `centreon-web.log`.
- User with an active password-expiration policy → **Edit profile** still shows the red *"Your password will expire in N days."* message.
- `php -l`: no syntax errors.


[MON-205632]: https://centreon.atlassian.net/browse/MON-205632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ