### PR TITLE
fix(web): honor scheme set in internal API base URL

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
+++ b/centreon/src/Core/Common/Infrastructure/Api/InternalApiClient.php
@@ -111,6 +111,10 @@ final class InternalApiClient
      * This ensures the request stays on the local server and doesn't go through
      * proxies, load balancers, or external network infrastructure.
      *
+     * When $internalApiBaseUrl explicitly defines a scheme (e.g. "http://host"), that
+     * scheme is honored; otherwise the request scheme is used. This allows an internal
+     * HTTPS -> HTTP redirection even when the external request is HTTPS.
+     *
      * @param string $url The original URL (may contain external hostname)
      *
      * @throws \RuntimeException When required parameters are null and cannot be resolved from the URL
@@ -146,6 +150,16 @@ final class InternalApiClient
             if ($localUrl !== null) {
                 if ($serverPort !== null && ! str_contains($localUrl, ':')) {
                     $localUrl .= ':' . $serverPort;
+                }
+                // Honor the scheme explicitly defined in the base URL so an internal
+                // HTTPS -> HTTP redirection stays possible even when the external request
+                // is HTTPS (e.g. behind a TLS-terminating proxy). Fall back to the request
+                // scheme when the base URL does not define one.
+                $baseScheme = str_contains($internalApiBaseUrl, '://')
+                    ? parse_url($internalApiBaseUrl, PHP_URL_SCHEME)
+                    : null;
+                if (is_string($baseScheme) && $baseScheme !== '') {
+                    $requestScheme = $baseScheme;
                 }
                 if ($requestScheme === null) {
                     throw new \RuntimeException(

--- a/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
+++ b/centreon/tests/php/Core/Common/Infrastructure/Api/InternalApiClientTest.php
@@ -164,7 +164,7 @@ class InternalApiClientTest extends TestCase
             'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1'],
         ];
 
-        yield 'Relative URL without / at start' => [
+        yield 'Relative URL without leading slash at start' => [
             'inputUrl' => 'api/hosts',
             'expectedUrl' => 'https://127.0.0.1:8080/api/hosts',
             'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1', 'requestScheme' => 'https', 'serverPort' => 8080],
@@ -188,10 +188,16 @@ class InternalApiClientTest extends TestCase
             'env' => ['CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1:9000', 'serverPort' => 8080],
         ];
 
-        yield 'CENTREON_INTERNAL_API_BASE_URL with full scheme has its scheme stripped' => [
+        yield 'CENTREON_INTERNAL_API_BASE_URL https scheme is honored (matches request scheme)' => [
             'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
             'expectedUrl' => 'https://127.0.0.1/centreon/api/latest/hosts',
             'env' => ['CENTREON_INTERNAL_API_BASE_URL' => 'https://127.0.0.1'],
+        ];
+
+        yield 'CENTREON_INTERNAL_API_BASE_URL http scheme is honored over an https request' => [
+            'inputUrl' => 'https://centreon.example.com/centreon/api/latest/hosts',
+            'expectedUrl' => 'http://127.0.0.1/centreon/api/latest/hosts',
+            'env' => ['CENTREON_INTERNAL_API_BASE_URL' => 'http://127.0.0.1', 'requestScheme' => 'https'],
         ];
 
         yield 'Relative URL with leading slash and base URL with port ignores serverPort' => [
@@ -204,6 +210,39 @@ class InternalApiClientTest extends TestCase
             'inputUrl' => '/api/hosts',
             'expectedUrl' => 'http://localhost:8080/api/hosts',
             'env' => ['requestScheme' => 'http', 'serverAddress' => 'localhost', 'serverPort' => 8080],
+        ];
+
+        yield 'Absolute URL using scheme and port of CENTREON_INTERNAL_API_BASE_URL' => [
+            'inputUrl' => 'http://localhost/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:9000/api/hosts',
+            'env' => [
+                'CENTREON_INTERNAL_API_BASE_URL' => 'https://127.0.0.1:9000',
+                'requestScheme' => 'http',
+                'serverAddress' => 'localhost',
+                'serverPort' => 8080,
+            ],
+        ];
+
+        yield 'Absolute URL using scheme of CENTREON_INTERNAL_API_BASE_URL' => [
+            'inputUrl' => 'http://localhost/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:8080/api/hosts',
+            'env' => [
+                'CENTREON_INTERNAL_API_BASE_URL' => 'https://127.0.0.1',
+                'requestScheme' => 'http',
+                'serverAddress' => 'localhost',
+                'serverPort' => 8080,
+            ],
+        ];
+
+        yield 'Schemeless CENTREON_INTERNAL_API_BASE_URL falls back to the request scheme' => [
+            'inputUrl' => '/api/hosts',
+            'expectedUrl' => 'https://127.0.0.1:8080/api/hosts',
+            'env' => [
+                'CENTREON_INTERNAL_API_BASE_URL' => '127.0.0.1',
+                'requestScheme' => 'https',
+                'serverAddress' => 'localhost',
+                'serverPort' => 8080,
+            ],
         ];
     }
 


### PR DESCRIPTION
## Description

When a client uses a TLS-terminating proxy and the external protocol is
HTTPS, internal API redirections were forced to HTTPS unless the
`X-Forwarded-Proto` header was forced to HTTP — which broke other
redirections. The scheme defined in `CENTREON_INTERNAL_API_BASE_URL` was
ignored.

This change honors the scheme when it is explicitly set in
`CENTREON_INTERNAL_API_BASE_URL` (e.g. `http://host`), so an internal
HTTPS → HTTP redirection is possible. A base URL without a scheme keeps
falling back to the request scheme, so existing setups are unaffected.

Covered by unit tests in `InternalApiClientTest` (scheme honored,
scheme fallback, and the existing guards preserved).

Backport of #11085.

**Fixes**: [MON-206118](https://centreon.atlassian.net/browse/MON-206118)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How to test

1. Put Centreon behind a TLS-terminating reverse proxy (external HTTPS,
   `X-Forwarded-Proto: https`) with the internal backend served over HTTP.
2. In the php-fpm configuration, set the internal base URL with an explicit
   `http://` scheme, then restart php-fpm:
   ```
   env[CENTREON_INTERNAL_API_BASE_URL] = http://127.0.0.1
   ```
   ```
   systemctl restart php-fpm
   ```
3. Trigger a feature that performs an internal API call (through `InternalApiClient`).
4. **Before the fix:** the internal call was made over HTTPS → failure / TLS error
   (unless `X-Forwarded-Proto` was forced to HTTP, which broke other redirections).
   **After the fix:** the internal call is made over HTTP → success.


[MON-206118]: https://centreon.atlassian.net/browse/MON-206118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ