### PR TITLE
refactor(knowledge): resolve service list order-by columns via match

### DIFF
--- a/centreon/www/include/configuration/configKnowledge/display-services.php
+++ b/centreon/www/include/configuration/configKnowledge/display-services.php
@@ -32,15 +32,18 @@ if (! isset($limit) || (int) $limit < 0) {
     $limit = $centreon->optGen['maxViewConfiguration'];
 }
 
-$allowedOrders = ['ASC' => 'ASC', 'DESC' => 'DESC'];
-$allowedOrderColumns = ['host_name' => 'host_name', 'service_description' => 'service_description'];
-
 $order = 'ASC';
 $orderBy = 'host_name';
 
 if (! empty($_POST['order']) && ! empty($_POST['orderby'])) {
-    $order = $allowedOrders[$_POST['order']] ?? 'ASC';
-    $orderBy = $allowedOrderColumns[$_POST['orderby']] ?? 'host_name';
+    $order = match ($_POST['order']) {
+        'DESC' => 'DESC',
+        default => 'ASC',
+    };
+    $orderBy = match ($_POST['orderby']) {
+        'service_description' => 'service_description',
+        default => 'host_name',
+    };
 }
 
 require_once './include/common/autoNumLimit.php';

--- a/centreon/www/include/configuration/configKnowledge/display-services.php
+++ b/centreon/www/include/configuration/configKnowledge/display-services.php
@@ -32,19 +32,14 @@ if (! isset($limit) || (int) $limit < 0) {
     $limit = $centreon->optGen['maxViewConfiguration'];
 }
 
-$order = 'ASC';
-$orderBy = 'host_name';
-
-if (! empty($_POST['order']) && ! empty($_POST['orderby'])) {
-    $order = match ($_POST['order']) {
-        'DESC' => 'DESC',
-        default => 'ASC',
-    };
-    $orderBy = match ($_POST['orderby']) {
-        'service_description' => 'service_description',
-        default => 'host_name',
-    };
-}
+$order = match ($_POST['order'] ?? '') {
+    'DESC' => 'DESC',
+    default => 'ASC',
+};
+$orderBy = match ($_POST['orderby'] ?? '') {
+    'service_description' => 'service_description',
+    default => 'host_name',
+};
 
 require_once './include/common/autoNumLimit.php';
 


### PR DESCRIPTION
## Description

The service list in the knowledge base configuration page builds its SQL
`ORDER BY` clause by interpolating a column name and sort direction (these
cannot be bound as query parameters). Previously these values were resolved
through an array-lookup allowlist keyed on request data; a static analysis
scanner flagged the interpolation because it could not prove the resulting
values were constant.

This change replaces the array lookups with `match` expressions that return
hardcoded literals. Behavior is unchanged:
* direction resolves to `ASC` / `DESC`, defaulting to `ASC`
* column resolves to `host_name` / `service_description`, defaulting to `host_name`

The values placed into the query are now provably constant literals.

**Fixes** # (no issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

Open **Configuration > Knowledge base > Services**, then sort the list by the
**Hosts** and **Services** columns in both ascending and descending order.
Verify the list sorts correctly and that search filters (host, service,
hostgroup, servicegroup, poller) still work in combination with sorting.
