### PR TITLE
fix(open-tickets): sanitize Dropzone.createElement output to fully close DOM XSS sink

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
@@ -26,7 +26,7 @@
  */
 
 (function() {
-  var Dropzone, Emitter, ExifRestore, camelize, contentLoaded, detectVerticalSquash, drawImageIOSFix, escapeHtml, noop, without,
+  var Dropzone, Emitter, ExifRestore, camelize, contentLoaded, detectVerticalSquash, drawImageIOSFix, escapeHtml, noop, sanitizeElement, without,
     slice = [].slice,
     extend1 = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
@@ -1669,10 +1669,36 @@
     });
   };
 
+  sanitizeElement = function(root) {
+    var attr, el, i, j, name, ref, scripts, value;
+    scripts = root.querySelectorAll("script");
+    for (i = 0; i < scripts.length; i++) {
+      scripts[i].parentNode.removeChild(scripts[i]);
+    }
+    ref = root.querySelectorAll("*");
+    for (j = 0; j < ref.length; j++) {
+      el = ref[j];
+      i = el.attributes.length - 1;
+      while (i >= 0) {
+        attr = el.attributes[i];
+        name = attr.name.toLowerCase();
+        value = attr.value;
+        if (name.indexOf("on") === 0) {
+          el.removeAttribute(attr.name);
+        } else if ((name === "href" || name === "src" || name === "xlink:href") && /^\s*javascript:/i.test(value)) {
+          el.removeAttribute(attr.name);
+        }
+        i--;
+      }
+    }
+    return root;
+  };
+
   Dropzone.createElement = function(string) {
     var div;
     div = document.createElement("div");
     div.innerHTML = string;
+    sanitizeElement(div);
     return div.childNodes[0];
   };
 

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
@@ -1682,8 +1682,8 @@
       while (i >= 0) {
         attr = el.attributes[i];
         name = attr.name.toLowerCase();
-        value = attr.value;
-        if (name.indexOf("on") === 0) {
+        value = attr.value.replace(/[\t\r\n]/g, "");
+        if (name.indexOf("on") === 0 || name === "srcdoc") {
           el.removeAttribute(attr.name);
         } else if ((name === "href" || name === "src" || name === "xlink:href") && /^\s*javascript:/i.test(value)) {
           el.removeAttribute(attr.name);


### PR DESCRIPTION
## Summary
- A follow-up scan (MON-204477) flagged that `Dropzone.createElement()` still assigns raw strings directly to `innerHTML`, and that `previewTemplate` in particular is passed through unescaped. In this module `previewTemplate` is never overridden with dynamic data, so it isn't exploitable today, but the API itself still trusts callers completely and would silently reintroduce DOM XSS if that ever changed.
- Rather than escaping `previewTemplate` (which would break it, since it's markup that defines the DOM structure, not plain text), this hardens the sink itself: after building the DOM from the input string, `Dropzone.createElement()` now strips `<script>` elements, all `on*` event-handler attributes, and `javascript:` URIs in `href`/`src`/`xlink:href` before returning the node.
- This applies uniformly to every call site (previewTemplate, fallback form, default message, remove link, etc.), not just the ones individually wrapped in `escapeHtml()` in the prior fix (#11084).

## Test plan
- [ ] `node --check` passes on the modified file
- [ ] Manually load the open-tickets submit form, confirm the Dropzone preview/upload UI still renders and functions (drag-drop, remove file, default message) unchanged
- [ ] Confirm the security scanner no longer flags the `Dropzone.createElement` sink

🤖 Generated with [Claude Code](https://claude.com/claude-code)