### PR TITLE
fix(upgrade): correct autodiscovery FK to reference nagios_server.uid

### DIFF
--- a/centreon/www/install/php/Update-26.07.0.php
+++ b/centreon/www/install/php/Update-26.07.0.php
@@ -259,6 +259,8 @@ $migrateModuleTableInstanceIds = function () use ($pearDB, &$errorMessage, $vers
         $pearDB->executeStatement("ALTER TABLE `{$table}` DROP FOREIGN KEY `{$constraint}`");
     }
 
+    $pearDB->executeStatement("ALTER TABLE `{$table}` MODIFY COLUMN `instance_id` BIGINT UNSIGNED NOT NULL");
+
     $pearDB->executeStatement(
         <<<SQL
             UPDATE `{$table}` t
@@ -266,8 +268,6 @@ $migrateModuleTableInstanceIds = function () use ($pearDB, &$errorMessage, $vers
             SET t.`instance_id` = ns.`uid`
             SQL
     );
-
-    $pearDB->executeStatement("ALTER TABLE `{$table}` MODIFY COLUMN `instance_id` BIGINT UNSIGNED NOT NULL");
 
     $pearDB->executeStatement(
         "ALTER TABLE `{$table}` ADD CONSTRAINT `{$constraint}`"

--- a/centreon/www/install/php/Update-26.07.0.php
+++ b/centreon/www/install/php/Update-26.07.0.php
@@ -259,14 +259,20 @@ $migrateModuleTableInstanceIds = function () use ($pearDB, &$errorMessage, $vers
         $pearDB->executeStatement("ALTER TABLE `{$table}` DROP FOREIGN KEY `{$constraint}`");
     }
 
+    $pearDB->executeStatement(
+        <<<SQL
+            UPDATE `{$table}` t
+            INNER JOIN `nagios_server` ns ON ns.`id` = t.`instance_id`
+            SET t.`instance_id` = ns.`uid`
+            SQL
+    );
+
     $pearDB->executeStatement("ALTER TABLE `{$table}` MODIFY COLUMN `instance_id` BIGINT UNSIGNED NOT NULL");
 
-    if ($fkExists) {
-        $pearDB->executeStatement(
-            "ALTER TABLE `{$table}` ADD CONSTRAINT `{$constraint}`"
-            . ' FOREIGN KEY (`instance_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE'
-        );
-    }
+    $pearDB->executeStatement(
+        "ALTER TABLE `{$table}` ADD CONSTRAINT `{$constraint}`"
+        . ' FOREIGN KEY (`instance_id`) REFERENCES `nagios_server` (`uid`) ON DELETE CASCADE'
+    );
 
     CentreonLog::create()->info(
         logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -797,8 +803,8 @@ try {
 
     // DDL statements for configuration database
     $addVmwareUpdatedField();
-    $migrateModuleTableInstanceIds();
     $renamePollerUuidToUid();
+    $migrateModuleTableInstanceIds();
     $addEventScriptLogger();
     $updateBbdoVersionDefault();
     $updateBbdoVersionValues();


### PR DESCRIPTION
## Description

The 26.07 upgrade migration changes `mod_auto_disco_inst_rule_relation.instance_id` to `BIGINT UNSIGNED` but re-creates the FK pointing to `nagios_server(id)` (still `int(11)`), causing MySQL error 3780 on incompatible types. Additionally, the execution order was wrong (`$migrateModuleTableInstanceIds` ran before `$renamePollerUuidToUid`) and existing data was not migrated from `id` to `uid` values.

**Fixes** MON-205872

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Set up a Centreon 26.05 instance with the autodiscovery module installed
2. Verify `mod_auto_disco_inst_rule_relation.instance_id` is `int(11)` with FK to `nagios_server(id)`
3. Run the 26.07 upgrade
4. Verify the upgrade completes without error 3780
5. Verify `mod_auto_disco_inst_rule_relation.instance_id` is now `BIGINT UNSIGNED` with FK to `nagios_server(uid)`
6. Verify the `instance_id` values now contain snowflake UIDs matching `nagios_server.uid`

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).