### PR TITLE
fix(export): remove orphaned temp directories left by interrupted workers

### DIFF
--- a/centreon/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/centreon/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Repository\TaskRepository;
 use Centreon\Infrastructure\Service\CentcoreCommandService;
 use Centreon\Infrastructure\Service\CentreonClapiServiceInterface;
 use CentreonRemote\Infrastructure\Export\ExportCommitment;
+use ConfigGenerateRemote\Backend;
 use Pimple\Container;
 
 /**
@@ -34,6 +35,12 @@ use Pimple\Container;
  */
 class CentreonWorker implements CentreonClapiServiceInterface
 {
+    /**
+     * Default staleness threshold (in seconds) used to remove orphaned export temp
+     * directories when no --commandTimeout is provided.
+     */
+    private const DEFAULT_ORPHAN_TMPDIR_MAX_AGE = 3600;
+
     /** @var Container */
     private $container;
 
@@ -59,6 +66,8 @@ class CentreonWorker implements CentreonClapiServiceInterface
      *
      * When --commandTimeout <seconds> is provided, import tasks stuck in 'inprogress'
      * state for longer than the given duration are deleted before processing begins.
+     * Orphaned export temp directories older than that same threshold are also removed
+     * from the export cache to prevent filesystem saturation.
      */
     public function processQueue(): void
     {
@@ -72,6 +81,17 @@ class CentreonWorker implements CentreonClapiServiceInterface
             echo date('Y-m-d H:i:s') . " - INFO - Deleted {$deleted} timed-out import task(s)"
                 . " (older than {$commandTimeout}s).\n";
         }
+
+        // remove orphaned temporary export directories left behind when a worker
+        // process was killed before movePath()/cleanPath() could run (e.g. gorgone
+        // command timeout). Reuse the gorgone command timeout as the staleness
+        // threshold when available: past that duration the process that created the
+        // directory has necessarily been killed, so it is safe to remove.
+        $orphanMaxAge = $commandTimeout ?? self::DEFAULT_ORPHAN_TMPDIR_MAX_AGE;
+        $removedEntries = Backend::cleanOrphanedTmpDirs($orphanMaxAge);
+
+        echo date('Y-m-d H:i:s') . " - INFO - Removed {$removedEntries} orphaned export"
+            . " temp entry(ies) (older than {$orphanMaxAge}s).\n";
 
         // check export tasks in database and execute these
         $this->processExportTasks();

--- a/centreon/tests/php/ConfigGenerateRemote/BackendTest.php
+++ b/centreon/tests/php/ConfigGenerateRemote/BackendTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\ConfigGenerateRemote;
+
+use ConfigGenerateRemote\Backend;
+use PHPUnit\Framework\TestCase;
+
+class BackendTest extends TestCase
+{
+    /** @var string */
+    private $exportPath;
+
+    protected function setUp(): void
+    {
+        $this->exportPath = sys_get_temp_dir() . '/centreon-export-' . uniqid('', true);
+        mkdir($this->exportPath, 0770, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->exportPath)) {
+            system('rm -rf ' . escapeshellarg($this->exportPath));
+        }
+    }
+
+    public function testCleanOrphanedTmpDirsRemovesStaleDirectory(): void
+    {
+        $stale = $this->exportPath . '/' . Backend::TMP_DIR_PREFIX . 'AAAAAA' . Backend::TMP_DIR_SUFFIX;
+        mkdir($stale, 0770, true);
+        touch($stale, time() - 7200);
+
+        $removed = Backend::cleanOrphanedTmpDirs(3600, $this->exportPath);
+
+        $this->assertSame(1, $removed);
+        $this->assertDirectoryDoesNotExist($stale);
+    }
+
+    public function testCleanOrphanedTmpDirsKeepsFreshDirectory(): void
+    {
+        $fresh = $this->exportPath . '/' . Backend::TMP_DIR_PREFIX . 'BBBBBB' . Backend::TMP_DIR_SUFFIX;
+        mkdir($fresh, 0770, true);
+        touch($fresh, time() - 60);
+
+        $removed = Backend::cleanOrphanedTmpDirs(3600, $this->exportPath);
+
+        $this->assertSame(0, $removed);
+        $this->assertDirectoryExists($fresh);
+    }
+
+    public function testCleanOrphanedTmpDirsRemovesStaleWitnessFile(): void
+    {
+        $witness = $this->exportPath . '/' . Backend::TMP_DIR_PREFIX . 'CCCCCC';
+        file_put_contents($witness, '');
+        touch($witness, time() - 7200);
+
+        $removed = Backend::cleanOrphanedTmpDirs(3600, $this->exportPath);
+
+        $this->assertSame(1, $removed);
+        $this->assertFileDoesNotExist($witness);
+    }
+
+    public function testCleanOrphanedTmpDirsIgnoresFinalizedPollerDirectories(): void
+    {
+        $pollerDir = $this->exportPath . '/1';
+        mkdir($pollerDir, 0770, true);
+        touch($pollerDir, time() - 7200);
+
+        $removed = Backend::cleanOrphanedTmpDirs(3600, $this->exportPath);
+
+        $this->assertSame(0, $removed);
+        $this->assertDirectoryExists($pollerDir);
+    }
+
+    public function testCleanOrphanedTmpDirsIsNoOpForNonPositiveMaxAge(): void
+    {
+        $stale = $this->exportPath . '/' . Backend::TMP_DIR_PREFIX . 'DDDDDD' . Backend::TMP_DIR_SUFFIX;
+        mkdir($stale, 0770, true);
+        touch($stale, time() - 7200);
+
+        $this->assertSame(0, Backend::cleanOrphanedTmpDirs(0, $this->exportPath));
+        $this->assertSame(0, Backend::cleanOrphanedTmpDirs(-10, $this->exportPath));
+        $this->assertDirectoryExists($stale);
+    }
+
+    public function testCleanOrphanedTmpDirsReturnsZeroWhenExportDirectoryMissing(): void
+    {
+        $removed = Backend::cleanOrphanedTmpDirs(3600, $this->exportPath . '/does-not-exist');
+
+        $this->assertSame(0, $removed);
+    }
+}

--- a/centreon/www/class/config-generate-remote/Backend.php
+++ b/centreon/www/class/config-generate-remote/Backend.php
@@ -41,6 +41,12 @@ if ($configFile !== false) {
  */
 class Backend
 {
+    /** Prefix of the temporary generation directory and of its witness file. */
+    public const TMP_DIR_PREFIX = 'tmpdir_';
+
+    /** Suffix appended to the temporary generation directory. */
+    public const TMP_DIR_SUFFIX = '.d';
+
     /** @var string */
     public $generatePath;
 
@@ -69,7 +75,7 @@ class Backend
     private $lineSeparatorInfile = '######';
 
     /** @var string */
-    private $tmpDirPrefix = 'tmpdir_';
+    private $tmpDirPrefix = self::TMP_DIR_PREFIX;
 
     /** @var string|null */
     private $tmpFile = null;
@@ -78,7 +84,7 @@ class Backend
     private $tmpDir = null;
 
     /** @var string */
-    private $tmpDirSuffix = '.d';
+    private $tmpDirSuffix = self::TMP_DIR_SUFFIX;
 
     /** @var string|null */
     private $fullPath = null;
@@ -262,6 +268,49 @@ class Backend
         }
 
         @unlink($subdir . '/' . $this->tmpFile);
+    }
+
+    /**
+     * Remove orphaned temporary generation entries left behind in the export cache.
+     *
+     * During a normal export the temporary directory is either renamed by movePath()
+     * or removed by cleanPath(). When the worker process is killed before either runs
+     * (e.g. gorgone command timeout, OOM), the "tmpdir_*" directory - and the witness
+     * file created by tempnam() - is orphaned forever and eventually saturates /var.
+     *
+     * Only entries whose last modification time is older than $maxAgeSeconds are
+     * removed. This is best-effort: filesystem errors never interrupt the caller.
+     *
+     * @param int $maxAgeSeconds entries strictly older than this (in seconds) are considered orphaned;
+     *                           a non-positive value is a no-op (nothing is removed)
+     * @param string|null $exportPath base export directory (defaults to the runtime cache path)
+     *
+     * @return int number of orphaned entries removed
+     */
+    public static function cleanOrphanedTmpDirs(int $maxAgeSeconds, ?string $exportPath = null): int
+    {
+        $exportPath ??= _CENTREON_CACHEDIR_ . '/config/export';
+
+        if ($maxAgeSeconds <= 0 || ! is_dir($exportPath)) {
+            return 0;
+        }
+
+        $threshold = time() - $maxAgeSeconds;
+        $removed = 0;
+
+        foreach (glob($exportPath . '/' . self::TMP_DIR_PREFIX . '*') ?: [] as $entry) {
+            $mtime = @filemtime($entry);
+            if ($mtime === false || $mtime >= $threshold) {
+                continue;
+            }
+
+            system('rm -rf ' . escapeshellarg($entry), $returnCode);
+            if ($returnCode === 0) {
+                $removed++;
+            }
+        }
+
+        return $removed;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `Backend::cleanOrphanedTmpDirs()` to remove `tmpdir_*` directories (and their `tempnam` witness files) left behind in `/var/cache/centreon/config/export/` when a `CentreonWorker processQueue` process is killed before `movePath()`/`cleanPath()` can run (e.g. gorgone command timeout, OOM).
- Call the sweep at the start of `CentreonWorker::processQueue()`, reusing the gorgone `--commandTimeout` as the staleness threshold (falling back to 1h): past that duration the process that created the directory has necessarily been killed, so a directory a concurrent worker may still be writing is never removed.
- The MON-172621 fix only deleted stuck import tasks from the database; it never touched the filesystem, so orphaned export temp directories kept accumulating and saturating `/var`. This closes that gap.

Fixes: [MON-204787](https://centreon.atlassian.net/browse/MON-204787)

## Test plan

- [ ] Unit: `tests/php/ConfigGenerateRemote/BackendTest.php` covers stale removal, fresh directory retention, witness-file removal, finalized poller directories left untouched, and a missing export directory.
- [ ] Manual: on a central + remote + poller platform, stop gorgoned, trigger the top-counter export 10-15 times, start gorgoned, wait ~3 min, and confirm `/var/cache/centreon/config/export/` holds no residual `tmpdir_*` entries.

[MON-204787]: https://centreon.atlassian.net/browse/MON-204787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ