### PR TITLE
fix(config-generate): stop hardcoding engine-context.json path and regenerate it if missing

### DIFF
--- a/centreon/www/class/config-generate/abstract/object.class.php
+++ b/centreon/www/class/config-generate/abstract/object.class.php
@@ -101,16 +101,26 @@ abstract class AbstractObject
         $this->backend_instance = Backend::getInstance($this->dependencyInjector);
         $this->engineContextEncryption = $this->kernel->getContainer()->get(EncryptionInterface::class);
 
-        $engineContext = file_get_contents('/etc/centreon-engine/engine-context.json');
+        $engineContextPath = $this->backend_instance->getEngineContextFilePath();
+
         try {
             $this->getVaultConfigurationStatus();
+
+            if (! is_file($engineContextPath) || filesize($engineContextPath) === 0) {
+                file_put_contents($engineContextPath, json_encode([
+                    'app_secret' => $this->kernel->getContainer()->getParameter('kernel.secret'),
+                    'salt' => $this->engineContextEncryption->generateRandomString(),
+                ], JSON_THROW_ON_ERROR));
+            }
+
+            $engineContext = file_get_contents($engineContextPath);
             if ($engineContext === false || empty($engineContext)) {
                 CentreonLog::create()->error(
                     logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-                    message: "Unable to parse content of '/etc/centreon-engine/engine-context.json'"
+                    message: "Unable to parse content of '{$engineContextPath}'"
                 );
 
-                throw new RuntimeException('/etc/centreon/engine-context.json does not exists or is empty');
+                throw new RuntimeException("{$engineContextPath} does not exist or is empty");
             }
             $engineContext = json_decode($engineContext, true, flags: JSON_THROW_ON_ERROR);
             $this->engineContextEncryption->setFirstKey($engineContext['app_secret']);
@@ -118,7 +128,7 @@ abstract class AbstractObject
         } catch (JsonException|RuntimeException $ex) {
             CentreonLog::create()->error(
                 logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-                message: "Unable to parse content of '/etc/centreon-engine/engine-context.json'",
+                message: "Unable to parse content of '{$engineContextPath}'",
                 exception: $ex
             );
 

--- a/centreon/www/class/config-generate/abstract/objectJSON.class.php
+++ b/centreon/www/class/config-generate/abstract/objectJSON.class.php
@@ -68,23 +68,34 @@ abstract class AbstractObjectJSON
         $this->dependencyInjector = $dependencyInjector;
         $this->backend_instance = Backend::getInstance($this->dependencyInjector);
         $this->engineContextEncryption = $this->kernel->getContainer()->get(EncryptionInterface::class);
-        $engineContext = file_get_contents('/etc/centreon-engine/engine-context.json');
+
+        $engineContextPath = $this->backend_instance->getEngineContextFilePath();
+
         try {
             $this->getVaultConfigurationStatus();
+
+            if (! is_file($engineContextPath) || filesize($engineContextPath) === 0) {
+                file_put_contents($engineContextPath, json_encode([
+                    'app_secret' => $this->kernel->getContainer()->getParameter('kernel.secret'),
+                    'salt' => $this->engineContextEncryption->generateRandomString(),
+                ], JSON_THROW_ON_ERROR));
+            }
+
+            $engineContext = file_get_contents($engineContextPath);
             if ($engineContext === false || empty($engineContext)) {
                 CentreonLog::create()->error(
                     logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-                    message: "Unable to parse content of '/etc/centreon-engine/engine-context.json'"
+                    message: "Unable to parse content of '{$engineContextPath}'"
                 );
 
-                throw new RuntimeException('/etc/centreon/engine-context.json does not exists or is empty');
+                throw new RuntimeException("{$engineContextPath} does not exist or is empty");
             }
             $engineContext = json_decode($engineContext, true, flags: JSON_THROW_ON_ERROR);
             $this->engineContextEncryption->setSecondKey($engineContext['salt']);
         } catch (JsonException|RuntimeException $ex) {
             CentreonLog::create()->error(
                 logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-                message: "Unable to parse content of '/etc/centreon-engine/engine-context.json'",
+                message: "Unable to parse content of '{$engineContextPath}'",
                 exception: $ex
             );
 

--- a/centreon/www/class/config-generate/backend.class.php
+++ b/centreon/www/class/config-generate/backend.class.php
@@ -78,6 +78,9 @@ class Backend
     /** @var string|null */
     private $central_poller_id = null;
 
+    /** @var string|null */
+    private $engine_context_file_path = null;
+
     /**
      * Backend constructor
      *
@@ -275,6 +278,30 @@ class Backend
         }
 
         throw new Exception('Cannot get central poller id');
+    }
+
+    /**
+     * @throws PDOException
+     * @return string
+     */
+    public function getEngineContextFilePath()
+    {
+        if (! is_null($this->engine_context_file_path)) {
+            return $this->engine_context_file_path;
+        }
+        $stmt = $this->db->prepare('SELECT cfg_dir FROM cfg_nagios WHERE nagios_server_id = :pollerId');
+        $stmt->bindValue(':pollerId', $this->getCentralPollerId(), PDO::PARAM_INT);
+        $stmt->execute();
+        if ($stmt->rowCount()) {
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (! empty($row['cfg_dir'])) {
+                $this->engine_context_file_path = rtrim($row['cfg_dir'], '/') . '/engine-context.json';
+
+                return $this->engine_context_file_path;
+            }
+        }
+
+        throw new Exception('Cannot get cfg_dir for the central poller');
     }
 
     /**


### PR DESCRIPTION
## Summary

`AbstractObject` and `AbstractObjectJSON` (the base classes for every `www/class/config-generate/*` object used during configuration export) both hardcoded the path `/etc/centreon-engine/engine-context.json` to read the encryption context (`app_secret` + `salt`) used during config generation. This assumes the local poller's Engine config directory is always the default location — it isn't guaranteed to be: `cfg_dir` is a user-configurable column (`cfg_nagios.cfg_dir`, editable from **Configuration > Pollers**). If an admin points the local poller's config directory somewhere else, this file would never be found.

Additionally, if the file was missing or empty, both classes just threw an error — there was no recovery path outside of the install wizard.

## What changed

### `www/class/config-generate/backend.class.php`

Added `Backend::getEngineContextFilePath()`, following the exact same cached-lookup pattern already used by the neighboring `getCentralPollerId()`:
- Resolves the local poller's id (`getCentralPollerId()`, already reused as-is).
- Looks up its actual configured `cfg_dir` (`SELECT cfg_dir FROM cfg_nagios WHERE nagios_server_id = :pollerId` — the exact same query already used in `www/class/centreon-clapi/centreon.Config.Poller.class.php` to decide where this file actually lives when it's synced there).
- Caches the computed path on the instance, same as `getCentralPollerId()` does.

### `www/class/config-generate/abstract/object.class.php` and `abstract/objectJSON.class.php`

- Both constructors now call `$this->backend_instance->getEngineContextFilePath()` instead of hardcoding the literal path.
- **If the file is missing or empty, it's now regenerated on the spot** (fresh `app_secret` from `kernel.secret` + a random salt via the existing `EncryptionInterface::generateRandomString()`) instead of throwing immediately — matching the exact same recovery behavior already used at install time in `www/install/steps/process/createEngineContextConfiguration.php` (`if (! $engineRepository->engineSecretsHasContent()) { $installationHelper->writeEngineContextFile(); }`), just inlined here since these legacy classes aren't wired to that same DI service.
- As a side effect, this also fixes a pre-existing inconsistency: the error log message referenced `/etc/centreon-engine/...` while the thrown exception's message referenced the wrong `/etc/centreon/...` (missing `-engine`) — both now reference the same actual computed path.

## Why this approach

Investigated whether the modern `Core\Engine\Application\Repository\EngineRepositoryInterface` / `FsEngineRepository` (added in a previous change, already used at install time) could just be reused via the DI container here. It can't, as-is: that service is wired with a **static** Symfony parameter (`engine_context_path` in `config/services.yaml`), so pulling it from the container wouldn't actually fix the underlying bug — it would just move the same hardcoded assumption up one layer. The `cfg_dir`-derived path has to be computed dynamically per-request, which is why the fix lives in `Backend` (already instantiated by both classes) rather than swapping in the DI-wired repository.

## How to test

Verified directly against a real environment where `/etc/centreon-engine/engine-context.json` didn't exist yet:
1. `Backend::getEngineContextFilePath()` correctly resolved to the poller's actual configured `cfg_dir` + `/engine-context.json` (confirmed via the DB, not a guess).
2. Instantiating a config-generate object (e.g. `Timezone::getInstance($dependencyInjector)`) with the file missing: constructed successfully, and the file was created afterward with valid `app_secret`/`salt` JSON content.
3. Running it a second time with the file now present: constructed successfully without modifying the existing file (verified via `md5sum` before/after — unchanged), confirming it doesn't clobber an existing context.
4. `php -l` clean on all three modified files.

## Scope

Only touches how the engine-context path is resolved and the missing-file recovery behavior. No change to what the file contains, how it's consumed elsewhere (`FsEngineRepository`, `bin/writeEngineSecrets.sh` are untouched), or any other config-generation logic.
