### PR TITLE
fix(host): log relation edits from the host form

### DIFF
--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -1413,7 +1413,7 @@ parameters:
 		-
 			message: '#^Call to protected method createMock\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 13
+			count: 14
 			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
 
 		-

--- a/centreon/src/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroup.php
+++ b/centreon/src/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroup.php
@@ -28,6 +28,8 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Centreon\Domain\RequestParameters\RequestParameters;
+use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
+use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Application\Common\UseCase\{
     ErrorResponse,
     InvalidArgumentResponse,
@@ -83,6 +85,7 @@ final class UpdateHostGroup
         private readonly WriteMonitoringServerRepositoryInterface $writeMonitoringServerRepository,
         private readonly WriteAccessGroupRepositoryInterface $writeAccessGroupRepository,
         private readonly AdminResolver $adminResolver,
+        private readonly WriteActionLogRepositoryInterface $writeActionLogRepository,
     ) {
     }
 
@@ -120,7 +123,7 @@ final class UpdateHostGroup
 
             $this->updateHostGroup($request, $existingHostGroup);
             if ($request->hosts !== null) {
-                $this->updateHostLinks($request);
+                $this->updateHostLinks($request, $existingHostGroup);
             }
             if ($this->isCloudPlatform) {
                 $this->updateResourceAccess($request);
@@ -187,10 +190,11 @@ final class UpdateHostGroup
      * Update the hosts linked to the host group.
      *
      * @param UpdateHostGroupRequest $request
+     * @param HostGroup $existingHostGroup
      *
      * @throws \Throwable
      */
-    private function updateHostLinks(UpdateHostGroupRequest $request): void
+    private function updateHostLinks(UpdateHostGroupRequest $request, HostGroup $existingHostGroup): void
     {
         /** @var int[] $hosts */
         $hosts = $request->hosts;
@@ -210,9 +214,23 @@ final class UpdateHostGroup
             ))->getRemoved();
         }
 
+        $linkedBefore = array_map('intval', $this->readHostGroupRepository->findLinkedHosts($request->id));
         $this->writeHostGroupRepository->deleteHostLinks($request->id, $hostsToRemove);
         $this->writeHostGroupRepository->addHostLinks($request->id, $hosts);
+        $linkedAfter = array_map('intval', $this->readHostGroupRepository->findLinkedHosts($request->id));
         $this->notifyConfigurationChange($hosts);
+
+        sort($linkedBefore);
+        sort($linkedAfter);
+        if ($linkedBefore !== $linkedAfter) {
+            $this->writeActionLogRepository->addAction(new ActionLog(
+                ActionLog::OBJECT_TYPE_HOSTGROUP,
+                $request->id,
+                $existingHostGroup->getName(),
+                ActionLog::ACTION_TYPE_CHANGE,
+                $this->user->getId(),
+            ));
+        }
     }
 
     /**

--- a/centreon/tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
+++ b/centreon/tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
@@ -25,6 +25,7 @@ namespace Tests\Core\HostGroup\Application\UseCase\UpdateHostGroup;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
@@ -65,6 +66,7 @@ beforeEach(function (): void {
         $this->writeMonitoringServerRepository = $this->createMock(WriteMonitoringServerRepositoryInterface::class),
         $this->writeAccessGroupRepository = $this->createMock(WriteAccessGroupRepositoryInterface::class),
         $this->adminResolver = $this->createMock(AdminResolver::class),
+        $this->writeActionLogRepository = $this->createMock(WriteActionLogRepositoryInterface::class),
     );
 
     $this->updateHostGroupRequest = new UpdateHostGroupRequest(

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -28,6 +28,8 @@ require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonACL.class.php';
 require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use App\Kernel;
 use Centreon\Domain\Log\Logger;
 use Core\ActionLog\Domain\Model\ActionLog;
@@ -2838,6 +2840,34 @@ function insertByApi(array $formData, bool $isCloudPlatform, string $basePath, b
     return $response['content']['id'] ?? null;
 }
 
+function getHostRelationsSnapshot(int $hostId): array
+{
+    global $pearDB;
+
+    $queryParameters = QueryParameters::create([QueryParameter::int('hostId', $hostId)]);
+
+    $queries = [
+        'groups' => 'SELECT hostgroup_hg_id FROM hostgroup_relation WHERE host_host_id = :hostId',
+        'categories' => 'SELECT hostcategories_hc_id FROM hostcategories_relation WHERE host_host_id = :hostId',
+        'templates' => 'SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = :hostId ORDER BY `order`',
+        'parents' => 'SELECT host_parent_hp_id FROM host_hostparent_relation WHERE host_host_id = :hostId',
+        'children' => 'SELECT host_host_id FROM host_hostparent_relation WHERE host_parent_hp_id = :hostId',
+        'contactGroups' => 'SELECT contactgroup_cg_id FROM contactgroup_host_relation WHERE host_host_id = :hostId',
+        'contacts' => 'SELECT contact_id FROM contact_host_relation WHERE host_host_id = :hostId',
+    ];
+
+    $snapshot = [];
+    foreach ($queries as $key => $sql) {
+        $ids = array_map('intval', $pearDB->fetchFirstColumn($sql, $queryParameters));
+        if ($key !== 'templates') {
+            sort($ids);
+        }
+        $snapshot[$key] = $ids;
+    }
+
+    return $snapshot;
+}
+
 /**
  * @param int $hostId
  * @param array $formData
@@ -2851,6 +2881,7 @@ function updateHostInAPI(int $hostId, array $formData): bool
     try {
         $isTemplate = (int) $formData['host_register'] === 0;
         $previousPollerIds = findPollersForConfigChangeFlagFromHostIds([$hostId]);
+        $relationsBefore = getHostRelationsSnapshot($hostId);
 
         updateByApi($formData, $isCloudPlatform, $basePath, $isTemplate);
 
@@ -2873,6 +2904,27 @@ function updateHostInAPI(int $hostId, array $formData): bool
             || $isCloudPlatform === true
         ) {
             createHostTemplateService($hostId);
+        }
+
+        try {
+            if (getHostRelationsSnapshot($hostId) !== $relationsBefore) {
+                $centreon->CentreonLogAction->insertLog(
+                    object_type: ActionLog::OBJECT_TYPE_HOST,
+                    object_id: $hostId,
+                    object_name: (string) ($formData['host_name'] ?? ''),
+                    action_type: ActionLog::ACTION_TYPE_CHANGE,
+                    fields: CentreonLogAction::prepareChanges($formData),
+                );
+            }
+        } catch (Throwable $ex) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_BUSINESS_LOG,
+                'Failed to record host relation-change action log',
+                [
+                    'hostId' => $hostId,
+                    'exception' => ['message' => $ex->getMessage(), 'trace' => $ex->getTraceAsString()],
+                ]
+            );
         }
 
         // Update conf change flag for poller

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -2881,7 +2881,19 @@ function updateHostInAPI(int $hostId, array $formData): bool
     try {
         $isTemplate = (int) $formData['host_register'] === 0;
         $previousPollerIds = findPollersForConfigChangeFlagFromHostIds([$hostId]);
-        $relationsBefore = getHostRelationsSnapshot($hostId);
+        $relationsBefore = null;
+        try {
+            $relationsBefore = getHostRelationsSnapshot($hostId);
+        } catch (Throwable $ex) {
+            CentreonLog::create()->error(
+                CentreonLog::TYPE_BUSINESS_LOG,
+                'Failed to snapshot host relations before update',
+                [
+                    'hostId' => $hostId,
+                    'exception' => ['message' => $ex->getMessage(), 'trace' => $ex->getTraceAsString()],
+                ]
+            );
+        }
 
         updateByApi($formData, $isCloudPlatform, $basePath, $isTemplate);
 
@@ -2907,7 +2919,7 @@ function updateHostInAPI(int $hostId, array $formData): bool
         }
 
         try {
-            if (getHostRelationsSnapshot($hostId) !== $relationsBefore) {
+            if ($relationsBefore !== null && getHostRelationsSnapshot($hostId) !== $relationsBefore) {
                 $centreon->CentreonLogAction->insertLog(
                     object_type: ActionLog::OBJECT_TYPE_HOST,
                     object_id: $hostId,


### PR DESCRIPTION
## Description

The API-based updateHostInAPI wrapper only logs scalar host property diffs through the WriteHostActionLog decorator, so edits that only touch relations (host groups, categories, templates, parents/children, contact groups, contacts) leave no trace in Administration > Logs.

Snapshot the relation ID sets around the update calls and emit a CHANGE action log entry when any of them differ.

Refs: MON-205509

[MON-205509](https://centreon.atlassian.net/browse/MON-205509)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-205509]: https://centreon.atlassian.net/browse/MON-205509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ