### PR TITLE
docs(security): clarify intentional SSL peer verification bypass

### DIFF
--- a/centreon/www/class/centreonRestHttp.class.php
+++ b/centreon/www/class/centreonRestHttp.class.php
@@ -109,6 +109,8 @@ class CentreonRestHttp
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
+        // SSL peer verification is intentionally disabled to support self-signed
+        // and internal-CA certificates used in on-premise deployments.
         if ($noCheckCertificate) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
## Summary
- Added a comment on `centreonRestHttp.class.php` to clarify that SSL peer verification is intentionally disabled to support self-signed and internal-CA certificates in on-premise deployments.

## Context
SAST flagged `CURLOPT_SSL_VERIFYPEER = false` as a security issue. This is expected behavior — Centreon is deployed in environments that use self-signed or internal-CA certificates for inter-component communication.