### PR TITLE
chore(ci): disable post-packaging jobs on release-29.01-next [TO REVERT]

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -294,138 +294,139 @@ jobs:
           php_version: ${{ needs.get-environment.outputs.php_version }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  dockerize:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      github.event.pull_request.head.repo.fork != true
-
-    env:
-      project: centreon-awie
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: dockerize ${{ matrix.operating_system }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Generate information according to matrix os
-        id: matrix_include
-        run: |
-          if [ "${{ matrix.operating_system }}" = "alma9" ]; then
-            DISTRIB=el9
-            PACKAGE_EXTENSION=rpm
-          elif [ "${{ matrix.operating_system }}" = "alma10" ]; then
-            DISTRIB=el10
-            PACKAGE_EXTENSION=rpm
-          elif [ "${{ matrix.operating_system }}" = "trixie" ]; then
-            DISTRIB=trixie
-            PACKAGE_EXTENSION=deb
-          elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
-            DISTRIB=jammy
-            PACKAGE_EXTENSION=deb
-          else
-            echo "::error::${{ matrix.operating_system }} is not managed"
-            exit 1
-          fi
-
-          echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
-          echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Login to registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - name: Compute image tag
-        id: image_tag
-        env:
-          REF: ${{ github.head_ref || github.ref_name }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [[ "$REF" == "develop" ]]; then
-            echo "tag=develop-${MAJOR_VERSION}" >> $GITHUB_OUTPUT
-            echo "additional_tag=develop" >> $GITHUB_OUTPUT
-          else
-            SANITIZED_REF="$(printf '%s' "$REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)"
-            if [[ -z "$SANITIZED_REF" ]]; then
-              echo "::error::Unable to derive a valid Docker tag from ref '$REF'"
-              exit 1
-            fi
-            echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
-            echo "additional_tag=" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
-      - name: Get FROM image tag
-        id: from_image_version
-        uses: ./.github/actions/get-docker-from-image-version
-        with:
-          from_image: centreon-web-${{ matrix.operating_system }}
-          current_tag: ${{ steps.image_tag.outputs.tag }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-
-      - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.${{ steps.matrix_include.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
-          fail-on-cache-miss: true
-
-      - env:
-          PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}
-        run: |
-          mkdir packages-centreon
-          mv *."$PACKAGE_EXTENSION" packages-centreon/
-        shell: bash
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Compute docker tags
-        id: docker_tags
-        env:
-          REGISTRY: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          IMAGE: ${{ env.project }}-${{ matrix.operating_system }}
-          TAG: ${{ steps.image_tag.outputs.tag }}
-          ADDITIONAL: ${{ steps.image_tag.outputs.additional_tag }}
-        run: |
-          TAGS="${REGISTRY}/${IMAGE}:${TAG}"
-          if [[ -n "$ADDITIONAL" ]]; then
-            TAGS="${TAGS},${REGISTRY}/${IMAGE}:${ADDITIONAL}"
-          fi
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build and push web image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
-          context: .
-          build-args: |
-            "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
-            "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
-          pull: true
-          push: true
-          tags: ${{ steps.docker_tags.outputs.tags }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_packaging == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       github.event.pull_request.head.repo.fork != true
+#
+#     env:
+#       project: centreon-awie
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: dockerize ${{ matrix.operating_system }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Generate information according to matrix os
+#         id: matrix_include
+#         run: |
+#           if [ "${{ matrix.operating_system }}" = "alma9" ]; then
+#             DISTRIB=el9
+#             PACKAGE_EXTENSION=rpm
+#           elif [ "${{ matrix.operating_system }}" = "alma10" ]; then
+#             DISTRIB=el10
+#             PACKAGE_EXTENSION=rpm
+#           elif [ "${{ matrix.operating_system }}" = "trixie" ]; then
+#             DISTRIB=trixie
+#             PACKAGE_EXTENSION=deb
+#           elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
+#             DISTRIB=jammy
+#             PACKAGE_EXTENSION=deb
+#           else
+#             echo "::error::${{ matrix.operating_system }} is not managed"
+#             exit 1
+#           fi
+#
+#           echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
+#           echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: Login to registry
+#         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Compute image tag
+#         id: image_tag
+#         env:
+#           REF: ${{ github.head_ref || github.ref_name }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [[ "$REF" == "develop" ]]; then
+#             echo "tag=develop-${MAJOR_VERSION}" >> $GITHUB_OUTPUT
+#             echo "additional_tag=develop" >> $GITHUB_OUTPUT
+#           else
+#             SANITIZED_REF="$(printf '%s' "$REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)"
+#             if [[ -z "$SANITIZED_REF" ]]; then
+#               echo "::error::Unable to derive a valid Docker tag from ref '$REF'"
+#               exit 1
+#             fi
+#             echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
+#             echo "additional_tag=" >> $GITHUB_OUTPUT
+#           fi
+#         shell: bash
+#
+#       - name: Get FROM image tag
+#         id: from_image_version
+#         uses: ./.github/actions/get-docker-from-image-version
+#         with:
+#           from_image: centreon-web-${{ matrix.operating_system }}
+#           current_tag: ${{ steps.image_tag.outputs.tag }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#
+#       - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
+#         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.${{ steps.matrix_include.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
+#           fail-on-cache-miss: true
+#
+#       - env:
+#           PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}
+#         run: |
+#           mkdir packages-centreon
+#           mv *."$PACKAGE_EXTENSION" packages-centreon/
+#         shell: bash
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Compute docker tags
+#         id: docker_tags
+#         env:
+#           REGISTRY: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           IMAGE: ${{ env.project }}-${{ matrix.operating_system }}
+#           TAG: ${{ steps.image_tag.outputs.tag }}
+#           ADDITIONAL: ${{ steps.image_tag.outputs.additional_tag }}
+#         run: |
+#           TAGS="${REGISTRY}/${IMAGE}:${TAG}"
+#           if [[ -n "$ADDITIONAL" ]]; then
+#             TAGS="${TAGS},${REGISTRY}/${IMAGE}:${ADDITIONAL}"
+#           fi
+#           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: Build and push web image
+#         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
+#           context: .
+#           build-args: |
+#             "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
+#             "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
+#           pull: true
+#           push: true
+#           tags: ${{ steps.docker_tags.outputs.tags }}
 
   xray-prepare-test-plan:
     name: xray-prepare-test-plan
@@ -447,263 +448,270 @@ jobs:
       XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
       XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
 
-  e2e-test:
-    needs:
-      [get-environment, changes, dockerize, xray-prepare-test-plan]
-    if: |
-      needs.changes.outputs.trigger_e2e_testing == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      github.event.pull_request.head.repo.fork != true
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
-    name: e2e-test-${{ matrix.operating_system }}-${{ matrix.database }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (e2e-test)
+#   e2e-test:
+#     needs:
+#       [get-environment, changes, dockerize, xray-prepare-test-plan]
+#     if: |
+#       needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       github.event.pull_request.head.repo.fork != true
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
+#     name: e2e-test-${{ matrix.operating_system }}-${{ matrix.database }}
+#
+#     uses: ./.github/workflows/cypress-e2e-parallelization.yml
+#     with:
+#       name: e2e
+#       module_name: centreon-awie
+#       jira_component_name: centreon-awie
+#       image_name: centreon-awie
+#       database_image: bitnamilegacy/${{ matrix.database }}
+#       database_name: ${{ matrix.database }}
+#       os: ${{ matrix.operating_system }}
+#       features_path: tests/e2e/features
+#       major_version: ${{ needs.get-environment.outputs.major_version }}
+#       minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#       stability: ${{ needs.get-environment.outputs.stability }}
+#       target_stability: ${{ needs.get-environment.outputs.target_stability }}
+#       package_cache_key: ${{ format('{0}-{1}-{2}', github.sha, github.run_id, case(matrix.operating_system == 'alma10', 'rpm-el10', matrix.operating_system == 'alma9', 'rpm-el9', 'deb-trixie') ) }}
+#       package_directory: centreon-awie/tests/e2e/fixtures/packages
+#       test_tags: ${{ matrix.test_tags }}
+#       dependencies_lock_file: centreon-awie/tests/e2e/pnpm-lock.yaml
+#       is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+#       jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
+#       xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
+#       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+#       jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+#       github_models_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-    uses: ./.github/workflows/cypress-e2e-parallelization.yml
-    with:
-      name: e2e
-      module_name: centreon-awie
-      jira_component_name: centreon-awie
-      image_name: centreon-awie
-      database_image: bitnamilegacy/${{ matrix.database }}
-      database_name: ${{ matrix.database }}
-      os: ${{ matrix.operating_system }}
-      features_path: tests/e2e/features
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-      target_stability: ${{ needs.get-environment.outputs.target_stability }}
-      package_cache_key: ${{ format('{0}-{1}-{2}', github.sha, github.run_id, case(matrix.operating_system == 'alma10', 'rpm-el10', matrix.operating_system == 'alma9', 'rpm-el9', 'deb-trixie') ) }}
-      package_directory: centreon-awie/tests/e2e/fixtures/packages
-      test_tags: ${{ matrix.test_tags }}
-      dependencies_lock_file: centreon-awie/tests/e2e/pnpm-lock.yaml
-      is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-      is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
-      jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
-      xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
-      xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-      github_models_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver sources
+#         uses: ./.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon-awie
+#           module_directory: centreon-awie
+#           module_name: centreon-awie
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver)
+#   deliver:
+#     needs: [changes, get-environment, package, e2e-test]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver RPM package on Artifactory
+#         if: matrix.package_extension == 'rpm'
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: awie
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+#
+#       - name: Deliver DEB package on Artifactory
+#         if: matrix.package_extension == 'deb'
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: awie
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Artifactory
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: awie
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Deliver sources
-        uses: ./.github/actions/release-sources
-        with:
-          bucket_directory: centreon-awie
-          module_directory: centreon-awie
-          module_name: centreon-awie
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml
 
-  deliver:
-    needs: [changes, get-environment, package, e2e-test]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-pulp)
+#   deliver-pulp:
+#     continue-on-error: true
+#     needs: [changes, get-environment, package, e2e-test]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: awie
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: deliver ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Deliver RPM package on Artifactory
-        if: matrix.package_extension == 'rpm'
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: awie
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
-      - name: Deliver DEB package on Artifactory
-        if: matrix.package_extension == 'deb'
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: awie
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote:
-    needs: [get-environment, deliver]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable on Artifactory
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: awie
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  set-skip-label:
-    needs: [get-environment, deliver, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
-
-  deliver-pulp:
-    continue-on-error: true
-    needs: [changes, get-environment, package, e2e-test]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: awie
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: awie
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: awie
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -123,327 +123,332 @@ jobs:
           php_version: ${{ needs.get-environment.outputs.php_version }}
           stability: ${{ needs.get-environment.outputs.stability }}
 
-  dockerize:
-    needs: [get-environment, package-centreon-trap, package-perl-libs]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [centreon-snmptrapd, centreon-centreontrapd]
-        operating_system: [trixie]
-    name: dockerize ${{ matrix.component }}-${{ matrix.operating_system }}
-    # Matrix job outputs come from the last completed matrix leg. Safe here
-    # because compute-tag only depends on the ref/major_version, never on
-    # matrix.component or matrix.operating_system, so every leg produces the same tag.
-    outputs:
-      image_tag: ${{ steps.compute-tag.outputs.tag }}
-      additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     needs: [get-environment, package-centreon-trap, package-perl-libs]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         component: [centreon-snmptrapd, centreon-centreontrapd]
+#         operating_system: [trixie]
+#     name: dockerize ${{ matrix.component }}-${{ matrix.operating_system }}
+#     # Matrix job outputs come from the last completed matrix leg. Safe here
+#     # because compute-tag only depends on the ref/major_version, never on
+#     # matrix.component or matrix.operating_system, so every leg produces the same tag.
+#     outputs:
+#       image_tag: ${{ steps.compute-tag.outputs.tag }}
+#       additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           persist-credentials: false
+#
+#       - name: Login to registry
+#         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Parse distrib name
+#         id: parse-distrib
+#         uses: ./.github/actions/parse-distrib
+#         with:
+#           distrib: ${{ matrix.operating_system }}
+#
+#       - name: Restore centreon-trap package
+#         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+#         with:
+#           path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ matrix.operating_system }}-trap
+#           fail-on-cache-miss: true
+#
+#       - name: Restore centreon-perl-libs packages
+#         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+#         with:
+#           path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ matrix.operating_system }}-perl
+#           fail-on-cache-miss: true
+#
+#       - name: Prepare packages-centreon directory
+#         env:
+#           PACKAGE_EXTENSION: ${{ steps.parse-distrib.outputs.package_extension }}
+#         run: |
+#           mkdir -p packages-centreon
+#           mv *."$PACKAGE_EXTENSION" packages-centreon/
+#         shell: bash
+#
+#       - name: Set up QEMU
+#         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+#
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+#
+#       - name: Compute Docker tag
+#         id: compute-tag
+#         env:
+#           RAW_REF: ${{ github.head_ref || github.ref_name }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [[ "$RAW_REF" == "develop" ]]; then
+#             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
+#           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
+#             echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=" >> "$GITHUB_OUTPUT"
+#           else
+#             docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
+#             if [[ -z "$docker_tag" ]]; then
+#               echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
+#               exit 1
+#             fi
+#             echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=" >> "$GITHUB_OUTPUT"
+#           fi
+#         shell: bash
+#
+#       - name: Docker build and push
+#         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           context: .
+#           file: .github/docker/${{ matrix.component }}/${{ matrix.operating_system }}/Dockerfile
+#           platforms: linux/amd64,linux/arm64
+#           pull: true
+#           push: true
+#           tags: |
+#             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (docker-boot-test)
+#   docker-boot-test:
+#     needs: [get-environment, dockerize]
+#     if: |
+#       ! cancelled() &&
+#       needs.dockerize.result == 'success' &&
+#       needs.get-environment.outputs.skip_workflow == 'false'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         component: [centreon-snmptrapd, centreon-centreontrapd]
+#         operating_system: [trixie]
+#         platform: [linux/amd64, linux/arm64]
+#     name: docker boot test ${{ matrix.component }}-${{ matrix.operating_system }} (${{ matrix.platform }})
+#     permissions:
+#       contents: read
+#     env:
+#       TRAPD_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           persist-credentials: false
+#
+#       - name: Login to registry
+#         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Set up QEMU
+#         if: ${{ matrix.platform == 'linux/arm64' }}
+#         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+#
+#       - name: Install sqlite3
+#         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3
+#         shell: bash
+#
+#       - name: Replace / with - in the platform name
+#         id: platform-name
+#         run: echo "dashed=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+#         shell: bash
+#
+#       - name: Pull image for ${{ matrix.platform }}
+#         run: docker pull --platform "${{ matrix.platform }}" "$TRAPD_IMAGE"
+#         shell: bash
+#
+#       - name: Run boot test
+#         env:
+#           IMAGE: ${{ env.TRAPD_IMAGE }}
+#           PLATFORM: ${{ matrix.platform }}
+#           COMPONENT: ${{ matrix.component }}
+#         run: ./.github/scripts/centreon-trapd-docker-boot-test.sh
+#         shell: bash
+#
+#       - name: Upload debug artifacts on failure
+#         if: failure()
+#         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+#         with:
+#           name: ${{ matrix.component }}-boot-test-${{ matrix.operating_system }}-${{ steps.platform-name.outputs.dashed }}
+#           path: /tmp/centreon-trapd-boot-test.log
+#           retention-days: 1
 
-      - name: Login to registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (docker-config-wiring-test)
+#   docker-config-wiring-test:
+#     needs: [get-environment, dockerize]
+#     if: |
+#       ! cancelled() &&
+#       needs.dockerize.result == 'success' &&
+#       needs.get-environment.outputs.skip_workflow == 'false'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         operating_system: [trixie]
+#     name: docker config/wiring test centreon-trapd-${{ matrix.operating_system }}
+#     permissions:
+#       contents: read
+#     env:
+#       CENTREONTRAPD_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-centreontrapd-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
+#       SNMPTRAPD_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-snmptrapd-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           persist-credentials: false
+#
+#       - name: Login to registry
+#         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Install snmptrap client and sqlite3
+#         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends snmp sqlite3
+#         shell: bash
+#
+#       - name: Pull images
+#         run: |
+#           docker pull --platform linux/amd64 "$CENTREONTRAPD_IMAGE"
+#           docker pull --platform linux/amd64 "$SNMPTRAPD_IMAGE"
+#         shell: bash
+#
+#       - name: Run config/wiring test scenarios
+#         run: ./.github/scripts/centreon-trapd-docker-config-wiring-test.sh
+#         shell: bash
+#
+#       - name: Dump compose logs on failure
+#         if: failure()
+#         run: docker compose -f .github/docker/centreon-trapd/docker-compose.config-wiring-test.yml -p centreon-trapd-config-wiring-test logs
 
-      - name: Parse distrib name
-        id: parse-distrib
-        uses: ./.github/actions/parse-distrib
-        with:
-          distrib: ${{ matrix.operating_system }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-docker-tag)
+#   promote-docker-tag:
+#     needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
+#     if: |
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.dockerize.outputs.additional_tag != ''
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         component: [centreon-snmptrapd, centreon-centreontrapd]
+#         operating_system: [trixie]
+#     name: promote ${{ matrix.component }}-${{ matrix.operating_system }} floating tag
+#     steps:
+#       - name: Login to registry
+#         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+#
+#       - name: Promote floating tag (manifest retag, no rebuild)
+#         run: |
+#           docker buildx imagetools create \
+#             --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
+#             "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
+#         shell: bash
 
-      - name: Restore centreon-trap package
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ matrix.operating_system }}-trap
-          fail-on-cache-miss: true
-
-      - name: Restore centreon-perl-libs packages
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ matrix.operating_system }}-perl
-          fail-on-cache-miss: true
-
-      - name: Prepare packages-centreon directory
-        env:
-          PACKAGE_EXTENSION: ${{ steps.parse-distrib.outputs.package_extension }}
-        run: |
-          mkdir -p packages-centreon
-          mv *."$PACKAGE_EXTENSION" packages-centreon/
-        shell: bash
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Compute Docker tag
-        id: compute-tag
-        env:
-          RAW_REF: ${{ github.head_ref || github.ref_name }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [[ "$RAW_REF" == "develop" ]]; then
-            echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
-          elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
-            echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=" >> "$GITHUB_OUTPUT"
-          else
-            docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
-            if [[ -z "$docker_tag" ]]; then
-              echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
-              exit 1
-            fi
-            echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-
-      - name: Docker build and push
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          context: .
-          file: .github/docker/${{ matrix.component }}/${{ matrix.operating_system }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          pull: true
-          push: true
-          tags: |
-            ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
-
-  docker-boot-test:
-    needs: [get-environment, dockerize]
-    if: |
-      ! cancelled() &&
-      needs.dockerize.result == 'success' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [centreon-snmptrapd, centreon-centreontrapd]
-        operating_system: [trixie]
-        platform: [linux/amd64, linux/arm64]
-    name: docker boot test ${{ matrix.component }}-${{ matrix.operating_system }} (${{ matrix.platform }})
-    permissions:
-      contents: read
-    env:
-      TRAPD_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Login to registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Set up QEMU
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Install sqlite3
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3
-        shell: bash
-
-      - name: Replace / with - in the platform name
-        id: platform-name
-        run: echo "dashed=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Pull image for ${{ matrix.platform }}
-        run: docker pull --platform "${{ matrix.platform }}" "$TRAPD_IMAGE"
-        shell: bash
-
-      - name: Run boot test
-        env:
-          IMAGE: ${{ env.TRAPD_IMAGE }}
-          PLATFORM: ${{ matrix.platform }}
-          COMPONENT: ${{ matrix.component }}
-        run: ./.github/scripts/centreon-trapd-docker-boot-test.sh
-        shell: bash
-
-      - name: Upload debug artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.component }}-boot-test-${{ matrix.operating_system }}-${{ steps.platform-name.outputs.dashed }}
-          path: /tmp/centreon-trapd-boot-test.log
-          retention-days: 1
-
-  docker-config-wiring-test:
-    needs: [get-environment, dockerize]
-    if: |
-      ! cancelled() &&
-      needs.dockerize.result == 'success' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        operating_system: [trixie]
-    name: docker config/wiring test centreon-trapd-${{ matrix.operating_system }}
-    permissions:
-      contents: read
-    env:
-      CENTREONTRAPD_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-centreontrapd-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
-      SNMPTRAPD_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-snmptrapd-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Login to registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Install snmptrap client and sqlite3
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends snmp sqlite3
-        shell: bash
-
-      - name: Pull images
-        run: |
-          docker pull --platform linux/amd64 "$CENTREONTRAPD_IMAGE"
-          docker pull --platform linux/amd64 "$SNMPTRAPD_IMAGE"
-        shell: bash
-
-      - name: Run config/wiring test scenarios
-        run: ./.github/scripts/centreon-trapd-docker-config-wiring-test.sh
-        shell: bash
-
-      - name: Dump compose logs on failure
-        if: failure()
-        run: docker compose -f .github/docker/centreon-trapd/docker-compose.config-wiring-test.yml -p centreon-trapd-config-wiring-test logs
-
-  promote-docker-tag:
-    needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
-    if: |
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.dockerize.outputs.additional_tag != ''
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [centreon-snmptrapd, centreon-centreontrapd]
-        operating_system: [trixie]
-    name: promote ${{ matrix.component }}-${{ matrix.operating_system }} floating tag
-    steps:
-      - name: Login to registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Promote floating tag (manifest retag, no rebuild)
-        run: |
-          docker buildx imagetools create \
-            --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
-            "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
-        shell: bash
-
-  promote-docker-to-pulp:
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: centreon-ubuntu-22.04
-    permissions:
-      contents: read
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [centreon-snmptrapd, centreon-centreontrapd]
-        operating_system: [trixie]
-    name: promote ${{ matrix.component }}-${{ matrix.operating_system }} to Pulp stable
-    # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
-    # that dockerize tagged the image with while that branch was 'testing'. release_type comes
-    # from the annotated component tag's message ("release ..."/"hotfix ...", see
-    # .github/actions/release-new/action.yml), not from this event's own ref.
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          persist-credentials: false
-
-      - name: Resolve release bundle tag
-        id: resolve-bundle-tag
-        # release-new (.github/actions/release-new) tags the release bundle
-        # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
-        # this component's stable tag, so it's always among the tags pointing
-        # at HEAD here. Soft failure: no match just means no bundle tag to add.
-        run: |
-          BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
-          echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
-        shell: bash
-
-      - name: Login to Harbor registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
-        continue-on-error: true
-        id: promote-pulp
-        env:
-          PULP_URL: https://pulp-api.apps.centreon.com
-          PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
-          BASE_PATH: centreon/${{ matrix.component }}-${{ matrix.operating_system }}
-          HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}
-          HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
-          PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
-          MODULE: ${{ matrix.component }}
-          OS: ${{ matrix.operating_system }}
-          STABILITY: ${{ needs.get-environment.outputs.stability }}
-          PLATFORMS: linux/amd64,linux/arm64
-        run: bash .github/scripts/docker-push-to-pulp.sh
-        shell: bash
-
-      - name: Warn if Pulp stable delivery failed
-        if: steps.promote-pulp.outcome == 'failure'
-        run: |
-          echo "::warning::Pulp delivery failed for ${{ matrix.component }}-${{ matrix.operating_system }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
-        shell: bash
+  # [release-bump test — TO REVERT] disabled: delivery/promote (promote-docker-to-pulp)
+#   promote-docker-to-pulp:
+#     needs: [get-environment]
+#     if: |
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: centreon-ubuntu-22.04
+#     permissions:
+#       contents: read
+#       id-token: write
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         component: [centreon-snmptrapd, centreon-centreontrapd]
+#         operating_system: [trixie]
+#     name: promote ${{ matrix.component }}-${{ matrix.operating_system }} to Pulp stable
+#     # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
+#     # that dockerize tagged the image with while that branch was 'testing'. release_type comes
+#     # from the annotated component tag's message ("release ..."/"hotfix ...", see
+#     # .github/actions/release-new/action.yml), not from this event's own ref.
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#         with:
+#           fetch-depth: 0
+#           fetch-tags: true
+#           persist-credentials: false
+#
+#       - name: Resolve release bundle tag
+#         id: resolve-bundle-tag
+#         # release-new (.github/actions/release-new) tags the release bundle
+#         # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
+#         # this component's stable tag, so it's always among the tags pointing
+#         # at HEAD here. Soft failure: no match just means no bundle tag to add.
+#         run: |
+#           BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
+#           echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+#           echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
+#         shell: bash
+#
+#       - name: Login to Harbor registry
+#         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+#
+#       - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
+#         continue-on-error: true
+#         id: promote-pulp
+#         env:
+#           PULP_URL: https://pulp-api.apps.centreon.com
+#           PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
+#           BASE_PATH: centreon/${{ matrix.component }}-${{ matrix.operating_system }}
+#           HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}
+#           HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
+#           PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
+#           MODULE: ${{ matrix.component }}
+#           OS: ${{ matrix.operating_system }}
+#           STABILITY: ${{ needs.get-environment.outputs.stability }}
+#           PLATFORMS: linux/amd64,linux/arm64
+#         run: bash .github/scripts/docker-push-to-pulp.sh
+#         shell: bash
+#
+#       - name: Warn if Pulp stable delivery failed
+#         if: steps.promote-pulp.outcome == 'failure'
+#         run: |
+#           echo "::warning::Pulp delivery failed for ${{ matrix.component }}-${{ matrix.operating_system }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
+#         shell: bash

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -259,214 +259,220 @@ jobs:
           php_version: ${{ needs.get-environment.outputs.php_version }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver sources
+#         uses: ./.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon-dsm
+#           module_directory: centreon-dsm
+#           module_name: centreon-dsm
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver)
+#   deliver:
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       github.event.pull_request.head.repo.fork != true &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: ubuntu-24.04
+#
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver RPM package on Artifactory
+#         if: matrix.package_extension == 'rpm'
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: dsm
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+#
+#       - name: Deliver DEB package on Artifactory
+#         if: matrix.package_extension == 'deb'
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: dsm
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Deliver sources
-        uses: ./.github/actions/release-sources
-        with:
-          bucket_directory: centreon-dsm
-          module_directory: centreon-dsm
-          module_name: centreon-dsm
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Artifactory
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: dsm
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  deliver:
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      github.event.pull_request.head.repo.fork != true &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-24.04
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml
 
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-pulp)
+#   deliver-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       github.event.pull_request.head.repo.fork != true &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: centreon-ubuntu-22.04
+#
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: dsm
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    name: deliver ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Deliver RPM package on Artifactory
-        if: matrix.package_extension == 'rpm'
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: dsm
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
-      - name: Deliver DEB package on Artifactory
-        if: matrix.package_extension == 'deb'
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: dsm
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote:
-    needs: [get-environment, deliver]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable on Artifactory
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: dsm
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  set-skip-label:
-    needs: [get-environment, deliver, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
-
-  deliver-pulp:
-    continue-on-error: true
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      github.event.pull_request.head.repo.fork != true &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: centreon-ubuntu-22.04
-
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: dsm
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: dsm
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: dsm
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -117,199 +117,204 @@ jobs:
           php_version: ${{ needs.get-environment.outputs.php_version }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver sources
+#         uses: ./.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon-ha
+#           module_directory: centreon-ha
+#           module_name: centreon-ha
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver)
+#   deliver:
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       needs.get-environment.outputs.is_cloud == 'false' &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver RPM package on Artifactory
+#         if: matrix.package_extension == 'rpm'
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: ha
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+#
+#       - name: Deliver DEB package on Artifactory
+#         if: matrix.package_extension == 'deb'
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: ha
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Deliver sources
-        uses: ./.github/actions/release-sources
-        with:
-          bucket_directory: centreon-ha
-          module_directory: centreon-ha
-          module_name: centreon-ha
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+  # [release-bump test — TO REVERT] disabled: delivery/promote (promote)
+#   promote:
+#     needs: [get-environment]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
+#       github.event_name != 'workflow_dispatch' &&
+#       needs.get-environment.outputs.is_cloud == 'false' &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Artifactory
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: ha
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  deliver:
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      needs.get-environment.outputs.is_cloud == 'false' &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-pulp)
+#   deliver-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       needs.get-environment.outputs.is_cloud == 'false' &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: ha
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: deliver ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Deliver RPM package on Artifactory
-        if: matrix.package_extension == 'rpm'
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: ha
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
-      - name: Deliver DEB package on Artifactory
-        if: matrix.package_extension == 'deb'
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: ha
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote:
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
-      github.event_name != 'workflow_dispatch' &&
-      needs.get-environment.outputs.is_cloud == 'false' &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable on Artifactory
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: ha
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-pulp:
-    continue-on-error: true
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      needs.get-environment.outputs.is_cloud == 'false' &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: ha
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
-      github.event_name != 'workflow_dispatch' &&
-      needs.get-environment.outputs.is_cloud == 'false' &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: ha
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
+  # [release-bump test — TO REVERT] disabled: delivery/promote (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
+#       github.event_name != 'workflow_dispatch' &&
+#       needs.get-environment.outputs.is_cloud == 'false' &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: ha
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -376,164 +376,166 @@ jobs:
           is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  dockerize:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      github.event.pull_request.head.repo.fork != true
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_packaging == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       github.event.pull_request.head.repo.fork != true
+#
+#     env:
+#       project: centreon-open-tickets
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: dockerize ${{ matrix.operating_system }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Generate information according to matrix os
+#         id: matrix_include
+#         run: |
+#           if [ "${{ matrix.operating_system }}" = "alma9" ]; then
+#             DISTRIB=el9
+#             PACKAGE_EXTENSION=rpm
+#           elif [ "${{ matrix.operating_system }}" = "alma10" ]; then
+#             DISTRIB=el10
+#             PACKAGE_EXTENSION=rpm
+#           elif [ "${{ matrix.operating_system }}" = "trixie" ]; then
+#             DISTRIB=trixie
+#             PACKAGE_EXTENSION=deb
+#           elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
+#             DISTRIB=jammy
+#             PACKAGE_EXTENSION=deb
+#           else
+#             echo "::error::${{ matrix.operating_system }} is not managed"
+#             exit 1
+#           fi
+#
+#           echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
+#           echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: Login to registry
+#         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Compute image tag
+#         id: image_tag
+#         env:
+#           REF: ${{ github.head_ref || github.ref_name }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [[ "$REF" == "develop" ]]; then
+#             echo "tag=develop-${MAJOR_VERSION}" >> $GITHUB_OUTPUT
+#             echo "additional_tag=develop" >> $GITHUB_OUTPUT
+#           else
+#             SANITIZED_REF="$(printf '%s' "$REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)"
+#             if [[ -z "$SANITIZED_REF" ]]; then
+#               echo "::error::Unable to derive a valid Docker tag from ref '$REF'"
+#               exit 1
+#             fi
+#             echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
+#             echo "additional_tag=" >> $GITHUB_OUTPUT
+#           fi
+#         shell: bash
+#
+#       - name: Get FROM image tag
+#         id: from_image_version
+#         uses: ./.github/actions/get-docker-from-image-version
+#         with:
+#           from_image: centreon-web-${{ matrix.operating_system }}
+#           current_tag: ${{ steps.image_tag.outputs.tag }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#
+#       - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
+#         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.${{ steps.matrix_include.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
+#           fail-on-cache-miss: true
+#
+#       - env:
+#           PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}
+#         run: |
+#           mkdir packages-centreon
+#           mv *."$PACKAGE_EXTENSION" packages-centreon/
+#         shell: bash
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Compute docker tags
+#         id: docker_tags
+#         env:
+#           REGISTRY: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           IMAGE: ${{ env.project }}-${{ matrix.operating_system }}
+#           TAG: ${{ steps.image_tag.outputs.tag }}
+#           ADDITIONAL: ${{ steps.image_tag.outputs.additional_tag }}
+#         run: |
+#           TAGS="${REGISTRY}/${IMAGE}:${TAG}"
+#           if [[ -n "$ADDITIONAL" ]]; then
+#             TAGS="${TAGS},${REGISTRY}/${IMAGE}:${ADDITIONAL}"
+#           fi
+#           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: Build and push web image
+#         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
+#           context: .
+#           build-args: |
+#             "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
+#             "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
+#           pull: true
+#           push: true
+#           tags: ${{ steps.docker_tags.outputs.tags }}
 
-    env:
-      project: centreon-open-tickets
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: dockerize ${{ matrix.operating_system }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Generate information according to matrix os
-        id: matrix_include
-        run: |
-          if [ "${{ matrix.operating_system }}" = "alma9" ]; then
-            DISTRIB=el9
-            PACKAGE_EXTENSION=rpm
-          elif [ "${{ matrix.operating_system }}" = "alma10" ]; then
-            DISTRIB=el10
-            PACKAGE_EXTENSION=rpm
-          elif [ "${{ matrix.operating_system }}" = "trixie" ]; then
-            DISTRIB=trixie
-            PACKAGE_EXTENSION=deb
-          elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
-            DISTRIB=jammy
-            PACKAGE_EXTENSION=deb
-          else
-            echo "::error::${{ matrix.operating_system }} is not managed"
-            exit 1
-          fi
-
-          echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
-          echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Login to registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - name: Compute image tag
-        id: image_tag
-        env:
-          REF: ${{ github.head_ref || github.ref_name }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [[ "$REF" == "develop" ]]; then
-            echo "tag=develop-${MAJOR_VERSION}" >> $GITHUB_OUTPUT
-            echo "additional_tag=develop" >> $GITHUB_OUTPUT
-          else
-            SANITIZED_REF="$(printf '%s' "$REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)"
-            if [[ -z "$SANITIZED_REF" ]]; then
-              echo "::error::Unable to derive a valid Docker tag from ref '$REF'"
-              exit 1
-            fi
-            echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
-            echo "additional_tag=" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
-      - name: Get FROM image tag
-        id: from_image_version
-        uses: ./.github/actions/get-docker-from-image-version
-        with:
-          from_image: centreon-web-${{ matrix.operating_system }}
-          current_tag: ${{ steps.image_tag.outputs.tag }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-
-      - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.${{ steps.matrix_include.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
-          fail-on-cache-miss: true
-
-      - env:
-          PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}
-        run: |
-          mkdir packages-centreon
-          mv *."$PACKAGE_EXTENSION" packages-centreon/
-        shell: bash
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Compute docker tags
-        id: docker_tags
-        env:
-          REGISTRY: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          IMAGE: ${{ env.project }}-${{ matrix.operating_system }}
-          TAG: ${{ steps.image_tag.outputs.tag }}
-          ADDITIONAL: ${{ steps.image_tag.outputs.additional_tag }}
-        run: |
-          TAGS="${REGISTRY}/${IMAGE}:${TAG}"
-          if [[ -n "$ADDITIONAL" ]]; then
-            TAGS="${TAGS},${REGISTRY}/${IMAGE}:${ADDITIONAL}"
-          fi
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build and push web image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
-          context: .
-          build-args: |
-            "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
-            "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
-          pull: true
-          push: true
-          tags: ${{ steps.docker_tags.outputs.tags }}
-
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Deliver sources
-        uses: ./.github/actions/release-sources
-        with:
-          bucket_directory: centreon-open-tickets
-          module_directory: centreon-open-tickets
-          module_name: centreon-open-tickets
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver sources
+#         uses: ./.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon-open-tickets
+#           module_directory: centreon-open-tickets
+#           module_name: centreon-open-tickets
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
   xray-prepare-test-plan:
     name: xray-prepare-test-plan
@@ -555,285 +557,293 @@ jobs:
       XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
       XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
 
-  e2e-test:
-    needs:
-      [get-environment, changes, xray-prepare-test-plan, dockerize]
-    if: |
-      needs.changes.outputs.trigger_e2e_testing == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      github.event.pull_request.head.repo.fork != true
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
-    name: e2e-test-${{ matrix.operating_system }}-${{ matrix.database }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (e2e-test)
+#   e2e-test:
+#     needs:
+#       [get-environment, changes, xray-prepare-test-plan, dockerize]
+#     if: |
+#       needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       github.event.pull_request.head.repo.fork != true
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
+#     name: e2e-test-${{ matrix.operating_system }}-${{ matrix.database }}
+#
+#     uses: ./.github/workflows/cypress-e2e-parallelization.yml
+#     with:
+#       name: e2e
+#       module_name: centreon-open-tickets
+#       image_name: centreon-open-tickets
+#       database_image: bitnamilegacy/${{ matrix.database }}
+#       os: ${{ matrix.operating_system }}
+#       features_path: tests/e2e/features
+#       major_version: ${{ needs.get-environment.outputs.major_version }}
+#       minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#       stability: ${{ needs.get-environment.outputs.stability }}
+#       target_stability: ${{ needs.get-environment.outputs.target_stability }}
+#       package_cache_key: ${{ format('{0}-{1}-{2}', github.sha, github.run_id, case(matrix.operating_system == 'alma10', 'rpm-el10', matrix.operating_system == 'alma9', 'rpm-el9', 'deb-trixie') ) }}
+#       package_directory: centreon-open-tickets/tests/e2e/fixtures/packages
+#       test_tags: ${{ matrix.test_tags }}
+#       dependencies_lock_file: centreon-open-tickets/tests/e2e/pnpm-lock.yaml
+#       jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
+#       xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
+#       database_name: ${{ matrix.database }}
+#       is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
+#       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+#       jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+#       github_models_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-    uses: ./.github/workflows/cypress-e2e-parallelization.yml
-    with:
-      name: e2e
-      module_name: centreon-open-tickets
-      image_name: centreon-open-tickets
-      database_image: bitnamilegacy/${{ matrix.database }}
-      os: ${{ matrix.operating_system }}
-      features_path: tests/e2e/features
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-      target_stability: ${{ needs.get-environment.outputs.target_stability }}
-      package_cache_key: ${{ format('{0}-{1}-{2}', github.sha, github.run_id, case(matrix.operating_system == 'alma10', 'rpm-el10', matrix.operating_system == 'alma9', 'rpm-el9', 'deb-trixie') ) }}
-      package_directory: centreon-open-tickets/tests/e2e/fixtures/packages
-      test_tags: ${{ matrix.test_tags }}
-      dependencies_lock_file: centreon-open-tickets/tests/e2e/pnpm-lock.yaml
-      jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
-      xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
-      database_name: ${{ matrix.database }}
-      is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-      is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
-      xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-      github_models_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver)
+#   deliver:
+#     needs: [get-environment, changes, package, e2e-test]
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver RPM package on Artifactory
+#         if: matrix.package_extension == 'rpm'
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: open-tickets
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+#
+#       - name: Deliver DEB package on Artifactory
+#         if: matrix.package_extension == 'deb'
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: open-tickets
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  deliver:
-    needs: [get-environment, changes, package, e2e-test]
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Artifactory
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: open-tickets
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-    name: deliver ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml
 
-      - name: Deliver RPM package on Artifactory
-        if: matrix.package_extension == 'rpm'
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: open-tickets
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (clear-branch-cache)
+#   clear-branch-cache:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, deliver]
+#     env:
+#       GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+#     if: |
+#       needs.get-environment.outputs.is_nightly == 'true' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: List and delete cache
+#         env:
+#           REF_NAME: ${{ github.ref_name }}
+#         run: |
+#           mapfile -t cache_keys < <(gh cache list --ref "refs/heads/$REF_NAME" --json key -q '.[] | .key')
+#           echo $cache_keys
+#           while read row; do
+#             gh cache delete $row
+#             echo "Cache $row was deleted."
+#           done <<< "$cache_keys"
+#         shell: bash
 
-      - name: Deliver DEB package on Artifactory
-        if: matrix.package_extension == 'deb'
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: open-tickets
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (create-jira-nightly-ticket)
+#   create-jira-nightly-ticket:
+#     runs-on: ubuntu-24.04
+#     needs: [
+#       get-environment,
+#       deliver
+#     ]
+#     if: |
+#       needs.get-environment.outputs.is_nightly == 'true' && github.run_attempt == 1 &&
+#       (failure() || cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) &&
+#       startsWith(github.ref_name, 'dev') &&
+#       github.event.pull_request.head.repo.fork != true
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Create Jira ticket based on nightly build failure
+#         uses: ./.github/actions/create-jira-ticket
+#         with:
+#           jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#           jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#           jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+#           module_name: "centreon-open-tickets"
+#           ticket_reason_for_creation: "Nightly"
 
-  promote:
-    needs: [get-environment, deliver]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-pulp)
+#   deliver-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, changes, package, e2e-test]
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: open-tickets
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    name: promote ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable on Artifactory
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: open-tickets
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  set-skip-label:
-    needs: [get-environment, deliver, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
-
-  clear-branch-cache:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, deliver]
-    env:
-      GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    if: |
-      needs.get-environment.outputs.is_nightly == 'true' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: List and delete cache
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          mapfile -t cache_keys < <(gh cache list --ref "refs/heads/$REF_NAME" --json key -q '.[] | .key')
-          echo $cache_keys
-          while read row; do
-            gh cache delete $row
-            echo "Cache $row was deleted."
-          done <<< "$cache_keys"
-        shell: bash
-
-  create-jira-nightly-ticket:
-    runs-on: ubuntu-24.04
-    needs: [
-      get-environment,
-      deliver
-    ]
-    if: |
-      needs.get-environment.outputs.is_nightly == 'true' && github.run_attempt == 1 &&
-      (failure() || cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) &&
-      startsWith(github.ref_name, 'dev') &&
-      github.event.pull_request.head.repo.fork != true
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Create Jira ticket based on nightly build failure
-        uses: ./.github/actions/create-jira-ticket
-        with:
-          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-          jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-          jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-          module_name: "centreon-open-tickets"
-          ticket_reason_for_creation: "Nightly"
-
-  deliver-pulp:
-    continue-on-error: true
-    needs: [get-environment, changes, package, e2e-test]
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: open-tickets
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-
-    name: promote ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: open-tickets
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#
+#     name: promote ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: open-tickets
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -915,182 +915,183 @@ jobs:
           is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  dockerize:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, changes, package]
-    permissions:
-      contents: read
-      packages: read
-      actions: write
-    outputs:
-      image_tag: ${{ steps.image_tag.outputs.tag }}
-    if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.stability != 'stable'
-
-    env:
-      project: centreon-web
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-    name: dockerize ${{ matrix.operating_system }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Generate information according to matrix os
-        id: matrix_include
-        run: |
-          if [ "${{ matrix.operating_system }}" = "alma9" ]; then
-            DISTRIB=el9
-            PACKAGE_EXTENSION=rpm
-          elif [ "${{ matrix.operating_system }}" = "alma10" ]; then
-            DISTRIB=el10
-            PACKAGE_EXTENSION=rpm
-          elif [ "${{ matrix.operating_system }}" = "trixie" ]; then
-            DISTRIB=trixie
-            PACKAGE_EXTENSION=deb
-          elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
-            DISTRIB=jammy
-            PACKAGE_EXTENSION=deb
-          else
-            echo "::error::${{ matrix.operating_system }} is not managed"
-            exit 1
-          fi
-
-          echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
-          echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Compute image tag
-        id: image_tag
-        env:
-          REF: ${{ github.head_ref || github.ref_name }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [[ "$REF" == "develop" ]]; then
-            echo "tag=develop-${MAJOR_VERSION}" >> $GITHUB_OUTPUT
-            echo "additional_tag=develop" >> $GITHUB_OUTPUT
-          else
-            SANITIZED_REF="$(printf '%s' "$REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)"
-            if [[ -z "$SANITIZED_REF" ]]; then
-              echo "::error::Unable to derive a valid Docker tag from ref '$REF'"
-              exit 1
-            fi
-            echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
-            echo "additional_tag=" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
-      - name: Login to registry
-        if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - name: Get FROM image tag
-        id: from_image_version
-        uses: ./.github/actions/get-docker-from-image-version
-        with:
-          from_image: centreon-web-dependencies-collect
-          current_tag: ${{ steps.image_tag.outputs.tag }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          registry_url: ghcr.io/${{ github.repository }}
-          tag_suffix: -${{ matrix.operating_system }}
-
-      - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.${{ steps.matrix_include.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
-          fail-on-cache-miss: true
-
-      - env:
-          PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [ "$PACKAGE_EXTENSION" = "rpm" ]; then
-            rm -f centreon{,-central,-mariadb,-mysql,-web-selinux}-"$MAJOR_VERSION"*.rpm
-          else
-            rm -f centreon{,-central,-mariadb,-mysql}_"$MAJOR_VERSION"*.deb
-          fi
-
-          mkdir packages-centreon
-          mv *."$PACKAGE_EXTENSION" packages-centreon/
-        shell: bash
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-        with:
-          images: |
-            docker.centreon.com/centreon/${{ env.project }}-${{ matrix.operating_system }}
-            docker.centreon.com/centreon/${{ env.project }}-slim-${{ matrix.operating_system }}
-          tags: |
-            type=raw,value=${{ steps.image_tag.outputs.tag }}
-            type=raw,value=${{ steps.image_tag.outputs.additional_tag }},enable=${{ steps.image_tag.outputs.additional_tag != '' }}
-
-      - name: Build and push web image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
-          context: .
-          build-args: |
-            "REGISTRY_URL=ghcr.io/${{ github.repository }}"
-            "MAJOR_VERSION=${{ needs.get-environment.outputs.major_version }}"
-            "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
-            "STABILITY=${{ needs.get-environment.outputs.stability }}"
-            "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
-            "PHP_VERSION=${{ needs.get-environment.outputs.php_version }}"
-          pull: true
-          push: ${{ github.event.pull_request.head.repo.fork != true }}
-          load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Store slim image in local archive
-        env:
-          OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          docker tag "docker.centreon.com/centreon/$project-slim-$OPERATING_SYSTEM:$IMAGE_VERSION" "$project-slim-$OPERATING_SYSTEM:$IMAGE_VERSION"
-          mkdir -p docker-image
-          docker save --output "./docker-image/$project-slim-$OPERATING_SYSTEM.tar" "$project-slim-$OPERATING_SYSTEM:$IMAGE_VERSION"
-        shell: bash
-
-      - name: Clear previous docker image from cache
-        if: ${{ github.event.pull_request.head.repo.fork != true }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          curl \
-            -X DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-image-$project-slim-$OPERATING_SYSTEM-$IMAGE_VERSION"
-        shell: bash
-
-      - name: Store slim image in cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./docker-image
-          key: docker-image-${{ env.project }}-slim-${{ matrix.operating_system }}-${{ steps.meta.outputs.version }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, changes, package]
+#     permissions:
+#       contents: read
+#       packages: read
+#       actions: write
+#     outputs:
+#       image_tag: ${{ steps.image_tag.outputs.tag }}
+#     if: |
+#       needs.changes.outputs.trigger_packaging == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.stability != 'stable'
+#
+#     env:
+#       project: centreon-web
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#     name: dockerize ${{ matrix.operating_system }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Generate information according to matrix os
+#         id: matrix_include
+#         run: |
+#           if [ "${{ matrix.operating_system }}" = "alma9" ]; then
+#             DISTRIB=el9
+#             PACKAGE_EXTENSION=rpm
+#           elif [ "${{ matrix.operating_system }}" = "alma10" ]; then
+#             DISTRIB=el10
+#             PACKAGE_EXTENSION=rpm
+#           elif [ "${{ matrix.operating_system }}" = "trixie" ]; then
+#             DISTRIB=trixie
+#             PACKAGE_EXTENSION=deb
+#           elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
+#             DISTRIB=jammy
+#             PACKAGE_EXTENSION=deb
+#           else
+#             echo "::error::${{ matrix.operating_system }} is not managed"
+#             exit 1
+#           fi
+#
+#           echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
+#           echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: Compute image tag
+#         id: image_tag
+#         env:
+#           REF: ${{ github.head_ref || github.ref_name }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [[ "$REF" == "develop" ]]; then
+#             echo "tag=develop-${MAJOR_VERSION}" >> $GITHUB_OUTPUT
+#             echo "additional_tag=develop" >> $GITHUB_OUTPUT
+#           else
+#             SANITIZED_REF="$(printf '%s' "$REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)"
+#             if [[ -z "$SANITIZED_REF" ]]; then
+#               echo "::error::Unable to derive a valid Docker tag from ref '$REF'"
+#               exit 1
+#             fi
+#             echo "tag=$SANITIZED_REF" >> $GITHUB_OUTPUT
+#             echo "additional_tag=" >> $GITHUB_OUTPUT
+#           fi
+#         shell: bash
+#
+#       - name: Login to registry
+#         if: ${{ github.event.pull_request.head.repo.fork != true }}
+#         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Get FROM image tag
+#         id: from_image_version
+#         uses: ./.github/actions/get-docker-from-image-version
+#         with:
+#           from_image: centreon-web-dependencies-collect
+#           current_tag: ${{ steps.image_tag.outputs.tag }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           registry_url: ghcr.io/${{ github.repository }}
+#           tag_suffix: -${{ matrix.operating_system }}
+#
+#       - name: Restore ${{ steps.matrix_include.outputs.package_extension }} files
+#         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.${{ steps.matrix_include.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.matrix_include.outputs.package_extension }}-${{ steps.matrix_include.outputs.distrib }}
+#           fail-on-cache-miss: true
+#
+#       - env:
+#           PACKAGE_EXTENSION: ${{ steps.matrix_include.outputs.package_extension }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [ "$PACKAGE_EXTENSION" = "rpm" ]; then
+#             rm -f centreon{,-central,-mariadb,-mysql,-web-selinux}-"$MAJOR_VERSION"*.rpm
+#           else
+#             rm -f centreon{,-central,-mariadb,-mysql}_"$MAJOR_VERSION"*.deb
+#           fi
+#
+#           mkdir packages-centreon
+#           mv *."$PACKAGE_EXTENSION" packages-centreon/
+#         shell: bash
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Extract metadata (tags, labels) for Docker
+#         id: meta
+#         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+#         with:
+#           images: |
+#             docker.centreon.com/centreon/${{ env.project }}-${{ matrix.operating_system }}
+#             docker.centreon.com/centreon/${{ env.project }}-slim-${{ matrix.operating_system }}
+#           tags: |
+#             type=raw,value=${{ steps.image_tag.outputs.tag }}
+#             type=raw,value=${{ steps.image_tag.outputs.additional_tag }},enable=${{ steps.image_tag.outputs.additional_tag != '' }}
+#
+#       - name: Build and push web image
+#         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
+#           context: .
+#           build-args: |
+#             "REGISTRY_URL=ghcr.io/${{ github.repository }}"
+#             "MAJOR_VERSION=${{ needs.get-environment.outputs.major_version }}"
+#             "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
+#             "STABILITY=${{ needs.get-environment.outputs.stability }}"
+#             "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
+#             "PHP_VERSION=${{ needs.get-environment.outputs.php_version }}"
+#           pull: true
+#           push: ${{ github.event.pull_request.head.repo.fork != true }}
+#           load: true
+#           tags: ${{ steps.meta.outputs.tags }}
+#           labels: ${{ steps.meta.outputs.labels }}
+#
+#       - name: Store slim image in local archive
+#         env:
+#           OPERATING_SYSTEM: ${{ matrix.operating_system }}
+#           IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+#         run: |
+#           docker tag "docker.centreon.com/centreon/$project-slim-$OPERATING_SYSTEM:$IMAGE_VERSION" "$project-slim-$OPERATING_SYSTEM:$IMAGE_VERSION"
+#           mkdir -p docker-image
+#           docker save --output "./docker-image/$project-slim-$OPERATING_SYSTEM.tar" "$project-slim-$OPERATING_SYSTEM:$IMAGE_VERSION"
+#         shell: bash
+#
+#       - name: Clear previous docker image from cache
+#         if: ${{ github.event.pull_request.head.repo.fork != true }}
+#         env:
+#           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           OPERATING_SYSTEM: ${{ matrix.operating_system }}
+#           IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+#         run: |
+#           curl \
+#             -X DELETE \
+#             -H "Accept: application/vnd.github.v3+json" \
+#             -H "Authorization: token $GH_TOKEN" \
+#             "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/caches?key=docker-image-$project-slim-$OPERATING_SYSTEM-$IMAGE_VERSION"
+#         shell: bash
+#
+#       - name: Store slim image in cache
+#         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./docker-image
+#           key: docker-image-${{ env.project }}-slim-${{ matrix.operating_system }}-${{ steps.meta.outputs.version }}
 
   xray-prepare-test-plan:
     name: xray-prepare-test-plan
@@ -1112,184 +1113,187 @@ jobs:
       XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
       XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
 
-  bruno-api-test:
-    needs: [get-environment, changes, xray-prepare-test-plan, dockerize]
-    if: |
-      needs.changes.outputs.trigger_api_testing == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
-    name: api-test ${{ matrix.operating_system }} ${{ matrix.database }}
-    uses: ./.github/workflows/bruno-api-test.yml
-    with:
-      collection_path: centreon/tests/api/web-api-workspace/collections
-      image_name: centreon-web-slim
-      operating_system: ${{ matrix.operating_system }}
-      database_image: bitnamilegacy/${{ matrix.database }}
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-      working_directory: centreon/tests/api/web-api-workspace
-      component-name: centreon
-      module_name: centreon-web
-      jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      database_name: ${{ matrix.database }}
-      upload_artifacts: ${{ contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      client_id: ${{ secrets.XRAY_CLIENT_ID }}
-      client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
-      jira_user: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_token_test: ${{ secrets.XRAY_JIRA_TOKEN }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (bruno-api-test)
+#   bruno-api-test:
+#     needs: [get-environment, changes, xray-prepare-test-plan, dockerize]
+#     if: |
+#       needs.changes.outputs.trigger_api_testing == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
+#     name: api-test ${{ matrix.operating_system }} ${{ matrix.database }}
+#     uses: ./.github/workflows/bruno-api-test.yml
+#     with:
+#       collection_path: centreon/tests/api/web-api-workspace/collections
+#       image_name: centreon-web-slim
+#       operating_system: ${{ matrix.operating_system }}
+#       database_image: bitnamilegacy/${{ matrix.database }}
+#       major_version: ${{ needs.get-environment.outputs.major_version }}
+#       stability: ${{ needs.get-environment.outputs.stability }}
+#       working_directory: centreon/tests/api/web-api-workspace
+#       component-name: centreon
+#       module_name: centreon-web
+#       jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
+#       minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#       database_name: ${{ matrix.database }}
+#       upload_artifacts: ${{ contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#       client_id: ${{ secrets.XRAY_CLIENT_ID }}
+#       client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+#       jira_user: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#       jira_token_test: ${{ secrets.XRAY_JIRA_TOKEN }}
 
-  e2e-test:
-    needs:
-      [
-        get-environment,
-        changes,
-        dockerize,
-        xray-prepare-test-plan,
-        gherkin-lint,
-        e2e-lint,
-      ]
-    if: |
-      needs.changes.outputs.trigger_e2e_testing == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.stability != 'stable'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
-    name: e2e-test ${{ matrix.operating_system }}-${{ matrix.database }}
-    uses: ./.github/workflows/cypress-e2e-parallelization.yml
-    with:
-      name: e2e
-      module_name: centreon
-      jira_component_name: centreon-web
-      image_name: centreon-web
-      database_image: bitnamilegacy/${{ matrix.database }}
-      os: ${{ matrix.operating_system }}
-      features_path: tests/e2e/features
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-      target_stability: ${{ needs.get-environment.outputs.target_stability }}
-      package_cache_key: ${{ format('{0}-{1}-{2}', github.sha, github.run_id, case(matrix.operating_system == 'alma10', 'rpm-el10', matrix.operating_system == 'alma9', 'rpm-el9', 'deb-trixie') ) }}
-      package_directory: fixtures/packages
-      test_tags: ${{ needs.changes.outputs.trigger_upgrade_testing == 'true' && matrix.test_tags || format('{0} and not @update and not @upgrade', matrix.test_tags) }}
-      dependencies_lock_file: centreon/pnpm-lock.yaml
-      jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
-      xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
-      database_name: ${{ matrix.database }}
-      is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-      is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
-      labels: ${{ needs.get-environment.outputs.labels }}
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
-      xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-      github_models_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (e2e-test)
+#   e2e-test:
+#     needs:
+#       [
+#         get-environment,
+#         changes,
+#         dockerize,
+#         xray-prepare-test-plan,
+#         gherkin-lint,
+#         e2e-lint,
+#       ]
+#     if: |
+#       needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.stability != 'stable'
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
+#     name: e2e-test ${{ matrix.operating_system }}-${{ matrix.database }}
+#     uses: ./.github/workflows/cypress-e2e-parallelization.yml
+#     with:
+#       name: e2e
+#       module_name: centreon
+#       jira_component_name: centreon-web
+#       image_name: centreon-web
+#       database_image: bitnamilegacy/${{ matrix.database }}
+#       os: ${{ matrix.operating_system }}
+#       features_path: tests/e2e/features
+#       major_version: ${{ needs.get-environment.outputs.major_version }}
+#       minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#       stability: ${{ needs.get-environment.outputs.stability }}
+#       target_stability: ${{ needs.get-environment.outputs.target_stability }}
+#       package_cache_key: ${{ format('{0}-{1}-{2}', github.sha, github.run_id, case(matrix.operating_system == 'alma10', 'rpm-el10', matrix.operating_system == 'alma9', 'rpm-el9', 'deb-trixie') ) }}
+#       package_directory: fixtures/packages
+#       test_tags: ${{ needs.changes.outputs.trigger_upgrade_testing == 'true' && matrix.test_tags || format('{0} and not @update and not @upgrade', matrix.test_tags) }}
+#       dependencies_lock_file: centreon/pnpm-lock.yaml
+#       jira_test_plan_key: ${{ needs.xray-prepare-test-plan.outputs.jira_test_plan_key }}
+#       xray_test_plan_issue_id: ${{ needs.xray-prepare-test-plan.outputs.xray_test_plan_issue_id }}
+#       database_name: ${{ matrix.database }}
+#       is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+#       labels: ${{ needs.get-environment.outputs.labels }}
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
+#       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+#       jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+#       github_models_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+#
+#   # performances-test:
+#   #   runs-on: ubuntu-24.04
+#   #   needs: [get-environment, changes, dockerize]
+#   #   if: |
+#   #     needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#   #     needs.get-environment.outputs.skip_workflow == 'false' &&
+#   #     ! cancelled() &&
+#   #     ! contains(needs.*.result, 'failure') &&
+#   #     ! contains(needs.*.result, 'cancelled') &&
+#   #     needs.get-environment.outputs.stability != 'stable'
+#   #   strategy:
+#   #     fail-fast: false
+#   #     matrix:
+#   #       include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).main }}
+#   #   name: performances-test ${{ matrix.operating_system }}
+#   #   steps:
+#   #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+#
+#   #     - name: Login to registry
+#   #       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+#   #       with:
+#   #         registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#   #         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#   #         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#   #     - name: Run Lighthouse
+#   #       uses: ./.github/actions/lighthouse-performance-testing
+#   #       with:
+#   #         path: "centreon/lighthouse"
+#   #         image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.operating_system }}
+#   #         image_version: ${{ github.head_ref || github.ref_name }}
+#   #         database_image: bitnamilegacy/mariadb:10.11
+#   #         image_lighthouse_version: ${{ needs.get-environment.outputs.major_version }}
+#   #         module: centreon
+#   #         dependencies_lock_file: centreon/pnpm-lock.yaml
+#
+#   #     - name: Publish report to S3
+#   #       if: ${{ github.event_name == 'push' }}
+#   #       uses: ./.github/actions/lighthouse-to-s3
+#   #       with:
+#   #         report_path: centreon/lighthouse/report/lighthouseci-index.html
+#   #         report_target: s3://centreon-lighthouse-report/
+#   #         access_key_id: ${{ secrets.LIGHTHOUSE_ID }}
+#   #         secret_access_key: ${{ secrets.LIGHTHOUSE_SECRET }}
+#
+#   #     - name: Publish report
+#   #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+#   #       with:
+#   #         name: lighthouse-report
+#   #         path: centreon/lighthouse/report/lighthouseci-index.html
+#   #         retention-days: 1
 
-  # performances-test:
-  #   runs-on: ubuntu-24.04
-  #   needs: [get-environment, changes, dockerize]
-  #   if: |
-  #     needs.changes.outputs.trigger_e2e_testing == 'true' &&
-  #     needs.get-environment.outputs.skip_workflow == 'false' &&
-  #     ! cancelled() &&
-  #     ! contains(needs.*.result, 'failure') &&
-  #     ! contains(needs.*.result, 'cancelled') &&
-  #     needs.get-environment.outputs.stability != 'stable'
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).main }}
-  #   name: performances-test ${{ matrix.operating_system }}
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-  #     - name: Login to registry
-  #       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-  #       with:
-  #         registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-  #         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-  #         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-  #     - name: Run Lighthouse
-  #       uses: ./.github/actions/lighthouse-performance-testing
-  #       with:
-  #         path: "centreon/lighthouse"
-  #         image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-${{ matrix.operating_system }}
-  #         image_version: ${{ github.head_ref || github.ref_name }}
-  #         database_image: bitnamilegacy/mariadb:10.11
-  #         image_lighthouse_version: ${{ needs.get-environment.outputs.major_version }}
-  #         module: centreon
-  #         dependencies_lock_file: centreon/pnpm-lock.yaml
-
-  #     - name: Publish report to S3
-  #       if: ${{ github.event_name == 'push' }}
-  #       uses: ./.github/actions/lighthouse-to-s3
-  #       with:
-  #         report_path: centreon/lighthouse/report/lighthouseci-index.html
-  #         report_target: s3://centreon-lighthouse-report/
-  #         access_key_id: ${{ secrets.LIGHTHOUSE_ID }}
-  #         secret_access_key: ${{ secrets.LIGHTHOUSE_SECRET }}
-
-  #     - name: Publish report
-  #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-  #       with:
-  #         name: lighthouse-report
-  #         path: centreon/lighthouse/report/lighthouseci-index.html
-  #         retention-days: 1
-
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, e2e-test]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event_name != 'workflow_dispatch' &&
-      github.event.pull_request.head.repo.fork != true &&
-      needs.get-environment.outputs.is_cloud == 'false'
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Deliver sources
-        uses: ./.github/actions/release-sources
-        with:
-          bucket_directory: centreon
-          module_directory: centreon
-          module_name: centreon-web
-          frontend_index_cache_key: ${{ github.sha }}-${{ github.run_id }}-index
-          frontend_index_file: centreon/www/index.html
-          frontend_static_cache_key: ${{ github.sha }}-${{ github.run_id }}-static
-          frontend_static_directory: centreon/www/static
-          backend_vendor_cache_key: ${{ github.sha }}-${{ github.run_id }}-vendor
-          backend_vendor_directory: centreon/vendor
-          translation_cache_key: ${{ github.sha }}-${{ github.run_id }}-translation
-          translation_directory: centreon/www/locale
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, e2e-test]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event_name != 'workflow_dispatch' &&
+#       github.event.pull_request.head.repo.fork != true &&
+#       needs.get-environment.outputs.is_cloud == 'false'
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver sources
+#         uses: ./.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon
+#           module_directory: centreon
+#           module_name: centreon-web
+#           frontend_index_cache_key: ${{ github.sha }}-${{ github.run_id }}-index
+#           frontend_index_file: centreon/www/index.html
+#           frontend_static_cache_key: ${{ github.sha }}-${{ github.run_id }}-static
+#           frontend_static_directory: centreon/www/static
+#           backend_vendor_cache_key: ${{ github.sha }}-${{ github.run_id }}-vendor
+#           backend_vendor_directory: centreon/vendor
+#           translation_cache_key: ${{ github.sha }}-${{ github.run_id }}-translation
+#           translation_directory: centreon/www/locale
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
   build-openapi-documentation:
     runs-on: ubuntu-24.04
@@ -1324,245 +1328,252 @@ jobs:
           cloudfront_role_doc_production: ${{ secrets.CLOUDFRONT_ROLE_DOC_PRODUCTION }}
           cloudfront_id_doc_api: ${{ secrets.CLOUDFRONT_ID_DOC_API }}
 
-  deliver:
-    runs-on: ubuntu-24.04
-    needs:
-      [
-        changes,
-        get-environment,
-        e2e-test,
-        bruno-api-test
-      ]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      github.event.pull_request.head.repo.fork != true
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-    name: deliver ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver)
+#   deliver:
+#     runs-on: ubuntu-24.04
+#     needs:
+#       [
+#         changes,
+#         get-environment,
+#         e2e-test,
+#         bruno-api-test
+#       ]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       github.event.pull_request.head.repo.fork != true
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#     name: deliver ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver RPM package on Artifactory
+#         if: matrix.package_extension == 'rpm'
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: web
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+#
+#       - name: Deliver DEB package on Artifactory
+#         if: matrix.package_extension == 'deb'
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: web
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Deliver RPM package on Artifactory
-        if: matrix.package_extension == 'rpm'
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: web
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#     name: promote ${{ matrix.distrib }}
+#     permissions:
+#       contents: read
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Artifactory
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: web
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Deliver DEB package on Artifactory
-        if: matrix.package_extension == 'deb'
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: web
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml
 
-  promote:
-    needs: [get-environment, deliver]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-    name: promote ${{ matrix.distrib }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (clear-branch-cache)
+#   clear-branch-cache:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, deliver]
+#     env:
+#       GH_TOKEN: ${{ github.event.pull_request.head.repo.fork == true && github.token || secrets.PERSONAL_ACCESS_TOKEN }}
+#     if: |
+#       needs.get-environment.outputs.is_nightly == 'true' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: List and delete cache
+#         env:
+#           REF_NAME: ${{ github.ref_name }}
+#         run: |
+#           mapfile -t cache_keys < <(gh cache list --ref "refs/heads/$REF_NAME" --json key -q '.[] | .key')
+#           echo $cache_keys
+#           while read row; do
+#             gh cache delete $row
+#             echo "Cache $row was deleted."
+#           done <<< "$cache_keys"
+#         shell: bash
 
-      - name: Promote ${{ matrix.distrib }} to stable on Artifactory
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: web
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (create-jira-nightly-ticket)
+#   create-jira-nightly-ticket:
+#     runs-on: ubuntu-24.04
+#     needs: [
+#       get-environment,
+#       deliver
+#     ]
+#     if: |
+#       needs.get-environment.outputs.is_nightly == 'true' && github.run_attempt == 1 &&
+#       (failure() || cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) &&
+#       startsWith(github.ref_name, 'dev') &&
+#       github.event.pull_request.head.repo.fork != true
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Create Jira ticket based on nightly build failure
+#         uses: ./.github/actions/create-jira-ticket
+#         with:
+#           jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#           jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#           jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+#           module_name: "centreon-web"
+#           ticket_reason_for_creation: "Nightly"
 
-  set-skip-label:
-    needs: [get-environment, deliver, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-pulp)
+#   deliver-pulp:
+#     continue-on-error: true
+#     runs-on: centreon-ubuntu-22.04
+#     needs:
+#       [
+#         changes,
+#         get-environment,
+#         e2e-test
+#       ]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       github.event.pull_request.head.repo.fork != true
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: web
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-  clear-branch-cache:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, deliver]
-    env:
-      GH_TOKEN: ${{ github.event.pull_request.head.repo.fork == true && github.token || secrets.PERSONAL_ACCESS_TOKEN }}
-    if: |
-      needs.get-environment.outputs.is_nightly == 'true' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: List and delete cache
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          mapfile -t cache_keys < <(gh cache list --ref "refs/heads/$REF_NAME" --json key -q '.[] | .key')
-          echo $cache_keys
-          while read row; do
-            gh cache delete $row
-            echo "Cache $row was deleted."
-          done <<< "$cache_keys"
-        shell: bash
-
-  create-jira-nightly-ticket:
-    runs-on: ubuntu-24.04
-    needs: [
-      get-environment,
-      deliver
-    ]
-    if: |
-      needs.get-environment.outputs.is_nightly == 'true' && github.run_attempt == 1 &&
-      (failure() || cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) &&
-      startsWith(github.ref_name, 'dev') &&
-      github.event.pull_request.head.repo.fork != true
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Create Jira ticket based on nightly build failure
-        uses: ./.github/actions/create-jira-ticket
-        with:
-          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-          jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-          jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-          module_name: "centreon-web"
-          ticket_reason_for_creation: "Nightly"
-
-  deliver-pulp:
-    continue-on-error: true
-    runs-on: centreon-ubuntu-22.04
-    needs:
-      [
-        changes,
-        get-environment,
-        e2e-test
-      ]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      github.event.pull_request.head.repo.fork != true
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: web
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.event.pull_request.head.repo.fork != true
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
-    name: promote ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: web
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.event.pull_request.head.repo.fork != true
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+#     name: promote ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: web
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."


### PR DESCRIPTION
Temporary, revert-marked change for testing the `release-bump-version` workflow.

Comments out every job **downstream of packaging** (dockerize, e2e/robot, API tests, deliver*, promote*, jira) so that **packaging is the terminal job** and nothing is delivered or promoted while we validate version bumps on `release-29.01-next`.

**Revert this PR/commit to restore the full pipeline.**