### PR TITLE
MON-199330-pollers-in-containers

### DIFF
--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -325,6 +325,15 @@ contents:
     dst: "/usr/share/centreon/examples/centreon-apache-https.conf"
     file_info:
       mode: 0644
+  - src: "./src/centreon-apache-gorgone.conf"
+    dst: "/usr/share/centreon/examples/centreon-apache-gorgone.conf"
+    file_info:
+      mode: 0644
+
+  - src: "./src/centreon-apache-https-gorgone.conf"
+    dst: "/usr/share/centreon/examples/centreon-apache-https-gorgone.conf"
+    file_info:
+      mode: 0644
 
   - src: "../GPL_LIB"
     dst: "/usr/share/centreon/GPL_LIB"

--- a/centreon/packaging/src/centreon-apache-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-gorgone.conf
@@ -8,9 +8,9 @@ Listen 8086
 <VirtualHost *:8086>
 
     <IfModule mod_proxy_wstunnel.c>
-        ProxyPass "/"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/"  "ws://127.0.0.1:8087/"
         ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
         ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPass "/"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/"  "ws://127.0.0.1:8087/"
     </IfModule>
 </VirtualHost>

--- a/centreon/packaging/src/centreon-apache-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-gorgone.conf
@@ -1,0 +1,16 @@
+#
+# Section added by Centreon Install Setup
+# Disabled by default. Can be enabled by administrator if they already had activated pullwss in previous Centreon version
+# if gorgone was configured manually by the user to listen websocket connection on port 8086
+
+ServerTokens Prod
+Listen 8086
+<VirtualHost *:8086>
+
+    <IfModule mod_proxy_wstunnel.c>
+        ProxyPass "/"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/"  "ws://127.0.0.1:8087/"
+        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+    </IfModule>
+</VirtualHost>

--- a/centreon/packaging/src/centreon-apache-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-gorgone.conf
@@ -1,7 +1,7 @@
 #
 # Section added by Centreon Install Setup
-# Disabled by default. Can be enabled by administrator if they already had activated pullwss in previous Centreon version
-# if gorgone was configured manually by the user to listen websocket connection on port 8086
+# Disabled by default. Can be enabled by the administrator if they already had activated pullwss on the previous Centreon version
+# if gorgone was manually configured by the user to listen to the websocket connection on port 8086
 
 ServerTokens Prod
 Listen 8086

--- a/centreon/packaging/src/centreon-apache-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-gorgone.conf
@@ -6,11 +6,8 @@
 ServerTokens Prod
 Listen 8086
 <VirtualHost *:8086>
-
     <IfModule mod_proxy_wstunnel.c>
-        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
-        ProxyPass "/"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/"  "ws://127.0.0.1:8087/"
+        ProxyPass "/"  "ws://localhost:8087/"
+        ProxyPassReverse "/"  "ws://localhost:8087/"
     </IfModule>
 </VirtualHost>

--- a/centreon/packaging/src/centreon-apache-https-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-https-gorgone.conf
@@ -1,7 +1,7 @@
 #
 # Section added by Centreon Install Setup
-# Disabled by default. Can be enabled by administrator if they already had activated pullwss in previous Centreon version
-# if gorgone was configured manually by the user to listen websocket connection on port 8086.
+# Disabled by default. Can be enabled by the administrator if they already had activated pullwss on the previous Centreon version
+# if gorgone was manually configured by the user to listen to the websocket connection on port 8086.
 
 ServerTokens Prod
 Listen 8086

--- a/centreon/packaging/src/centreon-apache-https-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-https-gorgone.conf
@@ -3,9 +3,6 @@
 # Disabled by default. Can be enabled by administrator if they already had activated pullwss in previous Centreon version
 # if gorgone was configured manually by the user to listen websocket connection on port 8086.
 
-Define base_uri "/centreon"
-Define install_dir "/usr/share/centreon"
-
 ServerTokens Prod
 Listen 8086
 <VirtualHost *:8086>
@@ -29,10 +26,8 @@ Listen 8086
     <IfModule mod_proxy_wstunnel.c>
         # gorgone have multiples communication mode, one of them is websocket.
         # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
-        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
-        ProxyPass "/"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/"  "ws://127.0.0.1:8087/"
+        ProxyPass "/"  "ws://localhost:8087/"
+        ProxyPassReverse "/"  "ws://localhost:8087/"
 
     </IfModule>
 

--- a/centreon/packaging/src/centreon-apache-https-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-https-gorgone.conf
@@ -1,0 +1,39 @@
+#
+# Section added by Centreon Install Setup
+# Disabled by default. Can be enabled by administrator if they already had activated pullwss in previous Centreon version
+# if gorgone was configured manually by the user to listen websocket connection on port 8086.
+
+Define base_uri "/centreon"
+Define install_dir "/usr/share/centreon"
+
+ServerTokens Prod
+Listen 8086
+<VirtualHost *:8086>
+    #####################
+    # SSL configuration #
+    #####################
+    SSLEngine On
+    SSLProtocol All -SSLv3 -SSLv2 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ADH:!IDEA
+    SSLHonorCipherOrder On
+    SSLCompression Off
+    SSLCertificateFile /etc/pki/tls/certs/ca.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/ca.key
+
+    Header set X-Frame-Options: "sameorigin"
+    Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;SameSite=Strict
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    ServerSignature Off
+    TraceEnable Off
+
+    <IfModule mod_proxy_wstunnel.c>
+        # gorgone have multiples communication mode, one of them is websocket.
+        # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
+        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPass "/"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/"  "ws://127.0.0.1:8087/"
+
+    </IfModule>
+
+</VirtualHost>

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -40,6 +40,12 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
+    <IfModule mod_proxy_wstunnel.c>
+        # gorgone have multiples communication mode, one of them is websocket.
+        # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
+        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+    </IfModule>
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -43,8 +43,8 @@ ServerTokens Prod
     <IfModule mod_proxy_wstunnel.c>
         # gorgone have multiples communication mode, one of them is websocket.
         # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
-        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPass "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPassReverse "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -41,7 +41,7 @@ ServerTokens Prod
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
     <IfModule mod_proxy_wstunnel.c>
-        # gorgone have multiples communication mode, one of them is websocket.
+        # gorgone has multiple communication modes, one of them is websocket.
         # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
         ProxyPass "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
         ProxyPassReverse "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -43,8 +43,8 @@ ServerTokens Prod
     <IfModule mod_proxy_wstunnel.c>
         # gorgone has multiple communication modes, one of them is websocket.
         # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
-        ProxyPass "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
-        ProxyPassReverse "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPass "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPassReverse "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -25,8 +25,8 @@ ServerTokens Prod
     <IfModule mod_proxy_wstunnel.c>
         # gorgone have multiples communication mode, one of them is websocket.
         # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate if the client set it up.
-        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
-        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPass "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPassReverse "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>
 
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -24,7 +24,7 @@ ServerTokens Prod
 
     <IfModule mod_proxy_wstunnel.c>
         # gorgone have multiples communication mode, one of them is websocket.
-        # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate if the client set it up.
+        # this allows it to use apache as a proxy for the websocket. By doing so, gorgone doesn't have to manage another certificate if the client set it up.
         ProxyPass "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
         ProxyPassReverse "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -25,8 +25,8 @@ ServerTokens Prod
     <IfModule mod_proxy_wstunnel.c>
         # gorgone have multiples communication mode, one of them is websocket.
         # this allows it to use apache as a proxy for the websocket. By doing so, gorgone doesn't have to manage another certificate if the client set it up.
-        ProxyPass "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
-        ProxyPassReverse "/${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPass "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPassReverse "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>
 
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -22,6 +22,13 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
+    <IfModule mod_proxy_wstunnel.c>
+        # gorgone have multiples communication mode, one of them is websocket.
+        # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate if the client set it up.
+        ProxyPass "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+        ProxyPassReverse "/gorgone/pullwss/websocket"  "ws://127.0.0.1:8087/"
+    </IfModule>
+
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>


### PR DESCRIPTION
## Description

redirect /gorgone/pullwss/websocket uri from apache to gorgone, allowing to share the same tcp port (and certificate) for both webapp and gorgone websocket poller connection (pullwss mode).

This pr include #10002, and was created to avoid problem with jira ticket number

**Fixes** # MON-199330

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

Install a centreon plateform with this PR : webapp should still be accessible on port 80 and if configured on pot 443

apply the documentation https://github.com/centreon/centreon-documentation/pull/5479 And add a poller

The poller should be able to connect to port 443 with the certificate you configured. Poller should be able to receive centreon-engine configuration.

Apply the part "Old poller configuration with certificate (HTTPS)" : the poller should be able to connect to both 443 and 8086 port.


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
