### PR TITLE
enh(poller): sync gorgone nodes on pullwss save

### DIFF
--- a/centreon/src/Centreon/Domain/Gorgone/Command/NodesSync.php
+++ b/centreon/src/Centreon/Domain/Gorgone/Command/NodesSync.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Centreon\Domain\Gorgone\Command;
+
+use Centreon\Domain\Gorgone\Interfaces\CommandInterface;
+use LogicException;
+
+/**
+ * Tells the Gorgone `centreon` module to re-sync its list of connected nodes.
+ * Sent after a poller is provisioned in pullwss mode so the central picks it up
+ * immediately.
+ *
+ * Not scoped to a specific poller: the URI is a static endpoint. The
+ * monitoringInstanceId inherited from AbstractCommand is therefore unused —
+ * getMonitoringInstanceId() throws to prevent any downstream code (e.g.
+ * ResponseRepositoryAPI, which builds /api/nodes/{id}/log/...) from silently
+ * hitting /api/nodes/0/... with the sentinel value.
+ */
+final class NodesSync extends AbstractCommand implements CommandInterface
+{
+    private const NAME = 'centreon::nodes::sync';
+    private const URI = 'centreon/nodes/sync';
+
+    public function __construct()
+    {
+        // The 0 monitoring-instance id is a sentinel — see getMonitoringInstanceId().
+        parent::__construct(0, '{}');
+    }
+
+    public function getUriRequest(): string
+    {
+        return self::URI;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function getMethod(): string
+    {
+        return self::METHOD_POST;
+    }
+
+    public function getMonitoringInstanceId(): int
+    {
+        throw new LogicException(
+            'NodesSync is not scoped to a poller: getMonitoringInstanceId() must not be called.',
+        );
+    }
+}

--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -500,24 +500,6 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             return ['error' => true, 'message' => $e->getMessage()];
         }
 
-        if (! $isRemoteConnection && ($this->arguments['gorgone_pull_wss'] ?? false) === true) {
-            // Notify the Gorgone `centreon` module that a new PullWSS poller was added.
-            // Fire-and-forget: any failure must not prevent the poller from being created.
-            try {
-                Kernel::createForWeb()
-                    ->getContainer()
-                    ->get(GorgoneServiceInterface::class)
-                    ->send(new NodesSync());
-            } catch (Throwable $exception) {
-                CentreonLog::create()->warning(
-                    CentreonLog::TYPE_BUSINESS_LOG,
-                    'Failed to trigger Gorgone nodes sync',
-                    ['source' => 'poller_wizard', 'poller_id' => $serverId],
-                    $exception,
-                );
-            }
-        }
-
         $taskId = null;
 
         // if it is remote server wizard, create an export task and link pollers to it if needed
@@ -589,6 +571,22 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
             ]);
+        }
+
+        if (! $isRemoteConnection && ($this->arguments['gorgone_pull_wss'] ?? false) === true) {
+            try {
+                Kernel::createForWeb()
+                    ->getContainer()
+                    ->get(GorgoneServiceInterface::class)
+                    ->send(new NodesSync());
+            } catch (Throwable $exception) {
+                CentreonLog::create()->warning(
+                    CentreonLog::TYPE_BUSINESS_LOG,
+                    'Failed to trigger Gorgone nodes sync',
+                    ['source' => 'poller_wizard', 'poller_id' => $serverId],
+                    $exception,
+                );
+            }
         }
 
         // Update session to reload ACL

--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -21,9 +21,13 @@
 
 namespace CentreonRemote\Application\Webservice;
 
+use App\Kernel;
 use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Centreon\Domain\Entity\Task;
+use Centreon\Domain\Gorgone\Command\NodesSync;
+use Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface;
 use Centreon\Domain\PlatformTopology\Model\PlatformPending;
+use CentreonLog;
 use CentreonRemote\Application\Validator\WizardConfigurationRequestValidator;
 use CentreonRemote\Domain\Resources\RemoteConfig\NagiosServer;
 use CentreonRemote\Domain\Service\ConfigurationWizard\{
@@ -31,6 +35,7 @@ use CentreonRemote\Domain\Service\ConfigurationWizard\{
     RemoteConnectionConfigurationService
 };
 use CentreonRemote\Domain\Value\ServerWizardIdentity;
+use Throwable;
 use Webmozart\Assert\InvalidArgumentException;
 
 /**
@@ -493,6 +498,24 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $serverId = $serverConfigurationService->insert();
         } catch (\Exception $e) {
             return ['error' => true, 'message' => $e->getMessage()];
+        }
+
+        if (! $isRemoteConnection && ($this->arguments['gorgone_pull_wss'] ?? false) === true) {
+            // Notify the Gorgone `centreon` module that a new PullWSS poller was added.
+            // Fire-and-forget: any failure must not prevent the poller from being created.
+            try {
+                Kernel::createForWeb()
+                    ->getContainer()
+                    ->get(GorgoneServiceInterface::class)
+                    ->send(new NodesSync());
+            } catch (Throwable $exception) {
+                CentreonLog::create()->warning(
+                    CentreonLog::TYPE_BUSINESS_LOG,
+                    'Failed to trigger Gorgone nodes sync',
+                    ['source' => 'poller_wizard', 'poller_id' => $serverId],
+                    $exception,
+                );
+            }
         }
 
         $taskId = null;

--- a/centreon/tests/php/Centreon/Domain/Gorgone/Command/NodesSyncTest.php
+++ b/centreon/tests/php/Centreon/Domain/Gorgone/Command/NodesSyncTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Centreon\Domain\Gorgone\Command;
+
+use Centreon\Domain\Gorgone\Command\NodesSync;
+use Centreon\Domain\Gorgone\Interfaces\CommandInterface;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class NodesSyncTest extends TestCase
+{
+    private NodesSync $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new NodesSync();
+    }
+
+    public function testUriPointsAtCentreonNodesSyncEndpoint(): void
+    {
+        self::assertSame('centreon/nodes/sync', $this->command->getUriRequest());
+    }
+
+    public function testNameMatchesTheGorgoneCentreonModuleAction(): void
+    {
+        self::assertSame('centreon::nodes::sync', $this->command->getName());
+    }
+
+    public function testMethodIsPost(): void
+    {
+        self::assertSame(CommandInterface::METHOD_POST, $this->command->getMethod());
+    }
+
+    public function testBodyIsAnEmptyJsonObject(): void
+    {
+        self::assertSame('{}', $this->command->getBodyRequest());
+    }
+
+    public function testGetMonitoringInstanceIdThrowsBecauseTheCommandIsNotPerPoller(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->command->getMonitoringInstanceId();
+    }
+}

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -22,6 +22,8 @@
 use App\Kernel;
 use App\MonitoringConfiguration\Infrastructure\Service\SnowflakePollerUidGenerator;
 use App\Shared\Domain\Assert\Assert;
+use Centreon\Domain\Gorgone\Command\NodesSync;
+use Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface;
 use Centreon\Domain\PlatformTopology\Model\PlatformRegistered;
 use Core\AgentConfiguration\Application\UseCase\DeployDefaultAgentConfigurationForPoller\DeployDefaultAgentConfigurationForPoller;
 use Core\AgentConfiguration\Application\UseCase\DeployDefaultAgentConfigurationForPoller\DeployDefaultAgentConfigurationForPollerRequest;
@@ -46,6 +48,40 @@ const GORGONE_DEFAULT_PORTS = [
     PULL => 5556,
     PULLWSS => 8086,
 ];
+
+/**
+ * Notify the Gorgone `centreon` module that the list of connected nodes changed.
+ * Called after nagios_server insert/update. No-op unless
+ * gorgone_communication_type is PullWSS. Fire-and-forget: any failure is
+ * logged and swallowed so a Gorgone outage cannot break the poller save.
+ *
+ * @param int|string|null $gorgoneCommunicationType raw value from the poller form
+ *                                                  (nagios_server.gorgone_communication_type).
+ *                                                  Expected to be one of ZMQ|SSH|PULL|PULLWSS or null;
+ *                                                  any non-numeric string casts to 0 and is treated
+ *                                                  as "not PullWSS".
+ * @param int|null $pollerId identifier of the server just persisted, used as log context
+ */
+function triggerGorgoneNodesSyncIfPullwss($gorgoneCommunicationType, ?int $pollerId = null): void
+{
+    if ((int) $gorgoneCommunicationType !== PULLWSS) {
+        return;
+    }
+
+    try {
+        Kernel::createForWeb()
+            ->getContainer()
+            ->get(GorgoneServiceInterface::class)
+            ->send(new NodesSync());
+    } catch (Throwable $exception) {
+        CentreonLog::create()->warning(
+            CentreonLog::TYPE_BUSINESS_LOG,
+            'Failed to trigger Gorgone nodes sync',
+            ['source' => 'poller_form', 'poller_id' => $pollerId],
+            $exception,
+        );
+    }
+}
 
 /**
  * Retrieve the next available suffixes for this server name from database
@@ -556,6 +592,11 @@ function insertServerInDB(array $data): int
         $deployAgentConfiguration($request);
     }
     addUserRessource($id);
+
+    triggerGorgoneNodesSyncIfPullwss(
+        $data['gorgone_communication_type']['gorgone_communication_type'] ?? null,
+        $id,
+    );
 
     return $id;
 }
@@ -1098,6 +1139,11 @@ function updateServer(int $id, array $data): void
         $instanceObj = new CentreonInstance($pearDB);
         $instanceObj->setCommands($id, $_REQUEST['pollercmd']);
     }
+
+    triggerGorgoneNodesSyncIfPullwss(
+        $data['gorgone_communication_type']['gorgone_communication_type'] ?? null,
+        $id,
+    );
 
     // Prepare value for changelog
     $fields = CentreonLogAction::prepareChanges($data);


### PR DESCRIPTION
## Description

When a poller is saved in PullWSS mode, call Gorgone's `POST /api/centreon/nodes/sync` so the central picks up the new/updated poller immediately. Fires from the wizard and the legacy Add/Edit form. Fire-and-forget: a Gorgone failure logs a warning but never blocks the save.

MON-194407

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
