### PR TITLE
test(e2e): web: cover Event Logs ACL visibility (dev-24.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Logs/07-event-log-acl.feature
+++ b/centreon/tests/e2e/features/Logs/07-event-log-acl.feature
@@ -1,0 +1,19 @@
+@MON-159125
+Feature: Event Logs visibility restricted by ACL
+  As a Centreon administrator
+  I want the Event Logs page to respect each user's resource access ACL
+  So that a restricted user only sees the events of the resources they are allowed to access
+
+  Background:
+    Given an administrator is logged in
+    And monitored resources have generated events
+    And a restricted user is granted access to the Event Logs menu only
+
+  Scenario: A restricted user without resource access sees no events
+    When the restricted user opens the Event Logs page
+    Then no event is displayed to the restricted user
+
+  Scenario: A restricted user sees only the events of the resources granted by ACL
+    Given the restricted user is granted access to specific resources
+    When the restricted user opens the Event Logs page
+    Then only the events of the granted resources are displayed to the restricted user

--- a/centreon/tests/e2e/features/Logs/07-event-log-acl/index.ts
+++ b/centreon/tests/e2e/features/Logs/07-event-log-acl/index.ts
@@ -1,0 +1,133 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { INTERCEPTORS } from 'e2e/fixtures/shared/constants/interceptors';
+
+import {
+  checkHostsAreMonitored,
+  checkServicesAreMonitored
+} from '../../../commons';
+import {
+  openEventLogsPageAsRestrictedUser,
+  openHostFilterDropdown
+} from '../common';
+
+const serviceTemplate = 'SNMP-Linux-Load-Average';
+
+const monitoredHosts = {
+  denied: { hostName: 'host-denied', serviceName: 'service-denied' },
+  granted: { hostName: 'host-granted', serviceName: 'service-granted' }
+};
+
+const baseAclProfile = 'resources/clapi/config-ACL/event-logs-acl-user.json';
+const resourceAclProfile =
+  'resources/clapi/config-ACL/event-logs-acl-resource.json';
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: INTERCEPTORS.api.navigation_list
+  }).as('getNavigationList');
+  cy.intercept({
+    method: 'GET',
+    url: INTERCEPTORS.pages.time_zone
+  }).as('getTimeZone');
+});
+
+Given('an administrator is logged in', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin', loginViaApi: true });
+});
+
+Given('monitored resources have generated events', () => {
+  cy.setUserTokenApiV1();
+
+  cy.addHost({
+    hostGroup: 'Linux-Servers',
+    name: monitoredHosts.granted.hostName,
+    template: 'generic-host'
+  }).addService({
+    activeCheckEnabled: false,
+    host: monitoredHosts.granted.hostName,
+    maxCheckAttempts: 1,
+    name: monitoredHosts.granted.serviceName,
+    template: serviceTemplate
+  });
+
+  cy.addHost({
+    hostGroup: 'Linux-Servers',
+    name: monitoredHosts.denied.hostName,
+    template: 'generic-host'
+  })
+    .addService({
+      activeCheckEnabled: false,
+      host: monitoredHosts.denied.hostName,
+      maxCheckAttempts: 1,
+      name: monitoredHosts.denied.serviceName,
+      template: serviceTemplate
+    })
+    .applyPollerConfiguration();
+
+  checkHostsAreMonitored([
+    { name: monitoredHosts.granted.hostName },
+    { name: monitoredHosts.denied.hostName }
+  ]);
+  checkServicesAreMonitored([
+    { name: monitoredHosts.granted.serviceName },
+    { name: monitoredHosts.denied.serviceName }
+  ]);
+
+  cy.submitResults([
+    {
+      host: monitoredHosts.granted.hostName,
+      output: 'submit_status_2',
+      service: monitoredHosts.granted.serviceName,
+      status: 'critical'
+    },
+    {
+      host: monitoredHosts.denied.hostName,
+      output: 'submit_status_2',
+      service: monitoredHosts.denied.serviceName,
+      status: 'critical'
+    }
+  ]);
+
+  checkServicesAreMonitored([
+    { name: monitoredHosts.granted.serviceName, status: 'critical' },
+    { name: monitoredHosts.denied.serviceName, status: 'critical' }
+  ]);
+});
+
+Given('a restricted user is granted access to the Event Logs menu only', () => {
+  cy.applyAclProfile(baseAclProfile);
+});
+
+Given('the restricted user is granted access to specific resources', () => {
+  cy.applyAclProfile(resourceAclProfile);
+});
+
+When('the restricted user opens the Event Logs page', () => {
+  openEventLogsPageAsRestrictedUser();
+});
+
+Then('no event is displayed to the restricted user', () => {
+  openHostFilterDropdown();
+
+  cy.getIframeBody()
+    .find('.select2-results-header__nb-elements-value')
+    .should('have.text', '0');
+});
+
+Then(
+  'only the events of the granted resources are displayed to the restricted user',
+  () => {
+    openHostFilterDropdown();
+
+    cy.getIframeBody()
+      .find('ul.select2-results__options')
+      .should('contain.text', monitoredHosts.granted.hostName)
+      .and('not.contain.text', monitoredHosts.denied.hostName);
+  }
+);
+
+afterEach(() => {
+  cy.stopContainers();
+});

--- a/centreon/tests/e2e/features/Logs/common.ts
+++ b/centreon/tests/e2e/features/Logs/common.ts
@@ -1,0 +1,20 @@
+import { PAGES } from 'e2e/fixtures/shared/constants/pages';
+
+const restrictedUserFixture = 'event-logs-restricted-user';
+
+const openEventLogsPageAsRestrictedUser = (): void => {
+  cy.logout();
+  cy.loginByTypeOfUser({ jsonName: restrictedUserFixture, loginViaApi: false });
+  cy.visit(PAGES.monitoring.eventLogsLegacy);
+  cy.wait('@getTimeZone');
+  cy.waitForElementInIframe('#main-content', 'select#host_filter');
+};
+
+const openHostFilterDropdown = (): void => {
+  cy.getIframeBody()
+    .find('select#host_filter')
+    .siblings('span.select2-container')
+    .click();
+};
+
+export { openEventLogsPageAsRestrictedUser, openHostFilterDropdown };

--- a/centreon/tests/e2e/fixtures/resources/clapi/config-ACL/event-logs-acl-resource.json
+++ b/centreon/tests/e2e/fixtures/resources/clapi/config-ACL/event-logs-acl-resource.json
@@ -1,0 +1,22 @@
+[
+    {
+        "action": "ADD",
+        "object": "ACLRESOURCE",
+        "values": "name=event-logs-ACLRESOURCE;acl_group=event-logs-ACLGROUP"
+    },
+    {
+        "action": "ADDRESOURCE",
+        "object": "ACLGROUP",
+        "values": "event-logs-ACLGROUP;name=event-logs-ACLRESOURCE"
+    },
+    {
+        "action": "GRANT_HOST",
+        "object": "ACLRESOURCE",
+        "values": "name=event-logs-ACLRESOURCE;host-granted"
+    },
+    {
+        "action": "RELOAD",
+        "object": "ACL",
+        "values": ""
+    }
+]

--- a/centreon/tests/e2e/fixtures/resources/clapi/config-ACL/event-logs-acl-user.json
+++ b/centreon/tests/e2e/fixtures/resources/clapi/config-ACL/event-logs-acl-user.json
@@ -1,0 +1,37 @@
+[
+    {
+        "action": "ADD",
+        "object": "CONTACT",
+        "values": "event-logs-acl-user;event-logs-acl-user;event-logs-acl-user@centreon.test;Centreon!2021User;0;1;en_US;local"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLGROUP",
+        "values": "event-logs-ACLGROUP;event-logs-ACLGROUP"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLMENU",
+        "values": "event-logs-ACLMENU;event-logs-ACLMENU"
+    },
+    {
+        "action": "GRANTRO",
+        "object": "ACLMENU",
+        "values": "event-logs-ACLMENU;1;Monitoring;Event Logs"
+    },
+    {
+        "action": "ADDMENU",
+        "object": "ACLGROUP",
+        "values": "event-logs-ACLGROUP;event-logs-ACLMENU"
+    },
+    {
+        "action": "SETCONTACT",
+        "object": "ACLGROUP",
+        "values": "event-logs-ACLGROUP;event-logs-acl-user"
+    },
+    {
+        "action": "RELOAD",
+        "object": "ACL",
+        "values": ""
+    }
+]

--- a/centreon/tests/e2e/fixtures/shared/constants/pages.ts
+++ b/centreon/tests/e2e/fixtures/shared/constants/pages.ts
@@ -60,6 +60,7 @@ export const PAGES = {
     dashboards: '/centreon/home/dashboards',
     dashboardsLibrary: '/centreon/home/dashboards/library',
     downtimesLegacy: '/centreon/main.php?p=21001',
+    eventLogsLegacy: '/centreon/main.php?p=20301',
     recurrentDowntimesLegacy: '/centreon/main.php?p=21003',
     performancesGraphsLegacy: '/centreon/main.php?p=20401',
     virtualMetricsLegacy: '/centreon/main.php?p=20408',

--- a/centreon/tests/e2e/fixtures/users/event-logs-restricted-user.json
+++ b/centreon/tests/e2e/fixtures/users/event-logs-restricted-user.json
@@ -1,0 +1,4 @@
+{
+  "login": "event-logs-acl-user",
+  "password": "Centreon!2021User"
+}

--- a/centreon/tests/e2e/support/commands.ts
+++ b/centreon/tests/e2e/support/commands.ts
@@ -21,6 +21,9 @@ import '../features/Resources-status/commands';
 import '../features/Commands/commands';
 import '../features/Macros/commands';
 
+import type { ActionClapi } from '../commons';
+
+
 Cypress.Commands.add('refreshListing', (): Cypress.Chainable => {
   return cy.get(refreshButton).click();
 });
@@ -77,6 +80,19 @@ Cypress.Commands.add('removeACL', (): Cypress.Chainable => {
     });
   });
 });
+
+Cypress.Commands.add(
+  'applyAclProfile',
+  (fixturePath: string): Cypress.Chainable => {
+    cy.fixture(fixturePath).then((actions: Array<ActionClapi>) => {
+      actions.forEach((action) => {
+        cy.executeActionViaClapi({ bodyContent: action });
+      });
+    });
+
+    return cy.applyAcl();
+  }
+);
 
 interface Serviceparams {
   name: string;
@@ -135,6 +151,7 @@ interface HtmlElt {
 declare global {
   namespace Cypress {
     interface Chainable {
+      applyAclProfile: (fixturePath: string) => Cypress.Chainable;
       disableListingAutoRefresh: () => Cypress.Chainable;
       isInProfileMenu: (targetedMenu: string) => Cypress.Chainable;
       loginKeycloak: (jsonName: string) => Cypress.Chainable;


### PR DESCRIPTION
Backport of #11137 to `dev-24.10.x`.

Fixes: [MON-205793](https://centreon.atlassian.net/browse/MON-205793)

Adds the Event Logs ACL E2E regression test (a restricted user only sees the events of the resources granted by their ACL). See #11137 for the full description.

Note: import paths use the `e2e/` prefix (`e2e/fixtures/...`) as required by the 24.10 e2e tsconfig `baseUrl`.


[MON-205793]: https://centreon.atlassian.net/browse/MON-205793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ