### PR TITLE
fix(upgrade): skip transaction middleware for upgrade and pass ConnectionInterface to modules

### DIFF
--- a/centreon/src/App/Shared/Application/Command/NonTransactionalCommand.php
+++ b/centreon/src/App/Shared/Application/Command/NonTransactionalCommand.php
@@ -21,10 +21,8 @@
 
 declare(strict_types=1);
 
-namespace App\Upgrade\Application\Command;
+namespace App\Shared\Application\Command;
 
-use App\Shared\Application\Command\NonTransactionalCommand;
-
-final readonly class UpdateCommand implements NonTransactionalCommand
+interface NonTransactionalCommand
 {
 }

--- a/centreon/src/App/Shared/Infrastructure/Messenger/DoctrineTransactionMiddleware.php
+++ b/centreon/src/App/Shared/Infrastructure/Messenger/DoctrineTransactionMiddleware.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Messenger;
 
+use App\Shared\Application\Command\NonTransactionalCommand;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Envelope;
@@ -39,6 +40,10 @@ final readonly class DoctrineTransactionMiddleware implements MiddlewareInterfac
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
+        if ($envelope->getMessage() instanceof NonTransactionalCommand) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
         $this->connection->beginTransaction();
 
         try {

--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalModuleRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalModuleRepository.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Infrastructure\Dbal;
 
+use Adaptation\Database\Connection\Adapter\Dbal\DbalConnectionAdapter;
+use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Domain\Repository\ModuleRepository;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
@@ -47,6 +49,7 @@ final class DbalModuleRepository implements ModuleRepository
         private readonly Connection $realtimeConnection,
         #[Autowire(param: 'upgrade.modules_dir')]
         private readonly string $modulesDir,
+        private readonly ConnectionConfig $connectionConfig,
         #[Autowire(param: 'upgrade.centreon_path')]
         private readonly string $centreonPath,
         private readonly LoggerInterface $logger,
@@ -292,9 +295,8 @@ final class DbalModuleRepository implements ModuleRepository
             return;
         }
 
-        // Variables expected by legacy module upgrade scripts.
-        $pearDB = $this->configConnection->getNativeConnection();
-        $pearDBStorage = $this->realtimeConnection->getNativeConnection();
+        $pearDB = DbalConnectionAdapter::createFromDbalConnection($this->configConnection, $this->connectionConfig);
+        $pearDBO = DbalConnectionAdapter::createFromDbalConnection($this->realtimeConnection, $this->connectionConfig);
         $centreon_path = $this->centreonPath;
 
         require_once $filePath;

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalModuleRepositoryTest.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalModuleRepositoryTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\App\Upgrade\Infrastructure\Dbal;
 
+use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Infrastructure\Dbal\DbalModuleRepository;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -57,6 +58,7 @@ final class DbalModuleRepositoryTest extends TestCase
             $this->configConnection,
             $this->realtimeConnection,
             $this->modulesDir,
+            new ConnectionConfig('localhost', 'centreon', 'password', 'centreon', 'centreon_storage'),
             '/usr/share/centreon/',
             new NullLogger(),
         );


### PR DESCRIPTION
## Description

Backport of #11216 to `release-26.07-next`.

Fix upgrade 26.05 → 26.07 failures caused by:
1. `DoctrineTransactionMiddleware` wrapping `UpdateCommand` in a transaction that conflicts with DDL implicit commits in MySQL
2. `DbalModuleRepository` passing raw `Pdo\Mysql` instead of `ConnectionInterface` to module upgrade scripts

**Fixes** MON-206119

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.07.x

## How this pull request can be tested ?

- Upgrade a Centreon platform from 26.05 to 26.07 with BAM module installed
- Verify the upgrade completes without transaction errors
- Verify module upgrade scripts execute successfully

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).