### PR TITLE
fix(trap): Fix duplicate headers in configuration form

### DIFF
--- a/centreon/www/include/configuration/configObject/traps/formTraps.ihtml
+++ b/centreon/www/include/configuration/configObject/traps/formTraps.ihtml
@@ -40,7 +40,7 @@
             <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="vendor"> {$form.manufacturer_id.label}</td><td class="FormRowValue">{$form.manufacturer_id.html}</td></tr>
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
-                    <h4>{$subtitle0}</h4>
+                    <h4>{$subtitle1}</h4>
                      </td>
                    </tr>
                    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="trap_args"> {$form.traps_args.label}</td><td class="FormRowValue">{$form.traps_args.html}</td></tr>
@@ -56,21 +56,21 @@
                    </tr>
                    <tr class="list_lvl_1">
                      <td class="ListColLvl1_name" colspan="2">
-                       <h4>{$subtitle1}</h4>
+                       <h4>{$subtitle2}</h4>
                      </td>
                    </tr>
                    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="submit_result_enabled"> {$form.traps_submit_result_enable.label}</td><td class="FormRowValue">{$form.traps_submit_result_enable.html}</td></tr>
 
                    <tr class="list_lvl_1">
                      <td class="ListColLvl1_name" colspan="2">
-                       <h4>{$subtitle2}</h4>
+                       <h4>{$subtitle3}</h4>
                      </td>
                    </tr>
                    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="reschedule_enabled"> {$form.traps_reschedule_svc_enable.label}</td><td class="FormRowValue">{$form.traps_reschedule_svc_enable.html}</td></tr>
 
                    <tr class="list_lvl_1">
                      <td class="ListColLvl1_name" colspan="2">
-                       <h4>{$subtitle3}</h4>
+                       <h4>{$subtitle4}</h4>
                      </td>
                    </tr>
                    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="command_enabled"> {$form.traps_execution_command_enable.label}</td><td class="FormRowValue">{$form.traps_execution_command_enable.html}</td></tr>
@@ -78,7 +78,7 @@
 
                    <tr class="list_lvl_1">
                      <td class="ListColLvl1_name" colspan="2">
-                       <h4>{$subtitle4}</h4>
+                       <h4>{$subtitle5}</h4>
                      </td>
                    </tr>
                    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="comments"> {$form.traps_comments.label}</td><td class="FormRowValue">{$form.traps_comments.html}</td></tr>

--- a/centreon/www/include/configuration/configObject/traps/formTraps.php
+++ b/centreon/www/include/configuration/configObject/traps/formTraps.php
@@ -370,11 +370,11 @@ if ($valid) {
     $tpl->assign('tabTitle_2', _('Relations'));
     $tpl->assign('tabTitle_3', _('Advanced'));
     $tpl->assign('subtitle0', _('Main information'));
-    $tpl->assign('subtitle0', _('Convert Trap information'));
-    $tpl->assign('subtitle1', _('Action 1 : Submit result to Monitoring Engine'));
-    $tpl->assign('subtitle2', _('Action 2 : Force rescheduling of service check'));
-    $tpl->assign('subtitle3', _('Action 3 : Execute a Command'));
-    $tpl->assign('subtitle4', _('Trap description'));
+    $tpl->assign('subtitle1', _('Convert Trap information'));
+    $tpl->assign('subtitle2', _('Action 1 : Submit result to Monitoring Engine'));
+    $tpl->assign('subtitle3', _('Action 2 : Force rescheduling of service check'));
+    $tpl->assign('subtitle4', _('Action 3 : Execute a Command'));
+    $tpl->assign('subtitle5', _('Trap description'));
     $tpl->assign('routingDefTxt', _('Route parameters'));
     $tpl->assign('resourceTxt', _('Resources'));
     $tpl->assign('preexecTxt', _('Pre execution commands'));


### PR DESCRIPTION
## Description

**Fixes** #[MON-205684](https://centreon.atlassian.net/browse/MON-205684)

Backport of #8604.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master


[MON-205684]: https://centreon.atlassian.net/browse/MON-205684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ