### PR TITLE
feat(dashboards): restyle the dashboards library toolbar and card grid (NOC dense variant)

### DIFF
--- a/centreon/packages/ui/src/components/DataTable/DataTable.styles.ts
+++ b/centreon/packages/ui/src/components/DataTable/DataTable.styles.ts
@@ -12,8 +12,8 @@ const useStyles = makeStyles()((theme) => ({
         width: 'auto'
       },
       display: 'grid',
-      gridGap: theme.spacing(2.5),
-      gridTemplateColumns: `repeat(auto-fill, ${theme.spacing(53)})`
+      gridGap: theme.spacing(2),
+      gridTemplateColumns: 'repeat(5, 1fr)'
     },
     '&[data-variant="listing"]': {
       height: '100%'

--- a/centreon/packages/ui/src/components/DataTable/Item/DataTableItem.styles.ts
+++ b/centreon/packages/ui/src/components/DataTable/Item/DataTableItem.styles.ts
@@ -7,31 +7,21 @@ const useStyles = makeStyles()((theme) => ({
     justifyContent: 'space-between'
   },
   cardActions: {
-    backgroundColor: theme.palette.background.paper,
-    bottom: 0,
-    position: 'absolute',
-    width: '100%'
+    flexShrink: 0,
+    padding: 0
   },
   cardContent: {
+    alignItems: 'flex-start',
+    display: 'flex',
+    gap: theme.spacing(1),
+    justifyContent: 'space-between',
     padding: theme.spacing(2),
     zIndex: 1
   },
+  cardContentText: {
+    minWidth: 0
+  },
   dataTableItem: {
-    '& .MuiCardActionArea-root': {
-      alignItems: 'flex-start',
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-      justifyContent: 'flex-start'
-    },
-    '& .MuiCardActions-root': {
-      '& > span': {
-        display: 'flex',
-        gap: theme.spacing(1)
-      },
-      display: 'flex',
-      justifyContent: 'space-between'
-    },
     '&:hover img[alt*="thumbnail"]': {
       transform: 'scale(1.1)',
       transformOrigin: 'center'
@@ -39,8 +29,7 @@ const useStyles = makeStyles()((theme) => ({
     borderRadius: theme.shape.borderRadius,
     display: 'flex',
     flexDirection: 'column',
-    height: '250px',
-    justifyContent: 'space-between',
+    height: '200px',
     p: {
       color: theme.palette.text.secondary,
       letterSpacing: '0',
@@ -49,15 +38,28 @@ const useStyles = makeStyles()((theme) => ({
     position: 'relative'
   },
   description: {
+    marginLeft: theme.spacing(1),
     maxHeight: '42px',
     overflow: 'hidden'
   },
   thumbnail: {
-    height: theme.spacing(10.25),
+    height: '100%',
     objectFit: 'cover',
     objectPosition: 'top',
     transition: 'transform 150ms ease-out',
     width: '100%'
+  },
+  thumbnailArea: {
+    display: 'block',
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+    position: 'relative'
+  },
+  title: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
   }
 }));
 

--- a/centreon/packages/ui/src/components/DataTable/Item/DataTableItem.tsx
+++ b/centreon/packages/ui/src/components/DataTable/Item/DataTableItem.tsx
@@ -52,7 +52,32 @@ const DataTableItem = forwardRef(
         ref={ref as RefObject<HTMLDivElement>}
         variant="outlined"
       >
-        <ActionArea aria-label="view" onClick={() => onClick?.()}>
+        <MuiCardContent className={classes.cardContent}>
+          <div className={classes.cardContentText}>
+            <MuiTypography
+              className={classes.title}
+              fontWeight={500}
+              variant="h6"
+            >
+              {title}
+            </MuiTypography>
+            {description && (
+              <MuiTypography className={classes.description}>
+                {description}
+              </MuiTypography>
+            )}
+          </div>
+          {hasActions && (
+            <MuiCardActions className={classes.cardActions}>
+              {Actions}
+            </MuiCardActions>
+          )}
+        </MuiCardContent>
+        <ActionArea
+          aria-label="view"
+          className={classes.thumbnailArea}
+          onClick={() => onClick?.()}
+        >
           {thumbnail && (
             <img
               alt={`thumbnail-${title}-${description}`}
@@ -62,23 +87,7 @@ const DataTableItem = forwardRef(
               src={thumbnail}
             />
           )}
-          <MuiCardContent className={classes.cardContent}>
-            <MuiTypography fontWeight={500} variant="h5">
-              {title}
-            </MuiTypography>
-            {description && (
-              <MuiTypography className={classes.description}>
-                {description}
-              </MuiTypography>
-            )}
-          </MuiCardContent>
         </ActionArea>
-        {hasActions && (
-          <MuiCardActions className={classes.cardActions}>
-            <span />
-            <span>{Actions}</span>
-          </MuiCardActions>
-        )}
       </MuiCard>
     );
   }

--- a/centreon/www/front_src/src/Dashboards/DashboardsPage.styles.ts
+++ b/centreon/www/front_src/src/Dashboards/DashboardsPage.styles.ts
@@ -1,0 +1,31 @@
+import { makeStyles } from 'tss-react/mui';
+
+export const useDashboardsPageStyles = makeStyles()((theme) => ({
+  headerRow: {
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'space-between'
+  },
+  titleDescription: {
+    color: theme.palette.header.page.description,
+    fontSize: '14px',
+    marginLeft: '20px'
+  },
+  titleGroup: {
+    alignItems: 'baseline',
+    display: 'flex',
+    gap: theme.spacing(1.5),
+    minWidth: 0
+  },
+  titleSeparator: {
+    alignSelf: 'center',
+    borderColor: theme.palette.header.page.border,
+    height: '16px'
+  },
+  titleText: {
+    color: theme.palette.header.page.title,
+    fontSize: '22px',
+    fontWeight: 700,
+    whiteSpace: 'nowrap'
+  }
+}));

--- a/centreon/www/front_src/src/Dashboards/DashboardsPage.tsx
+++ b/centreon/www/front_src/src/Dashboards/DashboardsPage.tsx
@@ -1,4 +1,6 @@
-import { PageHeader, PageLayout } from '@centreon/ui/components';
+import { Divider, Typography } from '@mui/material';
+
+import { PageLayout } from '@centreon/ui/components';
 
 import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,22 +11,43 @@ import DeleteDashboardModal from './components/DashboardLibrary/DeleteDashboardM
 import DuplicateDashboardModal from './components/DashboardLibrary/DuplicateDashboardModal';
 import DashboardNavbar from './components/DashboardNavbar/DashboardNavbar';
 import DashboardPageLayout from './components/DashboardPageLayout';
-import { labelDashboards } from './translatedLabels';
+import { useDashboardsPageStyles } from './DashboardsPage.styles';
+import {
+  labelDashboards,
+  labelDashboardsDescription
+} from './translatedLabels';
 
 const DashboardsPage = (): ReactElement => {
   const { t } = useTranslation();
+  const { classes } = useDashboardsPageStyles();
 
   return (
     <PageLayout>
       <PageLayout.Header>
-        <PageHeader>
-          <PageHeader.Main>
-            <PageHeader.Title title={t(labelDashboards)} />
-          </PageHeader.Main>
-          <PageHeader.Actions>
-            <DashboardNavbar />
-          </PageHeader.Actions>
-        </PageHeader>
+        <div className={classes.headerRow}>
+          <div className={classes.titleGroup}>
+            <Typography
+              aria-label="page header title"
+              className={classes.titleText}
+              variant="h1"
+            >
+              {t(labelDashboards)}
+            </Typography>
+            <Divider
+              className={classes.titleSeparator}
+              flexItem
+              orientation="vertical"
+            />
+            <Typography
+              aria-label="page header description"
+              className={classes.titleDescription}
+              variant="body2"
+            >
+              {t(labelDashboardsDescription)}
+            </Typography>
+          </div>
+          <DashboardNavbar />
+        </div>
       </PageLayout.Header>
       <PageLayout.Body>
         <DashboardPageLayout />

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/Actions.tsx
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/Actions.tsx
@@ -14,12 +14,15 @@ const Actions = ({ openConfig }: { openConfig: () => void }): JSX.Element => {
 
   return (
     <Box className={classes.actions}>
-      {!isViewer && <AddDashboard openConfig={openConfig} />}
+      <Box className={classes.leftCluster}>
+        {!isViewer && <AddDashboard openConfig={openConfig} />}
+        <ViewMode />
+        <FavoriteFilter />
+      </Box>
       <Box className={classes.filter}>
         <Filter />
       </Box>
-      <ViewMode />
-      <FavoriteFilter />
+      <Box className={classes.spacer} />
     </Box>
   );
 };

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/favoriteFilter/FavorieFilter.tsx
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/favoriteFilter/FavorieFilter.tsx
@@ -1,6 +1,9 @@
 // @ts-nocheck
 // TODO: re-enable type-check after fixing this file
-import { Checkbox } from '@centreon/ui';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+
+import { IconButton } from '@centreon/ui';
 
 import { useAtom } from 'jotai';
 import { memo } from 'react';
@@ -11,27 +14,25 @@ import { onlyFavoriteDashboardsAtom } from './atoms';
 import useFavoriteFilterStyles from './favoriteFilter.styles';
 
 const FavoriteFilter = () => {
-  const { classes } = useFavoriteFilterStyles();
+  const { classes, cx } = useFavoriteFilterStyles();
   const { t } = useTranslation();
   const [checked, setChecked] = useAtom(onlyFavoriteDashboardsAtom);
 
-  const labelProps = {
-    classes: { root: classes.label },
-    noWrap: true,
-    variant: 'body2' as const
-  };
-  const onChange = (event) => {
-    setChecked(event?.target?.checked);
-  };
+  const toggle = (): void => setChecked((current) => !current);
 
   return (
-    <Checkbox
-      checked={checked}
-      className={classes.container}
-      label={t(labelFavoriteFilter)}
-      labelProps={labelProps}
-      onChange={onChange}
-    />
+    <IconButton
+      ariaLabel={t(labelFavoriteFilter)}
+      className={cx(classes.container, checked && classes.containerActive)}
+      onClick={toggle}
+      title={t(labelFavoriteFilter)}
+    >
+      {checked ? (
+        <FavoriteIcon className={classes.iconActive} fontSize="small" />
+      ) : (
+        <FavoriteBorderIcon fontSize="small" />
+      )}
+    </IconButton>
   );
 };
 

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/favoriteFilter/favoriteFilter.styles.ts
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/favoriteFilter/favoriteFilter.styles.ts
@@ -2,12 +2,13 @@ import { makeStyles } from 'tss-react/mui';
 
 const useFavoriteFilterStyles = makeStyles()((theme) => ({
   container: {
-    display: 'flex',
-    flex: 1,
-    justifyContent: 'center'
+    border: `1px solid ${theme.palette.divider}`
   },
-  label: {
-    paddingLeft: theme.spacing(0.25)
+  containerActive: {
+    borderColor: theme.palette.error.main
+  },
+  iconActive: {
+    color: theme.palette.error.main
   }
 }));
 

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/useActionsStyles.ts
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Actions/useActionsStyles.ts
@@ -2,15 +2,32 @@ import { makeStyles } from 'tss-react/mui';
 
 export const useActionsStyles = makeStyles()((theme) => ({
   actions: {
-    display: 'flex',
-    gap: theme.spacing(3)
+    alignItems: 'center',
+    display: 'grid',
+    gap: theme.spacing(3),
+    gridTemplateColumns: '1fr auto 1fr',
+    width: '100%'
   },
   filter: {
-    width: theme.spacing(50)
+    justifySelf: 'center',
+    width: theme.spacing(70)
   },
-  viewMode: {
+  leftCluster: {
     alignItems: 'center',
     display: 'flex',
-    gap: theme.spacing(1)
+    gap: theme.spacing(2),
+    justifySelf: 'start'
+  },
+  spacer: {},
+  viewMode: {
+    '& [data-selected="true"]': {
+      backgroundColor: theme.palette.background.paper
+    },
+    alignItems: 'center',
+    backgroundColor: theme.palette.action.hover,
+    borderRadius: theme.shape.borderRadius,
+    display: 'flex',
+    gap: theme.spacing(0.25),
+    padding: theme.spacing(0.25)
   }
 }));

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Listing.tsx
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/Listing.tsx
@@ -31,9 +31,9 @@ interface ListingProp {
 const Listing = ({
   data: listingData,
   loading,
-  openConfig,
   customListingComponent,
-  displayCustomListing
+  displayCustomListing,
+  openConfig
 }: ListingProp): JSX.Element => {
   const { t } = useTranslation();
   const { columns, defaultColumnsIds } = useColumns();
@@ -80,6 +80,7 @@ const Listing = ({
         onRowClick={navigateToDashboard}
         onSelectColumns={setSelectedColumnIds}
         onSort={changeSort}
+        paginated
         rows={formattedRows}
         sortField={sortf}
         sortOrder={sorto}

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/atom.ts
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardListing/atom.ts
@@ -6,7 +6,7 @@ import { ViewMode } from './models';
 
 type SortOrder = 'asc' | 'desc';
 
-export const limitAtom = atom<number | undefined>(10);
+export const limitAtom = atom<number | undefined>(30);
 export const pageAtom = atom<number | undefined>(undefined);
 export const totalAtom = atom<number>(0);
 export const sortOrderAtom = atom<SortOrder>('asc');

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardsOverview/DashboardsOverview.styles.ts
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardsOverview/DashboardsOverview.styles.ts
@@ -12,20 +12,10 @@ export const useStyles = makeStyles()((theme) => ({
   thumbnailFallbackIcon: {
     backgroundColor: theme.palette.background.default,
     borderRadius: '50%',
+    bottom: theme.spacing(1),
     height: theme.spacing(3),
     position: 'absolute',
     right: theme.spacing(1),
-    top: theme.spacing(1),
     width: theme.spacing(3)
-  },
-  warning: {
-    color: theme.palette.action.disabled,
-    fontSize: theme.typography.body1.fontSize,
-    fontWeight: theme.typography.h6.fontWeight
-  },
-  warningContainer: {
-    display: 'flex',
-    gap: theme.spacing(0.5),
-    margin: theme.spacing(2, 0)
   }
 }));

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardsOverview/DashboardsOverview.tsx
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardsOverview/DashboardsOverview.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // TODO: re-enable type-check after fixing this file
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 
 import { DataTable, Tooltip } from '@centreon/ui/components';
 import { userAtom } from '@centreon/ui-context';
@@ -19,7 +19,6 @@ import { Dashboard } from '../../../api/models';
 import { DashboardLayout } from '../../../models';
 import {
   labelCreateADashboard,
-  labelDataDisplayedForRepresentativeUse,
   labelSaveYourDashboardForThumbnail,
   labelWelcomeToDashboardInterface
 } from '../../../translatedLabels';
@@ -88,12 +87,6 @@ const DashboardsOverview = (): ReactElement => {
 
   const GridTable = (
     <div>
-      <Box className={classes.warningContainer}>
-        <InfoOutlinedIcon color="primary" />
-        <Typography className={classes.warning}>
-          {t(labelDataDisplayedForRepresentativeUse)}
-        </Typography>
-      </Box>
       <DataTable isEmpty={isEmptyList} variant="grid">
         {dashboards.map((dashboard) => (
           <div className={classes.dashboardItemContainer} key={dashboard.id}>

--- a/centreon/www/front_src/src/Dashboards/translatedLabels.tsx
+++ b/centreon/www/front_src/src/Dashboards/translatedLabels.tsx
@@ -1,4 +1,6 @@
 export const labelDashboards = 'Dashboards';
+export const labelDashboardsDescription =
+  'Visualize and monitor your infrastructure through customizable dashboards';
 export const labelCreateADashboard = 'Create a dashboard';
 export const labelWelcomeToDashboardInterface =
   'Welcome to the Dashboards interface!';


### PR DESCRIPTION
## Summary

Modernize the "Dashboards" library page to match the app's current design language ("NOC dense grid" variant), and tighten up its toolbar/grid layout.

### Header
- Add a subtitle under the "Dashboards" title, with a vertical separator, matching the title/separator/description pattern used elsewhere in the app; extra left margin reserves room for the Pendo help bubble.

### Toolbar
- Reorganize into: Add + view-mode toggle on the left, search centered, favorites toggle on the right, all aligned with the title.
- Remove the vertical divider between the search and the rest of the toolbar.
- Widen the search input by 40%.
- Group the grid/list view-mode toggle into a single pill control.
- Turn "Show only favorite dashboards" into a heart icon-button instead of a checkbox with a label.
- Fix the search box centering (the toolbar grid had an empty third column after the above reshuffle, throwing off the centering).

### Cards
- Shrink cards to fit 5 per row (was fewer, larger cards).
- Move the thumbnail to the bottom of the card, with the title top-left and the actions (`...`, etc.) top-right; reduce the title size slightly.
- Add a thin border consistent with the rest of the app's card styling.
- Remove the "Thumbnails show a snapshot..." banner, no longer needed with the new layout.

## Screenshot

<img width="1710" height="900" alt="Capture d’écran 2026-08-01 à 15 34 42" src="https://github.com/user-attachments/assets/7ebcc7b2-5ea7-4ecb-980c-2ede3275154b" />

## Test plan
- [ ] Open the Dashboards library page, confirm title/subtitle/separator layout
- [ ] Confirm toolbar alignment: Add + view mode (left), search (centered), favorites (right)
- [ ] Search: confirm width and functional filtering
- [ ] Toggle grid/list view mode
- [ ] Toggle "favorites only" via the heart icon
- [ ] Confirm 5 cards per row in grid view, thumbnail at the bottom, title/actions at the top
- [ ] Confirm no leftover "Thumbnails show a snapshot..." banner
