### PR TITLE
fix(upgrade): correct autodiscovery FK to reference nagios_server.uid

### DIFF
--- a/centreon/www/install/php/Update-26.07.0.php
+++ b/centreon/www/install/php/Update-26.07.0.php
@@ -259,6 +259,8 @@ $migrateModuleTableInstanceIds = function () use ($pearDB, &$errorMessage, $vers
         $pearDB->executeStatement("ALTER TABLE `{$table}` DROP FOREIGN KEY `{$constraint}`");
     }
 
+    $pearDB->executeStatement("ALTER TABLE `{$table}` MODIFY COLUMN `instance_id` BIGINT UNSIGNED NOT NULL");
+
     $pearDB->executeStatement(
         <<<SQL
             UPDATE `{$table}` t
@@ -266,8 +268,6 @@ $migrateModuleTableInstanceIds = function () use ($pearDB, &$errorMessage, $vers
             SET t.`instance_id` = ns.`uid`
             SQL
     );
-
-    $pearDB->executeStatement("ALTER TABLE `{$table}` MODIFY COLUMN `instance_id` BIGINT UNSIGNED NOT NULL");
 
     $pearDB->executeStatement(
         "ALTER TABLE `{$table}` ADD CONSTRAINT `{$constraint}`"

--- a/centreon/www/install/php/Update-26.07.0.php
+++ b/centreon/www/install/php/Update-26.07.0.php
@@ -259,14 +259,20 @@ $migrateModuleTableInstanceIds = function () use ($pearDB, &$errorMessage, $vers
         $pearDB->executeStatement("ALTER TABLE `{$table}` DROP FOREIGN KEY `{$constraint}`");
     }
 
+    $pearDB->executeStatement(
+        <<<SQL
+            UPDATE `{$table}` t
+            INNER JOIN `nagios_server` ns ON ns.`id` = t.`instance_id`
+            SET t.`instance_id` = ns.`uid`
+            SQL
+    );
+
     $pearDB->executeStatement("ALTER TABLE `{$table}` MODIFY COLUMN `instance_id` BIGINT UNSIGNED NOT NULL");
 
-    if ($fkExists) {
-        $pearDB->executeStatement(
-            "ALTER TABLE `{$table}` ADD CONSTRAINT `{$constraint}`"
-            . ' FOREIGN KEY (`instance_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE'
-        );
-    }
+    $pearDB->executeStatement(
+        "ALTER TABLE `{$table}` ADD CONSTRAINT `{$constraint}`"
+        . ' FOREIGN KEY (`instance_id`) REFERENCES `nagios_server` (`uid`) ON DELETE CASCADE'
+    );
 
     CentreonLog::create()->info(
         logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -797,8 +803,8 @@ try {
 
     // DDL statements for configuration database
     $addVmwareUpdatedField();
-    $migrateModuleTableInstanceIds();
     $renamePollerUuidToUid();
+    $migrateModuleTableInstanceIds();
     $addEventScriptLogger();
     $updateBbdoVersionDefault();
     $updateBbdoVersionValues();


### PR DESCRIPTION
## Description

Backport of PR #11167 (MON-205872) to release-26.07-next.

Fixes the autodiscovery upgrade migration (`Update-26.07.0.php`) which re-created the FK constraint on `mod_auto_disco_inst_rule_relation.instance_id` pointing to `nagios_server(id)` instead of `nagios_server(uid)`, causing MySQL 8.0.16+ error 3780 on upgrade from 26.05 to 26.07.

Fixes: [MON-205953](https://centreon.atlassian.net/browse/MON-205953)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.07.x

## How this pull request can be tested ?

1. Set up a Centreon 26.05 environment with the autodiscovery module installed
2. Run the upgrade to 26.07 — verify the migration completes without error 3780
3. Check that `mod_auto_disco_inst_rule_relation.instance_id` FK points to `nagios_server(uid)`

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).

[MON-205953]: https://centreon.atlassian.net/browse/MON-205953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ