### PR TITLE
feat(dashboards): redesign the single-dashboard header and widget chrome (NOC dense variant)

### DIFF
--- a/centreon/packages/ui/src/Dashboard/Dashboard.styles.ts
+++ b/centreon/packages/ui/src/Dashboard/Dashboard.styles.ts
@@ -126,37 +126,80 @@ export const useDashboardLayoutStyles = makeStyles<boolean>()(
 export const useDashboardItemStyles = makeStyles<{ hasHeader: boolean }>()(
   (theme, { hasHeader }) => ({
     widgetContainer: {
+      '&:hover .cf-panel-resource-link': {
+        opacity: 1,
+        pointerEvents: 'auto'
+      },
       '&[data-padding="false"]': {
         padding: 0
       },
       background: theme.palette.background.widget,
-      border: 'none',
+      border: `1px solid ${theme.palette.divider}`,
       borderRadius: theme.spacing(1),
       height: '100%',
+      position: 'relative',
       width: '100%'
     },
     widgetContent: {
       height: hasHeader
         ? `calc(100% - ${theme.spacing(3.5)} - ${theme.spacing(0.5)})`
-        : `calc(100% - ${theme.spacing(3.5)})`
+        : '100%'
     },
     widgetHeader: {
-      '&:hover': {
-        backgroundColor: theme.palette.action.hover
-      },
-      '&[data-can-move="false"]': {
-        cursor: 'default'
-      },
-      '&[data-can-move="true"]': {
-        cursor: 'move'
-      },
       padding: theme.spacing(0, 1.5),
       position: 'relative'
     },
-    widgetHeaderDraggable: {
-      height: '100%',
+    widgetHeaderCollapsed: {
+      height: 0,
+      overflow: 'hidden',
+      padding: 0
+    },
+    widgetOverlayActions: {
+      alignItems: 'center',
+      backgroundColor: theme.palette.background.paper,
+      borderRadius: theme.shape.borderRadius,
+      display: 'flex',
+      gap: theme.spacing(0.5),
+      opacity: 0,
+      position: 'relative',
+      transition: theme.transitions.create(['box-shadow', 'opacity'])
+    },
+    widgetOverlayCorner: {
+      '&:hover .cf-widget-drag-handle': {
+        opacity: 1,
+        pointerEvents: 'auto'
+      },
+      '&:hover .cf-widget-overlay-actions': {
+        boxShadow: `0 0 0 4px ${alpha(theme.palette.primary.main, 0.15)}`,
+        opacity: 1
+      },
+      '&:hover .cf-widget-overlay-info': {
+        opacity: 0,
+        pointerEvents: 'none'
+      },
       position: 'absolute',
-      width: '95%'
+      right: theme.spacing(1),
+      top: theme.spacing(1),
+      zIndex: 1
+    },
+    widgetOverlayDragHandle: {
+      alignItems: 'center',
+      color: theme.palette.text.secondary,
+      cursor: 'move',
+      display: 'flex',
+      justifyContent: 'center',
+      opacity: 0,
+      padding: theme.spacing(0.5),
+      pointerEvents: 'none',
+      transition: theme.transitions.create('opacity')
+    },
+    widgetOverlayInfo: {
+      alignItems: 'center',
+      display: 'flex',
+      inset: 0,
+      justifyContent: 'center',
+      position: 'absolute',
+      transition: theme.transitions.create('opacity')
     },
     widgetPadding: {
       overflowX: 'auto',

--- a/centreon/packages/ui/src/Dashboard/Item.tsx
+++ b/centreon/packages/ui/src/Dashboard/Item.tsx
@@ -1,3 +1,4 @@
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { Card, useTheme } from '@mui/material';
 
 import { useAtomValue } from 'jotai';
@@ -26,11 +27,14 @@ interface DashboardItemProps {
   >;
   className?: string;
   disablePadding?: boolean;
+  hasVisibleHeader?: boolean;
   header?: ReactElement | ((params: Parameters) => ReactElement);
   id: string;
   onMouseDown?: (e: MouseEvent<HTMLDivElement>) => void;
   onMouseUp?: (e: MouseEvent<HTMLDivElement>) => void;
   onTouchEnd?: (e: React.TouchEvent<HTMLDivElement>) => void;
+  overlayActions?: ReactElement | ((params: Parameters) => ReactElement);
+  overlayInfo?: ReactElement | ((params: Parameters) => ReactElement);
   style?: CSSProperties;
   ref?: RefObject<HTMLDivElement>;
 }
@@ -40,6 +44,7 @@ const Item = ({
   style,
   className,
   header,
+  hasVisibleHeader,
   onMouseDown,
   onMouseUp,
   onTouchEnd,
@@ -47,14 +52,19 @@ const Item = ({
   disablePadding = false,
   canMove = false,
   additionalMemoProps = [],
+  overlayActions,
+  overlayInfo,
   ref
 }: DashboardItemProps): ReactElement => {
   const { isInViewport, setElement } = useViewportIntersection({
     rootMargin: '140px 0px 140px 0px'
   });
   const hasHeader = !isNil(header);
+  const showHeaderSpace = hasVisibleHeader ?? hasHeader;
 
-  const { classes, cx } = useDashboardItemStyles({ hasHeader });
+  const { classes, cx } = useDashboardItemStyles({
+    hasHeader: showHeaderSpace
+  });
   const theme = useTheme();
 
   const isResizingItem = useAtomValue(isResizingItemAtom);
@@ -104,15 +114,34 @@ const Item = ({
           {({ isExpanded, label, key, ...rest }) => {
             const canControl = isExpanded ? false : canMove;
 
+            const expandableParams = {
+              isExpanded,
+              key,
+              label,
+              ref: ref as RefObject<HTMLDivElement>,
+              ...rest
+            };
+
             const childrenHeader = equals(type(header), 'Function')
-              ? (header as (params: Parameters) => ReactElement)({
-                  isExpanded,
-                  key,
-                  label,
-                  ref: ref as RefObject<HTMLDivElement>,
-                  ...rest
-                })
+              ? (header as (params: Parameters) => ReactElement)(
+                  expandableParams
+                )
               : (header as ReactElement);
+
+            const childrenOverlayActions = equals(
+              type(overlayActions),
+              'Function'
+            )
+              ? (overlayActions as (params: Parameters) => ReactElement)(
+                  expandableParams
+                )
+              : (overlayActions as ReactElement);
+
+            const childrenOverlayInfo = equals(type(overlayInfo), 'Function')
+              ? (overlayInfo as (params: Parameters) => ReactElement)(
+                  expandableParams
+                )
+              : (overlayInfo as ReactElement);
 
             return (
               <div className={classes.widgetSubContainer} key={key}>
@@ -120,18 +149,54 @@ const Item = ({
                   className={classes.widgetContainer}
                   data-padding={!disablePadding}
                 >
+                  {(childrenOverlayActions || childrenOverlayInfo) && (
+                    <div
+                      className={cx(
+                        'cf-widget-overlay-corner',
+                        classes.widgetOverlayCorner
+                      )}
+                    >
+                      {childrenOverlayActions && (
+                        <div
+                          className={cx(
+                            'cf-widget-overlay-actions',
+                            classes.widgetOverlayActions
+                          )}
+                        >
+                          {canControl && (
+                            <div
+                              {...listeners}
+                              className={cx(
+                                'cf-widget-drag-handle',
+                                classes.widgetOverlayDragHandle
+                              )}
+                              data-testid={`${id}_move_panel`}
+                            >
+                              <DragIndicatorIcon fontSize="small" />
+                            </div>
+                          )}
+                          {childrenOverlayActions}
+                        </div>
+                      )}
+                      {childrenOverlayInfo && (
+                        <div
+                          className={cx(
+                            'cf-widget-overlay-info',
+                            classes.widgetOverlayInfo
+                          )}
+                        >
+                          {childrenOverlayInfo}
+                        </div>
+                      )}
+                    </div>
+                  )}
                   {childrenHeader && (
                     <div
-                      className={classes.widgetHeader}
-                      data-can-move={canControl}
-                    >
-                      {canControl && (
-                        <div
-                          {...listeners}
-                          className={classes.widgetHeaderDraggable}
-                          data-testid={`${id}_move_panel`}
-                        />
+                      className={cx(
+                        classes.widgetHeader,
+                        !showHeaderSpace && classes.widgetHeaderCollapsed
                       )}
+                    >
                       {childrenHeader}
                     </div>
                   )}
@@ -159,6 +224,9 @@ const Item = ({
           style,
           className,
           header,
+          hasVisibleHeader,
+          overlayActions,
+          overlayInfo,
           theme.palette.mode,
           canMove,
           isInViewport,

--- a/centreon/packages/ui/src/components/Layout/PageLayout/PageLayout.styles.ts
+++ b/centreon/packages/ui/src/components/Layout/PageLayout/PageLayout.styles.ts
@@ -2,6 +2,10 @@ import { makeStyles } from 'tss-react/mui';
 
 export const useStyles = makeStyles()((theme) => ({
   pageLayout: {
+    '&::backdrop': {
+      backgroundColor: theme.palette.background.paper
+    },
+    backgroundColor: theme.palette.background.paper,
     display: 'grid',
     gridTemplateRows: 'auto 1fr',
     height: '100%',

--- a/centreon/packages/ui/src/utils/useLocaleDateTimeFormat/index.ts
+++ b/centreon/packages/ui/src/utils/useLocaleDateTimeFormat/index.ts
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import humanizeDuration from 'humanize-duration';
 import { useAtomValue } from 'jotai';
+import { isNil } from 'ramda';
 
 import { useLocale } from '../useLocale';
 import shortLocales from './sortLocales';
@@ -17,7 +18,7 @@ export interface LocaleDateTimeFormat {
   format: (dateFormat: FormatParameters) => string;
   toDate: (date: Date | string) => string;
   toDateTime: (date: Date | string) => string;
-  toHumanizedDuration: (duration: number) => string;
+  toHumanizedDuration: (duration: number, largest?: number) => string;
   toIsoString: (date: Date) => string;
   toTime: (date: Date | string) => string;
 }
@@ -67,7 +68,7 @@ const useLocaleDateTimeFormat = (): LocaleDateTimeFormat => {
     return `${new Date(date).toISOString().substring(0, 19)}Z`;
   };
 
-  const toHumanizedDuration = (duration: number): string => {
+  const toHumanizedDuration = (duration: number, largest?: number): string => {
     const humanizer = humanizeDuration.humanizer();
     humanizer.languages = shortLocales;
     const normalizedLocale = locale.substring(0, 2).toUpperCase();
@@ -78,7 +79,8 @@ const useLocaleDateTimeFormat = (): LocaleDateTimeFormat => {
       language: `short${normalizedLocale}`,
       round: true,
       serialComma: false,
-      spacer: ''
+      spacer: '',
+      ...(isNil(largest) ? {} : { largest })
     });
   };
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.styles.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.styles.ts
@@ -2,7 +2,17 @@ import { makeStyles } from 'tss-react/mui';
 
 export const useDashboardStyles = makeStyles()((theme) => ({
   body: {
-    marginTop: theme.spacing(1.5)
+    '& > *': {
+      flex: 1,
+      minHeight: 0
+    },
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    marginLeft: theme.spacing(-2),
+    marginRight: theme.spacing(-2),
+    marginTop: theme.spacing(1.5),
+    overflow: 'hidden'
   },
   divider: {
     borderStyle: 'dashed'
@@ -12,5 +22,64 @@ export const useDashboardStyles = makeStyles()((theme) => ({
     display: 'flex',
     flexDirection: 'row',
     gap: theme.spacing(2)
+  },
+  headerActionButton: {
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover
+    },
+    alignItems: 'center',
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: '6px',
+    color: theme.palette.primary.main,
+    display: 'inline-flex',
+    justifyContent: 'center'
+  },
+  headerActionsRow: {
+    '& > span': {
+      display: 'flex',
+      gap: theme.spacing(1)
+    },
+    '&[data-fullscreen="true"]': {
+      '&:hover': {
+        opacity: 1
+      },
+      opacity: 0,
+      transition: theme.transitions.create('opacity')
+    },
+    alignItems: 'center',
+    display: 'flex',
+    gap: theme.spacing(2),
+    justifyContent: 'flex-end'
+  },
+  headerRow: {
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'space-between'
+  },
+  titleDescription: {
+    color: theme.palette.header.page.description,
+    fontSize: '14px',
+    maxWidth: '420px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
+  },
+  titleGroup: {
+    alignItems: 'baseline',
+    display: 'flex',
+    gap: theme.spacing(1.5),
+    minWidth: 0
+  },
+  titleSeparator: {
+    alignSelf: 'center',
+    borderColor: theme.palette.header.page.border,
+    height: '16px'
+  },
+  titleText: {
+    color: theme.palette.header.page.title,
+    fontSize: '22px',
+    fontWeight: 700,
+    whiteSpace: 'nowrap'
   }
 }));

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.tsx
@@ -1,18 +1,24 @@
 // @ts-nocheck
 // TODO: re-enable type-check after fixing this file
 import {
+  FullscreenExit as FullscreenExitIcon,
+  Fullscreen as FullscreenIcon,
   Settings as SettingsIcon,
   Share as ShareIcon
 } from '@mui/icons-material';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { Divider } from '@mui/material';
+import {
+  Divider,
+  IconButton as MuiIconButton,
+  Typography
+} from '@mui/material';
 
-import { IconButton, PageHeader, PageLayout } from '@centreon/ui/components';
+import { PageLayout } from '@centreon/ui/components';
 
 import { useIsFetching, useQueryClient } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { inc } from 'ramda';
-import { type ReactElement, useEffect } from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 
 import { type Dashboard as DashboardType, resource } from '../../api/models';
 import { isSharesOpenAtom } from '../../atoms';
@@ -20,7 +26,6 @@ import { DashboardAccessRightsModal } from '../../components/DashboardLibrary/Da
 import { DashboardConfigModal } from '../../components/DashboardLibrary/DashboardConfig/DashboardConfigModal';
 import { useDashboardConfig } from '../../components/DashboardLibrary/DashboardConfig/useDashboardConfig';
 import FavoriteAction from '../../components/DashboardLibrary/DashboardListing/Actions/favoriteAction';
-import { DashboardsQuickAccessMenu } from '../../components/DashboardLibrary/DashboardsQuickAccess/DashboardsQuickAccessMenu';
 import DashboardNavbar from '../../components/DashboardNavbar/DashboardNavbar';
 import { AddWidgetButton } from './AddEditWidget';
 import { dashboardAtom, isEditingAtom, refreshCountsAtom } from './atoms';
@@ -50,6 +55,30 @@ const Dashboard = (): ReactElement => {
   const setIsSharesOpen = useSetAtom(isSharesOpenAtom);
 
   const { canEdit } = useCanEditProperties();
+
+  const [isFullscreen, setIsFullscreen] = useState(
+    Boolean(document.fullscreenElement)
+  );
+
+  useEffect(() => {
+    const onFullscreenChange = (): void => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+
+    return () =>
+      document.removeEventListener('fullscreenchange', onFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = (): void => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen?.();
+
+      return;
+    }
+    document.getElementById('page')?.requestFullscreen?.();
+  };
 
   const refreshIframes = () => {
     const iframes = document.querySelectorAll(
@@ -95,58 +124,95 @@ const Dashboard = (): ReactElement => {
   return (
     <PageLayout>
       <PageLayout.Header>
-        <PageHeader>
-          <PageHeader.Main>
-            <PageHeader.Menu>
-              <DashboardsQuickAccessMenu dashboard={dashboard} />
-            </PageHeader.Menu>
-            <PageHeader.Title
-              actions={
-                <FavoriteAction
-                  dashboardId={dashboard?.id as number}
-                  isFavorite={dashboard?.isFavorite as boolean}
-                  isFetching={isFetchingListing > 0}
-                  refetch={updateFavorites}
+        <div className={classes.headerRow}>
+          <div className={classes.titleGroup}>
+            <Typography
+              aria-label="page header title"
+              className={classes.titleText}
+              variant="h1"
+            >
+              {dashboard?.name || ''}
+            </Typography>
+            {dashboard?.description && (
+              <>
+                <Divider
+                  className={classes.titleSeparator}
+                  flexItem
+                  orientation="vertical"
                 />
-              }
-              description={dashboard?.description || ''}
-              title={dashboard?.name || ''}
-            />
-          </PageHeader.Main>
-          <DashboardNavbar />
-        </PageHeader>
-      </PageLayout.Header>
-      <PageLayout.Body>
-        <div className={classes.body}>
-          <PageLayout.Actions rowReverse={isEditing}>
-            {!isEditing && canEdit && (
-              <span>
-                <IconButton
-                  aria-label="edit"
-                  data-testid="edit"
-                  icon={<SettingsIcon />}
-                  onClick={editDashboard(dashboard as DashboardType)}
-                  size="small"
-                  variant="primary"
-                />
-                <IconButton
-                  aria-label="share"
-                  data-testid="share"
-                  icon={<ShareIcon />}
-                  onClick={openAccessRights}
-                  size="small"
-                  variant="primary"
-                />
-                <IconButton
+                <Typography
+                  aria-label="page header description"
+                  className={classes.titleDescription}
+                  title={dashboard.description}
+                  variant="body2"
+                >
+                  {dashboard.description}
+                </Typography>
+              </>
+            )}
+          </div>
+          <div
+            className={classes.headerActionsRow}
+            data-fullscreen={isFullscreen}
+          >
+            <span>
+              {!isEditing && canEdit && (
+                <MuiIconButton
                   aria-label="refresh"
+                  className={classes.headerActionButton}
                   data-testid="refresh"
-                  icon={<RefreshIcon />}
                   onClick={refreshAllWidgets}
                   size="small"
-                  variant="primary"
-                />
-              </span>
-            )}
+                >
+                  <RefreshIcon fontSize="small" />
+                </MuiIconButton>
+              )}
+              {!isEditing && (
+                <span className={classes.headerActionButton}>
+                  <FavoriteAction
+                    dashboardId={dashboard?.id as number}
+                    isFavorite={dashboard?.isFavorite as boolean}
+                    isFetching={isFetchingListing > 0}
+                    refetch={updateFavorites}
+                  />
+                </span>
+              )}
+              {!isEditing && canEdit && (
+                <>
+                  <MuiIconButton
+                    aria-label="share"
+                    className={classes.headerActionButton}
+                    data-testid="share"
+                    onClick={openAccessRights}
+                    size="small"
+                  >
+                    <ShareIcon fontSize="small" />
+                  </MuiIconButton>
+                  <MuiIconButton
+                    aria-label="edit"
+                    className={classes.headerActionButton}
+                    data-testid="edit"
+                    onClick={editDashboard(dashboard as DashboardType)}
+                    size="small"
+                  >
+                    <SettingsIcon fontSize="small" />
+                  </MuiIconButton>
+                  <MuiIconButton
+                    aria-label="fullscreen"
+                    className={classes.headerActionButton}
+                    data-testid="fullscreen"
+                    onClick={toggleFullscreen}
+                    size="small"
+                  >
+                    {isFullscreen ? (
+                      <FullscreenExitIcon fontSize="small" />
+                    ) : (
+                      <FullscreenIcon fontSize="small" />
+                    )}
+                  </MuiIconButton>
+                </>
+              )}
+            </span>
             {canEdit && (
               <div className={classes.editActions}>
                 <AddWidgetButton />
@@ -160,9 +226,14 @@ const Dashboard = (): ReactElement => {
                 <DashboardEditActions panels={panels} />
               </div>
             )}
-          </PageLayout.Actions>
+          </div>
         </div>
-        <Layout />
+        <DashboardNavbar />
+      </PageLayout.Header>
+      <PageLayout.Body>
+        <div className={classes.body}>
+          <Layout />
+        </div>
       </PageLayout.Body>
       <DashboardConfigModal showRefreshIntervalFields />
       <DashboardAccessRightsModal />

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Layout.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Layout.tsx
@@ -3,7 +3,7 @@
 import { DashboardLayout } from '@centreon/ui';
 
 import { useAtomValue } from 'jotai';
-import { equals, isEmpty, isNil, lte } from 'ramda';
+import { equals, isEmpty, isNil } from 'ramda';
 import { ReactElement } from 'react';
 import type { Layout } from 'react-grid-layout';
 
@@ -11,8 +11,11 @@ import { federatedWidgetsPropertiesAtom } from '../../../../federatedModules/ato
 import { AddWidgetPanel } from '../AddEditWidget';
 import useLinkToResourceStatus from '../hooks/useLinkToResourceStatus';
 import type { Panel } from '../models';
+import ExpandableButton from './Panel/ExpandableButton';
 import DashboardPanel from './Panel/Panel';
 import PanelHeader from './Panel/PanelHeader';
+import PanelLastRefresh from './Panel/PanelLastRefresh';
+import PanelMoreActionsButton from './Panel/PanelMoreActionsButton';
 
 interface Props {
   canEdit?: boolean;
@@ -53,73 +56,98 @@ const PanelsLayout = ({
       layout={panels}
     >
       {panels.map(
-        ({ i, panelConfiguration, refreshCount, data, name, options, w }) => (
-          <DashboardLayout.Item
-            additionalMemoProps={[dashboardId, panelConfiguration?.path]}
-            canMove={
-              canEdit && isEditing && !panelConfiguration?.isAddWidgetPanel
-            }
-            disablePadding={panelConfiguration?.isAddWidgetPanel}
-            header={(headerData) => {
-              const enableExpand = Boolean(
-                federatedWidgetsProperties.find(({ moduleName }) =>
-                  equals(moduleName, name)
-                )?.canExpand
-              );
-              const expandableData = !enableExpand ? undefined : headerData;
+        ({ i, panelConfiguration, refreshCount, data, name, options }) => {
+          const isAddWidgetPanel = panelConfiguration?.isAddWidgetPanel;
+          const hasTitle = !isNil(options?.name) && !isEmpty(options?.name);
 
-              return (
-                <>
-                  {!panelConfiguration?.isAddWidgetPanel && (
-                    <PanelHeader
-                      changeViewMode={() =>
-                        changeViewMode(options?.displayType)
-                      }
-                      displayMoreActions={displayMoreActions}
-                      displayShrinkRefresh={
-                        lte(w, 6) &&
-                        !isNil(options?.name) &&
-                        !isEmpty(options?.name)
-                      }
-                      expandableData={expandableData}
-                      forceDisplayShrinkRefresh={
-                        lte(w, 4) &&
-                        !isNil(options?.name) &&
-                        !isEmpty(options?.name)
-                      }
-                      id={i}
-                      linkToResourceStatus={
-                        data?.resources
-                          ? getLinkToResourceStatusPage(data, name, options)
-                          : undefined
-                      }
-                      name={name}
-                      pageType={getPageType(data)}
-                      setRefreshCount={setRefreshCount}
-                    />
-                  )}
-                </>
-              );
-            }}
-            id={i}
-            key={i}
-          >
-            {({ isInViewport }) =>
-              panelConfiguration?.isAddWidgetPanel ? (
-                <AddWidgetPanel />
-              ) : (
-                <DashboardPanel
-                  dashboardId={dashboardId}
-                  id={i}
-                  isInViewport={isInViewport}
-                  name={name}
-                  playlistHash={playlistHash}
-                  refreshCount={refreshCount}
-                />
-              )
-            }
-          </DashboardLayout.Item>
-        )
+          const getExpandableData = (headerData) => {
+            const enableExpand = Boolean(
+              federatedWidgetsProperties.find(({ moduleName }) =>
+                equals(moduleName, name)
+              )?.canExpand
+            );
+
+            return !enableExpand ? undefined : headerData;
+          };
+
+          return (
+            <DashboardLayout.Item
+              additionalMemoProps={[dashboardId, panelConfiguration?.path]}
+              canMove={canEdit && isEditing && !isAddWidgetPanel}
+              disablePadding={isAddWidgetPanel}
+              hasVisibleHeader={isAddWidgetPanel || hasTitle}
+              header={
+                isAddWidgetPanel || hasTitle
+                  ? () => (
+                      <>
+                        {!isAddWidgetPanel && (
+                          <PanelHeader
+                            displayMoreActions={displayMoreActions}
+                            id={i}
+                            name={name}
+                          />
+                        )}
+                      </>
+                    )
+                  : undefined
+              }
+              id={i}
+              key={i}
+              overlayActions={
+                isAddWidgetPanel
+                  ? undefined
+                  : (headerData) => {
+                      const expandableData = getExpandableData(headerData);
+
+                      return !displayMoreActions ||
+                        expandableData?.isExpanded ? (
+                        <ExpandableButton expandableData={expandableData} />
+                      ) : (
+                        <PanelMoreActionsButton
+                          changeViewMode={() =>
+                            changeViewMode(options?.displayType)
+                          }
+                          expandableData={expandableData}
+                          id={i}
+                          linkToResourceStatus={
+                            data?.resources
+                              ? getLinkToResourceStatusPage(data, name, options)
+                              : undefined
+                          }
+                          pageType={getPageType(data)}
+                          setRefreshCount={setRefreshCount}
+                        />
+                      );
+                    }
+              }
+              overlayInfo={
+                isAddWidgetPanel
+                  ? undefined
+                  : () => (
+                      <PanelLastRefresh
+                        id={i}
+                        setRefreshCount={setRefreshCount}
+                      />
+                    )
+              }
+            >
+              {({ isInViewport }) =>
+                isAddWidgetPanel ? (
+                  <AddWidgetPanel />
+                ) : (
+                  <DashboardPanel
+                    dashboardId={dashboardId}
+                    id={i}
+                    isInViewport={isInViewport}
+                    name={name}
+                    playlistHash={playlistHash}
+                    refreshCount={refreshCount}
+                  />
+                )
+              }
+            </DashboardLayout.Item>
+          );
+        }
       )}
     </DashboardLayout.Layout>
   );

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/MorePanelActions.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/MorePanelActions.tsx
@@ -3,6 +3,7 @@
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import UpdateIcon from '@mui/icons-material/Update';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import { Menu } from '@mui/material';
 
@@ -27,9 +28,16 @@ import {
   labelDeleteWidget,
   labelDuplicate,
   labelEditWidget,
+  labelRefresh,
   labelViewProperties
 } from '../../translatedLabels';
 import { ExpandableData } from './models';
+
+interface ResourceStatusAction {
+  Icon: unknown;
+  label: string;
+  onClick: () => void;
+}
 
 interface Props {
   anchor: HTMLElement | null;
@@ -37,6 +45,8 @@ interface Props {
   duplicate: (event: React.MouseEvent) => void;
   id: string;
   expandableData?: ExpandableData;
+  onRefresh?: () => void;
+  resourceStatusAction?: ResourceStatusAction;
 }
 
 const MorePanelActions = ({
@@ -44,7 +54,9 @@ const MorePanelActions = ({
   close,
   id,
   duplicate,
-  expandableData
+  expandableData,
+  onRefresh,
+  resourceStatusAction
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
@@ -94,9 +106,30 @@ const MorePanelActions = ({
     close();
   };
 
+  const handleRefresh = (): void => {
+    onRefresh?.();
+    close();
+  };
+
   const displayEditButtons = canEdit;
 
+  const seeMoreResourceAction = resourceStatusAction
+    ? [ActionsListActionDivider.divider, resourceStatusAction]
+    : [];
+
+  const refreshAction = onRefresh
+    ? [
+        {
+          Icon: UpdateIcon,
+          label: t(labelRefresh),
+          onClick: handleRefresh
+        },
+        ActionsListActionDivider.divider
+      ]
+    : [];
+
   const defaultEditActions = [
+    ...refreshAction,
     {
       Icon: EditIcon,
       label: t(labelEditWidget),
@@ -107,7 +140,8 @@ const MorePanelActions = ({
       Icon: ContentCopyIcon,
       label: t(labelDuplicate),
       onClick: duplicate
-    }
+    },
+    ...seeMoreResourceAction
   ];
 
   const deleteAction = [
@@ -134,11 +168,13 @@ const MorePanelActions = ({
     : [...defaultEditActions, ...expandableAction, ...deleteAction];
 
   const defaultViewActions = [
+    ...refreshAction,
     {
       Icon: VisibilityOutlinedIcon,
       label: t(labelViewProperties),
       onClick: edit
-    }
+    },
+    ...seeMoreResourceAction
   ];
 
   const viewActions = !expandableData

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelHeader.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelHeader.tsx
@@ -1,120 +1,49 @@
 // @ts-nocheck
 // TODO: re-enable type-check after fixing this file
-import DvrIcon from '@mui/icons-material/Dvr';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import UpdateIcon from '@mui/icons-material/Update';
-import {
-  Button,
-  CardHeader,
-  CircularProgress,
-  Typography
-} from '@mui/material';
+import { CardHeader, Typography } from '@mui/material';
 
 import { IconButton, useDeepCompare } from '@centreon/ui';
 import { Tooltip } from '@centreon/ui/components';
 
-import { useIsFetching, useQueryClient } from '@tanstack/react-query';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { equals, isEmpty } from 'ramda';
-import { useMemo, useState } from 'react';
+import { useAtomValue } from 'jotai';
+import { equals } from 'ramda';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 
-import {
-  dashboardAtom,
-  duplicatePanelDerivedAtom,
-  isEditingAtom
-} from '../../atoms';
-import { useLastRefresh } from '../../hooks/useLastRefresh';
-import useResetDashboardFromSavedState from '../../hooks/useResetDashboardFromSavedState';
-import {
-  labelMoreActions,
-  labelResourcesStatus,
-  labelSeeMore
-} from '../../translatedLabels';
-import ExpandableButton from './ExpandableButton';
-import MorePanelActions from './MorePanelActions';
-import { ExpandableData } from './models';
+import { dashboardAtom } from '../../atoms';
+import { labelRefreshThePage } from '../../translatedLabels';
 import { usePanelHeaderStyles } from './usePanelStyles';
 import useRefreshWebPageWidget from './useRefreshWebPageWidget';
 
 interface PanelHeaderProps {
-  changeViewMode: (displayType: unknown) => void;
   displayMoreActions: boolean;
-  displayShrinkRefresh: boolean;
-  forceDisplayShrinkRefresh: boolean;
   id: string;
-  linkToResourceStatus?: string;
-  pageType: string | null;
-  setRefreshCount?: (id: string) => void;
   name: string;
-  expandableData?: ExpandableData;
 }
 
+/**
+ * Title strip for widgets that have a title. The "last updated" indicator,
+ * the "more actions" (…) trigger and the drag handle all live in a single
+ * floating overlay shared with titleless widgets (see Item.tsx's
+ * overlayInfo / overlayActions, Layout.tsx, PanelLastRefresh,
+ * PanelMoreActionsButton) so the interaction is identical either way,
+ * rather than duplicated here.
+ */
 const PanelHeader = ({
   id,
-  setRefreshCount,
-  linkToResourceStatus,
   displayMoreActions,
-  changeViewMode,
-  pageType,
-  displayShrinkRefresh,
-  forceDisplayShrinkRefresh,
-  name,
-  expandableData
+  name
 }: PanelHeaderProps): JSX.Element | null => {
-  const { t } = useTranslation();
-  const [moreActionsOpen, setMoreActionsOpen] = useState(null);
-
   const { classes } = usePanelHeaderStyles();
+  const { t } = useTranslation();
 
   const dashboard = useAtomValue(dashboardAtom);
-  const duplicatePanel = useSetAtom(duplicatePanelDerivedAtom);
-
-  const [isEditing, setIsEditing] = useAtom(isEditingAtom);
-
-  const resetDashboardFromSavedState = useResetDashboardFromSavedState();
 
   const panel = useMemo(
     () => dashboard.layout.find((dashbordPanel) => equals(dashbordPanel.i, id)),
     useDeepCompare([dashboard.layout])
   );
-
-  const widgetPrefixQuery = useMemo(
-    () => `${panel?.panelConfiguration.path}_${id}`,
-    [panel?.panelConfiguration.path, id]
-  );
-
-  const queryClient = useQueryClient();
-  const isFetching = useIsFetching({ queryKey: [widgetPrefixQuery] });
-
-  const { labelRefresh, isLastRefreshMoreThanADay } =
-    useLastRefresh(isFetching);
-
-  const hasQueryData = !isEmpty(
-    queryClient.getQueriesData({
-      queryKey: [widgetPrefixQuery]
-    })
-  );
-
-  const duplicate = (event: MouseEvent): void => {
-    event.preventDefault();
-    if (!isEditing) {
-      resetDashboardFromSavedState();
-    }
-    setIsEditing(() => true);
-    duplicatePanel(id);
-  };
-
-  const refresh = (): void => {
-    setRefreshCount?.(id);
-  };
-
-  const openMoreActions = (event: React.MouseEvent): void =>
-    setMoreActionsOpen(event.target as never);
-  const closeMoreActions = (): void => setMoreActionsOpen(null);
-
-  const page = t(pageType || labelResourcesStatus);
 
   const isWebPageWidget = equals(name, 'centreon-widget-webpage');
 
@@ -123,100 +52,21 @@ const PanelHeader = ({
   return (
     <CardHeader
       action={
-        displayMoreActions ? (
+        displayMoreActions && isWebPageWidget ? (
           <div className={classes.panelActionsIcons}>
-            {hasQueryData && (
-              <div>
-                {forceDisplayShrinkRefresh ||
-                (displayShrinkRefresh && isLastRefreshMoreThanADay) ? (
-                  <IconButton
-                    disabled={!!isFetching}
-                    onClick={refresh}
-                    size="small"
-                    title={labelRefresh}
-                    tooltipPlacement="top"
-                  >
-                    {isFetching ? (
-                      <CircularProgress size={22} />
-                    ) : (
-                      <UpdateIcon sx={{ height: 22, width: 22 }} />
-                    )}
-                  </IconButton>
-                ) : (
-                  <Button
-                    className={classes.panelHeaderRefreshButton}
-                    disabled={!!isFetching}
-                    onClick={refresh}
-                    size="small"
-                    startIcon={
-                      isFetching ? (
-                        <CircularProgress size={22} />
-                      ) : (
-                        <UpdateIcon sx={{ height: 22, width: 22 }} />
-                      )
-                    }
-                  >
-                    {labelRefresh}
-                  </Button>
-                )}
-              </div>
-            )}
-
-            {linkToResourceStatus && (
-              <Link
-                data-testid={t(labelSeeMore, { page })}
-                style={{ all: 'unset' }}
-                target="_blank"
-                to={linkToResourceStatus as string}
-              >
-                <IconButton
-                  ariaLabel={t(labelSeeMore, { page })}
-                  onClick={changeViewMode}
-                  title={t(labelSeeMore, { page })}
-                >
-                  <DvrIcon fontSize="small" />
-                </IconButton>
-              </Link>
-            )}
-
-            {isWebPageWidget && (
-              <IconButton
-                onClick={refresWebpageWidget}
-                size="small"
-                title={'Refresh the page'}
-                tooltipPlacement="top"
-              >
-                <UpdateIcon sx={{ height: 22, width: 22 }} />
-              </IconButton>
-            )}
-
-            {!expandableData || !expandableData?.isExpanded ? (
-              <IconButton
-                ariaLabel={t(labelMoreActions) as string}
-                onClick={openMoreActions}
-                title={t(labelMoreActions) as string}
-              >
-                <MoreHorizIcon fontSize="small" />
-              </IconButton>
-            ) : (
-              <ExpandableButton expandableData={expandableData} />
-            )}
-            <MorePanelActions
-              anchor={moreActionsOpen}
-              close={closeMoreActions}
-              duplicate={duplicate}
-              expandableData={expandableData}
-              id={id}
-            />
+            <IconButton
+              onClick={refresWebpageWidget}
+              size="small"
+              title={t(labelRefreshThePage)}
+              tooltipPlacement="top"
+            >
+              <UpdateIcon sx={{ height: 22, width: 22 }} />
+            </IconButton>
           </div>
-        ) : (
-          <ExpandableButton expandableData={expandableData} />
-        )
+        ) : null
       }
       classes={{
-        content: displayShrinkRefresh
-          ? classes.panelHeaderContentWithShrink
-          : classes.panelHeaderContent
+        content: classes.panelHeaderContent
       }}
       className={classes.panelHeader}
       title={

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelLastRefresh.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelLastRefresh.tsx
@@ -1,0 +1,80 @@
+// @ts-nocheck
+// TODO: re-enable type-check after fixing this file
+import { Typography } from '@mui/material';
+
+import { useDeepCompare } from '@centreon/ui';
+import { Tooltip } from '@centreon/ui/components';
+
+import { useIsFetching, useQueryClient } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { equals, isEmpty } from 'ramda';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { dashboardAtom } from '../../atoms';
+import { useLastRefresh } from '../../hooks/useLastRefresh';
+import { labelRefresh } from '../../translatedLabels';
+import { usePanelHeaderStyles } from './usePanelStyles';
+
+interface Props {
+  id: string;
+  setRefreshCount?: (id: string) => void;
+}
+
+/**
+ * Small "last updated" indicator shared by every widget, titled or not, via
+ * the floating overlay (see Item.tsx's overlayInfo / Layout.tsx) so its
+ * behavior and position stay identical regardless of whether the widget
+ * has a title bar.
+ */
+const PanelLastRefresh = ({
+  id,
+  setRefreshCount
+}: Props): JSX.Element | null => {
+  const { classes } = usePanelHeaderStyles();
+  const { t } = useTranslation();
+
+  const dashboard = useAtomValue(dashboardAtom);
+
+  const panel = useMemo(
+    () => dashboard.layout.find((dashbordPanel) => equals(dashbordPanel.i, id)),
+    useDeepCompare([dashboard.layout])
+  );
+
+  const widgetPrefixQuery = useMemo(
+    () => `${panel?.panelConfiguration.path}_${id}`,
+    [panel?.panelConfiguration.path, id]
+  );
+
+  const queryClient = useQueryClient();
+  const isFetching = useIsFetching({ queryKey: [widgetPrefixQuery] });
+
+  const { labelLastRefresh } = useLastRefresh(isFetching);
+
+  const hasQueryData = !isEmpty(
+    queryClient.getQueriesData({
+      queryKey: [widgetPrefixQuery]
+    })
+  );
+
+  if (!hasQueryData) {
+    return null;
+  }
+
+  const refresh = (): void => {
+    setRefreshCount?.(id);
+  };
+
+  return (
+    <Tooltip followCursor={false} label={t(labelRefresh)} placement="top">
+      <Typography
+        className={classes.panelLastRefresh}
+        onClick={!isFetching ? refresh : undefined}
+      >
+        {labelLastRefresh}
+      </Typography>
+    </Tooltip>
+  );
+};
+
+export default PanelLastRefresh;

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelMoreActionsButton.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelMoreActionsButton.tsx
@@ -1,0 +1,105 @@
+// @ts-nocheck
+// TODO: re-enable type-check after fixing this file
+import DvrIcon from '@mui/icons-material/Dvr';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+
+import { IconButton } from '@centreon/ui';
+
+import { useAtom, useSetAtom } from 'jotai';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { duplicatePanelDerivedAtom, isEditingAtom } from '../../atoms';
+import useResetDashboardFromSavedState from '../../hooks/useResetDashboardFromSavedState';
+import {
+  labelMoreActions,
+  labelResourcesStatus,
+  labelSeeMore
+} from '../../translatedLabels';
+import MorePanelActions from './MorePanelActions';
+import { ExpandableData } from './models';
+
+interface Props {
+  changeViewMode?: () => void;
+  expandableData?: ExpandableData;
+  id: string;
+  linkToResourceStatus?: string;
+  pageType?: string | null;
+  setRefreshCount?: (id: string) => void;
+}
+
+/**
+ * Single "more actions" trigger used by every widget (titled or not),
+ * rendered as a floating overlay (see Item.tsx's overlayActions) instead of
+ * inside the widget's CardHeader, so the interaction is identical
+ * regardless of whether the widget has a title.
+ */
+const PanelMoreActionsButton = ({
+  id,
+  expandableData,
+  linkToResourceStatus,
+  changeViewMode,
+  pageType,
+  setRefreshCount
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const [moreActionsOpen, setMoreActionsOpen] = useState(null);
+
+  const duplicatePanel = useSetAtom(duplicatePanelDerivedAtom);
+  const [isEditing, setIsEditing] = useAtom(isEditingAtom);
+  const resetDashboardFromSavedState = useResetDashboardFromSavedState();
+
+  const duplicate = (event: MouseEvent): void => {
+    event.preventDefault();
+    if (!isEditing) {
+      resetDashboardFromSavedState();
+    }
+    setIsEditing(() => true);
+    duplicatePanel(id);
+  };
+
+  const openMoreActions = (event: React.MouseEvent): void =>
+    setMoreActionsOpen(event.target as never);
+  const closeMoreActions = (): void => setMoreActionsOpen(null);
+
+  const page = t(pageType || labelResourcesStatus);
+
+  const openResourceStatus = (): void => {
+    changeViewMode?.();
+    window.open(linkToResourceStatus, '_blank', 'noopener,noreferrer');
+    closeMoreActions();
+  };
+
+  const resourceStatusAction = linkToResourceStatus
+    ? {
+        Icon: DvrIcon,
+        label: t(labelSeeMore, { page }),
+        onClick: openResourceStatus
+      }
+    : undefined;
+
+  const refresh = (): void => setRefreshCount?.(id);
+
+  return (
+    <>
+      <IconButton
+        ariaLabel={t(labelMoreActions) as string}
+        onClick={openMoreActions}
+        title={t(labelMoreActions) as string}
+      >
+        <MoreHorizIcon fontSize="small" />
+      </IconButton>
+      <MorePanelActions
+        anchor={moreActionsOpen}
+        close={closeMoreActions}
+        duplicate={duplicate}
+        expandableData={expandableData}
+        id={id}
+        onRefresh={setRefreshCount ? refresh : undefined}
+        resourceStatusAction={resourceStatusAction}
+      />
+    </>
+  );
+};
+
+export default PanelMoreActionsButton;

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/usePanelStyles.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/usePanelStyles.ts
@@ -1,3 +1,5 @@
+import { alpha } from '@mui/material';
+
 import { makeStyles } from 'tss-react/mui';
 
 export const usePanelHeaderStyles = makeStyles()((theme) => ({
@@ -38,16 +40,25 @@ export const usePanelHeaderStyles = makeStyles()((theme) => ({
     marginTop: '-8px',
     width: '45%'
   },
-  panelHeaderContentWithShrink: {
-    width: '20%'
+  panelLastRefresh: {
+    color: theme.palette.text.disabled,
+    cursor: 'pointer',
+    fontSize: '0.65rem',
+    whiteSpace: 'nowrap'
   },
-  panelHeaderRefreshButton: {
-    height: 'auto',
-    padding: `1px ${theme.spacing(0.5)}`
+  panelResourceLink: {
+    '&:hover': {
+      boxShadow: `0 0 0 4px ${alpha(theme.palette.primary.main, 0.15)}`
+    },
+    borderRadius: '50%',
+    display: 'inline-flex',
+    opacity: 0,
+    pointerEvents: 'none',
+    transition: theme.transitions.create(['opacity', 'box-shadow'])
   },
   panelTitle: {
-    fontSize: '1.3rem',
-    fontWeight: theme.typography.fontWeightBold,
+    fontSize: '1.1rem',
+    fontWeight: theme.typography.fontWeightMedium,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/components/DashboardEdit/DashboardEditActions.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/components/DashboardEdit/DashboardEditActions.tsx
@@ -102,7 +102,7 @@ const DashboardEditActions = ({
         iconVariant="start"
         onClick={startEditing}
         size="small"
-        variant="ghost"
+        variant="primary"
       >
         {t(labelEditDashboard)}
       </Button>
@@ -116,7 +116,7 @@ const DashboardEditActions = ({
         data-testid="cancel_dashboard"
         onClick={cancel}
         size="small"
-        variant="ghost"
+        variant="secondary"
       >
         {t(labelCancel)}
       </Button>

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/hooks/useLastRefresh.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/hooks/useLastRefresh.ts
@@ -1,18 +1,17 @@
 import { useLocaleDateTimeFormat } from '@centreon/ui';
 
-import { equals, gte } from 'ramda';
-import { useRef } from 'react';
+import { equals } from 'ramda';
+import { useEffect, useRef, useState } from 'react';
 
 interface UseLastRefreshState {
-  isLastRefreshMoreThanADay: boolean;
-  labelRefresh: string;
+  labelLastRefresh: string;
 }
 
 export const useLastRefresh = (isFetching: number): UseLastRefreshState => {
   const previousIsFetchingRef = useRef<number | null>(null);
-  const previousLastRefreshRef = useRef('');
-  const previousLastRefreshDateRef = useRef<number>(Date.now());
-  const { format } = useLocaleDateTimeFormat();
+  const lastRefreshDateRef = useRef<number>(Date.now());
+  const [, forceRender] = useState(0);
+  const { toHumanizedDuration } = useLocaleDateTimeFormat();
 
   const hasFetchStateChanged = !equals(
     isFetching,
@@ -20,25 +19,24 @@ export const useLastRefresh = (isFetching: number): UseLastRefreshState => {
   );
 
   if (isFetching && hasFetchStateChanged) {
-    previousLastRefreshDateRef.current = Date.now();
+    lastRefreshDateRef.current = Date.now();
   }
 
   previousIsFetchingRef.current = isFetching;
 
-  const now = Date.now();
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      forceRender((count) => count + 1);
+    }, 1000);
 
-  const isLastRefreshMoreThanADay = gte(
-    now - previousLastRefreshDateRef.current,
-    1_000 * 60 * 60 * 24
+    return () => clearInterval(intervalId);
+  }, []);
+
+  const elapsedSeconds = Math.floor(
+    (Date.now() - lastRefreshDateRef.current) / 1000
   );
 
-  const newLastRefresh = format({
-    date: new Date(previousLastRefreshDateRef.current),
-    formatString: isLastRefreshMoreThanADay ? 'L LT' : 'LT'
-  });
-
   return {
-    isLastRefreshMoreThanADay,
-    labelRefresh: newLastRefresh || previousLastRefreshRef.current
+    labelLastRefresh: toHumanizedDuration(elapsedSeconds, 1)
   };
 };

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/translatedLabels.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/translatedLabels.ts
@@ -108,6 +108,7 @@ export const labelStart = 'Start';
 export const labelEnd = 'End';
 export const labelBaseColor = 'Base color';
 export const labelRefresh = 'Refresh';
+export const labelRefreshThePage = 'Refresh the page';
 export const labelDuplicate = 'Duplicate';
 export const labelGlobalRefreshInterval = 'Global refresh interval';
 export const labelManualRefreshOnly = 'Manual refresh only';


### PR DESCRIPTION
## Summary

Modernize the single-dashboard header and widget chrome to match the app's current design language ("NOC dense grid" variant), and make it fit better for always-on, NOC-style displays.

### Header
- Collapse the header into one compact row: title, vertical separator, description, then the action buttons, all vertically aligned.
- Move the favorites (heart) toggle out of the title and into its own framed button in the action row, hidden while editing.
- Add a working Fullscreen toggle (Fullscreen API); the action row is hidden by default in fullscreen and revealed on hover so the dashboard gets the full screen real estate.
- Fix the fullscreen background: the page container had no background color, so entering fullscreen showed the browser's black backdrop instead of the app's background.
- Fix vertical scrolling being blocked when a dashboard's content is taller than the viewport.
- Give the Cancel button (edit mode) a visible outline, and align the spacing between Fullscreen and Edit actions.
- Use theme-aware color tokens throughout so title/description/action colors render correctly in both light and dark mode.

### Widgets
- Unify the "more actions" (`...`) trigger and drag handle for titled and titleless widgets into a single floating overlay in the top-right corner of every widget card, revealed on hover.
- Add a "last updated" indicator (e.g. `15s`, `2m`) to every widget, titled or not, shown in the same top-right corner and swapped for the `...` trigger on hover; replaces the old title-bar-only refresh button and localizes properly (previously hardcoded English suffixes).
- Add a "Refresh" entry to each widget's `...` menu.
- Move the "See more on Resources Status" link into the `...` menu (with a separator) so it's available on titleless widgets too, not just titled ones.
- Fix the resize handle sitting at the wrong vertical position on titleless widgets (it accounted for a title bar that wasn't visible).
- Add a thin, consistent border around every widget card, matching the border already used on the dashboard library's cards.

### Housekeeping
- Extend `toHumanizedDuration` with an optional `largest` param so a single-unit duration (`15s`) can be requested without touching its existing multi-unit callers.

## Screenshot

<img width="1707" height="894" alt="Capture d’écran 2026-08-01 à 15 34 33" src="https://github.com/user-attachments/assets/c3cc5ada-56c1-479d-bf65-70408504bab4" />

## Test plan
- [ ] Open a dashboard, confirm header layout (title/separator/description/actions) in both light and dark mode
- [ ] Toggle Fullscreen: confirm white background, action row hidden by default and revealed on hover, Escape/click exits correctly
- [ ] Scroll a dashboard taller than the viewport
- [ ] Hover a titled widget and a titleless widget: confirm `...` menu, drag handle, and refresh timer all appear in the same top-right spot
- [ ] Click "Refresh" from the `...` menu and from the timer itself
- [ ] Confirm "See more on Resources Status" appears in the `...` menu for widgets with resources, on both titled and titleless widgets
- [ ] Resize a titleless widget, confirm the resize handle is correctly positioned
