### PR TITLE
fix(poller): match legacy pollers by config id fallback

### DIFF
--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
@@ -170,9 +170,12 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
             }
         );
 
-        // instances.instance_id matches nagios_server.uid for up-to-date pollers, but legacy
-        // pollers that do not know the Snowflake UID still report nagios_server.id. Fall back on
-        // the config id so a mixed-version platform keeps showing their running state.
+        // instances.instance_id matches nagios_server.uid for up-to-date pollers. Legacy pollers
+        // unaware of the Snowflake UID still report nagios_server.id as instance_id, so fall back
+        // on the config id to keep showing the running state of every poller on a mixed-version
+        // platform. UIDs are large Snowflake integers and config ids small auto-increments, so a
+        // given instances row matches a single nagios_server row -- assuming a poller keeps one
+        // live instances row (a 26.07 -> legacy downgrade could briefly leave two and duplicate it).
         $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.uid OR instances.instance_id = nagios_server.id');
         $whereCondition = false;
 

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
@@ -170,7 +170,10 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
             }
         );
 
-        $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.uid');
+        // instances.instance_id matches nagios_server.uid for up-to-date pollers, but legacy
+        // pollers that do not know the Snowflake UID still report nagios_server.id. Fall back on
+        // the config id so a mixed-version platform keeps showing their running state.
+        $request = $this->translateDbName('SELECT SQL_CALC_FOUND_ROWS * FROM `:dbstg`.instances JOIN `:db`.nagios_server ON instances.instance_id = nagios_server.uid OR instances.instance_id = nagios_server.id');
         $whereCondition = false;
 
         // Search

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
@@ -384,6 +384,8 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
     {
         $statement = $this->db->prepare($this->translateDbName(
             <<<'SQL'
+                -- Legacy pollers unaware of the Snowflake UID still report nagios_server.id
+                -- as instance_id, so match on either the uid or the config id.
                 SELECT 1
                 FROM `:dbstg`.`instances` i
                 INNER JOIN `:db`.`nagios_server` ns ON ns.uid = i.instance_id OR ns.id = i.instance_id

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
@@ -386,7 +386,7 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
             <<<'SQL'
                 SELECT 1
                 FROM `:dbstg`.`instances` i
-                INNER JOIN `:db`.`nagios_server` ns ON ns.uid = i.instance_id
+                INNER JOIN `:db`.`nagios_server` ns ON ns.uid = i.instance_id OR ns.id = i.instance_id
                 WHERE ns.id = :monitoringServerId
                     AND i.is_encryption_ready = 1
                 SQL

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
@@ -390,6 +390,7 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
                 FROM `:dbstg`.`instances` i
                 INNER JOIN `:db`.`nagios_server` ns ON ns.uid = i.instance_id OR ns.id = i.instance_id
                 WHERE ns.id = :monitoringServerId
+                    AND i.deleted = 0
                     AND i.is_encryption_ready = 1
                 SQL
         ));

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
@@ -126,7 +126,7 @@ class DbWriteMonitoringServerRepository extends AbstractRepositoryRDB implements
             <<<'SQL'
                 UPDATE `:db`.nagios_server ns
                     INNER JOIN `:dbstg`.instances i
-                    ON ns.uid = i.instance_id
+                    ON ns.uid = i.instance_id OR ns.id = i.instance_id
                 SET ns.is_encryption_ready = i.is_encryption_ready
                 SQL
         ));

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
@@ -124,6 +124,8 @@ class DbWriteMonitoringServerRepository extends AbstractRepositoryRDB implements
     {
         $statement = $this->db->prepare($this->translateDbName(
             <<<'SQL'
+                -- Legacy pollers unaware of the Snowflake UID still report nagios_server.id
+                -- as instance_id, so match on either the uid or the config id.
                 UPDATE `:db`.nagios_server ns
                     INNER JOIN `:dbstg`.instances i
                     ON ns.uid = i.instance_id OR ns.id = i.instance_id

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbWriteMonitoringServerRepository.php
@@ -130,6 +130,7 @@ class DbWriteMonitoringServerRepository extends AbstractRepositoryRDB implements
                     INNER JOIN `:dbstg`.instances i
                     ON ns.uid = i.instance_id OR ns.id = i.instance_id
                 SET ns.is_encryption_ready = i.is_encryption_ready
+                WHERE i.deleted = 0
                 SQL
         ));
         $statement->execute();

--- a/centreon/www/api/class/centreon_monitoring_poller.class.php
+++ b/centreon/www/api/class/centreon_monitoring_poller.class.php
@@ -61,8 +61,8 @@ class CentreonMonitoringPoller extends CentreonConfigurationObjects
             $acl = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
             // getPollerString('ID') returns nagios_server.id (config) values; translate them
             // to the Snowflake UIDs (nagios_server.uid) that match instances.instance_id.
-            // Legacy pollers unaware of the UID still report nagios_server.id, so keep the id
-            // in the allowlist as a fallback for mixed-version platforms.
+            // Legacy pollers unaware of the Snowflake UID still report nagios_server.id as
+            // instance_id, so keep the id in the allowlist as a fallback for mixed-version platforms.
             $aclPollerIds = $acl->getPollerString('ID', $this->pearDBMonitoring);
             $runtimeIds = [];
             if ($aclPollerIds !== '') {

--- a/centreon/www/api/class/centreon_monitoring_poller.class.php
+++ b/centreon/www/api/class/centreon_monitoring_poller.class.php
@@ -61,17 +61,20 @@ class CentreonMonitoringPoller extends CentreonConfigurationObjects
             $acl = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
             // getPollerString('ID') returns nagios_server.id (config) values; translate them
             // to the Snowflake UIDs (nagios_server.uid) that match instances.instance_id.
+            // Legacy pollers unaware of the UID still report nagios_server.id, so keep the id
+            // in the allowlist as a fallback for mixed-version platforms.
             $aclPollerIds = $acl->getPollerString('ID', $this->pearDBMonitoring);
-            $uids = [];
+            $runtimeIds = [];
             if ($aclPollerIds !== '') {
                 $uidResult = $this->pearDB->query(
-                    'SELECT uid FROM nagios_server WHERE id IN (' . $aclPollerIds . ')'
+                    'SELECT id, uid FROM nagios_server WHERE id IN (' . $aclPollerIds . ')'
                 );
                 while ($uidRow = $uidResult->fetchRow()) {
-                    $uids[] = $uidRow['uid'];
+                    $runtimeIds[] = $uidRow['uid'];
+                    $runtimeIds[] = $uidRow['id'];
                 }
             }
-            $queryPoller .= 'AND instances.instance_id IN (' . ($uids === [] ? '0' : implode(',', $uids)) . ') ';
+            $queryPoller .= 'AND instances.instance_id IN (' . ($runtimeIds === [] ? '0' : implode(',', $runtimeIds)) . ') ';
         }
 
         $queryPoller .= ' ORDER BY name ';

--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -645,6 +645,8 @@ class CentreonTopCounter extends CentreonWebService
         foreach ($listConfPoller as $poller) {
             $listPoller[$poller['id']] = ['id' => $poller['id'], 'name' => $poller['name'], 'stability' => 0, 'database' => ['state' => 0, 'time' => null], 'latency' => ['state' => 0, 'time' => null]];
             $uidToId[$poller['uid']] = $poller['id'];
+            // Legacy pollers unaware of the Snowflake UID still report nagios_server.id as instance_id.
+            $uidToId[$poller['id']] = $poller['id'];
         }
 
         if ($uidToId === []) {

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -737,7 +737,7 @@ class CentreonConfigPoller
         $nagiosResult = $this->DB->query('SELECT id, uid FROM nagios_server');
         while ($row = $nagiosResult->fetchRow()) {
             $uidToId[$row['uid']] = $row['id'];
-            // Legacy pollers unaware of the UID still report nagios_server.id as instance_id.
+            // Legacy pollers unaware of the Snowflake UID still report nagios_server.id as instance_id.
             $uidToId[$row['id']] = $row['id'];
         }
 

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -737,6 +737,8 @@ class CentreonConfigPoller
         $nagiosResult = $this->DB->query('SELECT id, uid FROM nagios_server');
         while ($row = $nagiosResult->fetchRow()) {
             $uidToId[$row['uid']] = $row['id'];
+            // Legacy pollers unaware of the UID still report nagios_server.id as instance_id.
+            $uidToId[$row['id']] = $row['id'];
         }
 
         $pollerState = [];

--- a/centreon/www/class/centreonGMT.class.php
+++ b/centreon/www/class/centreonGMT.class.php
@@ -522,9 +522,9 @@ class CentreonGMT
             return $this->pollerLocations;
         }
 
-        // Key by nagios_server.uid: pollerLocations is matched against hosts.instance_id
-        // (centreon_storage), which now holds the Snowflake UID, not nagios_server.id.
-        // Legacy pollers unaware of the UID still report nagios_server.id, so key by id too.
+        // pollerLocations is matched against hosts.instance_id (centreon_storage), which usually
+        // holds the Snowflake UID (nagios_server.uid). Legacy pollers unaware of the Snowflake UID
+        // still report nagios_server.id as instance_id, so key by both uid and id.
         $query = 'SELECT ns.uid, ns.id, t.timezone_name '
             . 'FROM cfg_nagios cfgn, nagios_server ns, timezone t '
             . 'WHERE cfgn.nagios_activate = "1" '

--- a/centreon/www/class/centreonGMT.class.php
+++ b/centreon/www/class/centreonGMT.class.php
@@ -524,7 +524,8 @@ class CentreonGMT
 
         // Key by nagios_server.uid: pollerLocations is matched against hosts.instance_id
         // (centreon_storage), which now holds the Snowflake UID, not nagios_server.id.
-        $query = 'SELECT ns.uid, t.timezone_name '
+        // Legacy pollers unaware of the UID still report nagios_server.id, so key by id too.
+        $query = 'SELECT ns.uid, ns.id, t.timezone_name '
             . 'FROM cfg_nagios cfgn, nagios_server ns, timezone t '
             . 'WHERE cfgn.nagios_activate = "1" '
             . 'AND cfgn.nagios_server_id = ns.id '
@@ -533,6 +534,7 @@ class CentreonGMT
             $res = CentreonDBInstance::getDbCentreonInstance()->query($query);
             while ($row = $res->fetchRow()) {
                 $this->pollerLocations[$row['uid']] = $row['timezone_name'];
+                $this->pollerLocations[$row['id']] = $row['timezone_name'];
             }
         } catch (Exception $e) {
             // Nothing to do

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -171,8 +171,14 @@ foreach ($servers as $config) {
         . "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
         . "name='dupNbr[" . $config['id'] . "]' />";
 
-    if (! isset($nagiosInfo[$config['uid']]['is_currently_running'])) {
-        $nagiosInfo[$config['uid']]['is_currently_running'] = 0;
+    // instances.instance_id holds the Snowflake uid for up-to-date pollers; legacy pollers
+    // (older Engine/Broker) still report their config id as instance_id. Resolve the runtime
+    // row by uid, then fall back to the config id so a mixed-version platform shows the real
+    // running state.
+    $runtimeKey = isset($nagiosInfo[$config['uid']]) ? $config['uid'] : $config['id'];
+
+    if (! isset($nagiosInfo[$runtimeKey]['is_currently_running'])) {
+        $nagiosInfo[$runtimeKey]['is_currently_running'] = 0;
     }
 
     // Manage flag for changes
@@ -183,9 +189,9 @@ foreach ($servers as $config) {
 
     // Manage flag for update time
     $lastUpdateTimeFlag = 0;
-    if (! isset($nagiosInfo[$config['uid']]['last_alive'])) {
+    if (! isset($nagiosInfo[$runtimeKey]['last_alive'])) {
         $lastUpdateTimeFlag = 0;
-    } elseif (time() - $nagiosInfo[$config['uid']]['last_alive'] > 10 * 60) {
+    } elseif (time() - $nagiosInfo[$runtimeKey]['last_alive'] > 10 * 60) {
         $lastUpdateTimeFlag = 1;
     }
 
@@ -197,14 +203,14 @@ foreach ($servers as $config) {
     $cfg_id = $dbResult2->rowCount() ? $dbResult2->fetch() : -1;
 
     $uptime = '-';
-    $isRunning = (isset($nagiosInfo[$config['uid']]['is_currently_running'])
-        && $nagiosInfo[$config['uid']]['is_currently_running'] == 1)
+    $isRunning = (isset($nagiosInfo[$runtimeKey]['is_currently_running'])
+        && $nagiosInfo[$runtimeKey]['is_currently_running'] == 1)
         ? true
         : false;
-    $version = $nagiosInfo[$config['uid']]['version'] ?? _('N/A');
-    $updateTime = (isset($nagiosInfo[$config['uid']]['last_alive'])
-        && $nagiosInfo[$config['uid']]['last_alive'])
-        ? $nagiosInfo[$config['uid']]['last_alive']
+    $version = $nagiosInfo[$runtimeKey]['version'] ?? _('N/A');
+    $updateTime = (isset($nagiosInfo[$runtimeKey]['last_alive'])
+        && $nagiosInfo[$runtimeKey]['last_alive'])
+        ? $nagiosInfo[$runtimeKey]['last_alive']
         : '-';
     $serverType = $config['localhost'] ? _('Central') : _('Poller');
     $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
@@ -212,11 +218,11 @@ foreach ($servers as $config) {
         : $serverType;
 
     if (
-        isset($nagiosInfo[$config['uid']]['is_currently_running'])
-        && $nagiosInfo[$config['uid']]['is_currently_running'] == 1
+        isset($nagiosInfo[$runtimeKey]['is_currently_running'])
+        && $nagiosInfo[$runtimeKey]['is_currently_running'] == 1
     ) {
         $now = new DateTime();
-        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$config['uid']]['program_start_time']);
+        $startDate = (new DateTime())->setTimestamp($nagiosInfo[$runtimeKey]['program_start_time']);
         $interval = date_diff($now, $startDate);
         if (intval($interval->format('%a')) >= 2) {
             $uptime = $interval->format('%a days');
@@ -232,7 +238,7 @@ foreach ($servers as $config) {
     }
 
     $pollerProcessId = $isRunning
-        ? $nagiosInfo[$config['uid']]['process_id']
+        ? $nagiosInfo[$runtimeKey]['process_id']
         : '-';
 
     // Manage different styles between each line
@@ -252,7 +258,7 @@ foreach ($servers as $config) {
         'RowMenu_link' => $serverLink,
         'RowMenu_type' => $serverType,
         'RowMenu_is_running' => $isRunning ? _('Yes') : _('No'),
-        'RowMenu_is_runningFlag' => $nagiosInfo[$config['uid']]['is_currently_running'],
+        'RowMenu_is_runningFlag' => $nagiosInfo[$runtimeKey]['is_currently_running'],
         'RowMenu_is_default' => $config['is_default'] ? _('Yes') : _('No'),
         'RowMenu_hasChanged' => $confChangedMessage,
         'RowMenu_pid' => $pollerProcessId,


### PR DESCRIPTION
## Description

On a mixed-version platform (central **26.07** with a poller still running an older Engine/Broker, e.g. **25.10**), the poller is displayed as **not running** in the pollers list even though monitoring is working.

Since 26.07, config (`nagios_server`) and runtime (`centreon_storage.instances`) are matched on the Snowflake UID: `instances.instance_id = nagios_server.uid`. A legacy poller does not know this UID and keeps reporting its auto-incremented config id as `instance_id`, so the join fails and `instances.running` is never read for it.

This PR adds a fallback resolving a runtime instance to its poller by `nagios_server.uid` **or** `nagios_server.id`. UIDs are large Snowflake values and config ids small integers, so both branches are mutually exclusive per row (no duplicated rows, no false positives for up-to-date pollers). Applied to the pollers listing, top counter, encryption-ready read/write, ACL poller select, CLAPI poller state and GMT locations.

> Note: this is a **display** issue, distinct from the gorgone / `sudo NOPASSWD` plugin-installation root cause described in the ticket (which makes a poller genuinely empty). The long-term fix remains upgrading pollers to 26.07.

Fixes: [MON-205682](https://centreon.atlassian.net/browse/MON-205682)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

**1. Simulate a legacy poller** — force a poller's runtime row to report its config id:
```sql
-- centreon_storage (replace <configId>/<pollerName>)
INSERT INTO instances (instance_id, name, running, last_alive, deleted, is_encryption_ready)
VALUES (<configId>, '<pollerName>', 1, UNIX_TIMESTAMP(), 0, 1)
ON DUPLICATE KEY UPDATE instance_id=<configId>, running=1,
  last_alive=UNIX_TIMESTAMP(), deleted=0, is_encryption_ready=1;
```
Then `sudo -u apache /usr/share/centreon/bin/console c:c`.

**2. Verify** the poller now shows as running in: Configuration > Pollers (and `GET /monitoring/servers`), the header top-counter, the ACL poller select (non-admin), CLAPI `INSTANCE show`, and encryption-ready propagation.

**3. Non-regression:** an up-to-date poller (`instance_id = uid`) still shows as running with no duplicate row.


[MON-205682]: https://centreon.atlassian.net/browse/MON-205682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ