### PR TITLE
feat(configuration): redesign the contact form with CentreonForm (v2, rebased on shared lib)

### DIFF
--- a/centreon/www/Themes/Centreon-Dark/variables.css
+++ b/centreon/www/Themes/Centreon-Dark/variables.css
@@ -227,10 +227,10 @@
     --success-message-border-color: var(--up-to-date-color);
     --custom-macros-placeholder-font-color: var(--color-black);
     --custom-macros-font-color: var(--color-white);
-    --custom-macros-command-border-color: var(--color-menthol-2);
-    --custom-macros-template-border-color: var(--color-rayola-2);
-    --custom-macros-command-background-color: var(--color-menthol);
-    --custom-macros-template-background-color: var(--color-rayola);
+    --custom-macros-command-border-color: var(--color-boston-blue);
+    --custom-macros-template-border-color: var(--color-maya-blue);
+    --custom-macros-command-background-color: var(--color-malibu-2);
+    --custom-macros-template-background-color: var(--color-columbia-blue);
     --badge-color: var(--color-white);
     --badge-a-color : var(--color-white);
     --bt-success-hover-font-color: var(--color-white);

--- a/centreon/www/Themes/Generic-theme/Variables-css/variables.css
+++ b/centreon/www/Themes/Generic-theme/Variables-css/variables.css
@@ -820,10 +820,10 @@
     /* Custom macros variables */
     --custom-macros-placeholder-font-color: var(--color-black);
     --custom-macros-font-color: var(--color-black);
-    --custom-macros-command-border-color: var(--color-menthol-2);
-    --custom-macros-template-border-color: var(--color-rayola-2);
-    --custom-macros-command-background-color: var(--color-menthol);
-    --custom-macros-template-background-color: var(--color-rayola);
+    --custom-macros-command-border-color: var(--color-boston-blue);
+    --custom-macros-template-border-color: var(--color-maya-blue);
+    --custom-macros-command-background-color: var(--color-malibu-2);
+    --custom-macros-template-background-color: var(--color-columbia-blue);
     /* license manager error page variables */
     --license-manager-error-message-color: var(--color-primary-light);
     /* widget progress bar value color */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -700,7 +700,7 @@
 .cf-field > .oreonbutton .clearAllSelect2 {
     order: 2;
     flex-shrink: 0;
-    margin: 0;
+    margin-left: -32px;
 }
 
 .cf-field .select2-container .select2-selection {
@@ -708,6 +708,7 @@
     border: 1px solid var(--color-divider, #e3e3e3);
     border-radius: 6px;
     padding: 6px 12px;
+    padding-right: 36px;
 }
 
 .cf-field .select2-container--focus .select2-selection {
@@ -775,17 +776,29 @@
     color: var(--color-primary-hover, #255891) !important;
 }
 
-/* Select2 clear button — order it before help icon */
+/* Select2 clear button — sits inside the field's right edge instead of
+   as a separate icon after it. Stays a normal flex item (order 8, right
+   before the help icon) so it doesn't need to know whether a help icon
+   follows it or not; the negative margin-left just pulls its own box
+   back over the select2 field's right padding (see the matching
+   padding-right added to .select2-selection above) without taking it
+   out of flex flow or touching any markup. */
 .cf-field .clearAllSelect2 {
     order: 8;
     opacity: 0.4;
-    transition: opacity 0.15s;
+    transition: opacity 0.15s, background-color 0.15s;
     flex-shrink: 0;
     align-self: center;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     line-height: 0;
+    width: 28px;
+    height: 28px;
+    margin-left: -32px;
+    position: relative;
+    z-index: 2;
+    border-radius: 50%;
 }
 
 .cf-field .clearAllSelect2 img {
@@ -796,6 +809,7 @@
 
 .cf-field .clearAllSelect2:hover {
     opacity: 1;
+    background-color: rgba(0, 0, 0, 0.05);
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -18,6 +18,13 @@
     padding: 16px 20px 0;
     font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
     color: var(--list-color, #333);
+    /* Push .cf-actions to the bottom of the panel even when the form's own
+       content is short — position: sticky alone only keeps it in view
+       while scrolling, it doesn't pull it down when there's nothing to
+       scroll (see .cf-actions below). */
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 /* ==========================================================================
@@ -1186,7 +1193,10 @@
     justify-content: flex-end;
     gap: 12px;
     padding: 16px 0;
-    margin-top: 16px;
+    /* Flush against the bottom of .cf-form-wrapper's flex column when the
+       form's content is short (overrides the 16px default margin-top so it
+       doesn't fight with the auto push). */
+    margin-top: auto;
     /* Keep Reset/Save reachable while the form scrolls, same white banner
        treatment as .cf-tab-nav at the top. */
     position: sticky;

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -16,7 +16,7 @@
     max-width: 900px;
     margin: 0 auto;
     padding: 16px 20px 0;
-    font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: Roboto, -apple-system, BlinkMacSystemFont, sans-serif;
     color: var(--list-color, #333);
     /* Push .cf-actions to the bottom of the panel even when the form's own
        content is short — position: sticky alone only keeps it in view

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -822,9 +822,12 @@
 }
 
 /* The dropdown chevron sat at the field's far right, which the clear
-   button now also occupies — shift it 40px left to clear the overlap. */
+   button now also occupies — shift it left to clear the overlap, and
+   nudge it right/down slightly from that first pass to line up with
+   the eraser icon's height. */
 .cf-field .select2-container--default .select2-selection--single .select2-selection__arrow {
-    right: 41px;
+    right: 31px;
+    top: 4px;
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -676,7 +676,7 @@
      <label class="cl-toggle"><input type="checkbox"><span class="cl-toggle-slider"></span></label>
    ========================================================================== */
 
-.cf-form-wrapper .cl-toggle {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle {
     position: relative;
     display: inline-block;
     width: 42px;
@@ -690,7 +690,7 @@
     pointer-events: auto;
 }
 
-.cf-form-wrapper .cl-toggle input {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle input {
     position: absolute;
     opacity: 0;
     width: 0;
@@ -698,7 +698,7 @@
     margin: 0;
 }
 
-.cf-form-wrapper .cl-toggle-slider {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle-slider {
     position: absolute;
     inset: 0;
     border-radius: 20px;
@@ -707,7 +707,7 @@
     pointer-events: auto;
 }
 
-.cf-form-wrapper .cl-toggle-slider::before {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle-slider::before {
     content: '';
     position: absolute;
     width: 24px;
@@ -721,30 +721,30 @@
 }
 
 /* ON */
-.cf-form-wrapper .cl-toggle input:checked + .cl-toggle-slider {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle input:checked + .cl-toggle-slider {
     background: var(--color-success, #88B922);
 }
-.cf-form-wrapper .cl-toggle input:checked + .cl-toggle-slider::before {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle input:checked + .cl-toggle-slider::before {
     transform: translateX(22px);
 }
 
 /* Hover: subtle grey halo around the knob */
-.cf-form-wrapper .cl-toggle:hover .cl-toggle-slider::before {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle:hover .cl-toggle-slider::before {
     box-shadow: 0 0 0 6px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
 /* Focus: light-blue halo */
-.cf-form-wrapper .cl-toggle input:focus-visible + .cl-toggle-slider::before {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle input:focus-visible + .cl-toggle-slider::before {
     box-shadow: 0 0 0 6px rgba(46, 104, 170, 0.25), 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
 /* Disabled */
-.cf-form-wrapper .cl-toggle input:disabled + .cl-toggle-slider {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle input:disabled + .cl-toggle-slider {
     opacity: 0.5;
     cursor: not-allowed;
 }
-.cf-form-wrapper .cl-toggle input:disabled ~ .cl-toggle-slider,
-.cf-form-wrapper .cl-toggle:has(input:disabled) {
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle input:disabled ~ .cl-toggle-slider,
+:is(.cf-form-wrapper, .gen-wrap) .cl-toggle:has(input:disabled) {
     cursor: not-allowed;
 }
 

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -671,6 +671,100 @@
 }
 
 /* ==========================================================================
+   Switch / toggle — Centreon design system (34x20)
+   Shared component: markup is
+     <label class="cl-toggle"><input type="checkbox"><span class="cl-toggle-slider"></span></label>
+   ========================================================================== */
+
+.cf-form-wrapper .cl-toggle {
+    position: relative;
+    display: inline-block;
+    width: 42px;
+    height: 20px;
+    flex-shrink: 0;
+    margin: 0;
+    padding: 0;
+    top: auto;
+    left: auto;
+    cursor: pointer;
+    pointer-events: auto;
+}
+
+.cf-form-wrapper .cl-toggle input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    margin: 0;
+}
+
+.cf-form-wrapper .cl-toggle-slider {
+    position: absolute;
+    inset: 0;
+    border-radius: 20px;
+    background: var(--switch-off-color, #c2c7ce);
+    transition: background 0.2s ease;
+    pointer-events: auto;
+}
+
+.cf-form-wrapper .cl-toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    left: -2px;
+    top: -2px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* ON */
+.cf-form-wrapper .cl-toggle input:checked + .cl-toggle-slider {
+    background: var(--color-success, #88B922);
+}
+.cf-form-wrapper .cl-toggle input:checked + .cl-toggle-slider::before {
+    transform: translateX(22px);
+}
+
+/* Hover: subtle grey halo around the knob */
+.cf-form-wrapper .cl-toggle:hover .cl-toggle-slider::before {
+    box-shadow: 0 0 0 6px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+/* Focus: light-blue halo */
+.cf-form-wrapper .cl-toggle input:focus-visible + .cl-toggle-slider::before {
+    box-shadow: 0 0 0 6px rgba(46, 104, 170, 0.25), 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+/* Disabled */
+.cf-form-wrapper .cl-toggle input:disabled + .cl-toggle-slider {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+.cf-form-wrapper .cl-toggle input:disabled ~ .cl-toggle-slider,
+.cf-form-wrapper .cl-toggle:has(input:disabled) {
+    cursor: not-allowed;
+}
+
+/* A field turned into a toggle row: control + label side by side */
+.cf-field-toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.cf-field-toggle .cf-toggle-label {
+    position: static;
+    pointer-events: auto;
+    font-size: 13px;
+    color: var(--list-color, #333);
+}
+.cf-field-toggle .helpTooltip {
+    position: static;
+}
+
+/* ==========================================================================
    Dynamic entries (+ Add new entry)
    ========================================================================== */
 

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -945,6 +945,16 @@
     align-items: center;
     gap: 12px;
     padding: 8px 0;
+    /* Most pages place this inside a wider flex row and want it sized to
+       its own content rather than stretching — was previously repeated as
+       an inline style on every single usage (53 times across 16 branches).
+       Pages that do want it to grow use .cf-toggle-row--grow instead. */
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+.cf-toggle-row--grow {
+    flex: 1 1 auto;
 }
 
 .cf-toggle-row span {
@@ -1384,3 +1394,83 @@
 .cf-side-panel-body {
     overflow: visible;
 }
+
+/* ==========================================================================
+   Deploy-configuration wizard (generate / generate-traps forms)
+   Poller picker + Apply button, step indicator, progress bar, per-poller
+   tabs and consoles. Previously an identical <style> block duplicated in
+   both formGenerateFiles.ihtml and formGenerateTraps.ihtml.
+   ========================================================================== */
+
+.gen-wrap { max-width: 920px; }
+.gen-top { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; margin-bottom: 6px; }
+.gen-top .cf-field { flex: 1; min-width: 300px; }
+.gen-apply {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 12px 24px; font-size: 14px; font-weight: 600;
+    border: none; border-radius: 6px; cursor: pointer;
+    background: var(--bt-info-background-color, #2E68AA); color: #fff;
+    transition: filter .15s;
+}
+.gen-apply:hover { filter: brightness(0.94); }
+.gen-apply:disabled { opacity: .5; cursor: not-allowed; }
+.gen-nopoller { color: #FF4A4A; font-size: 13px; margin: 4px 0 0; }
+
+/* Advanced (just under the poller field) */
+.gen-adv { margin: 8px 0 4px; }
+.gen-adv summary { cursor: pointer; font-size: 13px; color: var(--color-primary-light, #2E68AA); font-weight: 500; }
+.gen-adv .gen-adv-body {
+    padding: 12px 14px; margin-top: 8px; display: flex; flex-direction: column; gap: 10px;
+    background: #f7f8fa; border: 1px solid var(--color-divider, #e6e8ec); border-radius: 6px;
+}
+.gen-adv-row { display: flex; align-items: center; gap: 10px; font-size: 13px; color: #333; }
+
+/* Toggle switch: inherits the shared design-system .cl-toggle from form.css */
+
+/* Stepper */
+.gen-stepper { display: flex; align-items: center; margin: 22px 0 14px; }
+.gen-step { display: flex; align-items: center; gap: 8px; font-size: 13px; color: #9aa3ad; font-weight: 500; }
+.gen-step .dot {
+    width: 24px; height: 24px; border-radius: 50%; background: #cfd6df; color: #fff;
+    display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600;
+    transition: background .2s;
+}
+.gen-step.active { color: var(--color-primary-light, #2E68AA); }
+.gen-step.active .dot { background: var(--color-primary-light, #2E68AA); }
+.gen-step.done { color: var(--color-success, #88B922); }
+.gen-step.done .dot { background: var(--color-success, #88B922); }
+.gen-step.err { color: #FF4A4A; }
+.gen-step.err .dot { background: #FF4A4A; }
+.gen-step.skipped { opacity: .4; }
+.gen-connector { flex: 1; height: 2px; background: #dde1e6; margin: 0 10px; min-width: 20px; }
+
+/* Progress */
+.gen-progress { height: 10px; background: #eceef1; border-radius: 6px; overflow: hidden; }
+.gen-progress > span { display: block; height: 100%; width: 0; background: var(--color-success, #88B922); transition: width .3s ease, background .2s; }
+.gen-pct { text-align: right; font-size: 12px; color: #888; margin-top: 4px; }
+
+/* One tab per poller (shown only when several pollers) */
+.gen-tabs { display: flex; flex-wrap: wrap; margin-top: 14px; }
+.gen-tab {
+    display: inline-flex; align-items: center; gap: 7px;
+    padding: 8px 16px; font-size: 13px; font-weight: 500; cursor: pointer;
+    color: var(--body-color, #666); border-bottom: 2px solid transparent; margin-bottom: -2px;
+}
+.gen-tab:hover { color: var(--list-color, #333); }
+.gen-tab.active { color: var(--color-primary-light, #2E68AA); border-bottom-color: var(--color-primary-light, #2E68AA); font-weight: 600; }
+.gen-tab .st { width: 9px; height: 9px; border-radius: 50%; background: #cfd6df; flex-shrink: 0; }
+.gen-tab.run .st { background: var(--color-primary-light, #2E68AA); animation: genpulse 1s infinite; }
+.gen-tab.ok  .st { background: var(--color-success, #88B922); }
+.gen-tab.err .st { background: #FF4A4A; }
+@keyframes genpulse { 0%,100% { opacity: 1; } 50% { opacity: .3; } }
+
+/* Console panels (one per poller) */
+.gen-console {
+    background: #1e222a; color: #d5dae1; font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
+    font-size: 12px; line-height: 1.6; padding: 14px 16px; border-radius: 8px;
+    margin-top: 10px; max-height: 340px; overflow: auto; white-space: pre-wrap;
+}
+.gen-console.attached { border-top-left-radius: 0; margin-top: 0; }
+.gen-console .ok { color: #8fce46; } .gen-console .err { color: #ff6b6b; }
+.gen-console .warn { color: #f3b34d; } .gen-console .muted { color: #8b95a1; }
+.gen-console b { color: #fff; }

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -845,6 +845,19 @@
     align-self: center;
 }
 
+/* Some fields (e.g. Check Command) have an extra static icon hand-coded
+   right after the field's own markup (view/edit template, view command
+   info — .ico-14/.ico-16, not part of the select2 field or the clear/
+   help icons). Being an unordered flex item, it otherwise lands between
+   the select2 box and the clear button, which breaks the clear button's
+   negative-margin trick (it assumes the select2 box is its immediate
+   flex predecessor). Push any such icon to the end instead. */
+.cf-field > img.ico-14,
+.cf-field > img.ico-16 {
+    order: 10;
+    align-self: center;
+}
+
 /* ==========================================================================
    Checkboxes
    ========================================================================== */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -347,97 +347,164 @@
     padding: 4px 0;
 }
 
-/* Macro clone entries — inline floating label layout */
+/* Macro clone entries — column headers + one pill-style row per macro */
+.cf-macro-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.cf-macro-header-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.cf-macro-header-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.cf-macro-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--body-color, #333);
+}
+
 .cf-form-wrapper .macroclone {
     padding: 0;
     margin: 0;
 }
 
+.cf-macro-columns {
+    display: flex;
+    gap: 10px;
+    padding: 0 0 4px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--body-color, #6b7280);
+}
+
+.cf-macro-columns-name { width: 220px; flex-shrink: 0; }
+.cf-macro-columns-value { flex: 1; min-width: 0; }
+
 .cf-form-wrapper .macroclone .onemacro {
-    padding: 4px 0;
     list-style: none;
+    padding: 0;
+    margin-bottom: 8px;
 }
 
-.cf-form-wrapper .macroclone .onemacro hr {
-    display: none;
-}
-
-.cf-form-wrapper .macroclone .onemacro .clone-cell {
+.cf-form-wrapper .macroclone .onemacro.cf-macro-row {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 10px;
 }
 
-/* Name span — fixed width */
-.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(1) {
-    width: 180px;
+/* Name — fixed width pill */
+.cf-macro-name {
+    width: 220px;
     flex-shrink: 0;
     display: flex;
 }
 
-/* Value span — takes remaining space */
-.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(2) {
+/* Value — takes remaining space */
+.cf-macro-value {
     flex: 1;
     min-width: 0;
     display: flex;
 }
 
-/* Password span — just the checkbox, no text */
-.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(3) {
-    font-size: 0;
-    display: flex;
-    align-items: center;
-}
-.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(3) input {
-    font-size: 12px;
-}
-
-/* Inputs fill their span */
-.cf-form-wrapper .macroclone .onemacro input[name^="macroInput"],
-.cf-form-wrapper .macroclone .onemacro input[name^="macroValue"] {
+.cf-macro-name input,
+.cf-macro-value input {
     width: 100%;
-    flex: 1;
-    padding: 8px 10px;
-    font-size: 12px;
-    border: 1px solid var(--color-divider, #e3e3e3);
+    height: 38px;
+    padding: 0 12px;
+    font-size: 13px;
+    font-weight: 600;
+    border: 1px solid var(--listing-border-botom-color, #e3e3e3);
     border-radius: 6px;
     background: var(--body-background, #fff);
-    color: var(--list-color, #333);
+    color: var(--body-color, #333);
     box-sizing: border-box;
+    transition: border-color 0.15s;
 }
 
-.cf-form-wrapper .macroclone .onemacro input[name^="macroInput"]:focus,
-.cf-form-wrapper .macroclone .onemacro input[name^="macroValue"]:focus {
+.cf-macro-value input {
+    font-weight: 400;
+}
+
+.cf-macro-name input:focus,
+.cf-macro-value input:focus {
     border-color: var(--color-primary-light, #2E68AA);
     outline: none;
 }
 
-/* Hide br and text labels in spans */
-.cf-form-wrapper .macroclone .onemacro .clone-cell > span > br {
-    display: none;
+/* Password — just the checkbox, no label text. Deliberately left with no
+   custom sizing/border/font-size here: the same plain
+   input[type="checkbox"] (no .md-checkbox wrapper) already renders as a
+   clean bordered square elsewhere in the app (e.g. the Escalation form's
+   "Host inheritance to services" checkbox) via the existing global rules
+   in style.css — overriding it here only fought that cascade and made it
+   worse. */
+.cf-macro-password {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+.cf-macro-password input {
+    margin: 0;
+    cursor: pointer;
 }
 
-/* Actions wrapper (built by JS) */
-.cf-form-wrapper .cf-macro-actions {
+/* Actions: description / move / delete, as small outlined icon buttons.
+   Fixed min-width so the value field's flex-basis doesn't shrink/grow
+   depending on how many action icons a given row happens to show
+   (frozen/inherited rows only show the description icon). */
+.cf-macro-actions {
     display: flex;
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+    min-width: 90px;
+    margin-left: 4px;
 }
 
-.cf-form-wrapper .cf-macro-actions img {
-    opacity: 0.4;
-    cursor: pointer;
-    transition: opacity 0.15s;
-}
-
-.cf-form-wrapper .cf-macro-actions img:hover {
-    opacity: 1;
-}
-
-.cf-form-wrapper .cf-macro-actions span {
-    display: flex;
+.cf-macro-action-btn {
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 4px;
+    color: var(--cl-link-color, #2E68AA);
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.cf-macro-action-btn:hover {
+    background: rgba(46, 104, 170, 0.1);
+}
+
+.cf-macro-action-btn--danger {
+    color: var(--color-danger, #FF4A4A);
+}
+
+.cf-macro-action-btn--danger:hover {
+    background: rgba(255, 74, 74, 0.1);
+}
+
+/* Invisible placeholder — keeps the icon slot's width reserved so every
+   row's action column (and therefore the value field next to it) stays
+   the same width, whether or not this particular row has that action. */
+.cf-macro-action-slot {
+    visibility: hidden;
+    pointer-events: none;
+    cursor: default;
 }
 
 .cf-form-wrapper .add-new-entry {
@@ -457,6 +524,23 @@
 .cf-form-wrapper .add-new-entry:hover {
     background-color: var(--color-primary-hover, #255891);
     text-decoration: none;
+}
+
+/* Macro legend — small, side-by-side badges below the macro rows */
+.macro_legend.cf-macro-legend {
+    float: none;
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin: 8px 0 0;
+    padding: 4px 0;
+    font-size: 11px;
+}
+
+.macro_legend.cf-macro-legend p {
+    display: flex;
+    align-items: center;
+    margin: 0;
 }
 
 /* ==========================================================================
@@ -545,6 +629,24 @@
     font-size: 11px;
     color: var(--body-color, #999);
     margin-top: 2px;
+}
+
+/* Trigger button that opens the geo coordinates picker popin */
+.cf-geo-picker-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border: 1px solid var(--listing-border-botom-color, #e3e3e3);
+    border-radius: 6px;
+    color: var(--cl-link-color, #2E68AA);
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.cf-geo-picker-btn:hover {
+    background: rgba(46, 104, 170, 0.1);
 }
 
 /* ==========================================================================

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -714,6 +714,14 @@
     border-color: var(--color-primary-light, #2E68AA);
 }
 
+/* Dropdown menu — match the closed field's 6px radius (the base select2
+   theme defaults to 4px, slightly out of step with the rest of the form).
+   The base theme already zeroes out the side that connects to the field
+   (--above/--below modifiers), so only the base radius needs bumping. */
+.select2-dropdown {
+    border-radius: 6px;
+}
+
 /* Select2 clear button — order it before help icon */
 .cf-field .clearAllSelect2 {
     order: 8;

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -88,8 +88,8 @@
     align-items: center;
     justify-content: space-between;
     padding: 8px 14px;
-    background: var(--table-header-background, #6b7888);
-    color: #fff;
+    background: #ddd;
+    color: var(--list-color, #333);
     font-size: 13px;
     font-weight: 500;
     cursor: pointer;
@@ -99,7 +99,7 @@
 }
 
 .cf-section-header:hover {
-    background: var(--table-header-background, #5a6773);
+    background: #d2d2d2;
 }
 
 .cf-section-chevron {

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -836,7 +836,7 @@
    the eraser icon's height. */
 .cf-field .select2-container--default .select2-selection--single .select2-selection__arrow {
     right: 21px;
-    top: -1px;
+    top: 4px;
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -713,6 +713,41 @@
 }
 
 /* ==========================================================================
+   Insert builder — stacked rows of "insert into field" controls
+   (a small [+] button next to a picker whose selection is pushed into a
+   textarea/input, e.g. command line / RPN builders)
+   ========================================================================== */
+
+.cf-insert-builder {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.cf-insert-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cf-insert-row select {
+    flex: 1;
+    min-width: 0;
+}
+
+.cf-insert-btn {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 1;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+/* ==========================================================================
    Switch / toggle — Centreon design system (34x20)
    Shared component: markup is
      <label class="cl-toggle"><input type="checkbox"><span class="cl-toggle-slider"></span></label>

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -722,6 +722,25 @@
     border-radius: 6px;
 }
 
+/* Multi-select "tags" — themed blue chips instead of the base theme's
+   plain grey, matching the soft-blue tint already used for hover/selected
+   states elsewhere (listing.css's rgba(46, 104, 170, ...) rows). */
+.select2-container--default .select2-selection--multiple .select2-selection__choice {
+    background-color: rgba(46, 104, 170, 0.10);
+    border: 1px solid rgba(46, 104, 170, 0.25);
+    color: var(--color-primary-light, #2E68AA);
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+    color: var(--color-primary-light, #2E68AA);
+    opacity: 0.6;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+    color: var(--color-primary-hover, #255891);
+    opacity: 1;
+}
+
 /* Select2 clear button — order it before help icon */
 .cf-field .clearAllSelect2 {
     order: 8;

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -836,7 +836,7 @@
    the eraser icon's height. */
 .cf-field .select2-container--default .select2-selection--single .select2-selection__arrow {
     right: 21px;
-    top: 4px;
+    top: 6px;
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -577,6 +577,17 @@
     width: 100% !important;
 }
 
+/* Dual-list / multiselect wrappers (<p class="oreonbutton">) take the full row width */
+.cf-field > .oreonbutton {
+    flex: 1 1 100%;
+    min-width: 0;
+    margin: 0;
+}
+.cf-field > .oreonbutton select,
+.cf-field > .oreonbutton .select2-container {
+    width: 100% !important;
+}
+
 .cf-field .select2-container .select2-selection {
     min-height: 44px;
     border: 1px solid var(--color-divider, #e3e3e3);

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -654,6 +654,30 @@
 }
 
 /* ==========================================================================
+   Sub-section heading / separator
+   Markup: <div class="cf-subsection">Label</div>
+   Modifiers: --flush (first heading under a section header, no top margin)
+              --gap   (extra breathing room below the heading)
+   ========================================================================== */
+
+.cf-subsection {
+    margin: 18px 0 8px;
+    padding-bottom: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--list-color, #555);
+    border-bottom: 1px solid var(--color-divider, #e3e3e3);
+}
+
+.cf-subsection--flush {
+    margin-top: 0;
+}
+
+.cf-subsection--gap {
+    margin-bottom: 22px;
+}
+
+/* ==========================================================================
    Toggle switch (reuse cl-toggle from listing)
    ========================================================================== */
 

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -748,6 +748,30 @@
 }
 
 /* ==========================================================================
+   Clone field — a repeatable (sheepIt) list of rows inside a form field.
+   The float-label pattern does not fit a multi-row clone, so use a static
+   title above the list plus an optional hint below.
+   ========================================================================== */
+
+.cf-field-clone {
+    display: block;
+}
+
+.cf-clone-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--c-text-primary, #255891);
+    margin-bottom: 6px;
+}
+
+.cf-clone-hint {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--c-text-secondary, #6b7280);
+}
+
+/* ==========================================================================
    Switch / toggle — Centreon design system (34x20)
    Shared component: markup is
      <label class="cl-toggle"><input type="checkbox"><span class="cl-toggle-slider"></span></label>

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -15,7 +15,7 @@
 .cf-form-wrapper {
     max-width: 900px;
     margin: 0 auto;
-    padding: 16px 20px 80px;
+    padding: 16px 20px 0;
     font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
     color: var(--list-color, #333);
 }
@@ -946,6 +946,13 @@
     gap: 12px;
     padding: 16px 0;
     margin-top: 16px;
+    /* Keep Reset/Save reachable while the form scrolls, same white banner
+       treatment as .cf-tab-nav at the top. */
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    background: var(--body-background, #fff);
+    border-top: 1px solid var(--color-divider, #e3e3e3);
 }
 
 .cf-btn {

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -578,16 +578,27 @@
 }
 
 /* Dual-list / multiselect wrappers (<p class="oreonbutton">) fill the remaining
-   row width while leaving the clear (×) and help (?) icons on the right. */
+   row width. The wrapper becomes a flex row so the select2 field and its clear
+   cross (×) sit side by side — field then ×, with the help (?) icon after. */
 .cf-field > .oreonbutton {
     flex: 1 1 0;
     min-width: 0;
     margin: 0;
     order: 1;
+    display: flex;
+    align-items: center;
+    gap: 6px;
 }
-.cf-field > .oreonbutton select,
-.cf-field > .oreonbutton .select2-container {
-    width: 100% !important;
+.cf-field > .oreonbutton > select,
+.cf-field > .oreonbutton > .select2-container {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto !important;
+}
+.cf-field > .oreonbutton .clearAllSelect2 {
+    order: 2;
+    flex-shrink: 0;
+    margin: 0;
 }
 
 .cf-field .select2-container .select2-selection {

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -700,7 +700,7 @@
 .cf-field > .oreonbutton .clearAllSelect2 {
     order: 2;
     flex-shrink: 0;
-    margin-left: -32px;
+    margin-left: -35px;
 }
 
 .cf-field .select2-container .select2-selection {
@@ -804,7 +804,7 @@
     line-height: 0;
     width: 28px;
     height: 28px;
-    margin-left: -32px;
+    margin-left: -35px;
     position: relative;
     z-index: 2;
     border-radius: 50%;
@@ -830,13 +830,27 @@
     background-color: rgba(0, 0, 0, 0.05);
 }
 
-/* The dropdown chevron sat at the field's far right, which the clear
-   button now also occupies — shift it left to clear the overlap, and
-   nudge it right/down slightly from that first pass to line up with
-   the eraser icon's height. */
+/* Hide the dropdown chevron entirely on every select2 field — it kept
+   fighting with the clear button for the same corner and needing
+   re-tuning; the clear button and the open dropdown are affordance
+   enough without it. */
 .cf-field .select2-container--default .select2-selection--single .select2-selection__arrow {
-    right: 21px;
-    top: 6px;
+    display: none;
+}
+
+/* Empty-state placeholder — show a plain "-" instead of repeating the
+   field's own label/prompt text back inside the box (each field's JS
+   init sets its own placeholder string, so this can't be fixed at the
+   source without editing every page; hide the real text and paint "-"
+   via ::after instead, applied to every select2 field). */
+.cf-field .select2-selection__placeholder {
+    font-size: 0;
+}
+
+.cf-field .select2-selection__placeholder::after {
+    content: "-";
+    font-size: 14px;
+    color: var(--body-color, #999);
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -661,7 +661,7 @@
    ========================================================================== */
 
 .cf-subsection {
-    margin: 18px 0 8px;
+    margin: 18px 0 18px;
     padding-bottom: 4px;
     font-size: 13px;
     font-weight: 600;
@@ -675,6 +675,24 @@
 
 .cf-subsection--gap {
     margin-bottom: 22px;
+}
+
+/* ==========================================================================
+   Disabled / greyed state
+   .cf-disabled is applied by CentreonForm toggle dependencies
+   (data-cf-disables / data-cf-enables). A natively disabled radio/checkbox
+   greys its md wrapper automatically.
+   ========================================================================== */
+
+.cf-form-wrapper .cf-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.cf-form-wrapper .md-radio:has(input:disabled),
+.cf-form-wrapper .md-checkbox:has(input:disabled) {
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 /* ==========================================================================

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -711,6 +711,15 @@
     padding-right: 36px;
 }
 
+/* Themes/Generic-theme/style.css forces multi-select boxes to
+   min-height: auto !important, which the rule above can't override —
+   that's why "Implied Contacts"-style multi-select fields render at a
+   different height than single-select ones on the same form. Force it
+   back to the same 44px. */
+.cf-field .select2-container .select2-selection--multiple {
+    min-height: 44px !important;
+}
+
 .cf-field .select2-container--focus .select2-selection {
     border-color: var(--color-primary-light, #2E68AA);
 }

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -577,11 +577,13 @@
     width: 100% !important;
 }
 
-/* Dual-list / multiselect wrappers (<p class="oreonbutton">) take the full row width */
+/* Dual-list / multiselect wrappers (<p class="oreonbutton">) fill the remaining
+   row width while leaving the clear (×) and help (?) icons on the right. */
 .cf-field > .oreonbutton {
-    flex: 1 1 100%;
+    flex: 1 1 0;
     min-width: 0;
     margin: 0;
+    order: 1;
 }
 .cf-field > .oreonbutton select,
 .cf-field > .oreonbutton .select2-container {

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -619,6 +619,16 @@
     transition: opacity 0.15s;
     flex-shrink: 0;
     align-self: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+}
+
+.cf-field .clearAllSelect2 img {
+    display: block;
+    vertical-align: middle;
+    margin: 0;
 }
 
 .cf-field .clearAllSelect2:hover {
@@ -987,9 +997,23 @@
 }
 
 .cf-actions input[type="submit"]:hover,
-.cf-actions input[type="reset"]:hover,
 .cf-actions button:hover {
     background-color: var(--color-primary-hover, #255891);
+}
+
+/* Reset uses a secondary (outlined) theme so it is not mistaken for Save.
+   Reviewers reported clicking it expecting to submit the form. */
+.cf-actions input[type="reset"],
+.cf-actions .bt_default {
+    color: var(--c-text-secondary, #555);
+    background-color: transparent;
+    border: 1px solid var(--c-stroke, #b0b7c3);
+}
+
+.cf-actions input[type="reset"]:hover,
+.cf-actions .bt_default:hover {
+    background-color: var(--color-divider, #e8e8e8);
+    color: var(--list-color, #333);
 }
 
 /* ==========================================================================

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -717,9 +717,13 @@
 /* Dropdown menu — match the closed field's 6px radius (the base select2
    theme defaults to 4px, slightly out of step with the rest of the form).
    The base theme already zeroes out the side that connects to the field
-   (--above/--below modifiers), so only the base radius needs bumping. */
+   (--above/--below modifiers), so only the base radius needs bumping.
+   overflow: hidden is required too — otherwise the scrollable results
+   list (which spans edge-to-edge, e.g. the highlighted-row background)
+   isn't clipped to the rounded shape and the corners look square anyway. */
 .select2-dropdown {
     border-radius: 6px;
+    overflow: hidden;
 }
 
 /* Multi-select "tags" — themed blue chips instead of the base theme's

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -740,6 +740,16 @@
     border-bottom-right-radius: 6px;
 }
 
+/* The multi-select "N element(s) found / Select all" header
+   (centreon-select2.js's initSelectAll) is prepended as the dropdown's
+   first child with its own full-width background — round its top
+   corners explicitly rather than relying only on the parent's
+   overflow: hidden to clip it. */
+.select2-dropdown .select2-results-header {
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+}
+
 /* Multi-select "tags" — themed blue chips instead of the base theme's
    plain grey, matching the soft-blue tint already used for hover/selected
    states elsewhere (listing.css's rgba(46, 104, 170, ...) rows).

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -835,8 +835,8 @@
    nudge it right/down slightly from that first pass to line up with
    the eraser icon's height. */
 .cf-field .select2-container--default .select2-selection--single .select2-selection__arrow {
-    right: 31px;
-    top: 4px;
+    right: 21px;
+    top: -1px;
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -716,14 +716,28 @@
 
 /* Dropdown menu — match the closed field's 6px radius (the base select2
    theme defaults to 4px, slightly out of step with the rest of the form).
-   The base theme already zeroes out the side that connects to the field
-   (--above/--below modifiers), so only the base radius needs bumping.
    overflow: hidden is required too — otherwise the scrollable results
    list (which spans edge-to-edge, e.g. the highlighted-row background)
    isn't clipped to the rounded shape and the corners look square anyway. */
 .select2-dropdown {
     border-radius: 6px;
     overflow: hidden;
+}
+
+/* The base theme deliberately squares off whichever side touches the
+   field (a "merged" look, no border on that side) when the menu opens
+   --above or --below it. Round that side too instead, so no select2
+   dropdown ever shows a flat/square corner. */
+.select2-container--open .select2-dropdown--below {
+    border-top: 1px solid var(--select2-dropdown-border-color, var(--color-divider, #e3e3e3));
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+}
+
+.select2-container--open .select2-dropdown--above {
+    border-bottom: 1px solid var(--select2-dropdown-border-color, var(--color-divider, #e3e3e3));
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
 }
 
 /* Multi-select "tags" — themed blue chips instead of the base theme's

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -801,15 +801,30 @@
     border-radius: 50%;
 }
 
+/* Hide the red circle-cross.png the JS still inserts and paint a grey
+   eraser icon instead (inline SVG — no new image asset to add/track). */
 .cf-field .clearAllSelect2 img {
-    display: block;
-    vertical-align: middle;
-    margin: 0;
+    visibility: hidden;
+    width: 14px;
+    height: 14px;
+}
+
+.cf-field .clearAllSelect2 {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg transform='rotate(-45 12 12)'%3E%3Crect x='4' y='8' width='16' height='10' rx='2' fill='%23999'/%3E%3Crect x='4' y='8' width='16' height='4' rx='2' fill='%23bbb'/%3E%3Crect x='4' y='8' width='16' height='10' rx='2' fill='none' stroke='%23777' stroke-width='1'/%3E%3C/g%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 14px 14px;
 }
 
 .cf-field .clearAllSelect2:hover {
     opacity: 1;
     background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* The dropdown chevron sat at the field's far right, which the clear
+   button now also occupies — shift it 40px left to clear the overlap. */
+.cf-field .select2-container--default .select2-selection--single .select2-selection__arrow {
+    right: 41px;
 }
 
 /* Help tooltip always last, vertically centered */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -724,21 +724,27 @@
 
 /* Multi-select "tags" — themed blue chips instead of the base theme's
    plain grey, matching the soft-blue tint already used for hover/selected
-   states elsewhere (listing.css's rgba(46, 104, 170, ...) rows). */
-.select2-container--default .select2-selection--multiple .select2-selection__choice {
-    background-color: rgba(46, 104, 170, 0.10);
-    border: 1px solid rgba(46, 104, 170, 0.25);
-    color: var(--color-primary-light, #2E68AA);
+   states elsewhere (listing.css's rgba(46, 104, 170, ...) rows).
+   Centreon's own Themes/Generic-theme/style.css (loaded before this file)
+   already forces .select2-selection__choice itself fully transparent
+   with !important and instead paints two child pill-halves: .select2-content
+   (the label, left half) and .select2-selection__choice__remove (the "x",
+   right half) — so those two are what need overriding, with !important to
+   beat style.css's own !important on some of these same properties. */
+.select2-container--default .select2-selection--multiple .select2-selection__choice .select2-content {
+    background-color: rgba(46, 104, 170, 0.10) !important;
+    border-color: rgba(46, 104, 170, 0.3) !important;
+    color: var(--color-primary-light, #2E68AA) !important;
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
-    color: var(--color-primary-light, #2E68AA);
-    opacity: 0.6;
+    background-color: rgba(46, 104, 170, 0.10) !important;
+    border-color: rgba(46, 104, 170, 0.3) !important;
+    color: var(--color-primary-light, #2E68AA) !important;
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
-    color: var(--color-primary-hover, #255891);
-    opacity: 1;
+    color: var(--color-primary-hover, #255891) !important;
 }
 
 /* Select2 clear button — order it before help icon */

--- a/centreon/www/include/common/form/form.css
+++ b/centreon/www/include/common/form/form.css
@@ -1,0 +1,905 @@
+/*
+ * Centreon Modern Form Styles
+ *
+ * Shared CSS for redesigned configuration form pages.
+ * Prefix: cf- (centreon-form)
+ *
+ * Applies the new design: single-column layout, floating labels,
+ * accordion sections, modern inputs, consistent with cl-* listing styles.
+ */
+
+/* ==========================================================================
+   Form container
+   ========================================================================== */
+
+.cf-form-wrapper {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 16px 20px 80px;
+    font-family: 'Roboto', -apple-system, BlinkMacSystemFont, sans-serif;
+    color: var(--list-color, #333);
+}
+
+/* ==========================================================================
+   Page title
+   ========================================================================== */
+
+.cf-page-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--list-color, #333);
+    margin: 0 0 8px;
+}
+
+/* ==========================================================================
+   Tab navigation (horizontal, above form)
+   ========================================================================== */
+
+.cf-tab-nav {
+    display: flex;
+    gap: 0;
+    border-bottom: 2px solid var(--color-divider, #e3e3e3);
+    margin-bottom: 16px;
+}
+
+.cf-tab-nav a {
+    padding: 10px 20px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--body-color, #666);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: color 0.15s, border-color 0.15s;
+    cursor: pointer;
+}
+
+.cf-tab-nav a:hover {
+    color: var(--list-color, #333);
+}
+
+.cf-tab-nav a.active {
+    color: var(--color-primary-light, #2E68AA);
+    border-bottom-color: var(--color-primary-light, #2E68AA);
+    font-weight: 600;
+}
+
+.cf-tab-nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--body-background, #fff);
+}
+
+/* ==========================================================================
+   Accordion sections
+   ========================================================================== */
+
+.cf-section {
+    margin-bottom: 8px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--body-background, #fff);
+}
+
+.cf-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 14px;
+    background: var(--table-header-background, #6b7888);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.15s;
+    border-radius: 4px;
+}
+
+.cf-section-header:hover {
+    background: var(--table-header-background, #5a6773);
+}
+
+.cf-section-chevron {
+    font-size: 12px;
+    transition: transform 0.2s;
+}
+
+.cf-section.collapsed .cf-section-chevron {
+    transform: rotate(-90deg);
+}
+
+.cf-section-body {
+    padding: 16px;
+    background: var(--body-background, #fff);
+}
+
+.cf-section.collapsed .cf-section-body {
+    display: none;
+}
+
+/* ==========================================================================
+   Form row (single field)
+   ========================================================================== */
+
+.cf-row {
+    margin-bottom: 16px;
+}
+
+.cf-row-inline {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.cf-row-inline > .cf-field {
+    flex: 1;
+}
+
+/* ==========================================================================
+   Floating label field
+   ========================================================================== */
+
+.cf-field {
+    position: relative;
+}
+
+.cf-field label {
+    position: absolute;
+    left: 12px;
+    top: 12px;
+    font-size: 14px;
+    color: var(--body-color, #999);
+    pointer-events: none;
+    transition: all 0.15s ease;
+    background: transparent;
+    padding: 0 4px;
+    z-index: 1;
+}
+
+.cf-field label.cf-label-float {
+    top: -8px;
+    left: 10px;
+    font-size: 11px;
+    color: var(--color-primary-light, #2E68AA);
+    background: var(--body-background, #fff);
+    font-weight: 500;
+}
+
+.cf-field input,
+.cf-field textarea {
+    width: 100%;
+    padding: 10px;
+    font-size: 12px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    outline: none;
+    background: var(--body-background, #fff);
+    color: var(--list-color, #333);
+    transition: border-color 0.15s;
+    box-sizing: border-box;
+}
+
+.cf-field input:focus,
+.cf-field textarea:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+.cf-field input::placeholder,
+.cf-field textarea::placeholder {
+    color: transparent;
+}
+
+.cf-field textarea {
+    min-height: 80px;
+    resize: vertical;
+}
+
+/* Required indicator — QuickForm already adds * in the label text */
+
+/* Custom form tooltip */
+.cf-tooltip {
+    position: fixed;
+    z-index: 99999;
+    max-width: 320px;
+    padding: 10px 14px;
+    background: #333;
+    color: #fff;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    text-align: left;
+}
+
+/* Field layout */
+.cf-field {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.cf-field input,
+.cf-field textarea,
+.cf-field select,
+.cf-field .select2-container {
+    flex: 1;
+    min-width: 0;
+}
+
+/* ==========================================================================
+   Segmented button group (Default / Yes / No)
+   ========================================================================== */
+
+.cf-segmented {
+    display: inline-flex;
+    border: 1px solid var(--color-divider, #d0d0d0);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.cf-segmented button {
+    padding: 6px 16px;
+    font-size: 12px;
+    font-weight: 500;
+    border: none;
+    background: var(--body-background, #fff);
+    color: var(--body-color, #666);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    border-right: 1px solid var(--color-divider, #d0d0d0);
+}
+
+.cf-segmented button:last-child {
+    border-right: none;
+}
+
+.cf-segmented button:hover {
+    background: var(--color-listing-hover, #E6EDF5);
+}
+
+.cf-segmented button.active {
+    background: var(--color-primary-light, #2E68AA);
+    color: #fff;
+}
+
+.cf-segmented-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 4px 0;
+}
+
+.cf-segmented-row > span {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+    min-width: 140px;
+}
+
+/* ==========================================================================
+   Clone template entries (host templates, macros)
+   ========================================================================== */
+
+.cf-form-wrapper .clonable .clone-cell {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 0;
+}
+
+.cf-form-wrapper .clonable .clone-cell select,
+.cf-form-wrapper .clonable .clone-cell .select2-container {
+    flex: 1;
+    min-width: 0;
+}
+
+.cf-form-wrapper .clonable .clone-cell select {
+    padding: 8px 10px;
+    font-size: 12px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    background: var(--body-background, #fff);
+    color: var(--list-color, #333);
+}
+
+.cf-form-wrapper .clonable .clone-cell .select2-container .select2-selection {
+    min-height: 36px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 12px;
+}
+
+.cf-form-wrapper .clonable .clone-cell img {
+    opacity: 0.5;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.cf-form-wrapper .clonable .clone-cell img:hover {
+    opacity: 1;
+}
+
+.cf-form-wrapper .clonable {
+    padding: 0;
+    margin: 0;
+}
+
+.cf-form-wrapper .clonable li {
+    list-style: none;
+    padding: 2px 0;
+}
+
+.cf-form-wrapper .clonable li hr {
+    display: none;
+}
+
+.cf-form-wrapper .clonable li p.muted {
+    margin: 0;
+    padding: 4px 0;
+}
+
+/* Macro clone entries — inline floating label layout */
+.cf-form-wrapper .macroclone {
+    padding: 0;
+    margin: 0;
+}
+
+.cf-form-wrapper .macroclone .onemacro {
+    padding: 4px 0;
+    list-style: none;
+}
+
+.cf-form-wrapper .macroclone .onemacro hr {
+    display: none;
+}
+
+.cf-form-wrapper .macroclone .onemacro .clone-cell {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* Name span — fixed width */
+.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(1) {
+    width: 180px;
+    flex-shrink: 0;
+    display: flex;
+}
+
+/* Value span — takes remaining space */
+.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(2) {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+}
+
+/* Password span — just the checkbox, no text */
+.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(3) {
+    font-size: 0;
+    display: flex;
+    align-items: center;
+}
+.cf-form-wrapper .macroclone .onemacro .clone-cell > span:nth-child(3) input {
+    font-size: 12px;
+}
+
+/* Inputs fill their span */
+.cf-form-wrapper .macroclone .onemacro input[name^="macroInput"],
+.cf-form-wrapper .macroclone .onemacro input[name^="macroValue"] {
+    width: 100%;
+    flex: 1;
+    padding: 8px 10px;
+    font-size: 12px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    background: var(--body-background, #fff);
+    color: var(--list-color, #333);
+    box-sizing: border-box;
+}
+
+.cf-form-wrapper .macroclone .onemacro input[name^="macroInput"]:focus,
+.cf-form-wrapper .macroclone .onemacro input[name^="macroValue"]:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+    outline: none;
+}
+
+/* Hide br and text labels in spans */
+.cf-form-wrapper .macroclone .onemacro .clone-cell > span > br {
+    display: none;
+}
+
+/* Actions wrapper (built by JS) */
+.cf-form-wrapper .cf-macro-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.cf-form-wrapper .cf-macro-actions img {
+    opacity: 0.4;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.cf-form-wrapper .cf-macro-actions img:hover {
+    opacity: 1;
+}
+
+.cf-form-wrapper .cf-macro-actions span {
+    display: flex;
+    align-items: center;
+}
+
+.cf-form-wrapper .add-new-entry {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 14px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #fff;
+    background-color: var(--color-primary-light, #2E68AA);
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color 0.15s;
+}
+
+.cf-form-wrapper .add-new-entry:hover {
+    background-color: var(--color-primary-hover, #255891);
+    text-decoration: none;
+}
+
+/* ==========================================================================
+   Chip selection (multi-select toggleable tags)
+   ========================================================================== */
+
+.cf-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.cf-chips-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+    margin-right: 6px;
+}
+
+.cf-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 14px;
+    font-size: 12px;
+    font-weight: 500;
+    border: 1px solid var(--color-divider, #d0d0d0);
+    border-radius: 20px;
+    background: var(--body-background, #fff);
+    color: var(--body-color, #666);
+    cursor: pointer;
+    transition: all 0.15s;
+    user-select: none;
+}
+
+.cf-chip:hover {
+    border-color: var(--color-primary-light, #2E68AA);
+    color: var(--color-primary-light, #2E68AA);
+}
+
+.cf-chip.active {
+    background: var(--color-primary-light, #2E68AA);
+    border-color: var(--color-primary-light, #2E68AA);
+    color: #fff;
+}
+
+/* Geo address autocomplete dropdown */
+.cf-geo-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--body-background, #fff);
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 0 0 6px 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+    z-index: 100;
+    max-height: 250px;
+    overflow-y: auto;
+}
+
+.cf-geo-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid var(--color-divider, #eee);
+    transition: background 0.1s;
+}
+
+.cf-geo-item:last-child {
+    border-bottom: none;
+}
+
+.cf-geo-item:hover {
+    background: var(--color-listing-hover, #E6EDF5);
+}
+
+.cf-geo-item-name {
+    display: block;
+    font-size: 12px;
+    color: var(--list-color, #333);
+}
+
+.cf-geo-item-coords {
+    display: block;
+    font-size: 11px;
+    color: var(--body-color, #999);
+    margin-top: 2px;
+}
+
+/* ==========================================================================
+   Select / Select2 overrides
+   ========================================================================== */
+
+.cf-field select {
+    width: 100%;
+    padding: 10px;
+    font-size: 12px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    outline: none;
+    background: var(--body-background, #fff);
+    color: var(--list-color, #333);
+    cursor: pointer;
+    box-sizing: border-box;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23999' stroke-width='1.5' fill='none'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 32px;
+}
+
+.cf-field select:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+.cf-field .select2-container {
+    width: 100% !important;
+}
+
+.cf-field .select2-container .select2-selection {
+    min-height: 44px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    padding: 6px 12px;
+}
+
+.cf-field .select2-container--focus .select2-selection {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+/* Select2 clear button — order it before help icon */
+.cf-field .clearAllSelect2 {
+    order: 8;
+    opacity: 0.4;
+    transition: opacity 0.15s;
+    flex-shrink: 0;
+    align-self: center;
+}
+
+.cf-field .clearAllSelect2:hover {
+    opacity: 1;
+}
+
+/* Help tooltip always last, vertically centered */
+.cf-field .helpTooltip {
+    order: 9;
+    align-self: center;
+}
+
+/* ==========================================================================
+   Checkboxes
+   ========================================================================== */
+
+.cf-checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 24px;
+    padding: 8px 0;
+}
+
+.cf-checkbox-group label {
+    position: static;
+    font-size: 14px;
+    color: var(--list-color, #555);
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+}
+
+/* ==========================================================================
+   Toggle switch (reuse cl-toggle from listing)
+   ========================================================================== */
+
+.cf-toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 0;
+}
+
+.cf-toggle-row span {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--list-color, #555);
+}
+
+/* ==========================================================================
+   Dynamic entries (+ Add new entry)
+   ========================================================================== */
+
+.cf-dynamic-list {
+    margin-top: 8px;
+}
+
+.cf-dynamic-entry {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.cf-dynamic-entry input {
+    flex: 1;
+    padding: 10px 12px;
+    font-size: 14px;
+    border: 1px solid var(--color-divider, #e3e3e3);
+    border-radius: 6px;
+    outline: none;
+    background: var(--body-background, #fff);
+    color: var(--list-color, #333);
+    box-sizing: border-box;
+}
+
+.cf-dynamic-entry input:focus {
+    border-color: var(--color-primary-light, #2E68AA);
+}
+
+.cf-dynamic-delete {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-danger, #FF4A4A);
+    font-size: 16px;
+    padding: 4px;
+    opacity: 0.6;
+    transition: opacity 0.15s;
+}
+
+.cf-dynamic-delete:hover {
+    opacity: 1;
+}
+
+.cf-add-entry {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    color: var(--color-primary-light, #2E68AA);
+    cursor: pointer;
+    padding: 4px 0;
+    font-weight: 500;
+}
+
+.cf-add-entry:hover {
+    text-decoration: underline;
+}
+
+/* ==========================================================================
+   Action buttons (bottom bar)
+   ========================================================================== */
+
+.cf-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 0;
+    margin-top: 16px;
+}
+
+.cf-btn {
+    padding: 10px 24px;
+    font-size: 14px;
+    font-weight: 500;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.cf-btn-primary {
+    background: var(--color-primary-light, #2E68AA);
+    color: #fff;
+}
+
+.cf-btn-primary:hover {
+    background: var(--color-primary-hover, #255891);
+}
+
+.cf-btn-secondary {
+    background: var(--color-divider, #e8e8e8);
+    color: var(--list-color, #555);
+}
+
+.cf-btn-secondary:hover {
+    background: #d0d0d0;
+}
+
+/* Override QuickForm button styles inside cf-actions to match cl-btn-add */
+.cf-actions input[type="submit"],
+.cf-actions input[type="reset"],
+.cf-actions button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 20px;
+    min-width: 100px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #fff;
+    background-color: var(--color-primary-light, #2E68AA);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color 0.15s ease;
+}
+
+.cf-actions input[type="submit"]:hover,
+.cf-actions input[type="reset"]:hover,
+.cf-actions button:hover {
+    background-color: var(--color-primary-hover, #255891);
+}
+
+/* ==========================================================================
+   Validation error state
+   ========================================================================== */
+
+.cf-field.cf-error input,
+.cf-field.cf-error select,
+.cf-field.cf-error textarea {
+    border-color: var(--color-danger, #FF4A4A);
+}
+
+.cf-field.cf-error label {
+    color: var(--color-danger, #FF4A4A);
+}
+
+.cf-error-msg {
+    font-size: 11px;
+    color: var(--color-danger, #FF4A4A);
+    margin-top: 4px;
+    padding-left: 12px;
+}
+
+/* ==========================================================================
+   Side panel (drawer from right)
+   ========================================================================== */
+
+.cf-side-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 9998;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s, visibility 0.25s;
+}
+
+.cf-side-overlay.open {
+    opacity: 1;
+    visibility: visible;
+}
+
+.cf-side-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 55vw;
+    min-width: 400px;
+    max-width: 95vw;
+    height: 100vh;
+    background: var(--body-background, #fff);
+    box-shadow: -4px 0 24px rgba(0, 0, 0, 0.3);
+    z-index: 9999;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    display: flex;
+    flex-direction: column;
+}
+
+.cf-side-panel.open {
+    transform: translateX(0);
+}
+
+.cf-side-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--color-divider, #e3e3e3);
+    background: var(--body-background, #fff);
+    flex-shrink: 0;
+}
+
+.cf-side-panel-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--list-color, #333);
+}
+
+.cf-side-panel-close {
+    background: none;
+    border: none;
+    font-size: 22px;
+    color: var(--body-color, #999);
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+}
+
+.cf-side-panel-close:hover {
+    background: var(--color-divider, #e8e8e8);
+    color: var(--list-color, #333);
+}
+
+.cf-side-panel-body {
+    flex: 1;
+    overflow: hidden;
+}
+
+.cf-side-panel-body iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+/* Resize handle on left edge */
+.cf-side-panel-resize {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 5px;
+    cursor: col-resize;
+    z-index: 10;
+    background: transparent;
+    transition: background 0.15s;
+}
+
+.cf-side-panel-resize:hover,
+.cf-side-panel-resize.active {
+    background: var(--color-primary-light, #2E68AA);
+}
+
+/* Ensure wz_tooltip inside side panel doesn't overflow */
+.cf-side-panel-body {
+    overflow: visible;
+}

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -410,7 +410,7 @@ var CentreonForm = (function () {
 
                 var base = g.name.replace(/\[.*\]$/, '');
 
-                // Build segmented buttons, ordered Default(2), Yes(1), No(0) when present
+                // Build segmented buttons, ordered Yes(1), No(0), Default(2) when present
                 var byVal = {};
                 g.items.forEach(function (it) {
                     var lbl = it.mdRadio.querySelector('label');
@@ -418,7 +418,7 @@ var CentreonForm = (function () {
                     if (!text) text = ({ '2': 'Default', '1': 'Yes', '0': 'No' })[it.input.value] || it.input.value;
                     byVal[it.input.value] = text;
                 });
-                var order = ['2', '1', '0'].filter(function (v) { return v in byVal; });
+                var order = ['1', '0', '2'].filter(function (v) { return v in byVal; });
 
                 var seg = document.createElement('div');
                 seg.className = 'cf-segmented';

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -450,9 +450,10 @@ var CentreonForm = (function () {
                     });
                 });
 
-                // Reuse the field's float label as the inline segment label
+                // Reuse the field's float label as the inline segment label, keep help icon
                 var floatLabel = g.field.querySelector('label.cf-label-float');
                 var labelText = floatLabel ? floatLabel.textContent.trim() : '';
+                var help = g.field.querySelector('img.helpTooltip');
                 var row = document.createElement('div');
                 row.className = 'cf-segmented-row';
                 if (labelText) {
@@ -461,11 +462,18 @@ var CentreonForm = (function () {
                     row.appendChild(span);
                 }
                 row.appendChild(seg);
+                if (help) row.appendChild(help);
 
-                // Insert the segmented control and hide the original radios + float label
+                // Move ALL original field content (radios, their labels, separators and any
+                // stray text node) into a hidden holder so nothing leaks before the segmented
+                // control (e.g. a dangling "Yes" label). Radios stay in the DOM and submit.
+                var holder = document.createElement('span');
+                holder.style.display = 'none';
+                while (g.field.firstChild) {
+                    holder.appendChild(g.field.firstChild);
+                }
+                g.field.appendChild(holder);
                 g.field.insertBefore(row, g.field.firstChild);
-                if (floatLabel) floatLabel.style.display = 'none';
-                g.items.forEach(function (it) { it.mdRadio.style.display = 'none'; });
             } catch (e) { /* leave this field as plain radios on any error */ }
         });
     }

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -579,10 +579,11 @@ var CentreonForm = (function () {
                 var help = g.field.querySelector('img.helpTooltip');
                 if (help) chips.appendChild(help);
 
-                // "None" option (value 'n') is exclusive, like the host form
+                // "None" option is exclusive, like the host form. Its element NAME is 'n'
+                // (rendered as name="group[n]", id like "notifN"); the value attribute is "1".
                 var exclusive = null;
                 g.items.forEach(function (it) {
-                    if (String(it.input.value).toLowerCase() === 'n') exclusive = it.input;
+                    if (/\[n\]$/i.test(it.input.name || '') || /N$/.test(it.input.id || '')) exclusive = it.input;
                 });
 
                 g.items.forEach(function (it) {

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -685,6 +685,32 @@ var CentreonForm = (function () {
         }
     }
 
+    /**
+     * Sync an iPhone-style toggle (cl-toggle) with a plain checkbox — for
+     * pages where the underlying QuickForm field is a lone checkbox rather
+     * than a radio pair (see syncToggle() above for the radio-pair case).
+     * One-directional: the toggle drives the checkbox's checked state; the
+     * checkbox itself stays hidden in the markup.
+     *
+     * @param {string} toggleId          - DOM id of the toggle <input type="checkbox">
+     * @param {string} checkboxSelector  - CSS selector for the real checkbox, e.g. '#all_hosts' or 'input[name="dupSvTplAssoc"]'
+     * @param {function} [onChange]      - Optional extra callback(checkbox), run once on init and again on every change
+     */
+    function syncToggleCheckbox(toggleId, checkboxSelector, onChange) {
+        var toggle = document.getElementById(toggleId);
+        var checkbox = document.querySelector(checkboxSelector);
+
+        if (!toggle || !checkbox) return;
+
+        toggle.checked = checkbox.checked;
+        if (onChange) onChange(checkbox);
+
+        toggle.addEventListener('change', function () {
+            checkbox.checked = toggle.checked;
+            if (onChange) onChange(checkbox);
+        });
+    }
+
     // =========================================================================
     //  MACRO ROW CLEANUP
     //  Restructures sheepIt macro clone rows for a cleaner layout.
@@ -1109,6 +1135,7 @@ var CentreonForm = (function () {
         initCheckboxChips:    initCheckboxChips,
         initChips:            initChips,
         syncToggle:           syncToggle,
+        syncToggleCheckbox:   syncToggleCheckbox,
         makeToggle:           makeToggle,
         initSoloToggles:      initSoloToggles,
         initToggleDependencies: initToggleDependencies,

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -863,7 +863,7 @@ var CentreonForm = (function () {
         // initYesNoSegments runs BEFORE initFloatLabels: otherwise float-labels tag the
         // radios' own "Yes/No/Default" <label> with cf-label-float and we'd pick that up
         // instead of the field's real parameter label.
-        var steps = [initYesNoSegments, initCheckboxChips, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
+        var steps = [initYesNoSegments, initCheckboxChips, initSoloToggles, initToggleDependencies, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
         if (options.exclusiveChip) steps.push(function () { initChips(options.exclusiveChip); });
         if (options.macros) steps.push(initMacroCleanup);
         if (options.geo) steps.push(initGeoAutocomplete);
@@ -910,30 +910,116 @@ var CentreonForm = (function () {
                 return;
             }
             var field = input.closest('.cf-field');
-            if (!field) {
-                return;
+            if (field) {
+                _convertToToggle(field, input);
             }
-            var lbl = field.querySelector('.cf-label-float') || field.querySelector('label');
-            var text = lbl ? lbl.textContent.trim() : '';
-            var help = field.querySelector('.helpTooltip');
+        });
+    }
 
-            var toggle = document.createElement('label');
-            toggle.className = 'cl-toggle';
-            toggle.appendChild(input);
-            var slider = document.createElement('span');
-            slider.className = 'cl-toggle-slider';
-            toggle.appendChild(slider);
+    /**
+     * @private Convert a single checkbox inside a .cf-field into a cl-toggle switch.
+     * The original <input> element is preserved (id, name, handlers) so submission
+     * and any bound JS keep working.
+     */
+    function _convertToToggle(field, input) {
+        if (field.classList.contains('cf-field-toggle')) {
+            return;
+        }
+        var lbl = field.querySelector('.cf-label-float') || field.querySelector('label');
+        var text = lbl ? lbl.textContent.trim() : '';
+        var help = field.querySelector('.helpTooltip');
 
-            field.innerHTML = '';
-            field.classList.add('cf-field-toggle');
-            field.appendChild(toggle);
-            var span = document.createElement('span');
-            span.className = 'cf-toggle-label';
-            span.textContent = text;
-            field.appendChild(span);
-            if (help) {
-                field.appendChild(help);
-            }
+        var toggle = document.createElement('label');
+        toggle.className = 'cl-toggle';
+        toggle.appendChild(input);
+        var slider = document.createElement('span');
+        slider.className = 'cl-toggle-slider';
+        toggle.appendChild(slider);
+
+        field.innerHTML = '';
+        field.classList.add('cf-field-toggle');
+        field.appendChild(toggle);
+        var span = document.createElement('span');
+        span.className = 'cf-toggle-label';
+        span.textContent = text;
+        field.appendChild(span);
+        if (help) {
+            field.appendChild(help);
+        }
+    }
+
+    // =========================================================================
+    //  AUTO SOLO TOGGLES
+    //  Turn every remaining single (solo) QuickForm checkbox into a design-system
+    //  toggle. Multi-checkbox groups (turned into chips) and hidden/clone
+    //  checkboxes are left alone; a field or container marked
+    //  [data-cf-no-auto-toggle] opts out.
+    // =========================================================================
+    function initSoloToggles() {
+        var wrapper = document.querySelector('.cf-form-wrapper');
+        if (!wrapper) return;
+
+        var fields = [];
+        var groups = [];
+        wrapper.querySelectorAll('.md-checkbox input[type="checkbox"]').forEach(function (input) {
+            var mdc = input.closest('.md-checkbox');
+            if (!mdc || mdc.offsetParent === null) return;                        // hidden
+            if (input.closest('.clonable') || input.closest('.macroclone')) return; // clone/macro rows
+            var field = input.closest('.cf-field');
+            if (!field) return;
+            if (field.querySelector('.cf-chips') || field.classList.contains('cf-field-toggle')) return;
+            if (field.closest('[data-cf-no-auto-toggle]')) return;                // opt-out
+            var idx = fields.indexOf(field);
+            if (idx === -1) { fields.push(field); groups.push({ field: field, items: [] }); idx = groups.length - 1; }
+            groups[idx].items.push(input);
+        });
+
+        groups.forEach(function (g) {
+            if (g.items.length !== 1) return;   // solo checkboxes only (groups become chips)
+            try { _convertToToggle(g.field, g.items[0]); } catch (e) {}
+        });
+    }
+
+    // =========================================================================
+    //  TOGGLE DEPENDENCIES (grey out dependent fields)
+    //  Declarative: on a checkbox/toggle set
+    //    data-cf-disables="<selector>"  -> targets disabled + greyed when checked
+    //    data-cf-enables="<selector>"   -> targets disabled + greyed when unchecked
+    //  The attribute may sit on the checkbox itself or on a container holding one.
+    // =========================================================================
+    function initToggleDependencies() {
+        document.querySelectorAll('[data-cf-disables],[data-cf-enables]').forEach(_applyToggleDependency);
+    }
+
+    /** @private Wire one dependency source and apply its initial state. */
+    function _applyToggleDependency(el) {
+        var input = (el.matches && el.matches('input[type="checkbox"]'))
+            ? el
+            : el.querySelector('input[type="checkbox"]');
+        if (!input) return;
+
+        var disSel = el.getAttribute('data-cf-disables');
+        var enSel  = el.getAttribute('data-cf-enables');
+        if (!disSel && !enSel) return;
+
+        function apply() {
+            if (disSel) _setFieldsDisabled(disSel, input.checked);
+            if (enSel)  _setFieldsDisabled(enSel, !input.checked);
+        }
+        input.addEventListener('change', apply);
+        apply();
+    }
+
+    /** @private Disable + grey (or restore) every field/control matched by a selector. */
+    function _setFieldsDisabled(selector, disabled) {
+        document.querySelectorAll(selector).forEach(function (target) {
+            var isControl = target.matches && target.matches('input,select,textarea,button');
+            var box = isControl ? (target.closest('.cf-field') || target) : target;
+            box.classList.toggle('cf-disabled', disabled);
+            if (isControl) target.disabled = disabled;
+            box.querySelectorAll('input,select,textarea,button').forEach(function (el) {
+                el.disabled = disabled;
+            });
         });
     }
 
@@ -963,6 +1049,8 @@ var CentreonForm = (function () {
         initChips:            initChips,
         syncToggle:           syncToggle,
         makeToggle:           makeToggle,
+        initSoloToggles:      initSoloToggles,
+        initToggleDependencies: initToggleDependencies,
         initMacroCleanup:     initMacroCleanup,
         initGeoAutocomplete:  initGeoAutocomplete,
         hideBreadcrumbInPanel: hideBreadcrumbInPanel,

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -1,0 +1,725 @@
+/**
+ * Centreon Form Library — Shared JS for modernized configuration forms.
+ *
+ * Provides reusable UI components for the redesigned Smarty form templates:
+ * - Side panel (drawer) management
+ * - Accordion sections with anchor navigation
+ * - Floating labels on text inputs
+ * - Segmented buttons (Default / Yes / No) synced with QuickForm radio groups
+ * - Chip selection (toggleable tags) synced with QuickForm checkboxes
+ * - Toggle switches synced with QuickForm radio groups
+ * - Custom hover tooltips replacing wz_tooltip
+ * - Macro row cleanup for sheepIt clone forms
+ * - Geo coordinates address autocomplete via Nominatim
+ *
+ * Usage in a form template (.ihtml):
+ *
+ *   // Initialize all form components
+ *   CentreonForm.initFormPage();
+ *
+ *   // Initialize side panel on a listing page
+ *   CentreonForm.initSidePanel(listingInstance);
+ *
+ * @copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ * @license Apache-2.0
+ */
+var CentreonForm = (function () {
+    'use strict';
+
+    // =========================================================================
+    //  SIDE PANEL (Drawer)
+    //  Opens a form in a slide-in panel from the right side of the listing page.
+    //  The form loads in an iframe so all QuickForm JS works natively.
+    // =========================================================================
+
+    /**
+     * Open the side panel with a form URL.
+     *
+     * @param {string} url   - The URL to load in the panel iframe (e.g. main.get.php?p=60101&o=c&host_id=14)
+     * @param {string} title - The title displayed in the panel header (e.g. "Modify Host - central")
+     */
+    function openPanel(url, title) {
+        var titleEl = document.getElementById('cfSidePanelTitle');
+        var frameEl = document.getElementById('cfSidePanelFrame');
+        var overlay = document.getElementById('cfSideOverlay');
+        var panel   = document.getElementById('cfSidePanel');
+
+        if (!titleEl || !frameEl || !overlay || !panel) {
+            return;
+        }
+
+        titleEl.textContent = title || '';
+        frameEl.src = url;
+        overlay.classList.add('open');
+        panel.classList.add('open');
+    }
+
+    /**
+     * Close the side panel and refresh the listing.
+     *
+     * @param {object} [listingInstance] - The CentreonListing instance to refresh after close.
+     *                                     If null, no refresh is performed.
+     */
+    function closePanel(listingInstance) {
+        // Use the stored listing reference if none provided
+        var listing = listingInstance || _sidePanelListing;
+
+        var overlay = document.getElementById('cfSideOverlay');
+        var panel   = document.getElementById('cfSidePanel');
+        var frameEl = document.getElementById('cfSidePanelFrame');
+
+        if (!overlay || !panel) {
+            return;
+        }
+
+        overlay.classList.remove('open');
+        panel.classList.remove('open');
+
+        // Reset iframe after the CSS transition completes (300ms)
+        setTimeout(function () {
+            if (frameEl) {
+                frameEl.src = 'about:blank';
+            }
+        }, 300);
+
+        // Silently refresh the listing data
+        if (listing && typeof listing.getState === 'function') {
+            var state = listing.getState();
+            listing.fetch(state.num, state.limit, state.search, true);
+        }
+    }
+
+    /**
+     * Initialize the side panel: resize handle, Escape key, overlay click.
+     * Call this once on each listing page that uses a side panel.
+     *
+     * @param {object} listingInstance - The CentreonListing instance to refresh on close.
+     */
+    function initSidePanel(listingInstance) {
+        // Store the listing reference for closePanel calls
+        _sidePanelListing = listingInstance;
+        CentreonForm._sidePanelListing = listingInstance;
+
+        // --- Resize handle (drag left edge to resize) ---
+        var handle  = document.getElementById('cfSidePanelResize');
+        var panel   = document.getElementById('cfSidePanel');
+        var dragging = false;
+
+        if (handle && panel) {
+            handle.addEventListener('mousedown', function (e) {
+                e.preventDefault();
+                dragging = true;
+                handle.classList.add('active');
+                document.body.style.cursor = 'col-resize';
+
+                // Disable iframe pointer events during drag to prevent mouse capture
+                var iframe = document.getElementById('cfSidePanelFrame');
+                if (iframe) {
+                    iframe.style.pointerEvents = 'none';
+                }
+            });
+
+            document.addEventListener('mousemove', function (e) {
+                if (!dragging) return;
+                var width = window.innerWidth - e.clientX;
+                if (width < 400) width = 400;
+                if (width > window.innerWidth * 0.95) width = window.innerWidth * 0.95;
+                panel.style.width = width + 'px';
+            });
+
+            document.addEventListener('mouseup', function () {
+                if (!dragging) return;
+                dragging = false;
+                handle.classList.remove('active');
+                document.body.style.cursor = '';
+
+                var iframe = document.getElementById('cfSidePanelFrame');
+                if (iframe) {
+                    iframe.style.pointerEvents = '';
+                }
+            });
+        }
+
+        // --- Close on Escape key ---
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') {
+                closePanel(listingInstance);
+            }
+        });
+    }
+
+    /** @private Reference to the listing instance for closePanel */
+    var _sidePanelListing = null;
+
+    /**
+     * Detect if the current page is loaded inside the side panel iframe.
+     * If so, close the parent's panel (used after a form save redirects to the listing).
+     *
+     * Call this at the top of every listing template.
+     */
+    function detectSidePanelClose() {
+        if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+            try {
+                var parentForm = window.parent.CentreonForm;
+                parentForm.closePanel(parentForm._sidePanelListing);
+            } catch (e) {
+                // Silently ignore — may fail on cross-origin or missing lib
+            }
+        }
+    }
+
+    // =========================================================================
+    //  ACCORDION SECTIONS
+    //  Collapsible sections with a header bar. Click to expand/collapse.
+    // =========================================================================
+
+    /**
+     * Toggle an accordion section open/closed.
+     * The section element gets the CSS class "collapsed" which hides its body.
+     *
+     * @param {HTMLElement} header - The .cf-section-header element that was clicked.
+     */
+    function toggleSection(header) {
+        var section = header.parentElement;
+        if (section) {
+            section.classList.toggle('collapsed');
+        }
+    }
+
+    /**
+     * Smooth-scroll to a section and expand it if collapsed.
+     * Used by the tab navigation anchors at the top of the form.
+     *
+     * @param {string}      sectionId   - The DOM id of the target section (e.g. "cf-sec-basic").
+     * @param {HTMLElement}  clickedLink - The anchor element that was clicked (to update active state).
+     */
+    function scrollTo(sectionId, clickedLink) {
+        var section = document.getElementById(sectionId);
+        if (section) {
+            // Expand if currently collapsed
+            if (section.classList.contains('collapsed')) {
+                section.classList.remove('collapsed');
+            }
+            section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+
+        // Update active state on all tab nav links
+        document.querySelectorAll('.cf-tab-nav a').forEach(function (a) {
+            a.classList.remove('active');
+        });
+        if (clickedLink) {
+            clickedLink.classList.add('active');
+        }
+    }
+
+    // =========================================================================
+    //  FLOATING LABELS
+    //  Labels that float above the input when it has a value or is focused.
+    //  The label gets the CSS class "cf-label-float" to trigger the animation.
+    // =========================================================================
+
+    /**
+     * Initialize floating labels on all .cf-field inputs and textareas.
+     * - On page load: float labels for pre-filled inputs
+     * - On focus: float the label
+     * - On blur: un-float if the input is empty
+     */
+    function initFloatLabels() {
+        document.querySelectorAll('.cf-field input, .cf-field textarea').forEach(function (input) {
+            var label = input.parentElement.querySelector('label');
+            if (!label) return;
+
+            // Float label if input already has a value
+            if (input.value && input.value.trim() !== '') {
+                label.classList.add('cf-label-float');
+            }
+
+            input.addEventListener('focus', function () {
+                var lbl = this.parentElement.querySelector('label');
+                if (lbl) lbl.classList.add('cf-label-float');
+            });
+
+            input.addEventListener('blur', function () {
+                if (!this.value || this.value.trim() === '') {
+                    var lbl = this.parentElement.querySelector('label');
+                    if (lbl) lbl.classList.remove('cf-label-float');
+                }
+            });
+        });
+    }
+
+    // =========================================================================
+    //  CUSTOM TOOLTIPS
+    //  Hover tooltips that replace the legacy wz_tooltip / TagToTip system.
+    //  Positioned above the icon, dark background, auto-dismiss on mouseout.
+    // =========================================================================
+
+    /**
+     * Initialize custom hover tooltips on all .helpTooltip elements.
+     * Reads the help text from hidden <span id="help:{name}"> elements
+     * generated by the PHP help.php include.
+     *
+     * @param {number} [delay=500] - Delay in ms before showing the tooltip.
+     */
+    function initTooltips(delay) {
+        delay = delay || 500;
+
+        // Wait for the footer's CentreonToolTip.render() to finish
+        setTimeout(function () {
+            var hoverTimer = null;
+            var tipEl = null;
+
+            jQuery('.helpTooltip')
+                .off('click')
+                .css('cursor', 'help')
+                .on('mouseenter', function () {
+                    var self = this;
+                    hoverTimer = setTimeout(function () {
+                        var helpSpan = document.getElementById('help:' + jQuery(self).attr('name'));
+                        if (!helpSpan) return;
+
+                        // Remove existing tooltip
+                        if (tipEl) tipEl.remove();
+
+                        // Create tooltip element
+                        tipEl = document.createElement('div');
+                        tipEl.className = 'cf-tooltip';
+                        tipEl.innerHTML = helpSpan.innerHTML;
+                        document.body.appendChild(tipEl);
+
+                        // Position above the icon, centered, with edge detection
+                        var rect = self.getBoundingClientRect();
+                        var tipH = tipEl.offsetHeight;
+                        var tipW = tipEl.offsetWidth;
+
+                        var top = rect.top - tipH - 8;
+                        if (top < 4) top = rect.bottom + 8; // Flip below if no room above
+
+                        var left = rect.left + rect.width / 2 - tipW / 2;
+                        if (left < 4) left = 4;
+                        if (left + tipW > window.innerWidth - 4) {
+                            left = window.innerWidth - tipW - 4;
+                        }
+
+                        tipEl.style.top = top + 'px';
+                        tipEl.style.left = left + 'px';
+                        tipEl.style.opacity = '1';
+                    }, delay);
+                })
+                .on('mouseleave', function () {
+                    clearTimeout(hoverTimer);
+                    if (tipEl) {
+                        tipEl.remove();
+                        tipEl = null;
+                    }
+                });
+        }, 500);
+    }
+
+    // =========================================================================
+    //  SEGMENTED BUTTONS (Default / Yes / No)
+    //  Replace QuickForm radio groups with a row of toggle buttons.
+    //  The active button gets the "active" CSS class and the hidden radio
+    //  is updated to match.
+    // =========================================================================
+
+    /**
+     * Initialize all segmented button groups on the page.
+     * Each group is a .cf-segmented element with data-radio-name attribute
+     * pointing to the QuickForm radio group name.
+     *
+     * QuickForm generates radio names as either:
+     *   - name="fieldname[fieldname]" (for addGroup)
+     *   - name="fieldname" (for simple radios)
+     * This function tries both patterns.
+     */
+    function initSegmentedButtons() {
+        document.querySelectorAll('.cf-segmented').forEach(function (group) {
+            var radioName = group.dataset.radioName;
+            var buttons = group.querySelectorAll('button');
+
+            buttons.forEach(function (btn) {
+                var val = btn.dataset.value;
+
+                // Find the matching radio button (try both naming patterns)
+                var radio = _findRadio(radioName, val);
+
+                // Set initial active state from the checked radio
+                if (radio && radio.checked) {
+                    btn.classList.add('active');
+                }
+
+                // Click handler: update visual state and hidden radio
+                btn.addEventListener('click', function () {
+                    buttons.forEach(function (b) {
+                        b.classList.remove('active');
+                    });
+                    this.classList.add('active');
+
+                    var r = _findRadio(radioName, val);
+                    if (r) r.checked = true;
+                });
+            });
+        });
+    }
+
+    // =========================================================================
+    //  CHIP SELECTION (toggleable tags)
+    //  Replace QuickForm checkbox groups with pill-shaped toggle buttons.
+    //  Supports exclusive options (e.g. "None" unchecks all others).
+    // =========================================================================
+
+    /**
+     * Initialize chip selection on all .cf-chip elements.
+     * Each chip has a data-checkbox attribute pointing to the checkbox ID.
+     *
+     * @param {string} [exclusiveChip] - The data-checkbox value of the exclusive option
+     *                                    (e.g. "notifN"). Selecting it unchecks all others.
+     */
+    function initChips(exclusiveChip) {
+        document.querySelectorAll('.cf-chip').forEach(function (chip) {
+            var cbId = chip.dataset.checkbox;
+            var cb = document.getElementById(cbId);
+
+            // Set initial active state
+            if (cb && cb.checked) {
+                chip.classList.add('active');
+            }
+
+            chip.addEventListener('click', function () {
+                if (exclusiveChip && cbId === exclusiveChip) {
+                    // Exclusive chip: uncheck all others
+                    document.querySelectorAll('.cf-chip').forEach(function (c) {
+                        if (c.dataset.checkbox !== exclusiveChip) {
+                            c.classList.remove('active');
+                            var other = document.getElementById(c.dataset.checkbox);
+                            if (other) other.checked = false;
+                        }
+                    });
+                } else if (exclusiveChip) {
+                    // Non-exclusive chip: uncheck the exclusive one
+                    var exChip = document.querySelector('.cf-chip[data-checkbox="' + exclusiveChip + '"]');
+                    if (exChip) exChip.classList.remove('active');
+                    var exCb = document.getElementById(exclusiveChip);
+                    if (exCb) exCb.checked = false;
+                }
+
+                // Toggle this chip
+                this.classList.toggle('active');
+                if (cb) cb.checked = this.classList.contains('active');
+            });
+        });
+    }
+
+    // =========================================================================
+    //  TOGGLE SWITCH SYNC
+    //  Sync an iPhone-style toggle (cl-toggle) with hidden QuickForm radios.
+    // =========================================================================
+
+    /**
+     * Sync a toggle switch checkbox with a QuickForm radio group.
+     *
+     * @param {string} toggleId  - The DOM id of the toggle <input type="checkbox">
+     * @param {string} radioName - The QuickForm radio group name
+     * @param {string} onValue   - The radio value when toggle is ON (usually "1")
+     * @param {string} offValue  - The radio value when toggle is OFF (usually "0")
+     */
+    function syncToggle(toggleId, radioName, onValue, offValue) {
+        var toggle = document.getElementById(toggleId);
+        var radioOn  = _findRadio(radioName, onValue);
+        var radioOff = _findRadio(radioName, offValue);
+
+        if (!toggle || !radioOn) return;
+
+        // Set initial state from the checked radio
+        toggle.checked = radioOn.checked;
+
+        // Update hidden radio on toggle change
+        toggle.addEventListener('change', function () {
+            if (this.checked) {
+                radioOn.checked = true;
+            } else if (radioOff) {
+                radioOff.checked = true;
+            }
+        });
+    }
+
+    // =========================================================================
+    //  MACRO ROW CLEANUP
+    //  Restructures sheepIt macro clone rows for a cleaner layout.
+    //  Removes inline text labels, adds placeholders, wraps action icons.
+    // =========================================================================
+
+    /**
+     * Clean up macro clone rows generated by cloneMacro.ihtml + sheepIt.
+     * - Removes text node labels ("Name", "Value", "Password")
+     * - Adds placeholder text to Name and Value inputs
+     * - Wraps trailing action icons in an aligned flex container
+     *
+     * Automatically re-runs when sheepIt adds or refreshes rows
+     * via a MutationObserver.
+     */
+    function initMacroCleanup() {
+        _cleanMacroRows();
+
+        // Watch for sheepIt adding new rows
+        var macroList = document.querySelector('ul.macroclone');
+        if (macroList) {
+            var observer = new MutationObserver(function () {
+                setTimeout(_cleanMacroRows, 100);
+            });
+            observer.observe(macroList, { childList: true, subtree: true });
+        }
+    }
+
+    /** @private Clean all macro rows */
+    function _cleanMacroRows() {
+        document.querySelectorAll('.macroclone .onemacro .clone-cell').forEach(function (cell) {
+            if (cell.dataset.cfProcessed) return;
+            cell.dataset.cfProcessed = '1';
+
+            // Remove text nodes from label spans
+            cell.querySelectorAll(':scope > span').forEach(function (span) {
+                Array.from(span.childNodes).forEach(function (node) {
+                    if (node.nodeType === 3 && node.textContent.trim()) {
+                        node.textContent = '';
+                    }
+                });
+            });
+
+            // Add placeholders
+            var nameInput = cell.querySelector('input[name^="macroInput"]');
+            if (nameInput) nameInput.placeholder = 'Name';
+            var valInput = cell.querySelector('input[name^="macroValue"]');
+            if (valInput) valInput.placeholder = 'Value';
+
+            // Wrap trailing icons in a flex container
+            var icons = [];
+            var children = Array.from(cell.children);
+            var passedSpans = 0;
+            children.forEach(function (child) {
+                if (child.tagName === 'SPAN') passedSpans++;
+                if (passedSpans >= 3 && (child.tagName === 'IMG' || child.tagName === 'INPUT'
+                    || (child.tagName === 'SPAN' && (child.classList.contains('clonehandle')
+                        || child.id.indexOf('remove_current') !== -1)))) {
+                    icons.push(child);
+                }
+            });
+            if (icons.length > 0) {
+                var wrapper = document.createElement('div');
+                wrapper.className = 'cf-macro-actions';
+                wrapper.style.cssText = 'display:flex;align-items:center;gap:4px;flex-shrink:0;';
+                icons.forEach(function (icon) {
+                    wrapper.appendChild(icon);
+                });
+                cell.appendChild(wrapper);
+            }
+        });
+    }
+
+    // =========================================================================
+    //  GEO COORDINATES AUTOCOMPLETE
+    //  Address search via Nominatim (OpenStreetMap) API.
+    //  Type 3+ characters to search, results appear in a dropdown.
+    // =========================================================================
+
+    /**
+     * Initialize the geo coordinates address autocomplete.
+     * Requires two elements:
+     * - An input with id="cfGeoAddress" (the search field)
+     * - A div with id="cfGeoResults" (the dropdown container)
+     * - A target input with name="geo_coords" (where the lat,lon is written)
+     *
+     * @param {number} [debounce=400] - Debounce delay in ms before searching.
+     */
+    function initGeoAutocomplete(debounce) {
+        debounce = debounce || 400;
+
+        var geoInput   = document.getElementById('cfGeoAddress');
+        var geoResults = document.getElementById('cfGeoResults');
+        if (!geoInput || !geoResults) return;
+
+        var timer = null;
+
+        // Search on input (debounced)
+        geoInput.addEventListener('input', function () {
+            clearTimeout(timer);
+            var query = this.value.trim();
+            if (query.length < 3) {
+                geoResults.style.display = 'none';
+                return;
+            }
+
+            timer = setTimeout(function () {
+                var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=5&q='
+                    + encodeURIComponent(query);
+
+                fetch(url)
+                    .then(function (r) { return r.json(); })
+                    .then(function (data) {
+                        if (!data || data.length === 0) {
+                            geoResults.style.display = 'none';
+                            return;
+                        }
+
+                        var html = '';
+                        data.forEach(function (item) {
+                            html += '<div class="cf-geo-item" data-coords="'
+                                + item.lat + ',' + item.lon + '">'
+                                + '<span class="cf-geo-item-name">'
+                                + item.display_name + '</span>'
+                                + '<span class="cf-geo-item-coords">'
+                                + item.lat + ', ' + item.lon + '</span></div>';
+                        });
+
+                        geoResults.innerHTML = html;
+                        geoResults.style.display = 'block';
+                    })
+                    .catch(function () {
+                        geoResults.style.display = 'none';
+                    });
+            }, debounce);
+        });
+
+        // Select a result
+        geoResults.addEventListener('click', function (e) {
+            var item = e.target.closest('.cf-geo-item');
+            if (!item) return;
+
+            var coordInput = document.querySelector('input[name="geo_coords"]');
+            if (coordInput) {
+                coordInput.value = item.dataset.coords;
+            }
+
+            // Float the label
+            var label = coordInput
+                ? coordInput.parentElement.querySelector('label')
+                : null;
+            if (label) label.classList.add('cf-label-float');
+
+            // Show the selected address in the search field
+            geoInput.value = item.querySelector('.cf-geo-item-name').textContent;
+            geoResults.style.display = 'none';
+        });
+
+        // Hide dropdown on outside click
+        document.addEventListener('click', function (e) {
+            if (!geoInput.contains(e.target) && !geoResults.contains(e.target)) {
+                geoResults.style.display = 'none';
+            }
+        });
+
+        // Prevent form submit on Enter in search field
+        geoInput.addEventListener('keypress', function (e) {
+            if (e.key === 'Enter') e.preventDefault();
+        });
+    }
+
+    // =========================================================================
+    //  BREADCRUMB HIDE (in side panel context)
+    // =========================================================================
+
+    /**
+     * Hide the breadcrumb and page title when the form is loaded
+     * inside the side panel iframe (they're redundant with the panel header).
+     */
+    function hideBreadcrumbInPanel() {
+        if (window.frameElement && window.frameElement.id === 'cfSidePanelFrame') {
+            var breadcrumb = document.querySelector('.pathway');
+            if (breadcrumb) breadcrumb.style.display = 'none';
+
+            var title = document.querySelector('.cf-page-title');
+            if (title) title.style.display = 'none';
+        }
+    }
+
+    // =========================================================================
+    //  CONVENIENCE INITIALIZERS
+    // =========================================================================
+
+    /**
+     * Initialize all form components on a form page.
+     * Call this once in the form template's DOMContentLoaded handler.
+     *
+     * @param {object} [options]
+     * @param {string} [options.exclusiveChip]  - Exclusive chip ID for initChips (e.g. "notifN")
+     * @param {boolean} [options.macros=false]  - Whether to initialize macro cleanup
+     * @param {boolean} [options.geo=false]     - Whether to initialize geo autocomplete
+     */
+    function initFormPage(options) {
+        options = options || {};
+
+        initFloatLabels();
+        initSegmentedButtons();
+        initTooltips();
+        hideBreadcrumbInPanel();
+
+        if (options.exclusiveChip) {
+            initChips(options.exclusiveChip);
+        }
+
+        if (options.macros) {
+            initMacroCleanup();
+        }
+
+        if (options.geo) {
+            initGeoAutocomplete();
+        }
+    }
+
+    // =========================================================================
+    //  PRIVATE HELPERS
+    // =========================================================================
+
+    /**
+     * Find a QuickForm radio button by name and value.
+     * Tries both naming patterns: "name[name]" (addGroup) and "name" (simple).
+     *
+     * @private
+     * @param {string} name  - The radio group name
+     * @param {string} value - The radio value to find
+     * @returns {HTMLElement|null}
+     */
+    function _findRadio(name, value) {
+        return document.querySelector('input[name="' + name + '[' + name + ']"][value="' + value + '"]')
+            || document.querySelector('input[name="' + name + '"][value="' + value + '"]');
+    }
+
+    // =========================================================================
+    //  PUBLIC API
+    // =========================================================================
+
+    return {
+        // Side panel
+        openPanel:            openPanel,
+        closePanel:           closePanel,
+        initSidePanel:        initSidePanel,
+        detectSidePanelClose: detectSidePanelClose,
+        /** @internal Exposed for cross-iframe access in detectSidePanelClose */
+        _sidePanelListing:    null,
+
+        // Accordion
+        toggleSection: toggleSection,
+        scrollTo:      scrollTo,
+
+        // Form components
+        initFloatLabels:      initFloatLabels,
+        initTooltips:         initTooltips,
+        initSegmentedButtons: initSegmentedButtons,
+        initChips:            initChips,
+        syncToggle:           syncToggle,
+        initMacroCleanup:     initMacroCleanup,
+        initGeoAutocomplete:  initGeoAutocomplete,
+        hideBreadcrumbInPanel: hideBreadcrumbInPanel,
+
+        // Convenience
+        initFormPage: initFormPage
+    };
+
+})();
+
+// Global aliases for use in onclick attributes in Smarty templates
+var cfOpenPanel     = CentreonForm.openPanel;
+var cfClosePanel    = function () { CentreonForm.closePanel(CentreonForm._sidePanelListing); };
+var cfToggleSection = CentreonForm.toggleSection;
+var cfScrollTo      = CentreonForm.scrollTo;

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -792,18 +792,26 @@ var CentreonForm = (function () {
 
     /**
      * Initialize the geo coordinates address autocomplete.
-     * Requires two elements:
-     * - An input with id="cfGeoAddress" (the search field)
-     * - A div with id="cfGeoResults" (the dropdown container)
+     * Requires two elements (ids configurable — see options — for pages
+     * that tuck the picker inside a popin/modal instead of an inline field):
+     * - An input, id="cfGeoAddress" by default (the search field)
+     * - A div, id="cfGeoResults" by default (the dropdown container)
      * - A target input with name="geo_coords" (where the lat,lon is written)
      *
-     * @param {number} [debounce=400] - Debounce delay in ms before searching.
+     * @param {Object} [options]
+     * @param {string}   [options.inputId='cfGeoAddress']
+     * @param {string}   [options.resultsId='cfGeoResults']
+     * @param {number}   [options.debounce=400] - Debounce delay in ms before searching.
+     * @param {function} [options.onSelect] - Called (item, coordInput) after a
+     *   result is picked, instead of the default behavior of echoing the
+     *   picked address back into the search field (e.g. to close a popin).
      */
-    function initGeoAutocomplete(debounce) {
-        debounce = debounce || 400;
+    function initGeoAutocomplete(options) {
+        options = options || {};
+        var debounce = options.debounce || 400;
 
-        var geoInput   = document.getElementById('cfGeoAddress');
-        var geoResults = document.getElementById('cfGeoResults');
+        var geoInput   = document.getElementById(options.inputId || 'cfGeoAddress');
+        var geoResults = document.getElementById(options.resultsId || 'cfGeoResults');
         if (!geoInput || !geoResults) return;
 
         var timer = null;
@@ -864,8 +872,12 @@ var CentreonForm = (function () {
                 : null;
             if (label) label.classList.add('cf-label-float');
 
-            // Show the selected address in the search field
-            geoInput.value = item.querySelector('.cf-geo-item-name').textContent;
+            if (options.onSelect) {
+                options.onSelect(item, coordInput);
+            } else {
+                // Show the selected address in the search field
+                geoInput.value = item.querySelector('.cf-geo-item-name').textContent;
+            }
             geoResults.style.display = 'none';
         });
 

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -357,9 +357,95 @@ var CentreonForm = (function () {
                     this.classList.add('active');
 
                     var r = _findRadio(radioName, val);
-                    if (r) r.checked = true;
+                    if (r) {
+                        r.checked = true;
+                        // Notify dependent handlers bound to the underlying radio
+                        try { r.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) {}
+                        try { r.dispatchEvent(new Event('click', { bubbles: true })); } catch (e) {}
+                    }
                 });
             });
+        });
+    }
+
+    // =========================================================================
+    //  AUTO YES/NO/DEFAULT SEGMENTS
+    //  Convert visible QuickForm radio groups (.md-radio with values in {0,1,2})
+    //  into segmented controls, consistently with the host form. Hidden radios
+    //  (host's explicit segments, cl-toggle activate fields) are skipped via the
+    //  visibility check, so this never double-processes them.
+    // =========================================================================
+    function initYesNoSegments() {
+        var wrapper = document.querySelector('.cf-form-wrapper');
+        if (!wrapper) return;
+
+        // Group visible radios by their (field, name)
+        var groups = [];
+        var index = {};
+        wrapper.querySelectorAll('.md-radio input[type="radio"]').forEach(function (input) {
+            var mdRadio = input.closest('.md-radio');
+            if (!mdRadio) return;
+            // Skip hidden radios (host explicit segments, activate toggles, hidden tabs)
+            if (mdRadio.offsetParent === null) return;
+            var field = input.closest('.cf-field') || input.closest('.cf-segmented-row');
+            if (!field || field.classList.contains('cf-segmented-row')) return;
+            if (field.querySelector('.cf-segmented')) return;
+
+            var key = field.dataset.cfRid || (field.dataset.cfRid = String(groups.length) + ':' + input.name);
+            if (!(key in index)) {
+                index[key] = groups.length;
+                groups.push({ field: field, name: input.name, items: [] });
+            }
+            groups[index[key]].items.push({ input: input, mdRadio: mdRadio });
+        });
+
+        groups.forEach(function (g) {
+            if (g.items.length < 2 || g.items.length > 3) return;
+            // Only yes/no/default style groups (values within {0,1,2})
+            var ok = g.items.every(function (it) {
+                return ['0', '1', '2'].indexOf(String(it.input.value)) !== -1;
+            });
+            if (!ok) return;
+
+            var base = g.name.replace(/\[.*\]$/, '');
+
+            // Build segmented buttons, ordered Default(2), Yes(1), No(0) when present
+            var byVal = {};
+            g.items.forEach(function (it) {
+                var lbl = it.mdRadio.querySelector('label');
+                var text = lbl ? lbl.textContent.trim() : '';
+                if (!text) text = ({ '2': 'Default', '1': 'Yes', '0': 'No' })[it.input.value] || it.input.value;
+                byVal[it.input.value] = text;
+            });
+            var order = ['2', '1', '0'].filter(function (v) { return v in byVal; });
+
+            var seg = document.createElement('div');
+            seg.className = 'cf-segmented';
+            seg.setAttribute('data-radio-name', base);
+            order.forEach(function (v) {
+                var b = document.createElement('button');
+                b.type = 'button';
+                b.setAttribute('data-value', v);
+                b.textContent = byVal[v];
+                seg.appendChild(b);
+            });
+
+            // Reuse the field's float label as the inline segment label
+            var floatLabel = g.field.querySelector('label.cf-label-float');
+            var labelText = floatLabel ? floatLabel.textContent.trim() : '';
+            var row = document.createElement('div');
+            row.className = 'cf-segmented-row';
+            if (labelText) {
+                var span = document.createElement('span');
+                span.textContent = labelText;
+                row.appendChild(span);
+            }
+            row.appendChild(seg);
+
+            // Insert the segmented control and hide the original radios + float label
+            g.field.insertBefore(row, g.field.firstChild);
+            if (floatLabel) floatLabel.style.display = 'none';
+            g.items.forEach(function (it) { it.mdRadio.style.display = 'none'; });
         });
     }
 
@@ -650,6 +736,7 @@ var CentreonForm = (function () {
         options = options || {};
 
         initFloatLabels();
+        initYesNoSegments();
         initSegmentedButtons();
         initTooltips();
         hideBreadcrumbInPanel();
@@ -706,6 +793,7 @@ var CentreonForm = (function () {
         initFloatLabels:      initFloatLabels,
         initTooltips:         initTooltips,
         initSegmentedButtons: initSegmentedButtons,
+        initYesNoSegments:    initYesNoSegments,
         initChips:            initChips,
         syncToggle:           syncToggle,
         initMacroCleanup:     initMacroCleanup,

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -225,26 +225,13 @@ var CentreonForm = (function () {
      * - On blur: un-float if the input is empty
      */
     function initFloatLabels() {
+        // The templates render every field label with the .cf-label-float class,
+        // so labels sit on the top border at all times. We keep them there and no
+        // longer drop them back into the field on blur (which looked inconsistent
+        // once a field had been focused). This just guarantees the class is set.
         document.querySelectorAll('.cf-field input, .cf-field textarea').forEach(function (input) {
             var label = input.parentElement.querySelector('label');
-            if (!label) return;
-
-            // Float label if input already has a value
-            if (input.value && input.value.trim() !== '') {
-                label.classList.add('cf-label-float');
-            }
-
-            input.addEventListener('focus', function () {
-                var lbl = this.parentElement.querySelector('label');
-                if (lbl) lbl.classList.add('cf-label-float');
-            });
-
-            input.addEventListener('blur', function () {
-                if (!this.value || this.value.trim() === '') {
-                    var lbl = this.parentElement.querySelector('label');
-                    if (lbl) lbl.classList.remove('cf-label-float');
-                }
-            });
+            if (label) label.classList.add('cf-label-float');
         });
     }
 

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -892,6 +892,52 @@ var CentreonForm = (function () {
     }
 
     // =========================================================================
+    //  MAKE TOGGLE
+    //  Turn QuickForm checkbox field(s) into a Centreon design-system switch.
+    //  Call BEFORE initFormPage so the chip auto-transform skips them.
+    // =========================================================================
+
+    /**
+     * @param {string|string[]} names one or more checkbox element names
+     */
+    function makeToggle(names) {
+        if (!Array.isArray(names)) {
+            names = [names];
+        }
+        names.forEach(function (name) {
+            var input = document.querySelector('input[name="' + name + '"]');
+            if (!input) {
+                return;
+            }
+            var field = input.closest('.cf-field');
+            if (!field) {
+                return;
+            }
+            var lbl = field.querySelector('.cf-label-float') || field.querySelector('label');
+            var text = lbl ? lbl.textContent.trim() : '';
+            var help = field.querySelector('.helpTooltip');
+
+            var toggle = document.createElement('label');
+            toggle.className = 'cl-toggle';
+            toggle.appendChild(input);
+            var slider = document.createElement('span');
+            slider.className = 'cl-toggle-slider';
+            toggle.appendChild(slider);
+
+            field.innerHTML = '';
+            field.classList.add('cf-field-toggle');
+            field.appendChild(toggle);
+            var span = document.createElement('span');
+            span.className = 'cf-toggle-label';
+            span.textContent = text;
+            field.appendChild(span);
+            if (help) {
+                field.appendChild(help);
+            }
+        });
+    }
+
+    // =========================================================================
     //  PUBLIC API
     // =========================================================================
 
@@ -916,6 +962,7 @@ var CentreonForm = (function () {
         initCheckboxChips:    initCheckboxChips,
         initChips:            initChips,
         syncToggle:           syncToggle,
+        makeToggle:           makeToggle,
         initMacroCleanup:     initMacroCleanup,
         initGeoAutocomplete:  initGeoAutocomplete,
         hideBreadcrumbInPanel: hideBreadcrumbInPanel,
@@ -931,3 +978,4 @@ var cfOpenPanel     = CentreonForm.openPanel;
 var cfClosePanel    = function () { CentreonForm.closePanel(CentreonForm._sidePanelListing); };
 var cfToggleSection = CentreonForm.toggleSection;
 var cfScrollTo      = CentreonForm.scrollTo;
+var cfMakeToggle    = CentreonForm.makeToggle;

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -451,7 +451,13 @@ var CentreonForm = (function () {
                 });
 
                 // Reuse the field's float label as the inline segment label, keep help icon
-                var floatLabel = g.field.querySelector('label.cf-label-float');
+                // The field's real parameter label = a cf-label-float that is NOT a radio's
+                // own label (those live inside .md-radio).
+                var floatLabel = null;
+                var candidates = g.field.querySelectorAll('label.cf-label-float');
+                Array.prototype.forEach.call(candidates, function (l) {
+                    if (!floatLabel && !l.closest('.md-radio')) floatLabel = l;
+                });
                 var labelText = floatLabel ? floatLabel.textContent.trim() : '';
                 var help = g.field.querySelector('img.helpTooltip');
                 var row = document.createElement('div');
@@ -765,7 +771,10 @@ var CentreonForm = (function () {
         options = options || {};
 
         // Each step is isolated so a failure in one never aborts the others.
-        var steps = [initFloatLabels, initYesNoSegments, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
+        // initYesNoSegments runs BEFORE initFloatLabels: otherwise float-labels tag the
+        // radios' own "Yes/No/Default" <label> with cf-label-float and we'd pick that up
+        // instead of the field's real parameter label.
+        var steps = [initYesNoSegments, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
         if (options.exclusiveChip) steps.push(function () { initChips(options.exclusiveChip); });
         if (options.macros) steps.push(initMacroCleanup);
         if (options.geo) steps.push(initGeoAutocomplete);

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -533,6 +533,94 @@ var CentreonForm = (function () {
     }
 
     // =========================================================================
+    //  AUTO CHECKBOX CHIPS
+    //  Convert visible QuickForm checkbox GROUPS (2+ .md-checkbox in one field —
+    //  e.g. notification/escalation/stalking options Up/Down/Unreachable/…) into
+    //  clickable chips, like the host form. Single checkboxes are left untouched.
+    //  Hidden checkboxes (host explicit chips) are skipped via the visibility check.
+    // =========================================================================
+    function initCheckboxChips() {
+        var wrapper = document.querySelector('.cf-form-wrapper');
+        if (!wrapper) return;
+
+        var groups = [];
+        var fields = [];
+        wrapper.querySelectorAll('.md-checkbox input[type="checkbox"]').forEach(function (input) {
+            var mdc = input.closest('.md-checkbox');
+            if (!mdc || mdc.offsetParent === null) return;            // skip hidden
+            if (input.closest('.clonable') || input.closest('.macroclone')) return; // skip clone/macro rows
+            var field = input.closest('.cf-field');
+            if (!field || field.querySelector('.cf-chips')) return;
+            var idx = fields.indexOf(field);
+            if (idx === -1) { fields.push(field); groups.push({ field: field, items: [] }); idx = groups.length - 1; }
+            groups[idx].items.push({ input: input, mdc: mdc });
+        });
+
+        groups.forEach(function (g) {
+            try {
+                if (g.items.length < 2) return;   // only multi-option groups become chips
+
+                var chips = document.createElement('div');
+                chips.className = 'cf-chips';
+                chips.setAttribute('data-cf-auto', '1');
+
+                // Field's real parameter label (not a checkbox's own label)
+                var floatLabel = null;
+                Array.prototype.forEach.call(g.field.querySelectorAll('label.cf-label-float'), function (l) {
+                    if (!floatLabel && !l.closest('.md-checkbox')) floatLabel = l;
+                });
+                var labelText = floatLabel ? floatLabel.textContent.trim() : '';
+                if (labelText) {
+                    var lab = document.createElement('span');
+                    lab.className = 'cf-chips-label';
+                    lab.textContent = labelText;
+                    chips.appendChild(lab);
+                }
+                var help = g.field.querySelector('img.helpTooltip');
+                if (help) chips.appendChild(help);
+
+                // "None" option (value 'n') is exclusive, like the host form
+                var exclusive = null;
+                g.items.forEach(function (it) {
+                    if (String(it.input.value).toLowerCase() === 'n') exclusive = it.input;
+                });
+
+                g.items.forEach(function (it) {
+                    var lbl = it.mdc.querySelector('label');
+                    var chip = document.createElement('span');
+                    chip.className = 'cf-chip';
+                    chip.textContent = lbl ? lbl.textContent.trim() : (it.input.value || '');
+                    if (it.input.checked) chip.classList.add('active');
+                    chip.addEventListener('click', function () {
+                        var isExclusive = (it.input === exclusive);
+                        if (exclusive && isExclusive) {
+                            g.items.forEach(function (o) {
+                                if (o.input !== exclusive) { o.input.checked = false; o.chipEl.classList.remove('active'); }
+                            });
+                        } else if (exclusive) {
+                            exclusive.checked = false;
+                            if (exclusive.chipEl) exclusive.chipEl.classList.remove('active');
+                        }
+                        this.classList.toggle('active');
+                        it.input.checked = this.classList.contains('active');
+                        try { it.input.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) {}
+                    });
+                    it.chipEl = chip;
+                    it.input.chipEl = chip;
+                    chips.appendChild(chip);
+                });
+
+                // Hide original checkboxes/labels behind a holder; show the chips
+                var holder = document.createElement('span');
+                holder.style.display = 'none';
+                while (g.field.firstChild) { holder.appendChild(g.field.firstChild); }
+                g.field.appendChild(holder);
+                g.field.insertBefore(chips, g.field.firstChild);
+            } catch (e) { /* leave as plain checkboxes on error */ }
+        });
+    }
+
+    // =========================================================================
     //  TOGGLE SWITCH SYNC
     //  Sync an iPhone-style toggle (cl-toggle) with hidden QuickForm radios.
     // =========================================================================
@@ -774,7 +862,7 @@ var CentreonForm = (function () {
         // initYesNoSegments runs BEFORE initFloatLabels: otherwise float-labels tag the
         // radios' own "Yes/No/Default" <label> with cf-label-float and we'd pick that up
         // instead of the field's real parameter label.
-        var steps = [initYesNoSegments, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
+        var steps = [initYesNoSegments, initCheckboxChips, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
         if (options.exclusiveChip) steps.push(function () { initChips(options.exclusiveChip); });
         if (options.macros) steps.push(initMacroCleanup);
         if (options.geo) steps.push(initGeoAutocomplete);
@@ -824,6 +912,7 @@ var CentreonForm = (function () {
         initTooltips:         initTooltips,
         initSegmentedButtons: initSegmentedButtons,
         initYesNoSegments:    initYesNoSegments,
+        initCheckboxChips:    initCheckboxChips,
         initChips:            initChips,
         syncToggle:           syncToggle,
         initMacroCleanup:     initMacroCleanup,

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -830,6 +830,7 @@ var CentreonForm = (function () {
         if (!geoInput || !geoResults) return;
 
         var timer = null;
+        var activeRequest = null;
 
         // Search on input (debounced)
         geoInput.addEventListener('input', function () {
@@ -841,12 +842,20 @@ var CentreonForm = (function () {
             }
 
             timer = setTimeout(function () {
+                // Cancel a still-pending previous lookup so a slow older
+                // response can't overwrite what the user is now typing.
+                if (activeRequest) activeRequest.abort();
+                var controller = new AbortController();
+                activeRequest = controller;
+                var timeoutId = setTimeout(function () { controller.abort(); }, 5000);
+
                 var url = 'https://nominatim.openstreetmap.org/search?format=json&limit=5&q='
                     + encodeURIComponent(query);
 
-                fetch(url)
+                fetch(url, { signal: controller.signal })
                     .then(function (r) { return r.json(); })
                     .then(function (data) {
+                        clearTimeout(timeoutId);
                         if (!data || data.length === 0) {
                             geoResults.style.display = 'none';
                             return;
@@ -866,6 +875,7 @@ var CentreonForm = (function () {
                         geoResults.style.display = 'block';
                     })
                     .catch(function () {
+                        clearTimeout(timeoutId);
                         geoResults.style.display = 'none';
                     });
             }, debounce);

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -334,7 +334,7 @@ var CentreonForm = (function () {
      * This function tries both patterns.
      */
     function initSegmentedButtons() {
-        document.querySelectorAll('.cf-segmented').forEach(function (group) {
+        document.querySelectorAll('.cf-segmented:not([data-cf-auto])').forEach(function (group) {
             var radioName = group.dataset.radioName;
             var buttons = group.querySelectorAll('button');
 
@@ -400,52 +400,73 @@ var CentreonForm = (function () {
         });
 
         groups.forEach(function (g) {
-            if (g.items.length < 2 || g.items.length > 3) return;
-            // Only yes/no/default style groups (values within {0,1,2})
-            var ok = g.items.every(function (it) {
-                return ['0', '1', '2'].indexOf(String(it.input.value)) !== -1;
-            });
-            if (!ok) return;
+            try {
+                if (g.items.length < 2 || g.items.length > 3) return;
+                // Only yes/no/default style groups (values within {0,1,2})
+                var ok = g.items.every(function (it) {
+                    return ['0', '1', '2'].indexOf(String(it.input.value)) !== -1;
+                });
+                if (!ok) return;
 
-            var base = g.name.replace(/\[.*\]$/, '');
+                var base = g.name.replace(/\[.*\]$/, '');
 
-            // Build segmented buttons, ordered Default(2), Yes(1), No(0) when present
-            var byVal = {};
-            g.items.forEach(function (it) {
-                var lbl = it.mdRadio.querySelector('label');
-                var text = lbl ? lbl.textContent.trim() : '';
-                if (!text) text = ({ '2': 'Default', '1': 'Yes', '0': 'No' })[it.input.value] || it.input.value;
-                byVal[it.input.value] = text;
-            });
-            var order = ['2', '1', '0'].filter(function (v) { return v in byVal; });
+                // Build segmented buttons, ordered Default(2), Yes(1), No(0) when present
+                var byVal = {};
+                g.items.forEach(function (it) {
+                    var lbl = it.mdRadio.querySelector('label');
+                    var text = lbl ? lbl.textContent.trim() : '';
+                    if (!text) text = ({ '2': 'Default', '1': 'Yes', '0': 'No' })[it.input.value] || it.input.value;
+                    byVal[it.input.value] = text;
+                });
+                var order = ['2', '1', '0'].filter(function (v) { return v in byVal; });
 
-            var seg = document.createElement('div');
-            seg.className = 'cf-segmented';
-            seg.setAttribute('data-radio-name', base);
-            order.forEach(function (v) {
-                var b = document.createElement('button');
-                b.type = 'button';
-                b.setAttribute('data-value', v);
-                b.textContent = byVal[v];
-                seg.appendChild(b);
-            });
+                var seg = document.createElement('div');
+                seg.className = 'cf-segmented';
+                seg.setAttribute('data-radio-name', base);
+                seg.setAttribute('data-cf-auto', '1');   // self-wired: skipped by initSegmentedButtons
+                order.forEach(function (v) {
+                    var b = document.createElement('button');
+                    b.type = 'button';
+                    b.setAttribute('data-value', v);
+                    b.textContent = byVal[v];
+                    seg.appendChild(b);
+                });
 
-            // Reuse the field's float label as the inline segment label
-            var floatLabel = g.field.querySelector('label.cf-label-float');
-            var labelText = floatLabel ? floatLabel.textContent.trim() : '';
-            var row = document.createElement('div');
-            row.className = 'cf-segmented-row';
-            if (labelText) {
-                var span = document.createElement('span');
-                span.textContent = labelText;
-                row.appendChild(span);
-            }
-            row.appendChild(seg);
+                // Wire the buttons immediately (do not rely on a second init pass)
+                var btns = seg.querySelectorAll('button');
+                Array.prototype.forEach.call(btns, function (btn) {
+                    var v = btn.getAttribute('data-value');
+                    var radio = _findRadio(base, v);
+                    if (radio && radio.checked) btn.classList.add('active');
+                    btn.addEventListener('click', function () {
+                        Array.prototype.forEach.call(btns, function (b) { b.classList.remove('active'); });
+                        btn.classList.add('active');
+                        var r = _findRadio(base, v);
+                        if (r) {
+                            r.checked = true;
+                            try { r.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) {}
+                            try { r.dispatchEvent(new Event('click', { bubbles: true })); } catch (e) {}
+                        }
+                    });
+                });
 
-            // Insert the segmented control and hide the original radios + float label
-            g.field.insertBefore(row, g.field.firstChild);
-            if (floatLabel) floatLabel.style.display = 'none';
-            g.items.forEach(function (it) { it.mdRadio.style.display = 'none'; });
+                // Reuse the field's float label as the inline segment label
+                var floatLabel = g.field.querySelector('label.cf-label-float');
+                var labelText = floatLabel ? floatLabel.textContent.trim() : '';
+                var row = document.createElement('div');
+                row.className = 'cf-segmented-row';
+                if (labelText) {
+                    var span = document.createElement('span');
+                    span.textContent = labelText;
+                    row.appendChild(span);
+                }
+                row.appendChild(seg);
+
+                // Insert the segmented control and hide the original radios + float label
+                g.field.insertBefore(row, g.field.firstChild);
+                if (floatLabel) floatLabel.style.display = 'none';
+                g.items.forEach(function (it) { it.mdRadio.style.display = 'none'; });
+            } catch (e) { /* leave this field as plain radios on any error */ }
         });
     }
 
@@ -735,23 +756,15 @@ var CentreonForm = (function () {
     function initFormPage(options) {
         options = options || {};
 
-        initFloatLabels();
-        initYesNoSegments();
-        initSegmentedButtons();
-        initTooltips();
-        hideBreadcrumbInPanel();
+        // Each step is isolated so a failure in one never aborts the others.
+        var steps = [initFloatLabels, initYesNoSegments, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
+        if (options.exclusiveChip) steps.push(function () { initChips(options.exclusiveChip); });
+        if (options.macros) steps.push(initMacroCleanup);
+        if (options.geo) steps.push(initGeoAutocomplete);
 
-        if (options.exclusiveChip) {
-            initChips(options.exclusiveChip);
-        }
-
-        if (options.macros) {
-            initMacroCleanup();
-        }
-
-        if (options.geo) {
-            initGeoAutocomplete();
-        }
+        steps.forEach(function (step) {
+            try { step(); } catch (e) { if (window.console) console.error('CentreonForm init step failed', e); }
+        });
     }
 
     // =========================================================================

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -639,6 +639,18 @@ var CentreonForm = (function () {
                 radioOff.checked = true;
             }
         });
+
+        // Keep the toggle in sync when the form is reset: the toggle checkbox
+        // has no default checked state, so a native reset would always turn it
+        // off. Re-read the (post-reset) radio value on the next tick.
+        var form = toggle.form || radioOn.form;
+        if (form) {
+            form.addEventListener('reset', function () {
+                setTimeout(function () {
+                    toggle.checked = radioOn.checked;
+                }, 0);
+            });
+        }
     }
 
     // =========================================================================

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -784,6 +784,21 @@ var CentreonForm = (function () {
         });
     }
 
+    /**
+     * @private Escape a value for safe use as HTML text content or inside an
+     * HTML attribute (escapes &, <, >, " and '). Used for third-party API
+     * data (e.g. Nominatim results) that gets concatenated into an HTML
+     * string before being assigned to innerHTML — never trust it as-is.
+     */
+    function _escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     // =========================================================================
     //  GEO COORDINATES AUTOCOMPLETE
     //  Address search via Nominatim (OpenStreetMap) API.
@@ -840,11 +855,11 @@ var CentreonForm = (function () {
                         var html = '';
                         data.forEach(function (item) {
                             html += '<div class="cf-geo-item" data-coords="'
-                                + item.lat + ',' + item.lon + '">'
+                                + _escapeHtml(item.lat) + ',' + _escapeHtml(item.lon) + '">'
                                 + '<span class="cf-geo-item-name">'
-                                + item.display_name + '</span>'
+                                + _escapeHtml(item.display_name) + '</span>'
                                 + '<span class="cf-geo-item-coords">'
-                                + item.lat + ', ' + item.lon + '</span></div>';
+                                + _escapeHtml(item.lat) + ', ' + _escapeHtml(item.lon) + '</span></div>';
                         });
 
                         geoResults.innerHTML = html;

--- a/centreon/www/include/common/form/form.js
+++ b/centreon/www/include/common/form/form.js
@@ -32,6 +32,30 @@ var CentreonForm = (function () {
     //  The form loads in an iframe so all QuickForm JS works natively.
     // =========================================================================
 
+    /** @private localStorage key used to remember the side panel's last width */
+    var SIDE_PANEL_WIDTH_KEY = 'cf_side_panel_width';
+
+    /** @private Read the last resized width from localStorage, if any */
+    function getSavedSidePanelWidth() {
+        try {
+            var stored = parseInt(window.localStorage.getItem(SIDE_PANEL_WIDTH_KEY), 10);
+
+            return stored > 0 ? stored : null;
+        } catch (e) {
+            // localStorage can throw (e.g. private browsing) — just skip restoring
+            return null;
+        }
+    }
+
+    /** @private Persist the current side panel width to localStorage */
+    function saveSidePanelWidth(width) {
+        try {
+            window.localStorage.setItem(SIDE_PANEL_WIDTH_KEY, width);
+        } catch (e) {
+            // Ignore: not critical if the width isn't remembered
+        }
+    }
+
     /**
      * Open the side panel with a form URL.
      *
@@ -106,6 +130,12 @@ var CentreonForm = (function () {
         var dragging = false;
 
         if (handle && panel) {
+            // Restore the width the user picked last time, if any.
+            var savedWidth = getSavedSidePanelWidth();
+            if (savedWidth) {
+                panel.style.width = savedWidth + 'px';
+            }
+
             handle.addEventListener('mousedown', function (e) {
                 e.preventDefault();
                 dragging = true;
@@ -137,6 +167,8 @@ var CentreonForm = (function () {
                 if (iframe) {
                     iframe.style.pointerEvents = '';
                 }
+
+                saveSidePanelWidth(parseInt(panel.style.width, 10));
             });
         }
 
@@ -862,13 +894,43 @@ var CentreonForm = (function () {
         // initYesNoSegments runs BEFORE initFloatLabels: otherwise float-labels tag the
         // radios' own "Yes/No/Default" <label> with cf-label-float and we'd pick that up
         // instead of the field's real parameter label.
-        var steps = [initYesNoSegments, initCheckboxChips, initSoloToggles, initToggleDependencies, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel];
+        var steps = [initYesNoSegments, initCheckboxChips, initSoloToggles, initToggleDependencies, initFloatLabels, initSegmentedButtons, initTooltips, hideBreadcrumbInPanel, initEnterToSubmit];
         if (options.exclusiveChip) steps.push(function () { initChips(options.exclusiveChip); });
         if (options.macros) steps.push(initMacroCleanup);
         if (options.geo) steps.push(initGeoAutocomplete);
 
         steps.forEach(function (step) {
             try { step(); } catch (e) { if (window.console) console.error('CentreonForm init step failed', e); }
+        });
+    }
+
+    /**
+     * Pressing Enter in a plain text field submits the form via its visible
+     * Save button, same as a native <input type="submit"> is supposed to do.
+     * Explicit instead of relying on the browser default so it's consistent
+     * regardless of field/browser quirks (e.g. select2's own search box,
+     * which manages Enter itself to confirm the highlighted option).
+     *
+     * @private
+     */
+    function initEnterToSubmit() {
+        document.addEventListener('keydown', function (e) {
+            if (e.key !== 'Enter') return;
+
+            var target = e.target;
+            if (!target || target.tagName !== 'INPUT') return;
+            if (target.classList.contains('select2-search__field')) return;
+
+            var type = (target.getAttribute('type') || 'text').toLowerCase();
+            if (['text', 'email', 'number', 'tel', 'url', 'password', 'search'].indexOf(type) === -1) return;
+
+            var form = target.closest('form');
+            if (!form) return;
+            var submitBtn = form.querySelector('.cf-actions input[type="submit"]:not([disabled])');
+            if (!submitBtn) return;
+
+            e.preventDefault();
+            submitBtn.click();
         });
     }
 

--- a/centreon/www/include/common/templates/cloneMacro.ihtml
+++ b/centreon/www/include/common/templates/cloneMacro.ihtml
@@ -1,51 +1,83 @@
-<div id="{$cloneId}_controls">
-    <div id="{$cloneId}_add">
-        <p class="add-new-entry">
-            {assign var=isFrozen value=0}
-            {foreach from=$cloneSet item=v}
-                {if $v->isFrozen()}
-                    {assign var=isFrozen value=1}
+<div class="cf-macro-header">
+    <div class="cf-macro-header-left">
+        <span class="cf-macro-title">{$custom_macro_label}</span>
+        <img class="helpTooltip" name="macro">
+    </div>
+    <div class="cf-macro-header-right">
+        <div id="{$cloneId}_controls">
+            <span id="{$cloneId}_add">
+                {assign var=isFrozen value=0}
+                {foreach from=$cloneSet item=v}
+                    {if $v->isFrozen()}
+                        {assign var=isFrozen value=1}
+                    {/if}
+                {/foreach}
+                {if $isFrozen == 0}
+                <span class="add-new-entry">{t} + Add a new entry{/t}</span>
                 {/if}
-            {/foreach}
-            {if $isFrozen == 0}
-                {t} + Add a new entry{/t}
-            {/if}
-        </p>
+            </span>
+        </div>
     </div>
 </div>
+<div class="cf-macro-columns">
+    <span class="cf-macro-columns-name">{t}Macro name{/t}</span>
+    <span class="cf-macro-columns-value">{t}Macro value{/t}</span>
+</div>
 <ul id="{$cloneId}" class="macroclone no-deco-list">
-    <li class="clone_template onemacro" id="{$cloneId}_template">
-        <hr style='margin:2;'/>
-        <div class="clone-cell">
-            {foreach from=$cloneSet item=v}
-                <span>
-                {if $v->isFrozen()}
-                    {$v->getLabel()} : {$v->unfreeze()}{$v->setAttribute('disabled', 'disabled')}{$v->toHtml()}
-                {else}
-                    {$v->getLabel()}  {$v->toHtml()}
-                {/if}
+    <li class="clone_template onemacro cf-macro-row" id="{$cloneId}_template">
+        {foreach from=$cloneSet item=v key=cf_idx}
+            {if $cf_idx == 1}
+                <span class="cf-macro-name">
+                    {if $v->isFrozen()}{$v->unfreeze()}{$v->setAttribute('disabled', 'disabled')}{/if}
+                    {$v->toHtml()}
                 </span>
-            {/foreach}
-            <input type='hidden' id='macroTplValue_#index#' name='macroTplValue_#index#' value="" />
-            <input type='hidden' id='macroOriginalName_#index#' name='macroOriginalName_#index#' value="" />
-            <input type='hidden' id='macroTplValToDisplay_#index#' name='macroTplValToDisplay_#index#' value="0" />
-            <input type='hidden' id='macroDescription_#index#' name='macroDescription_#index#' value="" />
-            <input type='hidden' id='macroTpl_#index#' name='macroTpl_#index#' value="" />
-            <input type='hidden' id='macroOldValue_#index#' name='macroOldValue_#index#' value="" />
-            <input type='hidden' id='isFrozen_#index#' name='isFrozen_#index#' value="{$isFrozen}" />
-            <img src="./img/icons/description.png" style='vertical-align: middle;cursor:pointer;' class="ico-14" onclick='javascript:loadDescription(#index#)' />
-            {if $isFrozen == 0}
-            <span style="cursor:pointer;" class="clonehandle">
-                <img src="./img/icons/move.png" class="ico-14" style="vertical-align:middle;">
-            </span>
-            <span id="{$cloneId}_remove_current" style=''>
-                <img src="./img/icons/circle-cross.png" class='ico-14' style="vertical-align:middle;">
-            </span>
+            {elseif $cf_idx == 2}
+                <span class="cf-macro-value">
+                    {if $v->isFrozen()}{$v->unfreeze()}{$v->setAttribute('disabled', 'disabled')}{/if}
+                    {$v->toHtml()}
+                </span>
+            {elseif $cf_idx == 3}
+                <span class="cf-macro-password" title="{t}Password{/t}">
+                    {$v->toHtml()}
+                </span>
+            {else}
+                {$v->toHtml()}
             {/if}
-        </div>
+        {/foreach}
+        <input type='hidden' id='macroTplValue_#index#' name='macroTplValue_#index#' value="" />
+        <input type='hidden' id='macroOriginalName_#index#' name='macroOriginalName_#index#' value="" />
+        <input type='hidden' id='macroTplValToDisplay_#index#' name='macroTplValToDisplay_#index#' value="0" />
+        <input type='hidden' id='macroDescription_#index#' name='macroDescription_#index#' value="" />
+        <input type='hidden' id='macroTpl_#index#' name='macroTpl_#index#' value="" />
+        <input type='hidden' id='macroOldValue_#index#' name='macroOldValue_#index#' value="" />
+        <input type='hidden' id='isFrozen_#index#' name='isFrozen_#index#' value="{$isFrozen}" />
+        <span class="cf-macro-actions">
+            {if $isFrozen == 0}
+            <span id="{$cloneId}_remove_current" class="cf-macro-action-btn cf-macro-action-btn--danger" title="{t}Delete{/t}">
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+            </span>
+            {else}
+            <span class="cf-macro-action-btn cf-macro-action-slot"></span>
+            {/if}
+            <span class="cf-macro-action-btn" title="{t}Show description{/t}" onclick='javascript:loadDescription(#index#)'>
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><line x1="8" y1="13" x2="16" y2="13"/><line x1="8" y1="17" x2="16" y2="17"/></svg>
+            </span>
+            {if $isFrozen == 0}
+            <span class="cf-macro-action-btn clonehandle" title="{t}Move{/t}">
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 9 2 12 5 15"/><polyline points="9 5 12 2 15 5"/><polyline points="15 19 12 22 9 19"/><polyline points="19 9 22 12 19 15"/><line x1="2" y1="12" x2="22" y2="12"/><line x1="12" y1="2" x2="12" y2="22"/></svg>
+            </span>
+            {else}
+            <span class="cf-macro-action-btn cf-macro-action-slot"></span>
+            {/if}
+            <span class="cf-macro-action-btn cf-macro-action-slot cf-macro-reset-slot"></span>
+        </span>
         <input type="hidden" name="clone_order_{$cloneId}_#index#" id="clone_order_#index#" />
     </li>
     <li id="{$cloneId}_noforms_template">
         <p class="muted">{t}Nothing here, use the "Add" button{/t}</p>
     </li>
 </ul>
+<div class="macro_legend cf-macro-legend">
+    <p><span class="state_badge" style="background-color: var(--custom-macros-template-background-color);"></span>{$template_inheritance}</p>
+    <p><span class="state_badge" style="background-color: var(--custom-macros-command-background-color);"></span>{$command_inheritance}</p>
+</div>

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -1,289 +1,418 @@
-<style>
-{literal}
-    /* Si l'input interne est disabled (géré par votre PHP), le parent md-radio se grise tout seul */
-    .md-radio:has(input[disabled]) {
-        opacity: 0.5;
-        pointer-events: none;
-    }
-{/literal}
-</style>
 {$form.javascript}
+
 <form {$form.attributes}>
-<div class="headerTabContainer">
-<ul id="mainnav">
-    <li class="a" id='c1'><a href="#" onclick="javascript:montre('1');">{$form.header.information}</a></li>
-    <li class="b" id='c2'><a href="#" onclick="javascript:montre('2');">{$form.header.centreon}</a></li>
-    <li class="b" id='c3'><a href="#" onclick="javascript:montre('3');">{$form.header.additional}</a></li>
-</ul>
-<div id="validFormTop">
-  {if $o == "a" || $o == "c" || $o == "mc"}
-      <p class="oreonbutton">
-        {if isset($form.submitC)}
-            {$form.submitC.html}
-        {elseif isset($form.submitMC)}
-            {$form.submitMC.html}
-        {else}
-            {$form.submitA.html}
-        {/if}
-        &nbsp;&nbsp;&nbsp;{$form.reset.html}
-      </p>
-  {else if $o == "w"}
-      <p class="oreonbutton">
-        {if isset($form.change)}
-            {$form.change.html}
-        {/if}
-      </p>
-  {/if}
-</div>
-</div>
-    <div id='tab1' class='tab'>
-        <table class="formTable table">
-        <tr class="ListHeader">
-            <td class="FormHeader" colspan="2">
-                <h3>| {$form.header.title}</h3>
-            </td>
-        </tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.information}</h4>
-            </td>
-        </tr>
-        {if $o != "mc"}
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="alias"> {$form.contact_alias.label}</td><td class="FormRowValue">{$form.contact_alias.html}</td></tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="contact_name"> {$form.contact_name.label}</td><td class="FormRowValue">{$form.contact_name.html}</td></tr>
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="email"> {$form.contact_email.label}</td><td class="FormRowValue">{$form.contact_email.html}</td></tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="pager"> {$form.contact_pager.label}</td><td class="FormRowValue">{$form.contact_pager.html}</td></tr>
-        {/if}
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="pager"> {$form.contact_template_id.label}</td><td class="FormRowValue">{$form.contact_template_id.html}</td></tr>
+<div class="cf-form-wrapper">
 
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.groupLinks}</h4>
-            </td>
-        </tr>
-        {if $o == "mc"}
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_cg.label}</td><td class="FormRowValue">{$form.mc_mod_cg.html}</td></tr>
-        {/if}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="contactgroups"> {$form.contact_cgNotif.label}</td><td class="FormRowValue"><p  class="oreonbutton">{$form.contact_cgNotif.html}</p></td></tr>
-        {if $o != "mc" and isset($ldapGroups)}
-            <tr class="list_two">
-                <td class="FormRowField"><img class="helpTooltip" name="ldap_group"> {$ldap_group}</td>
-                <td class="FormRowValue">
-                {foreach item=group from=$ldapGroups}&nbsp;{$group}<br/>{/foreach}
-                </td>
-            </tr>
-        {/if}
+    <h1 class="cf-page-title">{$form.header.title}</h1>
 
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.notification}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="contact_enable_notifications"> {$form.contact_enable_notifications.label}</td><td class="FormRowValue">{$form.contact_enable_notifications.html}</td></tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.hostNotification}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="host_notification_options"> {$form.contact_hostNotifOpts.label}</td><td class="FormRowValue">{$form.contact_hostNotifOpts.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="host_notification_period"> {$form.timeperiod_tp_id.label}</td><td class="FormRowValue">{$form.timeperiod_tp_id.html}</td></tr>
-        {if $o == "mc"}
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_hcmds.label}</td><td class="FormRowValue">{$form.mc_mod_hcmds.html}</td></tr>
-        {/if}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="host_notification_commands"> {$form.contact_hostNotifCmds.label}</td><td class="FormRowValue"><p  class="oreonbutton">{$form.contact_hostNotifCmds.html}</p></td></tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.serviceNotification}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="service_notification_options"> {$form.contact_svNotifOpts.label}</td><td class="FormRowValue">{$form.contact_svNotifOpts.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="service_notification_period"> {$form.timeperiod_tp_id2.label}</td><td class="FormRowValue">{$form.timeperiod_tp_id2.html}</td></tr>
-        {if $o == "mc"}
-            <tr class="list_one">
+    <div class="cf-tab-nav">
+        <a href="#cf-sec-info" class="active" onclick="cfScrollTo('cf-sec-info', this); return false;">{$form.header.information}</a>
+        <a href="#cf-sec-notif" onclick="cfScrollTo('cf-sec-notif', this); return false;">{$form.header.notification}</a>
+        <a href="#cf-sec-centreon" onclick="cfScrollTo('cf-sec-centreon', this); return false;">{$form.header.centreon}</a>
+        <a href="#cf-sec-access" onclick="cfScrollTo('cf-sec-access', this); return false;">{t}Access Restriction{/t}</a>
+        <a href="#cf-sec-additional" onclick="cfScrollTo('cf-sec-additional', this); return false;">{$form.header.additional}</a>
+    </div>
 
-                <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="mc_update">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.mc_mod_svcmds.label}
-                            </p>
+    <!-- ================================================================ -->
+    <!-- Section 1: Information & Notifications (was tab1)                 -->
+    <!-- ================================================================ -->
+    <div class="cf-section" id="cf-sec-info">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.information}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            {if $o != "mc"}
+            <div class="cf-row-inline">
+                <div class="cf-field" style="max-width:320px;">
+                    {$form.contact_alias.html}
+                    <label class="cf-label-float">{$form.contact_alias.label}</label>
+                    <img class="helpTooltip" name="alias">
+                </div>
+                <div class="cf-field" style="max-width:440px;">
+                    {$form.contact_name.html}
+                    <label class="cf-label-float">{$form.contact_name.label}</label>
+                    <img class="helpTooltip" name="contact_name">
+                </div>
+                <div class="cf-toggle-row">
+                    <span>{$form.contact_activate.label}</span>
+                    <label class="cl-toggle">
+                        <input type="checkbox" id="cf-contact-activate-toggle" />
+                        <span class="cl-toggle-slider"></span>
+                    </label>
+                    <span style="display:none;">{$form.contact_activate.html}</span>
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.contact_email.html}
+                    <label class="cf-label-float">{$form.contact_email.label}</label>
+                    <img class="helpTooltip" name="email">
+                </div>
+                <div class="cf-field">
+                    {$form.contact_pager.html}
+                    <label class="cf-label-float">{$form.contact_pager.label}</label>
+                    <img class="helpTooltip" name="pager">
+                </div>
+            </div>
+            {/if}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.contact_template_id.html}
+                    <label class="cf-label-float">{$form.contact_template_id.label}</label>
+                    <img class="helpTooltip" name="pager">
+                </div>
+            </div>
 
-                        </div>
-                    </div>
-                   </td>
-                <td class="FormRowValue">{$form.mc_mod_svcmds.html}</td>
+            <div class="cf-subsection">{t}Groups{/t}</div>
+            {if $o == "mc"}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.mc_mod_cg.html}
+                    <label class="cf-label-float">{$form.mc_mod_cg.label}</label>
+                    <img class="helpTooltip" name="mc_update">
+                </div>
+            </div>
+            {/if}
+            <div class="cf-row">
+                <div class="cf-field">
+                    <p class="oreonbutton">{$form.contact_cgNotif.html}</p>
+                    <label class="cf-label-float">{t}Contact Groups{/t}</label>
+                    <img class="helpTooltip" name="contactgroups">
+                </div>
+            </div>
+            {if $o != "mc" and isset($ldapGroups)}
+            <div class="cf-row">
+                <div class="cf-field">
+                    <div>{foreach item=group from=$ldapGroups}&nbsp;{$group}<br/>{/foreach}</div>
+                    <label class="cf-label-float">{$ldap_group}</label>
+                    <img class="helpTooltip" name="ldap_group">
+                </div>
+            </div>
+            {/if}
 
-            </tr>
-        {/if}
-        <tr class="list_one">
-            <td class="FormRowField">
-                <div class="formRowLabel">
-                    <div>
-                        <img class="helpTooltip" name="service_notification_commands">
-                    </div>
-                    <div>
-                        <p class="fieldLabel">
-                            {$form.contact_svNotifCmds.label}
-                        </p>
+            <div class="cf-subsection">{t}Misc{/t}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.contact_lang.html}
+                    <label class="cf-label-float">{$form.contact_lang.label}</label>
+                    <img class="helpTooltip" name="language">
+                </div>
+                <div class="cf-field">
+                    {$form.default_page.html}
+                    <label class="cf-label-float">{$form.default_page.label}</label>
+                    <img class="helpTooltip" name="default_page">
+                </div>
+                <div class="cf-field">
+                    {$form.contact_location.html}
+                    <label class="cf-label-float">{$form.contact_location.label}</label>
+                    <img class="helpTooltip" name="location">
+                </div>
+            </div>
+            {if $o == "a" || $o == "c"}
+                {if isset($form.required)}
+                <div class="cf-row"><small>{$form.required._note}</small></div>
+                {/if}
+            {/if}
+            {if isset($modules_template) && is_array($modules_template)}
+                {foreach item=module_template from=$modules_template}
+                    {include file=$module_template}
+                {/foreach}
+            {/if}
+        </div>
+    </div>
 
+    <!-- ================================================================ -->
+    <!-- Section: Notifications                                            -->
+    <!-- ================================================================ -->
+    <div class="cf-section" id="cf-sec-notif">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.notification}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.contact_enable_notifications.html}
+                    <label class="cf-label-float">{$form.contact_enable_notifications.label}</label>
+                    <img class="helpTooltip" name="contact_enable_notifications">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$form.header.hostNotification}</div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.contact_hostNotifOpts.html}
+                    <label class="cf-label-float">{$form.contact_hostNotifOpts.label}</label>
+                    <img class="helpTooltip" name="host_notification_options">
+                </div>
+            </div>
+            {if $o == "mc"}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.mc_mod_hcmds.html}
+                    <label class="cf-label-float">{$form.mc_mod_hcmds.label}</label>
+                    <img class="helpTooltip" name="mc_update">
+                </div>
+            </div>
+            {/if}
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.timeperiod_tp_id.html}
+                    <label class="cf-label-float">{$form.timeperiod_tp_id.label}</label>
+                    <img class="helpTooltip" name="host_notification_period">
+                </div>
+                <div class="cf-field">
+                    <p class="oreonbutton">{$form.contact_hostNotifCmds.html}</p>
+                    <label class="cf-label-float">{$form.contact_hostNotifCmds.label}</label>
+                    <img class="helpTooltip" name="host_notification_commands">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$form.header.serviceNotification}</div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.contact_svNotifOpts.html}
+                    <label class="cf-label-float">{$form.contact_svNotifOpts.label}</label>
+                    <img class="helpTooltip" name="service_notification_options">
+                </div>
+            </div>
+            {if $o == "mc"}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.mc_mod_svcmds.html}
+                    <label class="cf-label-float">{$form.mc_mod_svcmds.label}</label>
+                    <img class="helpTooltip" name="mc_update">
+                </div>
+            </div>
+            {/if}
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.timeperiod_tp_id2.html}
+                    <label class="cf-label-float">{$form.timeperiod_tp_id2.label}</label>
+                    <img class="helpTooltip" name="service_notification_period">
+                </div>
+                <div class="cf-field">
+                    <p class="oreonbutton">{$form.contact_svNotifCmds.html}</p>
+                    <label class="cf-label-float">{$form.contact_svNotifCmds.label}</label>
+                    <img class="helpTooltip" name="service_notification_commands">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ================================================================ -->
+    <!-- Section 2: Centreon authentication (was tab2)                    -->
+    <!-- ================================================================ -->
+    <div class="cf-section" id="cf-sec-centreon">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.centreon}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.contact_oreon.html}
+                    <label class="cf-label-float">{$form.contact_oreon.label}</label>
+                    <img class="helpTooltip" name="centreon_login">
+                </div>
+                <div class="cf-field">
+                    {$form.contact_auth_type.html}
+                    <label class="cf-label-float">{$form.contact_auth_type.label}</label>
+                    <img class="helpTooltip" name="auth_type">
+                </div>
+            </div>
+            {if isset($ldap) && $ldap == "1"}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.contact_ldap_dn.html}
+                    <label class="cf-label-float">{$form.contact_ldap_dn.label}</label>
+                    <img class="helpTooltip" name="ldap_dn">
+                </div>
+            </div>
+            {/if}
+            {if $authTypeConnectedUser == 'local' && $authTypeContact != 'ldap' && $o != "mc" && $o != "w"}
+            <div id="cf-password-block">
+                <div class="cf-subsection">{t}Password{/t}</div>
+                {if $o == "c"}
+                <div class="cf-row">
+                    <div class="cf-field" style="max-width:50%;">
+                        {$form.current_password.html}
+                        <label class="cf-label-float">{$form.current_password.label}</label>
+                        <img class="helpTooltip" name="current_password">
                     </div>
                 </div>
-                </td>
-
-            <td class="FormRowValue"><p  class="oreonbutton">{$form.contact_svNotifCmds.html}</p></td></tr>
-        {if $o == "a" || $o == "c"}
-            <tr class="list_lvl_1"><td class="ListColLvl2_name" colspan="2">
-                {if isset($form.required)}
-                    {$form.required._note}
                 {/if}
-            </td></tr>
-        {/if}
-        {if isset($modules_template) && is_array($modules_template)}
-            {foreach item=module_template from=$modules_template}
-                {include file=$module_template}
-            {/foreach}
-        {/if}
-    </table>
-    </div>
-    <div id='tab2' class='tab'>
-        <table class="formTable table">
-        <tr class="ListHeader">
-            <td class="FormHeader" colspan="2">
-                <h3>| {$form.header.title}</h3>
-            </td>
-        </tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.oreon}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreon_login"> {$form.contact_oreon.label}</td><td class="FormRowValue">{$form.contact_oreon.html}</td></tr>
-        {if $authTypeConnectedUser == 'local' && $authTypeContact != 'ldap' && $o != "mc" && $o != "w"}
-        {if $o == "c"}
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="current_password"> {$form.current_password.label}</td><td class="FormRowValue">{$form.current_password.html}</td></tr>
-        {/if}
-        <tr class="list_one">
-            <td class="FormRowField"><img class="helpTooltip" name="password"> {$form.contact_passwd.label}</td>
-            <td class="FormRowValue">{$form.contact_passwd.html} {$form.contact_gen_passwd.html}</td>
-        </tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="password2"> {$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
-        {/if}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="language"> {$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="default_page"> {$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="location"> {$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
-        {if $authTypeConnectedUser == 'local' && $authTypeContact != 'ldap' && $o != "mc" && $o != "w" && $autologinEnabled}
-        <tr class="list_two">
-            <td class="FormRowField"><img class="helpTooltip" name="autologin_key"> {$form.contact_autologin_key.label}</td>
-            <td class="FormRowValue">{$form.contact_autologin_key.html} {$form.contact_gen_akey.html}</td>
-        </tr>
-        {/if}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="auth_type"> {$form.contact_auth_type.label}</td><td class="FormRowValue">{$form.contact_auth_type.html}</td></tr>
-            {if isset($ldap) && $ldap == "1"}
-                <tr class="list_two">
-                    <td class="FormRowField">
-                    <div class="formRowLabel">
-                        <div>
-                            <img class="helpTooltip" name="ldap_dn">
-                        </div>
-                        <div>
-                            <p class="fieldLabel">
-                                {$form.contact_ldap_dn.label}
-                            </p>
-
-                        </div>
-                    </div></td>
-                    <td class="FormRowValue">{$form.contact_ldap_dn.html}</td>
-                </tr>
+                <div class="cf-row-inline">
+                    <div class="cf-field" style="max-width:320px;">
+                        {$form.contact_passwd.html}
+                        <label class="cf-label-float">{$form.contact_passwd.label}</label>
+                        <img class="helpTooltip" name="password">
+                    </div>
+                    <div style="flex:0 0 auto;white-space:nowrap;align-self:center;">
+                        {$form.contact_gen_passwd.html}
+                    </div>
+                    <div class="cf-field" style="max-width:240px;">
+                        {$form.contact_passwd2.html}
+                        <label class="cf-label-float">{$form.contact_passwd2.label}</label>
+                        <img class="helpTooltip" name="password2">
+                    </div>
+                </div>
+            </div>
             {/if}
-        {if $displayAdminFlag == 1}
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="admin"> {$form.contact_admin.label}</td><td class="FormRowValue">{$form.contact_admin.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="reach_api"> {$form.reach_api.label}</td><td class="FormRowValue">{$form.reach_api.html}</td></tr>
-        <tr class="list_two">
-            <td class="FormRowField">
-                <img class="helpTooltip" name="reach_api_rt">
-                {$form.reach_api_rt.label}
-            </td>
-            <td class="FormRowValue">{$form.reach_api_rt.html}</td>
-        </tr>
-        {/if}
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.acl}</h4>
-            </td>
-        </tr>
-        {if $o == "mc"}
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_acl.label}</td><td class="FormRowValue">{$form.mc_mod_acl.html}</td></tr>
-        {/if}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="aclgroups"> {$form.contact_acl_groups.label}</td><td class="FormRowValue">{$form.contact_acl_groups.html}</td></tr>
-        {if $o == "a" || $o == "c"}
-            <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">
-                {if isset($form.required)}
-                    {$form.required._note}
-                {/if}
-            </td></tr>
-        {/if}
-        {if $o == "a" || $o == "c"}
-            <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">
-                {if isset($form.required)}
-                    {$form.required._note}
-                {/if}
-            </td></tr>
-        {/if}
-    </table>
+            {if $authTypeConnectedUser == 'local' && $authTypeContact != 'ldap' && $o != "mc" && $o != "w" && $autologinEnabled}
+            <div class="cf-subsection">{t}Autologin{/t}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field" style="max-width:420px;">
+                    {$form.contact_autologin_key.html}
+                    <label class="cf-label-float">{$form.contact_autologin_key.label}</label>
+                    <img class="helpTooltip" name="autologin_key">
+                </div>
+                <div style="flex:0 0 auto;white-space:nowrap;align-self:center;">
+                    {$form.contact_gen_akey.html}
+                </div>
+            </div>
+            {/if}
+        </div>
     </div>
-    <div id='tab3' class='tab'>
-        <table class="formTable table">
-        <tr class="ListHeader">
-            <td class="FormHeader" colspan="2">
-                <h3>| {$form.header.title}</h3>
-            </td>
-        </tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.furtherAddress}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="addressx"> {$form.contact_address1.label}</td><td class="FormRowValue">{$form.contact_address1.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="addressx"> {$form.contact_address2.label}</td><td class="FormRowValue">{$form.contact_address2.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="addressx"> {$form.contact_address3.label}</td><td class="FormRowValue">{$form.contact_address3.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="addressx"> {$form.contact_address4.label}</td><td class="FormRowValue">{$form.contact_address4.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="addressx"> {$form.contact_address5.label}</td><td class="FormRowValue">{$form.contact_address5.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="addressx"> {$form.contact_address6.label}</td><td class="FormRowValue">{$form.contact_address6.html}</td></tr>
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2">
-                <h4>{$form.header.furtherInfos}</h4>
-            </td>
-        </tr>
-        <tr class="list_one"><td class="FormRowField">{$form.contact_activate.label}</td><td class="FormRowValue">{$form.contact_activate.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField">{$form.contact_comment.label}</td><td class="FormRowValue">{$form.contact_comment.html}</td></tr>
-        {if $o == "a" || $o == "c"}
-            <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">
-                {if isset($form.required)}
-                    {$form.required._note}
+
+    <!-- ================================================================ -->
+    <!-- Section 3: Access restriction                                    -->
+    <!-- ================================================================ -->
+    <div class="cf-section" id="cf-sec-access">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {t}Access Restriction{/t}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection cf-subsection--flush">{t}Global Access Right{/t}</div>
+            {if $o == "mc"}
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.mc_mod_acl.html}
+                    <label class="cf-label-float">{$form.mc_mod_acl.label}</label>
+                    <img class="helpTooltip" name="mc_update">
+                </div>
+            </div>
+            {/if}
+            <div class="cf-row-inline">
+                {if $displayAdminFlag == 1}
+                <div class="cf-field">
+                    {$form.contact_admin.html}
+                    <label class="cf-label-float">{$form.contact_admin.label}</label>
+                    <img class="helpTooltip" name="admin">
+                </div>
                 {/if}
-            </td></tr>
-        {/if}
-    </table>
+                <div class="cf-field">
+                    {$form.contact_acl_groups.html}
+                    <label class="cf-label-float">{$form.contact_acl_groups.label}</label>
+                    <img class="helpTooltip" name="aclgroups">
+                </div>
+            </div>
+            {if $displayAdminFlag == 1}
+            <div class="cf-subsection">{t}API Access{/t}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.reach_api.html}
+                    <label class="cf-label-float">{$form.reach_api.label}</label>
+                    <img class="helpTooltip" name="reach_api">
+                </div>
+                <div class="cf-field">
+                    {$form.reach_api_rt.html}
+                    <label class="cf-label-float">{$form.reach_api_rt.label}</label>
+                    <img class="helpTooltip" name="reach_api_rt">
+                </div>
+            </div>
+            {/if}
+            {if $o == "a" || $o == "c"}
+                {if isset($form.required)}
+                <div class="cf-row"><small>{$form.required._note}</small></div>
+                {/if}
+            {/if}
+        </div>
     </div>
-    <div id="validForm">
-    {if $o == "a" || $o == "c" || $o == "mc"}
-        <p class="oreonbutton">
-        {if isset($form.submitC)}
-            {$form.submitC.html}
-        {elseif isset($form.submitMC)}
-            {$form.submitMC.html}
-        {else}
-            {$form.submitA.html}
-        {/if}
-        &nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-    {else if $o == "w"}
-        <p class="oreonbutton">{if isset($form.change)}{$form.change.html}{/if}</p>
-    {/if}
+
+    <!-- ================================================================ -->
+    <!-- Section 3: Additional (was tab3)                                 -->
+    <!-- ================================================================ -->
+    <div class="cf-section collapsed" id="cf-sec-additional">
+        <div class="cf-section-header" onclick="cfToggleSection(this)">
+            {$form.header.additional}
+            <span class="cf-section-chevron">&#9660;</span>
+        </div>
+        <div class="cf-section-body">
+            <div class="cf-subsection cf-subsection--flush">{$form.header.furtherAddress}</div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.contact_address1.html}
+                    <label class="cf-label-float">{$form.contact_address1.label}</label>
+                    <img class="helpTooltip" name="addressx">
+                </div>
+                <div class="cf-field">
+                    {$form.contact_address2.html}
+                    <label class="cf-label-float">{$form.contact_address2.label}</label>
+                    <img class="helpTooltip" name="addressx">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.contact_address3.html}
+                    <label class="cf-label-float">{$form.contact_address3.label}</label>
+                    <img class="helpTooltip" name="addressx">
+                </div>
+                <div class="cf-field">
+                    {$form.contact_address4.html}
+                    <label class="cf-label-float">{$form.contact_address4.label}</label>
+                    <img class="helpTooltip" name="addressx">
+                </div>
+            </div>
+            <div class="cf-row-inline">
+                <div class="cf-field">
+                    {$form.contact_address5.html}
+                    <label class="cf-label-float">{$form.contact_address5.label}</label>
+                    <img class="helpTooltip" name="addressx">
+                </div>
+                <div class="cf-field">
+                    {$form.contact_address6.html}
+                    <label class="cf-label-float">{$form.contact_address6.label}</label>
+                    <img class="helpTooltip" name="addressx">
+                </div>
+            </div>
+
+            <div class="cf-subsection">{$form.header.furtherInfos}</div>
+            <div class="cf-row">
+                <div class="cf-field">
+                    {$form.contact_comment.html}
+                    <label class="cf-label-float">{$form.contact_comment.label}</label>
+                </div>
+            </div>
+            {if $o == "a" || $o == "c"}
+                {if isset($form.required)}
+                <div class="cf-row"><small>{$form.required._note}</small></div>
+                {/if}
+            {/if}
+        </div>
     </div>
-    {$form.hidden}
+
+    <!-- Action buttons -->
+    <div class="cf-actions">
+        {if $o == "a" || $o == "c" || $o == "mc"}
+            {$form.reset.html}
+            {if isset($form.submitC)}
+                {$form.submitC.html}
+            {elseif isset($form.submitMC)}
+                {$form.submitMC.html}
+            {else}
+                {$form.submitA.html}
+            {/if}
+        {else if $o == "w"}
+            {if isset($form.change)}{$form.change.html}{/if}
+        {/if}
+    </div>
+
+</div>
+
+{$form.hidden}
 </form>
 {$helptext}
 <script type="text/javascript">
@@ -319,6 +448,51 @@
 
         if (frontEndYes) frontEndYes.addEventListener('click', handleReachRealTimeChange);
         if (frontEndNo) frontEndNo.addEventListener('click', handleReachRealTimeChange);
+    });
+
+    // Hide all password fields unless the auth source is Centreon (local)
+    function cfToggleContactPasswords() {
+        var authEl = document.getElementById('contact_auth_type');
+        var block = document.getElementById('cf-password-block');
+        if (!block) return;
+        var val = authEl ? String(authEl.value || '').toLowerCase() : 'local';
+        block.style.display = (val === 'local') ? '' : 'none';
+    }
+
+    // Grey out the ACL access list when the contact is an admin (admin = full access)
+    function cfToggleAclByAdmin() {
+        var yes = document.getElementById('contact_admin_yes');
+        var isAdmin = !!(yes && yes.checked);
+        var acl = document.getElementById('contact_acl_groups');
+        if (!acl) return;
+        if (window.jQuery) {
+            jQuery(acl).prop('disabled', isAdmin);
+            if (jQuery(acl).data('select2')) { jQuery(acl).trigger('change.select2'); }
+        } else {
+            acl.disabled = isAdmin;
+        }
+        var wrap = acl.closest('.cf-field') || acl.parentElement;
+        if (wrap) {
+            wrap.style.opacity = isAdmin ? '0.5' : '';
+            wrap.style.pointerEvents = isAdmin ? 'none' : '';
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        CentreonForm.initFormPage();
+        CentreonForm.syncToggle('cf-contact-activate-toggle', 'contact_activate', '1', '0');
+        if (window.jQuery) {
+            jQuery('#contact_auth_type').on('change', cfToggleContactPasswords);
+            jQuery('input[name^="contact_admin"]').on('change', cfToggleAclByAdmin);
+        }
+        var authEl = document.getElementById('contact_auth_type');
+        if (authEl) authEl.addEventListener('change', cfToggleContactPasswords);
+        ['contact_admin_yes', 'contact_admin_no'].forEach(function (id) {
+            var el = document.getElementById(id);
+            if (el) el.addEventListener('change', cfToggleAclByAdmin);
+        });
+        cfToggleContactPasswords();
+        cfToggleAclByAdmin();
     });
 {/literal}
 </script>

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -110,6 +110,9 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
     <link href="./include/common/javascript/jquery/plugins/colorbox/colorbox.css" rel="stylesheet" type="text/css"/>
     <link href="./include/common/javascript/jquery/plugins/qtip/jquery-qtip.css" rel="stylesheet" type="text/css"/>
 
+    <!-- Modern form styles -->
+    <link href="./include/common/form/form.css<?php echo $versionParam . '&t=' . time(); ?>" rel="stylesheet" type="text/css" />
+
     <!-- graph css -->
     <link href="./include/common/javascript/charts/c3.min.css" type="text/css" rel="stylesheet" />
     <link href="./include/views/graphs/javascript/centreon-status-chart.css" type="text/css" rel="stylesheet" />
@@ -134,6 +137,8 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
 if (! isset($_REQUEST['iframe']) || (isset($_REQUEST['iframe']) && $_REQUEST['iframe'] != 1)) {
     ?>
     <script type="text/javascript" src="./include/common/javascript/jquery/jquery.min.js"></script>
+    <!-- Modern form JS (must load after jQuery) -->
+    <script type="text/javascript" src="./include/common/form/form.js<?php echo $versionParam . '&t=' . time(); ?>"></script>
     <script type="text/javascript" src="./include/common/javascript/jquery/plugins/toggleClick/jquery.toggleClick.js">
     </script>
     <script type="text/javascript" src="./include/common/javascript/jquery/plugins/select2/js/select2.full.min.js">

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -111,7 +111,7 @@ if ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
     <link href="./include/common/javascript/jquery/plugins/qtip/jquery-qtip.css" rel="stylesheet" type="text/css"/>
 
     <!-- Modern form styles -->
-    <link href="./include/common/form/form.css<?php echo $versionParam . '&t=' . time(); ?>" rel="stylesheet" type="text/css" />
+    <link href="./include/common/form/form.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css" />
 
     <!-- graph css -->
     <link href="./include/common/javascript/charts/c3.min.css" type="text/css" rel="stylesheet" />
@@ -138,7 +138,7 @@ if (! isset($_REQUEST['iframe']) || (isset($_REQUEST['iframe']) && $_REQUEST['if
     ?>
     <script type="text/javascript" src="./include/common/javascript/jquery/jquery.min.js"></script>
     <!-- Modern form JS (must load after jQuery) -->
-    <script type="text/javascript" src="./include/common/form/form.js<?php echo $versionParam . '&t=' . time(); ?>"></script>
+    <script type="text/javascript" src="./include/common/form/form.js<?php echo $versionParam; ?>"></script>
     <script type="text/javascript" src="./include/common/javascript/jquery/plugins/toggleClick/jquery.toggleClick.js">
     </script>
     <script type="text/javascript" src="./include/common/javascript/jquery/plugins/select2/js/select2.full.min.js">


### PR DESCRIPTION
## Summary

Redesign of the **contact / user** form (*Configuration > Users > Contacts / Users*) with the shared **CentreonForm** design system.

> Stacked on `feature/config-form-shared-lib` — this branch is built directly on top of its current tip, so the diff only shows the form-specific file. Supersedes #10994, which carried its own duplicated copy of `form.js`/`form.css`/`htmlHeader.php` that had drifted from the shared library over time; this branch has none of that, it only touches the file below.

## What changed

- Rebuilt the form in structured sections: General information, Notifications, Centreon authentication, Access restriction, and a collapsed Additional section.
- Activation on the name row; notification options full width; period + command paired.
- Centreon authentication: passwords are hidden when the authentication source is not local; Password / Autologin separators, resized password fields and generate buttons.
- Access restriction: Global Access Right separator; access-list is greyed out when the contact is an administrator; API Access block with Reach API.
- Consistent spacing below separators; all labels/separators translatable.

Only the presentation layer is touched — `HTML_QuickForm` field names and submission are unchanged.

## How to test

1. Go to **Configuration > Users > Contacts / Users**.
2. **Add**/**Edit** a user; switch the authentication type and confirm the password fields show/hide accordingly.
3. Toggle **Admin** and confirm the access-list group is greyed out.
4. Set notification options, timezone/language, API access; save; reopen and confirm persistence.

## Scope

Only `formContact.ihtml`. No changes to `form.js`, `form.css`, or `htmlHeader.php` — those are inherited from `feature/config-form-shared-lib`.
