### PR TITLE
chore(release) bump oss 25.10 2026-07-27

### DIFF
--- a/.version.centreon-awie
+++ b/.version.centreon-awie
@@ -1,1 +1,1 @@
-MINOR=7
+MINOR=8

--- a/centreon-awie/www/modules/centreon-awie/conf.php
+++ b/centreon-awie/www/modules/centreon-awie/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-awie']['rname'] = 'Centreon Api Web Import Export';
 $module_conf['centreon-awie']['name'] = 'centreon-awie';
-$module_conf['centreon-awie']['mod_release'] = '25.10.7';
+$module_conf['centreon-awie']['mod_release'] = '25.10.8';
 $module_conf['centreon-awie']['infos'] = 'The Centreon AWIE (Application Web Import Export) module has been '
     . 'designed to help users configure several Centreon Web platforms in a faster and easier way, thanks to its '
     . 'import/export mechanism.
@@ -35,7 +35,7 @@ Centreon AWIE is based on CLAPI commands but its added value is to allow using C
 $module_conf['centreon-awie']['is_removeable'] = '1';
 $module_conf['centreon-awie']['author'] = 'Centreon';
 $module_conf['centreon-awie']['stability'] = 'stable';
-$module_conf['centreon-awie']['last_update'] = '2026-06-01';
+$module_conf['centreon-awie']['last_update'] = '2026-07-27';
 $module_conf['centreon-awie']['images'] = [
     'images/image1.png',
 ];


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-205876

Bump OSS versions to 25.10 (2026-07-27):
- centreon-awie: 25.10.8


File change check (expected vs modified):
- centreon-awie: expected 2, modified 2

Total: expected 2, modified 2