### PR TITLE
fix(ci): exclude fork PRs from Pulp feature-repository deletion

### DIFF
--- a/.github/workflows/delete-feature-repositories.yml
+++ b/.github/workflows/delete-feature-repositories.yml
@@ -81,7 +81,11 @@ jobs:
 
   delete-pulp-feature-repositories:
     needs: [check-other-feature-prs]
-    if: needs.check-other-feature-prs.outputs.feature_prs_found == 'false'
+    # id-token: write below mints a Pulp OIDC token; never do that for a fork PR,
+    # consistent with the deliver-pulp / promote-pulp guard in web.yml
+    if: |
+      needs.check-other-feature-prs.outputs.feature_prs_found == 'false' &&
+      github.event.pull_request.head.repo.fork != true
     # same runner as the deliver-pulp / promote-pulp jobs: the Pulp api must be
     # reachable from here, and continue-on-error would mask a network failure
     runs-on: centreon-ubuntu-22.04


### PR DESCRIPTION
## Summary
- `delete-pulp-feature-repositories` (in `delete-feature-repositories.yml`) requests `id-token: write` and destroys Pulp repositories/distributions on PR close, but unlike `deliver-pulp`/`promote-pulp` in `web.yml` it had no `github.event.pull_request.head.repo.fork != true` guard.
- Adds the same guard used elsewhere in the file, so a Pulp OIDC token is never minted from a fork PR close event.

Found during an audit of CI-to-Pulp permission scoping (see centreon/delivery-tooling#138).

## Test plan
- [ ] Confirm the job shows as `skipped` on a fork PR close event
- [ ] Confirm the job still runs normally on a same-repo PR close (no regression)