### PR TITLE
feat(platform-topology): add central_address column

### DIFF
--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -531,6 +531,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
+                'central_address' => $this->arguments['centreon_central_ip'],
                 'children_pollers' => $pollers ?? null,
             ]);
             // if it is poller wizard and poller is linked to another poller/remote server (instead of central)
@@ -546,6 +547,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
+                'central_address' => $this->arguments['centreon_central_ip'],
                 'parent' => $parentPoller->getId(),
             ]);
         } else {
@@ -554,6 +556,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
+                'central_address' => $this->arguments['centreon_central_ip'],
             ]);
         }
 
@@ -726,22 +729,25 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $statement = $this->pearDB->prepare(
                 "UPDATE `platform_topology` SET
                 `name` = :name,
+                `central_address` = :centralAddress,
                 parent_id = :parentId,
                 server_id = :nagiosId,
                 pending = '0'
                 WHERE id = :topologyId"
             );
             $statement->bindValue(':name', $topologyInformation['server_name'], \PDO::PARAM_STR);
+            $statement->bindValue(':centralAddress', $topologyInformation['central_address'], \PDO::PARAM_STR);
             $statement->bindValue(':parentId', (int) $parent['id'], \PDO::PARAM_INT);
             $statement->bindValue(':nagiosId', $topologyInformation['nagios_id'], \PDO::PARAM_INT);
             $statement->bindValue(':topologyId', (int) $server['id'], \PDO::PARAM_INT);
             $statement->execute();
         } else {
             $statement = $this->pearDB->prepare(
-                "INSERT INTO `platform_topology` (`address`,`name`,`type`,`parent_id`,`server_id`, `pending`)
-                VALUES (:address, :name, :type, :parentId, :serverId, '0')"
+                "INSERT INTO `platform_topology` (`address`,`central_address`,`name`,`type`,`parent_id`,`server_id`, `pending`)
+                VALUES (:address, :centralAddress, :name, :type, :parentId, :serverId, '0')"
             );
             $statement->bindValue(':address', $topologyInformation['address'], \PDO::PARAM_STR);
+            $statement->bindValue(':centralAddress', $topologyInformation['central_address'], \PDO::PARAM_STR);
             $statement->bindValue(':name', $topologyInformation['server_name'], \PDO::PARAM_STR);
             $statement->bindValue(':type', $topologyInformation['type'], \PDO::PARAM_STR);
             $statement->bindValue(':parentId', (int) $parent['id'], \PDO::PARAM_INT);

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2360,6 +2360,7 @@ CREATE TABLE `user_filter` (
 CREATE TABLE `platform_topology` (
     `id` int(11) NOT NULL AUTO_INCREMENT,
     `address` varchar(255) NOT NULL,
+    `central_address` varchar(255) NULL,
     `hostname` varchar(255) NULL,
     `name` varchar(255) NOT NULL,
     `type` varchar(255) NOT NULL,

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -21,6 +21,8 @@
 
 use Adaptation\Database\Connection\ConnectionInterface;
 use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\QueryParameters\QueryParameter;
+use Adaptation\Database\QueryParameters\QueryParameters;
 use Adaptation\Log\LoggerUpgrade;
 
 require_once __DIR__ . '/../../../bootstrap.php';
@@ -33,35 +35,190 @@ $errorMessage = '';
  * @var ConnectionInterface $pearDB
  * @var ConnectionInterface $pearDBO
  */
-$removeDebugLevelFromOptions = function () use ($pearDB, &$errorMessage, $version): void {
-    $errorMessage = "Unable to remove 'debug_level' from options table";
-    LoggerUpgrade::create()->info($version, "Removing 'debug_level' from options table");
+$addCentralAddressColumn = function () use ($pearDB, &$errorMessage, $version): void {
+    if ($pearDB->columnExists(
+        $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+        'platform_topology',
+        'central_address'
+    )) {
+        LoggerUpgrade::create()->info($version, 'central_address column already exists, skipping');
+
+        return;
+    }
+
+    $errorMessage = 'Unable to add central_address column to platform_topology';
+    LoggerUpgrade::create()->info($version, 'Adding central_address column to platform_topology');
 
     $pearDB->executeStatement(
         <<<'SQL'
-            DELETE FROM `options` WHERE `key` = 'debug_level'
+            ALTER TABLE `platform_topology`
+            ADD COLUMN `central_address` varchar(255) NULL AFTER `address`
             SQL
     );
 
-    LoggerUpgrade::create()->info($version, "Successfully removed 'debug_level' from options table");
+    LoggerUpgrade::create()->info($version, 'Successfully added central_address column');
+};
+
+/**
+ * Resolve central address from /etc/centreon/poller_installation (cloud only).
+ * Builds address as: {orga}.{region}.{domain}/{site}
+ */
+$resolveCloudCentralAddress = function () use ($version): ?string {
+    $filePath = '/etc/centreon/poller_installation';
+
+    if (! is_readable($filePath)) {
+        LoggerUpgrade::create()->warning(
+            $version,
+            "Cloud platform: {$filePath} not found or not readable"
+        );
+
+        return null;
+    }
+
+    $content = file_get_contents($filePath);
+
+    if ($content === false) {
+        LoggerUpgrade::create()->warning(
+            $version,
+            "Cloud platform: could not read {$filePath}"
+        );
+
+        return null;
+    }
+
+    $hasAllFields = preg_match('/CLOUD_REGION="([^"]+)"/', $content, $regionMatch)
+        && preg_match('/CLOUD_DOMAIN="([^"]+)"/', $content, $domainMatch)
+        && preg_match('/\binstall\b.*-o\s+([^\s;]+)/s', $content, $orgaMatch)
+        && preg_match('/\binstall\b.*-s\s+([^\s;]+)/s', $content, $siteMatch);
+
+    if (! $hasAllFields) {
+        LoggerUpgrade::create()->warning(
+            $version,
+            "Cloud platform: could not extract CLOUD_REGION, CLOUD_DOMAIN, -o or -s from {$filePath}"
+        );
+
+        return null;
+    }
+
+    return "{$orgaMatch[1]}.{$regionMatch[1]}.{$domainMatch[1]}/{$siteMatch[1]}";
+};
+
+/**
+ * Resolve central address from broker output configs (on-prem).
+ * Looks for IPv4 or BBDO Client outputs with a non-empty host.
+ * When multiple outputs exist, takes the most recent one (highest id).
+ *
+ * @param array{server_id: ?int} $platform
+ */
+$resolveOnPremCentralAddress = function (array $platform) use ($pearDB): ?string {
+    if ($platform['server_id'] === null) {
+        return null;
+    }
+
+    $host = $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT cbi_host.config_value
+            FROM cfg_centreonbroker_info cbi_host
+            JOIN cfg_centreonbroker_info cbi_type
+                ON cbi_type.config_id = cbi_host.config_id
+                AND cbi_type.config_group = cbi_host.config_group
+                AND cbi_type.config_group_id = cbi_host.config_group_id
+                AND cbi_type.config_key = 'type'
+                AND cbi_type.config_value IN ('ipv4', 'bbdo_client')
+            JOIN cfg_centreonbroker cb
+                ON cb.config_id = cbi_host.config_id
+            WHERE cb.ns_nagios_server = :serverId
+                AND cbi_host.config_group = 'output'
+                AND cbi_host.config_key = 'host'
+                AND TRIM(cbi_host.config_value) != ''
+            ORDER BY cbi_host.id DESC
+            LIMIT 1
+            SQL,
+        QueryParameters::create([
+            QueryParameter::int('serverId', (int) $platform['server_id']),
+        ])
+    );
+
+    return is_string($host) && trim($host) !== '' ? trim($host) : null;
+};
+
+$populateCentralAddress = function () use ($pearDB, &$errorMessage, $version, $resolveCloudCentralAddress, $resolveOnPremCentralAddress): void {
+    $isCloudPlatform = filter_var(
+        $_ENV['IS_CLOUD_PLATFORM'] ?? null,
+        FILTER_VALIDATE_BOOL,
+        FILTER_NULL_ON_FAILURE
+    ) === true;
+
+    $errorMessage = 'Unable to populate central_address for central servers';
+    LoggerUpgrade::create()->info($version, 'Setting central_address = address for central servers');
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            UPDATE `platform_topology`
+            SET `central_address` = `address`
+            WHERE `type` = 'central'
+            SQL
+    );
+
+    $errorMessage = 'Unable to fetch non-central platforms';
+    $platforms = $pearDB->fetchAllAssociative(
+        <<<'SQL'
+            SELECT `id`, `server_id`, `address`, `type`
+            FROM `platform_topology`
+            WHERE `type` != 'central'
+            SQL
+    );
+
+    $cloudCentralAddress = $isCloudPlatform ? $resolveCloudCentralAddress() : null;
+
+    foreach ($platforms as $platform) {
+        if ($isCloudPlatform) {
+            $centralAddress = $cloudCentralAddress ?? $platform['address'];
+        } else {
+            $centralAddress = $resolveOnPremCentralAddress($platform) ?? $platform['address'];
+        }
+
+        if ($centralAddress === $platform['address']) {
+            $reason = $isCloudPlatform
+                ? 'Could not resolve central address from /etc/centreon/poller_installation'
+                : "No broker output host found (server_id={$platform['server_id']})";
+
+            LoggerUpgrade::create()->warning(
+                $version,
+                "{$reason} for platform id={$platform['id']}, "
+                . "falling back to address '{$centralAddress}'. "
+                . 'Please verify this value is correct.'
+            );
+        }
+
+        $errorMessage = "Unable to update central_address for platform id={$platform['id']}";
+        $pearDB->executeStatement(
+            <<<'SQL'
+                UPDATE `platform_topology`
+                SET `central_address` = :centralAddress
+                WHERE `id` = :platformId
+                SQL,
+            QueryParameters::create([
+                QueryParameter::string('centralAddress', $centralAddress),
+                QueryParameter::int('platformId', (int) $platform['id']),
+            ])
+        );
+    }
+
+    LoggerUpgrade::create()->info($version, 'Successfully populated central_address for all platforms');
 };
 
 try {
     LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
 
-    // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
+    $addCentralAddressColumn();
 
-    // DDL statements for configuration database
-    // TODO add your function calls to update the configuration database structure here
-
-    // Transactional queries for configuration database
     $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
-    $removeDebugLevelFromOptions();
+    $populateCentralAddress();
 
     $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -35,6 +35,19 @@ $errorMessage = '';
  * @var ConnectionInterface $pearDB
  * @var ConnectionInterface $pearDBO
  */
+$removeDebugLevelFromOptions = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = "Unable to remove 'debug_level' from options table";
+    LoggerUpgrade::create()->info($version, "Removing 'debug_level' from options table");
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            DELETE FROM `options` WHERE `key` = 'debug_level'
+            SQL
+    );
+
+    LoggerUpgrade::create()->info($version, "Successfully removed 'debug_level' from options table");
+};
+
 $addCentralAddressColumn = function () use ($pearDB, &$errorMessage, $version): void {
     if ($pearDB->columnExists(
         $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
@@ -64,7 +77,7 @@ $addCentralAddressColumn = function () use ($pearDB, &$errorMessage, $version): 
  * Builds address as: {orga}.{region}.{domain}/{site}
  */
 $resolveCloudCentralAddress = function () use ($version): ?string {
-    $filePath = '/etc/centreon/poller_installation';
+    $filePath = _CENTREON_ETC_ . '/poller_installation';
 
     if (! is_readable($filePath)) {
         LoggerUpgrade::create()->warning(
@@ -218,6 +231,7 @@ try {
         $pearDB->startTransaction();
     }
 
+    $removeDebugLevelFromOptions();
     $populateCentralAddress();
 
     $errorMessage = 'Unable to commit the configuration database transaction';

--- a/centreon/www/install/steps/process/insertBaseConf.php
+++ b/centreon/www/install/steps/process/insertBaseConf.php
@@ -109,6 +109,7 @@ if ($row = $centralServerQuery->fetch()) {
     $stmt = $link->prepare("
         INSERT INTO `platform_topology` (
             `address`,
+            `central_address`,
             `hostname`,
             `name`,
             `type`,
@@ -116,6 +117,7 @@ if ($row = $centralServerQuery->fetch()) {
             `server_id`,
             `pending`
         ) VALUES (
+            :centralAddress,
             :centralAddress,
             :hostname,
             :name,


### PR DESCRIPTION
## Description

Add a `central_address` column (`VARCHAR(255) NULL`) to the `platform_topology` table. This column stores the address used by pollers and remote servers to reach the central server.

**Note: the column is NULLABLE**, unlike what was initially planned in the ticket. This is necessary because the platform auto-registration API (`PlatformTopologyRepositoryRDB::addPlatformToTopology`) creates pending entries before the wizard completes, and `central_address` is not known at that point. The value will be validated later by `FindInstallationCommand` (parent ticket MON-205730), which will raise an error if `central_address` is still NULL when needed.

Changes:
- **Schema** (`createTables.sql`): add `central_address` column definition
- **Upgrade migration** (`Update-next.php`): DDL to add the column with idempotency guard (`columnExists`), then populate it — centrals get `address` copied, pollers/remotes get the value resolved from broker output configs (on-prem) or from `/etc/centreon/poller_installation` fields (cloud), with fallback to `address` and a warning log
- **Fresh install** (`insertBaseConf.php`): insert `central_address` alongside `address` for the initial central row
- **Wizard** (`CentreonConfigurationRemote.php`): pass and persist `central_address` from `centreon_central_ip` argument when adding pollers/remotes via wizard

**Fixes** MON-205949

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. **Fresh install**: after a fresh Centreon install, check the `platform_topology` table — the central row should have `central_address` equal to its `address` value
2. **Upgrade (on-prem)**: upgrade an on-prem platform with at least one poller configured with IPv4 or BBDO Client broker outputs — verify `central_address` is populated with the broker output `host` value for pollers, and `address` for the central
3. **Upgrade (cloud)**: on a cloud platform (`IS_CLOUD_PLATFORM=true`) with `/etc/centreon/poller_installation` present, verify `central_address` is built as `{orga}.{region}.{domain}/{site}` from the file fields
4. **Upgrade idempotency**: run the upgrade script a second time — it should detect the column already exists and skip the DDL without error
5. **Wizard**: add a poller or remote server via the wizard, providing a central IP — verify the new row in `platform_topology` has `central_address` set to the provided central IP

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).