### PR TITLE
fix(open-tickets): use canonical ITILCategory itemtype casing for GLPI REST API

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
@@ -1240,7 +1240,8 @@ class GlpiRestApiProvider extends AbstractProvider
     protected function getItilCategories()
     {
         // add the api endpoint and method to our info array
-        $info['query_endpoint'] = '/itilCategory';
+        // ITILCategory is the canonical itemtype casing accepted by every GLPI version (9.1 -> 11)
+        $info['query_endpoint'] = '/ITILCategory';
         $info['method'] = 0;
         // set headers
         $info['headers'] = ['App-Token: ' . $this->getFormValue('app_token'), 'Content-Type: application/json'];


### PR DESCRIPTION
Fixes: [MON-192238](https://centreon.atlassian.net/browse/MON-192238)

## Description

GLPI's REST API routes itemtypes case-sensitively to internal PHP class names. The `GlpiRestApi` open-tickets provider queried the ITIL Category endpoint as `/itilCategory`, which no longer matches the class name on GLPI ≥ 9.5.0, so the **ITIL Category** dropdown failed on recent GLPI versions.

The fix is to use `/ITILCategory`, the **canonical itemtype casing accepted by every GLPI version from 9.1 to 11**:
- **≤ 9.4** — the autoloader lowercases the itemtype and resolves `inc/itilcategory.class.php`
- **9.5.x** — exact PSR-4 match on `ITILCategory`
- **10.0.0+** — normalized through `fixItemtypeCase()`

The **Group** endpoint already used the canonical `/Group` casing on `develop`, so it needed no change.

This intentionally replaces an earlier version-selector approach: **no new form field, no default value to manage, no migration of existing rules, and nothing new to document.**

## Changes
- `GlpiRestApiProvider::getItilCategories()`: `/itilCategory` → `/ITILCategory`.

## How to test
Configure a GlpiRestApi open-tickets rule against a GLPI instance and open a ticket using ITIL Category / Group mappings. The **ITIL Category** and **GLPI Group** dropdowns should populate without error on:
- GLPI ≤ 9.4
- GLPI 9.5.x
- GLPI 10.0.0+


[MON-192238]: https://centreon.atlassian.net/browse/MON-192238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
