### PR TITLE
fix(acc): keep vault entries in sync on update and delete

### DIFF
--- a/centreon/src/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6ReadVaultAccRepository.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6ReadVaultAccRepository.php
@@ -69,11 +69,6 @@ class VmWareV6ReadVaultAccRepository implements ReadVaultAccRepositoryInterface
         $vaultPath = null;
 
         foreach ($data['vcenters'] as $vcenter) {
-            if (str_starts_with($vcenter['username'], VaultConfiguration::VAULT_PATH_PATTERN)) {
-                $vaultPath = $vcenter['username'];
-
-                break;
-            }
             if (str_starts_with($vcenter['password'], VaultConfiguration::VAULT_PATH_PATTERN)) {
                 $vaultPath = $vcenter['password'];
 
@@ -88,9 +83,9 @@ class VmWareV6ReadVaultAccRepository implements ReadVaultAccRepositoryInterface
         $vaultDatas = $this->readVaultRepository->findFromPath($vaultPath);
 
         foreach ($data['vcenters'] as $index => $vcenter) {
-            if (in_array($vcenter['name'] . '_username', array_keys($vaultDatas), true)) {
-                $data['vcenters'][$index]['username'] = $vaultDatas[$vcenter['name'] . '_username'];
-                $data['vcenters'][$index]['password'] = $vaultDatas[$vcenter['name'] . '_password'];
+            $passwordKey = $vcenter['name'] . '_password';
+            if (array_key_exists($passwordKey, $vaultDatas)) {
+                $data['vcenters'][$index]['password'] = $vaultDatas[$passwordKey];
             }
         }
 

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6WriteVaultAccRepository.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6WriteVaultAccRepository.php
@@ -106,16 +106,18 @@ class VmWareV6WriteVaultAccRepository implements WriteVaultAccRepositoryInterfac
 
         /** @var _VmWareV6Parameters $parameters */
         $parameters = $acc->getParameters()->getData();
-        $vaultPath = null;
+        $uuids = [];
         foreach ($parameters['vcenters'] as $vcenter) {
-            if (str_starts_with($vcenter['password'], VaultConfiguration::VAULT_PATH_PATTERN) === true) {
-                $vaultPath = $vcenter['password'];
-
-                break;
+            if (str_starts_with($vcenter['password'], VaultConfiguration::VAULT_PATH_PATTERN) === false) {
+                continue;
+            }
+            $uuid = $this->getUuidFromPath($vcenter['password']);
+            if ($uuid !== null) {
+                $uuids[$uuid] = true;
             }
         }
 
-        if ($vaultPath !== null && null !== $uuid = $this->getUuidFromPath($vaultPath)) {
+        foreach (array_keys($uuids) as $uuid) {
             $this->writeVaultRepository->delete($uuid);
         }
     }

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6ReadVaultAccRepositoryTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6ReadVaultAccRepositoryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\AdditionalConnectorConfiguration\Infrastructure\Repository\Vault;
+
+use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
+use Core\AdditionalConnectorConfiguration\Domain\Model\VmWareV6\VmWareV6Parameters;
+use Core\AdditionalConnectorConfiguration\Infrastructure\Repository\Vault\VmWareV6ReadVaultAccRepository;
+use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
+use Security\Interfaces\EncryptionInterface;
+
+beforeEach(function (): void {
+    $this->encryption = $this->createMock(EncryptionInterface::class);
+    $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class);
+    $this->readVaultRepository->method('isVaultConfigured')->willReturn(true);
+
+    $this->repository = new VmWareV6ReadVaultAccRepository(
+        $this->encryption,
+        $this->readVaultRepository,
+    );
+});
+
+it('should be valid only for the vmware_v6 type', function (): void {
+    expect($this->repository->isValidFor(Type::VMWARE_V6))->toBeTrue();
+});
+
+it('should return parameters unchanged when vault is not configured', function (): void {
+    $readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class);
+    $readVaultRepository->method('isVaultConfigured')->willReturn(false);
+    $repository = new VmWareV6ReadVaultAccRepository($this->encryption, $readVaultRepository);
+
+    $parameters = new VmWareV6Parameters($this->encryption, [
+        'port' => 443,
+        'vcenters' => [[
+            'id' => 1,
+            'name' => 'vc1',
+            'url' => 'http://10.0.0.1/sdk',
+            'username' => 'admin',
+            'password' => 'plaintext',
+        ]],
+    ]);
+
+    expect($repository->getCredentialsFromVault($parameters))->toBe($parameters);
+});
+
+it('should return parameters unchanged when no vcenter has a vault path', function (): void {
+    $parameters = new VmWareV6Parameters($this->encryption, [
+        'port' => 443,
+        'vcenters' => [[
+            'id' => 1,
+            'name' => 'vc1',
+            'url' => 'http://10.0.0.1/sdk',
+            'username' => 'admin',
+            'password' => 'plaintext',
+        ]],
+    ]);
+
+    $this->readVaultRepository->expects($this->never())->method('findFromPath');
+
+    expect($this->repository->getCredentialsFromVault($parameters))->toBe($parameters);
+});
+
+it(
+    'should restore plaintext passwords for every vcenter whose _password key exists in vault',
+    function (): void {
+        $vaultPath = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1::vc1_password';
+        $parameters = new VmWareV6Parameters($this->encryption, [
+            'port' => 443,
+            'vcenters' => [
+                [
+                    'id' => 1,
+                    'name' => 'vc1',
+                    'url' => 'http://10.0.0.1/sdk',
+                    'username' => 'admin1',
+                    'password' => $vaultPath,
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'vc2',
+                    'url' => 'http://10.0.0.2/sdk',
+                    'username' => 'admin2',
+                    'password' => 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1::vc2_password',
+                ],
+            ],
+        ]);
+
+        $this->readVaultRepository
+            ->expects($this->once())
+            ->method('findFromPath')
+            ->with($vaultPath)
+            ->willReturn([
+                'vc1_password' => 'pwd-1',
+                'vc2_password' => 'pwd-2',
+            ]);
+
+        $result = $this->repository->getCredentialsFromVault($parameters)->getData();
+
+        expect($result['vcenters'][0]['password'])->toBe('pwd-1')
+            ->and($result['vcenters'][1]['password'])->toBe('pwd-2')
+            ->and($result['vcenters'][0]['username'])->toBe('admin1')
+            ->and($result['vcenters'][1]['username'])->toBe('admin2');
+    }
+);
+
+it(
+    'should keep the vault path unchanged for a vcenter whose _password key is missing from vault',
+    function (): void {
+        $vaultPath = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1::vc1_password';
+        $danglingPath = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1::dangling_password';
+        $parameters = new VmWareV6Parameters($this->encryption, [
+            'port' => 443,
+            'vcenters' => [
+                [
+                    'id' => 1,
+                    'name' => 'vc1',
+                    'url' => 'http://10.0.0.1/sdk',
+                    'username' => 'admin1',
+                    'password' => $vaultPath,
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'renamed-vc',
+                    'url' => 'http://10.0.0.2/sdk',
+                    'username' => 'admin2',
+                    'password' => $danglingPath,
+                ],
+            ],
+        ]);
+
+        $this->readVaultRepository
+            ->method('findFromPath')
+            ->willReturn(['vc1_password' => 'pwd-1']);
+
+        $result = $this->repository->getCredentialsFromVault($parameters)->getData();
+
+        expect($result['vcenters'][0]['password'])->toBe('pwd-1')
+            ->and($result['vcenters'][1]['password'])->toBe($danglingPath);
+    }
+);

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6WriteVaultAccRepositoryTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Infrastructure/Repository/Vault/VmWareV6WriteVaultAccRepositoryTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\AdditionalConnectorConfiguration\Infrastructure\Repository\Vault;
+
+use Core\AdditionalConnectorConfiguration\Domain\Model\Acc;
+use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
+use Core\AdditionalConnectorConfiguration\Domain\Model\VmWareV6\VmWareV6Parameters;
+use Core\AdditionalConnectorConfiguration\Infrastructure\Repository\Vault\VmWareV6WriteVaultAccRepository;
+use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Security\Interfaces\EncryptionInterface;
+
+beforeEach(function (): void {
+    $this->encryption = $this->createMock(EncryptionInterface::class);
+    $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class);
+    $this->writeVaultRepository->method('isVaultConfigured')->willReturn(true);
+
+    $this->repository = new VmWareV6WriteVaultAccRepository(
+        $this->encryption,
+        $this->writeVaultRepository,
+    );
+});
+
+it('should be valid only for the vmware_v6 type', function (): void {
+    expect($this->repository->isValidFor(Type::VMWARE_V6))->toBeTrue();
+});
+
+it('should push every plaintext password to vault under a single UUID', function (): void {
+    $parameters = new VmWareV6Parameters($this->encryption, [
+        'port' => 443,
+        'vcenters' => [
+            [
+                'id' => null,
+                'name' => 'vc1',
+                'url' => 'http://10.0.0.1/sdk',
+                'username' => 'admin1',
+                'password' => 'pwd-1',
+            ],
+            [
+                'id' => null,
+                'name' => 'vc2',
+                'url' => 'http://10.0.0.2/sdk',
+                'username' => 'admin2',
+                'password' => 'pwd-2',
+            ],
+        ],
+    ]);
+
+    $vaultBase = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1';
+    $this->writeVaultRepository
+        ->expects($this->once())
+        ->method('upsert')
+        ->with(null, ['vc1_password' => 'pwd-1', 'vc2_password' => 'pwd-2'])
+        ->willReturn([
+            'vc1_password' => $vaultBase . '::vc1_password',
+            'vc2_password' => $vaultBase . '::vc2_password',
+        ]);
+
+    $result = $this->repository->saveCredentialInVault($parameters)->getData();
+
+    expect($result['vcenters'][0]['password'])->toBe($vaultBase . '::vc1_password')
+        ->and($result['vcenters'][1]['password'])->toBe($vaultBase . '::vc2_password');
+});
+
+it(
+    'should skip existing vault paths and only push plaintext passwords',
+    function (): void {
+        $existingPath = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1::vc1_password';
+        $newPath = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-2::vc2_password';
+
+        $parameters = new VmWareV6Parameters($this->encryption, [
+            'port' => 443,
+            'vcenters' => [
+                [
+                    'id' => 1,
+                    'name' => 'vc1',
+                    'url' => 'http://10.0.0.1/sdk',
+                    'username' => 'admin1',
+                    'password' => $existingPath,
+                ],
+                [
+                    'id' => null,
+                    'name' => 'vc2',
+                    'url' => 'http://10.0.0.2/sdk',
+                    'username' => 'admin2',
+                    'password' => 'pwd-2',
+                ],
+            ],
+        ]);
+
+        $this->writeVaultRepository
+            ->expects($this->once())
+            ->method('upsert')
+            ->with(null, ['vc2_password' => 'pwd-2'])
+            ->willReturn(['vc2_password' => $newPath]);
+
+        $result = $this->repository->saveCredentialInVault($parameters)->getData();
+
+        expect($result['vcenters'][0]['password'])->toBe($existingPath)
+            ->and($result['vcenters'][1]['password'])->toBe($newPath);
+    }
+);
+
+it('should not call upsert when there is nothing to insert', function (): void {
+    $existingPath = 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-1::vc1_password';
+
+    $parameters = new VmWareV6Parameters($this->encryption, [
+        'port' => 443,
+        'vcenters' => [[
+            'id' => 1,
+            'name' => 'vc1',
+            'url' => 'http://10.0.0.1/sdk',
+            'username' => 'admin',
+            'password' => $existingPath,
+        ]],
+    ]);
+
+    $this->writeVaultRepository->expects($this->never())->method('upsert');
+
+    expect($this->repository->saveCredentialInVault($parameters)->getData()['vcenters'][0]['password'])
+        ->toBe($existingPath);
+});
+
+it('should delete every unique UUID referenced by the ACC vcenters', function (): void {
+    $acc = new Acc(
+        id: 1,
+        name: 'acc',
+        type: Type::VMWARE_V6,
+        createdBy: 1,
+        updatedBy: 1,
+        createdAt: new \DateTimeImmutable(),
+        updatedAt: new \DateTimeImmutable(),
+        parameters: new VmWareV6Parameters($this->encryption, [
+            'port' => 443,
+            'vcenters' => [
+                [
+                    'id' => 1,
+                    'name' => 'vc1',
+                    'url' => 'http://10.0.0.1/sdk',
+                    'username' => 'admin1',
+                    'password' => 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-A::vc1_password',
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'vc2',
+                    'url' => 'http://10.0.0.2/sdk',
+                    'username' => 'admin2',
+                    'password' => 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-A::vc2_password',
+                ],
+                [
+                    'id' => 3,
+                    'name' => 'vc3',
+                    'url' => 'http://10.0.0.3/sdk',
+                    'username' => 'admin3',
+                    'password' => 'secret::my_vault::configuration/additionalConnectorConfigurations/uuid-B::vc3_password',
+                ],
+            ],
+        ]),
+    );
+
+    $deleted = [];
+    $this->writeVaultRepository
+        ->expects($this->exactly(2))
+        ->method('delete')
+        ->willReturnCallback(function (string $uuid) use (&$deleted): void {
+            $deleted[] = $uuid;
+        });
+
+    $this->repository->deleteFromVault($acc);
+
+    expect($deleted)->toBe(['uuid-A', 'uuid-B']);
+});
+
+it('should not call delete when no vcenter has a vault path', function (): void {
+    $acc = new Acc(
+        id: 1,
+        name: 'acc',
+        type: Type::VMWARE_V6,
+        createdBy: 1,
+        updatedBy: 1,
+        createdAt: new \DateTimeImmutable(),
+        updatedAt: new \DateTimeImmutable(),
+        parameters: new VmWareV6Parameters($this->encryption, [
+            'port' => 443,
+            'vcenters' => [[
+                'id' => 1,
+                'name' => 'vc1',
+                'url' => 'http://10.0.0.1/sdk',
+                'username' => 'admin',
+                'password' => 'plaintext',
+            ]],
+        ]),
+    );
+
+    $this->writeVaultRepository->expects($this->never())->method('delete');
+
+    $this->repository->deleteFromVault($acc);
+});


### PR DESCRIPTION
## Description

Reading credentials back from Vault looked up a `name_username` key that saveCredentialInVault never stores (only `name_password` is written). As a result, retrieveCredentials in UpdateAcc kept the raw Vault paths in the parameters, and the reuse-old-password logic in VmWareV6Parameters::update then propagated those stale paths. saveCredentialInVault later skipped them, so adding a new vCenter or renaming an existing one wiped previous entries and left the DB pointing at a deleted UUID.

Look up `<name>_password` on read, and make deleteFromVault iterate every unique UUID referenced by the vcenters so pre-existing dirty state is fully cleaned up on ACC deletion.

MON-204500

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
