### PR TITLE
feat(branding): rename tagline and add dynamic per-page browser title

### DIFF
--- a/centreon/www/front_src/public/index.html
+++ b/centreon/www/front_src/public/index.html
@@ -15,7 +15,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Centreon - IT & Network Monitoring</title>
+    <title>Centreon Infrastructure Monitoring</title>
   </head>
   <body>
     <noscript>

--- a/centreon/www/front_src/src/BreadcrumbTrail/index.tsx
+++ b/centreon/www/front_src/src/BreadcrumbTrail/index.tsx
@@ -7,7 +7,7 @@ import { IconButton, Tooltip } from '@centreon/ui/components';
 
 import { useAtomValue } from 'jotai';
 import { isNil, pluck } from 'ramda';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
@@ -137,15 +137,24 @@ const Breadcrumbs = (): JSX.Element | null => {
   const navigation = useAtomValue(navigationAtom);
   const { pathname } = router.useLocation();
 
+  const breadcrumbsByPath = navigation
+    ? getBreadcrumbsByPath(navigation.result)
+    : {};
+  const breadcrumbs = getBreadcrumbs({ breadcrumbsByPath, path: pathname });
+
+  useEffect(() => {
+    const currentPageLabel = breadcrumbs[breadcrumbs.length - 1]?.label;
+    document.title = currentPageLabel
+      ? `${currentPageLabel} - Centreon Infrastructure Monitoring`
+      : 'Centreon Infrastructure Monitoring';
+  }, [breadcrumbs]);
+
   if (isNil(navigation)) {
     return null;
   }
 
   return (
-    <BreadcrumbTrail
-      breadcrumbsByPath={getBreadcrumbsByPath(navigation.result)}
-      path={pathname}
-    />
+    <BreadcrumbTrail breadcrumbsByPath={breadcrumbsByPath} path={pathname} />
   );
 };
 

--- a/centreon/www/front_src/src/Main/index.tsx
+++ b/centreon/www/front_src/src/Main/index.tsx
@@ -62,6 +62,10 @@ const Main = (): JSX.Element => {
   });
 
   useEffect(() => {
+    document.title = 'Centreon Infrastructure Monitoring';
+  }, []);
+
+  useEffect(() => {
     if (isNil(platformInstallationStatus) || isNil(areUserParametersLoaded)) {
       return;
     }

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2026 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,12 @@ $versionParam = isset($centreon->informations) && isset($centreon->informations[
     ? '?version=' . $centreon->informations['version']
     : '';
 
+$brandName = 'Centreon Infrastructure Monitoring';
+$pageTitle = (isset($redirect) && is_array($redirect) && ! empty($redirect['topology_name']))
+    ? $redirect['topology_name'] . ' - ' . $brandName
+    : $brandName;
+$pageTitle = htmlspecialchars($pageTitle, ENT_QUOTES, 'UTF-8');
+
 echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
 
 $variablesThemeCSS  = 'Centreon-Light';
@@ -50,10 +56,10 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $centreon->user->lang; ?>">
-    <title>Centreon - IT & Network Monitoring</title>
+    <title><?php echo $pageTitle; ?></title>
     <link rel="shortcut icon" href="./img/favicon.ico"/>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2021 Open Source Matters. All rights reserved."/>
+    <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2026 Open Source Matters. All rights reserved."/>
     <meta name="robots" content="index, nofollow"/>
 
     <?php if (isset($isMobile) && $isMobile) { ?>


### PR DESCRIPTION
## Summary

- Renames the app's brand tagline from **"Centreon - IT & Network Monitoring"** to **"Centreon Infrastructure Monitoring"**.
- Introduces a dynamic browser tab title, formatted **"{Page Name} - Centreon Infrastructure Monitoring"**. There was no per-page title before — every page showed the exact same static string regardless of what was open, which makes it hard to tell tabs apart when several pages are open at once (a common pattern for this kind of ops tool). Page name first, brand suffix after, since browser tabs truncate from the right and the distinguishing part should stay visible.

## What changed

### React SPA (controls the tab title for the vast majority of navigation — legacy pages render inside an iframe within the SPA shell, so an iframe's own `<title>` doesn't reach the actual browser tab)

- **`www/front_src/src/BreadcrumbTrail/index.tsx`**: the `Breadcrumbs` component is already mounted on every authenticated route (internal pages, dashboards, and federated/external modules alike — see `components/ReactRouter/index.tsx`) and already computes the current page's breadcrumb trail for the visible breadcrumb UI. Reused that exact same `breadcrumbs` array: a `useEffect` now sets `document.title` from the last (deepest/current) breadcrumb's `label`, falling back to the plain brand name if there's no breadcrumb for the current path.
- **`www/front_src/src/Main/index.tsx`**: sets the plain brand name as a default/fallback title on mount, covering routes that don't render `BreadcrumbTrail` (login, public pages).
- **`www/front_src/public/index.html`**: updated the static pre-JS title (shown before React mounts).

### Legacy PHP

- **`www/include/core/header/htmlHeader.php`**: `main.get.php` already resolves the current page's `topology_name` from the DB into `$redirect` before including this file (`$redirect = $loadTopology((int) $p);`, line 122, then `include_once` at line 236 — plain include, so the variable is in scope). Built the title from `$redirect['topology_name']` when available, escaped via `htmlspecialchars()`, falling back to the plain brand name otherwise (e.g. ACL-denied or feature-flag-disabled pages, where `$redirect` is `false`). This mainly matters for mobile view and any direct/bookmarked hit of a legacy page outside the SPA iframe — most desktop navigation is governed by the React-side fix above.
- Also bumped the copyright year in this file's license header and `Generator` meta tag (2005 - 2026), noticed while in there.

## Why this approach

Investigated the existing navigation/breadcrumb machinery before adding anything new — `BreadcrumbTrail` already had 100% of the data needed (the current page's human-readable name, in the exact right order), so this reuses it rather than introducing a new atom, hook, or route-to-label mapping. No new dependencies, no new state.

## How to test

1. Navigate between two different pages (e.g. Resources → Host Groups) and watch the browser tab title update to match each page's name.
2. Hit `/login` or a `/public/...` URL directly and confirm the tab shows just "Centreon Infrastructure Monitoring" (no page-name prefix).
3. For the legacy PHP side: load a page in mobile view (or hit a legacy page directly, outside the SPA shell) and confirm the same title logic applies.

Verified:
- `pnpm type-check` passes clean across the whole app.
- `pnpm biome check` passes clean on both touched React files.
- Existing Jest suite for `Main` (`Main/index.test.tsx`) passes.
- The PHP title-computation logic was unit-verified standalone (topology name present / `$redirect` false / `$redirect` unset / special characters requiring escaping) — all four cases produce the expected title.

## Scope

Only touches title-setting logic and the static tagline string. No change to routing, navigation data, ACL, or any other behavior.
