### PR TITLE
feat(resources): add host_id and service_id to the resource status CSV export

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
@@ -93,6 +93,12 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
             $csvHeader = $this->sortHeaderByFilteredColumns($csvHeader, $response->getFilteredColumns());
         }
 
+        // host_id and service_id are always exported, regardless of the selected
+        // columns: they are the stable identifiers used by the REST API and
+        // downstream integrations to correlate each exported row.
+        $csvHeader->put('host_id', _('Host ID'));
+        $csvHeader->put('service_id', _('Service ID'));
+
         $csvResources = $this->transformToCsvByHeader($response->getResources(), $csvHeader);
 
         $this->viewModel->setHeaders($csvHeader);
@@ -148,6 +154,8 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
                 _('Notif') => $resource->isNotificationEnabled()
                     ? _('Notifications enabled') : _('Notifications disabled'),
                 _('Check') => _($this->getResourceCheck($resource)),
+                _('Host ID') => $this->getHostId($resource),
+                _('Service ID') => $this->getServiceId($resource),
             ];
 
             $line = array_map(
@@ -315,6 +323,40 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
         }
 
         return $check;
+    }
+
+    /**
+     * Host identifier of the resource: the resource's own id for a host, the
+     * parent's id for a service (or any host-parented resource), empty otherwise.
+     *
+     * @param ResourceEntity $resource
+     *
+     * @return string
+     */
+    private function getHostId(ResourceEntity $resource): string
+    {
+        if ($resource->getType() === ResourceEntity::TYPE_HOST) {
+            return $resource->getId() !== null ? (string) $resource->getId() : '';
+        }
+
+        return $resource->getParent()?->getId() !== null
+            ? (string) $resource->getParent()->getId()
+            : '';
+    }
+
+    /**
+     * Service identifier of the resource: the resource's own id for a service,
+     * empty for any other resource type.
+     *
+     * @param ResourceEntity $resource
+     *
+     * @return string
+     */
+    private function getServiceId(ResourceEntity $resource): string
+    {
+        return $resource->getType() === ResourceEntity::TYPE_SERVICE && $resource->getId() !== null
+            ? (string) $resource->getId()
+            : '';
     }
 
     /**

--- a/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
@@ -395,7 +395,10 @@ Then(
               const expectedRow = firstTwoExpected[index];
 
               UpdatedColumns.forEach((key) => {
-                if (key === 'Last Check') return;
+                // Last Check is time-dependent; Host ID / Service ID are
+                // runtime-generated, so their values are not compared against
+                // the static fixture (their presence is asserted via the header).
+                if (['Last Check', 'Host ID', 'Service ID'].includes(key)) return;
                 expect(
                   actualRow[key],
                   `Line ${index + 1} - Key: ${key}`

--- a/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
@@ -41,7 +41,9 @@ const AllColumns = [
   'FQDN / Address',
   'Monitoring server',
   'Notif',
-  'Check'
+  'Check',
+  'Host ID',
+  'Service ID'
 ];
 
 const UpdatedColumns = [
@@ -57,7 +59,9 @@ const UpdatedColumns = [
   'Action',
   'FQDN / Address',
   'Notif',
-  'Check'
+  'Check',
+  'Host ID',
+  'Service ID'
 ];
 
 const downloadsFolder = Cypress.config('downloadsFolder');

--- a/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
@@ -398,7 +398,8 @@ Then(
                 // Last Check is time-dependent; Host ID / Service ID are
                 // runtime-generated, so their values are not compared against
                 // the static fixture (their presence is asserted via the header).
-                if (['Last Check', 'Host ID', 'Service ID'].includes(key)) return;
+                if (['Last Check', 'Host ID', 'Service ID'].includes(key))
+                  return;
                 expect(
                   actualRow[key],
                   `Line ${index + 1} - Key: ${key}`

--- a/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
@@ -69,6 +69,29 @@ const downloadsFolder = Cypress.config('downloadsFolder');
 const normalize = (text: string) =>
   text.trim().replace(/^"|"$/g, '').replace(/\\"/g, '').replace(/"/g, '');
 
+// Host ID / Service ID values are runtime-generated, so instead of comparing
+// them against a static fixture we assert the type-based contract on every row:
+// a host has only Host ID, a service has both identifiers.
+const assertIdentifierContract = (
+  rows: Array<Record<string, string>>
+): void => {
+  rows.forEach((row, index) => {
+    const type = (row['Resource Type'] ?? '').replace(/"/g, '');
+    const hostId = (row['Host ID'] ?? '').replace(/"/g, '');
+    const serviceId = (row['Service ID'] ?? '').replace(/"/g, '');
+
+    if (type === 'Service') {
+      expect(hostId, `Row ${index + 1} (service) Host ID`).to.match(/^\d+$/);
+      expect(serviceId, `Row ${index + 1} (service) Service ID`).to.match(
+        /^\d+$/
+      );
+    } else if (type === 'Host') {
+      expect(hostId, `Row ${index + 1} (host) Host ID`).to.match(/^\d+$/);
+      expect(serviceId, `Row ${index + 1} (host) Service ID`).to.equal('');
+    }
+  });
+};
+
 before(() => {
   cy.intercept({
     method: 'POST',
@@ -293,6 +316,8 @@ Then(
         cy.log(
           `Formatted JSON from CSV:\n${JSON.stringify(rowObjects, null, 2)}`
         );
+        assertIdentifierContract(rowObjects);
+
         const firstTwoRows = rowObjects.slice(0, 2);
 
         cy.fixture('resources/csvFIleWithAllPagesAndColumns.json').then(
@@ -386,6 +411,8 @@ Then(
         cy.log(
           `Formatted JSON from CSV:\n${JSON.stringify(rowObjects, null, 2)}`
         );
+        assertIdentifierContract(rowObjects);
+
         const firstTwoRows = rowObjects.slice(0, 2);
 
         cy.fixture('resources/csvFIleWithOnlyVisiblePagesAndColumns.json').then(


### PR DESCRIPTION
Linked ticket: [MON-204988](https://centreon.atlassian.net/browse/MON-204988)

## What

Adds two columns to the **Resource Status** CSV export: `host_id` and `service_id`. These are the stable numeric identifiers the REST API, configuration objects and external integrations key on, so the exported CSV becomes directly machine-usable instead of requiring a name→id re-lookup.

## Behavior

The two ID columns are **always appended** to the export, regardless of the "visible columns / all columns" choice in the export modal — they are technical identifiers, not display fields. Values are derived from the resource itself:

| Resource type | `host_id` | `service_id` |
|---|---|---|
| Host | own id | *(empty)* |
| Service | parent host's id | own id |
| Meta-service / other | *(empty)* | *(empty)* |

Verified against the repository hydration: `getId()` is the real host/service id (and the parent's id is the host id), not the internal `resources` surrogate key.

## Changes

- `ExportResourcesPresenterCsv.php` — append `host_id`/`service_id` to the CSV header after column filtering; two private helpers derive the values per resource type.
- `07-csv-export/index.ts` (e2e) — the expected-header assertions (`AllColumns` and `UpdatedColumns`) now include the two ID columns.

## Notes for review

- **Header wording:** the CSV headers read `Host ID` / `Service ID` to match the human-readable style of the other columns; the underlying column keys are `host_id` / `service_id`. Easy to switch the headers to raw snake_case if the ticket intends that literally.
- **No isolated PHP unit test** was added: this presenter has no existing unit harness and its row builder is coupled to a fully-hydrated `Resource` entity + request context (`HttpUrlTrait`), which makes a unit test brittle. The new columns are covered end-to-end by the updated Cypress e2e. Happy to extract the id derivation into a pure helper and unit-test it if preferred.

## Test done

- `php -l`, php-cs-fixer and rector (core tier): clean on the changed file.
- e2e `Resources-status/07-csv-export` header expectations updated for both the all-columns and visible-columns scenarios.


[MON-204988]: https://centreon.atlassian.net/browse/MON-204988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ