### PR TITLE
fix(logging): disable deprecation channel in prod by default

### DIFF
--- a/centreon/config.new/packages/monolog.yaml
+++ b/centreon/config.new/packages/monolog.yaml
@@ -138,10 +138,8 @@ when@prod:
                 channels: ["!event", "!doctrine", "!deprecation"]
                 formatter: monolog.formatter.line
             deprecation:
-                type: stream
+                type: 'null'
                 channels: [deprecation]
-                path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
-                formatter: monolog.formatter.line
             authentication:
                 type: stream
                 channels: [authentication]

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -464,7 +464,7 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 | Excluded channel | Reason |
 |------------------|--------|
 | `event`, `doctrine`, `console` | Internal Symfony / DBAL noise — not desired in `prod.web.log`. |
-| `deprecation` | disabled in prod by default (Monolog `NullHandler` — records discarded). In dev, written to `dev.deprecations.log` via a `rotating_file` handler. Re-enable in prod by overriding the `deprecation` handler in a local `monolog.yaml`. |
+| `deprecation` | disabled in prod by default (Monolog `NullHandler` — records discarded). In dev, written to `dev.deprecations.log` via a `rotating_file` handler. To re-enable in prod, override the `deprecation` handler in a local `monolog.yaml`; `logrotate/centreon` still declares `prod.deprecations.log` so the override path inherits the standard rotation policy. |
 | `authentication` | merged into `prod.access.log` on the centreon-web side (see the backward-compatibility note below for `login.log`). |
 | `token` | dedicated file `prod.token.log`. |
 | `password`, `plugin-pack-manager`, `upgrade` | dedicated files. Not Monolog channels strictly speaking today (written directly by legacy `CentreonLog` code), but listed in anticipation of a future migration to Monolog. |
@@ -492,6 +492,7 @@ In production, the `prod.*.log` files are rotated by **logrotate** (config `cent
 - `prod.password.log`
 - `prod.upgrade.log`
 - `prod.plugin-pack-manager.log`
+- `prod.deprecations.log` — file is not created in the default configuration (`NullHandler`); the entry is retained so operators who override the `deprecation` handler locally inherit rotation. `missingok` in the shared block covers the absent-file case.
 
 Default retention: `weekly` × `rotate 52` (1 year), with `compress` + `delaycompress` + `copytruncate`.
 

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -464,7 +464,7 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 | Excluded channel | Reason |
 |------------------|--------|
 | `event`, `doctrine`, `console` | Internal Symfony / DBAL noise — not desired in `prod.web.log`. |
-| `deprecation` | dedicated file `prod.deprecations.log`. |
+| `deprecation` | disabled in prod by default (Monolog `NullHandler` — records discarded). In dev, written to `dev.deprecations.log` via a `rotating_file` handler. Re-enable in prod by overriding the `deprecation` handler in a local `monolog.yaml`. |
 | `authentication` | merged into `prod.access.log` on the centreon-web side (see the backward-compatibility note below for `login.log`). |
 | `token` | dedicated file `prod.token.log`. |
 | `password`, `plugin-pack-manager`, `upgrade` | dedicated files. Not Monolog channels strictly speaking today (written directly by legacy `CentreonLog` code), but listed in anticipation of a future migration to Monolog. |
@@ -487,7 +487,6 @@ Consequence: every handler using `monolog.formatter.line` (centreon-web + any mo
 In production, the `prod.*.log` files are rotated by **logrotate** (config `centreon/logrotate/centreon`, deployed to `/etc/logrotate.d/centreon`). The files listed:
 
 - `prod.web.log` (catch-all)
-- `prod.deprecations.log`
 - `prod.access.log` (authentication)
 - `prod.token.log`
 - `prod.password.log`

--- a/centreon/logrotate/centreon
+++ b/centreon/logrotate/centreon
@@ -1,4 +1,4 @@
-@CENTREON_LOG@/centAcl.log @CENTREON_LOG@/centreon-backup.log @CENTREON_LOG@/centreon-partitioning.log @CENTREON_LOG@/centreon-purge.log @CENTREON_LOG@/dashboardBuilder.log @CENTREON_LOG@/downtimeManager.log @CENTREON_LOG@/eventReportBuilder.log @CENTREON_LOG@/knowledgebase.log @CENTREON_LOG@/ldap*.log @CENTREON_LOG@/login.log @CENTREON_LOG@/prod.access.log @CENTREON_LOG@/prod.password.log @CENTREON_LOG@/prod.plugin-pack-manager.log @CENTREON_LOG@/prod.token.log @CENTREON_LOG@/prod.upgrade.log @CENTREON_LOG@/prod.web.log {
+@CENTREON_LOG@/centAcl.log @CENTREON_LOG@/centreon-backup.log @CENTREON_LOG@/centreon-partitioning.log @CENTREON_LOG@/centreon-purge.log @CENTREON_LOG@/dashboardBuilder.log @CENTREON_LOG@/downtimeManager.log @CENTREON_LOG@/eventReportBuilder.log @CENTREON_LOG@/knowledgebase.log @CENTREON_LOG@/ldap*.log @CENTREON_LOG@/login.log @CENTREON_LOG@/prod.access.log @CENTREON_LOG@/prod.deprecations.log @CENTREON_LOG@/prod.password.log @CENTREON_LOG@/prod.plugin-pack-manager.log @CENTREON_LOG@/prod.token.log @CENTREON_LOG@/prod.upgrade.log @CENTREON_LOG@/prod.web.log {
     copytruncate
     weekly
     rotate 52

--- a/centreon/logrotate/centreon
+++ b/centreon/logrotate/centreon
@@ -1,4 +1,4 @@
-@CENTREON_LOG@/centAcl.log @CENTREON_LOG@/centreon-backup.log @CENTREON_LOG@/centreon-partitioning.log @CENTREON_LOG@/centreon-purge.log @CENTREON_LOG@/dashboardBuilder.log @CENTREON_LOG@/downtimeManager.log @CENTREON_LOG@/eventReportBuilder.log @CENTREON_LOG@/knowledgebase.log @CENTREON_LOG@/ldap*.log @CENTREON_LOG@/login.log @CENTREON_LOG@/prod.access.log @CENTREON_LOG@/prod.deprecations.log @CENTREON_LOG@/prod.password.log @CENTREON_LOG@/prod.plugin-pack-manager.log @CENTREON_LOG@/prod.token.log @CENTREON_LOG@/prod.upgrade.log @CENTREON_LOG@/prod.web.log {
+@CENTREON_LOG@/centAcl.log @CENTREON_LOG@/centreon-backup.log @CENTREON_LOG@/centreon-partitioning.log @CENTREON_LOG@/centreon-purge.log @CENTREON_LOG@/dashboardBuilder.log @CENTREON_LOG@/downtimeManager.log @CENTREON_LOG@/eventReportBuilder.log @CENTREON_LOG@/knowledgebase.log @CENTREON_LOG@/ldap*.log @CENTREON_LOG@/login.log @CENTREON_LOG@/prod.access.log @CENTREON_LOG@/prod.password.log @CENTREON_LOG@/prod.plugin-pack-manager.log @CENTREON_LOG@/prod.token.log @CENTREON_LOG@/prod.upgrade.log @CENTREON_LOG@/prod.web.log {
     copytruncate
     weekly
     rotate 52


### PR DESCRIPTION
## Description

The prod deprecation handler ran with the default debug level, so every INFO-level deprecation record was written to prod.deprecations.log on every request. Under normal traffic the file grew  and saturated /var/log.

Switch the handler to Monolog NullHandler in when@prod, drop prod.deprecations.log from logrotate/centreon, and update the logging doc. Dev is unchanged: dev.deprecations.log keeps flowing through the rotating_file handler for local debugging and the newman CI collector.

[MON-205991](https://centreon.atlassian.net/browse/MON-205991)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-205991]: https://centreon.atlassian.net/browse/MON-205991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ