### PR TITLE
feat(poller): add centralAddress to create poller endpoint

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -9967,6 +9967,9 @@ components:
           minLength: 1
           maxLength: 255
           type: string
+        central_address:
+          type: string
+          nullable: true
         id:
           type: integer
           nullable: true
@@ -9986,6 +9989,10 @@ components:
             - docker
           type: string
         address:
+          minLength: 1
+          maxLength: 255
+          type: string
+        central_address:
           minLength: 1
           maxLength: 255
           type: string
@@ -10009,6 +10016,9 @@ components:
               minLength: 1
               maxLength: 255
               type: string
+            central_address:
+              type: string
+              nullable: true
             id:
               type: integer
               nullable: true
@@ -10054,6 +10064,9 @@ components:
           type: string
         address:
           type: string
+        central_address:
+          type: string
+          nullable: true
         id:
           type: integer
           nullable: true
@@ -10084,8 +10097,13 @@ components:
           minLength: 1
           maxLength: 255
           type: string
+        central_address:
+          minLength: 1
+          maxLength: 255
+          type: string
       required:
         - poller_token_name
+        - central_address
     Poller.InstallationCommandResource:
       type: object
       properties:
@@ -10117,6 +10135,9 @@ components:
               type: string
             address:
               type: string
+            central_address:
+              type: string
+              nullable: true
             id:
               type: integer
               nullable: true

--- a/centreon/src/App/MonitoringConfiguration/Application/Command/CreatePollerCommand.php
+++ b/centreon/src/App/MonitoringConfiguration/Application/Command/CreatePollerCommand.php
@@ -35,6 +35,7 @@ final readonly class CreatePollerCommand
         public PollerTypeEnum $pollerType,
         public PollerAddress $address,
         public int $creatorId,
+        public PollerAddress $centralAddress,
         public GorgoneCommunicationTypeEnum $gorgoneCommunicationType = GorgoneCommunicationTypeEnum::ZMQ,
     ) {
     }

--- a/centreon/src/App/MonitoringConfiguration/Application/Command/CreatePollerCommandHandler.php
+++ b/centreon/src/App/MonitoringConfiguration/Application/Command/CreatePollerCommandHandler.php
@@ -72,6 +72,7 @@ final readonly class CreatePollerCommandHandler
             connectorConfiguration: new ConnectorConfiguration(),
             trapConfiguration: new TrapConfiguration(),
             pollerCommands: new Collection([], PollerCommand::class),
+            centralAddress: $command->centralAddress,
         );
 
         $seenMacroNames = [];

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/Poller.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/Poller.php
@@ -52,6 +52,7 @@ final class Poller extends AggregateRoot
         public readonly ConnectorConfiguration $connectorConfiguration,
         public readonly TrapConfiguration $trapConfiguration,
         public readonly Collection $pollerCommands,
+        public readonly ?PollerAddress $centralAddress = null,
         public ?PollerCMACertificates $cmaCertificates = null,
         public readonly ?PollerRemoteAttachment $remoteAttachment = null,
     ) {

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Dto/CreatePollerInput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Dto/CreatePollerInput.php
@@ -46,6 +46,10 @@ final readonly class CreatePollerInput
         #[Assert\Length(min: 1, max: 255)]
         #[ExistingPollerToken]
         public string $pollerTokenName,
+
+        #[Assert\NotBlank(normalizer: 'trim')]
+        #[Assert\Length(min: PollerAddress::MIN_LENGTH, max: PollerAddress::MAX_LENGTH)]
+        public string $centralAddress,
     ) {
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
@@ -60,6 +60,8 @@ final class PollerResource
 
         public string $address,
 
+        public ?string $centralAddress,
+
         #[ApiProperty(identifier: true)]
         public int $id,
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -86,6 +86,7 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
             pollerType: PollerTypeEnum::from($data->pollerType),
             address: new PollerAddress($data->address),
             creatorId: $credentialUser->credential->userId->value,
+            centralAddress: new PollerAddress($data->centralAddress),
             gorgoneCommunicationType: $this->isCloudPlatform
                 ? GorgoneCommunicationTypeEnum::PullWss
                 : GorgoneCommunicationTypeEnum::ZMQ,
@@ -104,6 +105,7 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
             $appSecret,
             $salt,
             $this->isCloudPlatform,
+            $data->centralAddress,
         );
 
         $resource = $this->transformer->transform($model);

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
@@ -25,6 +25,7 @@ namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
@@ -63,12 +64,17 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
             ? $this->pollerTokenRepository->getValidPollerTokenByName($tokenName)
             : $this->pollerTokenRepository->getFirstValidPollerToken();
 
+        if (! $poller->centralAddress instanceof PollerAddress) {
+            throw new BadRequestHttpException(sprintf('No central address configured for poller #%d.', $pollerId->value));
+        }
+
         $factory = new PollerInstallationCommandFactory(
             $poller,
             $token,
             $this->engineSecretsRepository->getAppSecret(),
             $this->engineSecretsRepository->getSalt(),
             $this->isCloudPlatform,
+            $poller->centralAddress->value,
         );
 
         return new InstallationCommandResource(

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ResourcePollerTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ResourcePollerTransformer.php
@@ -40,6 +40,7 @@ final readonly class ResourcePollerTransformer implements TransformerInterface
             name: $from->name->value,
             pollerType: $from->pollerType->value,
             address: $from->address->value,
+            centralAddress: $from->centralAddress?->value,
             uid: (string) $from->uid->value,
             gorgoneCommunicationType: $this->communicationTypeToString($from->gorgoneConfiguration->communicationType),
         );

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
@@ -72,6 +72,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *   centreonconnector_path: string|null,
  *   init_script_centreontrapd: string|null,
  *   snmp_trapd_path_conf: string|null,
+ *   central_address: string|null,
  * }
  * @phpstan-type JoinRowTypeAlias = array{
  *   poller_id: int,
@@ -100,6 +101,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *   centreonconnector_path: string|null,
  *   init_script_centreontrapd: string|null,
  *   snmp_trapd_path_conf: string|null,
+ *   central_address: string|null,
  *   gm_resource_id: int,
  *   gm_resource_name: string,
  *   gm_resource_line: string,
@@ -209,6 +211,32 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
 
         $this->setId($poller, new PollerId($pollerId));
         $this->linkGlobalMacros($poller);
+
+        $centralTopologyId = $this->connection->createQueryBuilder()
+            ->select('id')
+            ->from('platform_topology')
+            ->where("type = 'central'")
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        $this->connection->createQueryBuilder()
+            ->insert('platform_topology')
+            ->values([
+                'address' => ':address',
+                'central_address' => ':centralAddress',
+                'name' => ':name',
+                'type' => "'poller'",
+                'parent_id' => ':parentId',
+                'server_id' => ':serverId',
+                'pending' => "'0'",
+            ])
+            ->setParameter('address', $poller->address->value)
+            ->setParameter('centralAddress', $poller->centralAddress?->value)
+            ->setParameter('name', $poller->name->value)
+            ->setParameter('parentId', is_int($centralTopologyId) || is_string($centralTopologyId) ? (int) $centralTopologyId : null)
+            ->setParameter('serverId', $pollerId)
+            ->executeStatement();
     }
 
     public function findOneByName(PollerName $name): ?Poller
@@ -216,7 +244,9 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
         $qb = $this->connection->createQueryBuilder();
 
         $qb->select(...self::getSelectColumns())
+            ->addSelect('pt.central_address AS central_address')
             ->from(self::TABLE_NAME, 'p')
+            ->leftJoin('p', 'platform_topology', 'pt', 'pt.server_id = p.id')
             ->where('p.name = :name')
             ->setParameter('name', $name->value)
             ->setMaxResults(1);
@@ -236,7 +266,9 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
         $qb = $this->connection->createQueryBuilder();
 
         $qb->select(...self::getSelectColumns())
+            ->addSelect('pt.central_address AS central_address')
             ->from(self::TABLE_NAME, 'p')
+            ->leftJoin('p', 'platform_topology', 'pt', 'pt.server_id = p.id')
             ->where('p.ns_ip_address = :address')
             ->setParameter('address', $address->value)
             ->setMaxResults(1);
@@ -255,8 +287,10 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
     {
         $qb = $this->connection->createQueryBuilder();
         $qb->select(...self::getSelectColumns(), ...DbalGlobalMacroRepository::getSelectColumns())
+            ->addSelect('pt.central_address AS central_address')
             ->from(self::GLOBAL_MACRO_JOIN_TABLE_NAME, 'pg1')
             ->innerJoin('pg1', self::TABLE_NAME, 'p', 'p.id = pg1.instance_id')
+            ->leftJoin('p', 'platform_topology', 'pt', 'pt.server_id = p.id')
             ->leftJoin('p', self::GLOBAL_MACRO_JOIN_TABLE_NAME, 'pg2', 'pg2.instance_id = p.id')
             ->leftJoin('pg2', DbalGlobalMacroRepository::TABLE_NAME, 'gm', 'gm.resource_id = pg2.resource_id') // ensures still filter on relevant pollers
             ->where('pg1.resource_id = :resource_id')
@@ -297,7 +331,9 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
     {
         $qb = $this->connection->createQueryBuilder();
         $qb->select(...self::getSelectColumns())
+            ->addSelect('pt.central_address AS central_address')
             ->from(self::TABLE_NAME, 'p')
+            ->leftJoin('p', 'platform_topology', 'pt', 'pt.server_id = p.id')
             ->where('p.id = :poller_id')
             ->setParameter('poller_id', $pollerId->value);
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerTransformer.php
@@ -60,6 +60,7 @@ final readonly class DbalPollerTransformer implements TransformerInterface
             uid: new PollerUid((int) $from['poller_uid']),
             globalMacros: new Collection([], GlobalMacro::class),
             pollerCommands: new Collection([], PollerCommand::class),
+            centralAddress: is_string($from['central_address'] ?? null) ? new PollerAddress($from['central_address']) : null,
             brokerConfiguration: new BrokerConfiguration(
                 reloadCommand: $from['broker_reload_command'],
                 configurationPath: $from['centreonbroker_cfg_path'],

--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -547,6 +547,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
+                'central_address' => $this->arguments['centreon_central_ip'],
                 'children_pollers' => $pollers ?? null,
             ]);
             // if it is poller wizard and poller is linked to another poller/remote server (instead of central)
@@ -562,6 +563,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
+                'central_address' => $this->arguments['centreon_central_ip'],
                 'parent' => $parentPoller->getId(),
             ]);
         } else {
@@ -570,6 +572,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'server_name' => $serverName,
                 'nagios_id' => $serverId,
                 'address' => $serverIP,
+                'central_address' => $this->arguments['centreon_central_ip'],
             ]);
         }
 
@@ -758,22 +761,25 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $statement = $this->pearDB->prepare(
                 "UPDATE `platform_topology` SET
                 `name` = :name,
+                `central_address` = :centralAddress,
                 parent_id = :parentId,
                 server_id = :nagiosId,
                 pending = '0'
                 WHERE id = :topologyId"
             );
             $statement->bindValue(':name', $topologyInformation['server_name'], \PDO::PARAM_STR);
+            $statement->bindValue(':centralAddress', $topologyInformation['central_address'], \PDO::PARAM_STR);
             $statement->bindValue(':parentId', (int) $parent['id'], \PDO::PARAM_INT);
             $statement->bindValue(':nagiosId', $topologyInformation['nagios_id'], \PDO::PARAM_INT);
             $statement->bindValue(':topologyId', (int) $server['id'], \PDO::PARAM_INT);
             $statement->execute();
         } else {
             $statement = $this->pearDB->prepare(
-                "INSERT INTO `platform_topology` (`address`,`name`,`type`,`parent_id`,`server_id`, `pending`)
-                VALUES (:address, :name, :type, :parentId, :serverId, '0')"
+                "INSERT INTO `platform_topology` (`address`,`central_address`,`name`,`type`,`parent_id`,`server_id`, `pending`)
+                VALUES (:address, :centralAddress, :name, :type, :parentId, :serverId, '0')"
             );
             $statement->bindValue(':address', $topologyInformation['address'], \PDO::PARAM_STR);
+            $statement->bindValue(':centralAddress', $topologyInformation['central_address'], \PDO::PARAM_STR);
             $statement->bindValue(':name', $topologyInformation['server_name'], \PDO::PARAM_STR);
             $statement->bindValue(':type', $topologyInformation['type'], \PDO::PARAM_STR);
             $statement->bindValue(':parentId', (int) $parent['id'], \PDO::PARAM_INT);

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create Docker poller returns installation command - HTTP 201.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create Docker poller returns installation command - HTTP 201.bru
@@ -15,7 +15,8 @@ body:json {
     "name": "{{PollerNameDocker}}",
     "address": "{{PollerAddress}}",
     "poller_type": "docker",
-    "poller_token_name": "{{PollerTokenName}}"
+    "poller_token_name": "{{PollerTokenName}}",
+    "central_address": "{{CentralAddress}}"
   }
 }
 
@@ -31,6 +32,8 @@ tests {
     expect(body.installation_command).to.be.a("string");
     expect(body.installation_command).to.include("curl -fsSL");
     expect(body.installation_command).to.include("--type docker");
+    expect(body.central_address).to.eql(bru.getEnvVar("CentralAddress"));
+    expect(body.installation_command).to.include(bru.getEnvVar("CentralAddress"));
   });
 }
 

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create VM poller returns installation command - HTTP 201.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create VM poller returns installation command - HTTP 201.bru
@@ -15,7 +15,8 @@ body:json {
     "name": "{{PollerName}}",
     "address": "{{PollerAddress}}",
     "poller_type": "vm",
-    "poller_token_name": "{{PollerTokenName}}"
+    "poller_token_name": "{{PollerTokenName}}",
+    "central_address": "{{CentralAddress}}"
   }
 }
 
@@ -34,6 +35,8 @@ tests {
     expect(body.installation_command).to.be.a("string");
     expect(body.installation_command).to.include("curl -fsSL");
     expect(body.installation_command).to.include("--type vm");
+    expect(body.central_address).to.eql(bru.getEnvVar("CentralAddress"));
+    expect(body.installation_command).to.include(bru.getEnvVar("CentralAddress"));
   });
 }
 

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Unknown poller token name - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Unknown poller token name - HTTP 400.bru
@@ -15,7 +15,8 @@ body:json {
     "name": "poller-bruno-unknown-token",
     "address": "1.2.3.6",
     "poller_type": "vm",
-    "poller_token_name": "{{UnknownPollerTokenName}}"
+    "poller_token_name": "{{UnknownPollerTokenName}}",
+    "central_address": "{{CentralAddress}}"
   }
 }
 

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/POST -pollers - Access denied - HTTP 403.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Unprivileged Profile/POST -pollers - Access denied - HTTP 403.bru
@@ -15,7 +15,8 @@ body:json {
     "name": "poller-bruno-forbidden",
     "address": "1.2.3.7",
     "poller_type": "vm",
-    "poller_token_name": "{{PollerTokenName}}"
+    "poller_token_name": "{{PollerTokenName}}",
+    "central_address": "{{CentralAddress}}"
   }
 }
 

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/environments/poller-configuration-collection-environment.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/environments/poller-configuration-collection-environment.bru
@@ -4,4 +4,5 @@ vars {
   PollerAddress: 1.2.3.5
   PollerTokenName: poller-default
   UnknownPollerTokenName: this-token-does-not-exist
+  CentralAddress: 192.168.1.254
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Application/Command/CreatePollerCommandHandlerTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Application/Command/CreatePollerCommandHandlerTest.php
@@ -57,6 +57,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
+            centralAddress: new PollerAddress('10.0.0.1'),
         );
 
         $poller = $handler($command);
@@ -85,6 +86,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
             gorgoneCommunicationType: GorgoneCommunicationTypeEnum::PullWss,
+            centralAddress: new PollerAddress('10.0.0.1'),
         );
 
         $poller = $handler($command);
@@ -105,6 +107,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::Docker,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
+            centralAddress: new PollerAddress('10.0.0.1'),
         );
 
         $poller = $handler($command);
@@ -125,6 +128,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 42,
+            centralAddress: new PollerAddress('10.0.0.1'),
         ));
 
         $events = $eventBus->getDispatchedEvents(PollerCreated::class);
@@ -156,6 +160,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
+            centralAddress: new PollerAddress('10.0.0.1'),
         ));
 
         self::assertCount(1, $poller->globalMacros);
@@ -204,6 +209,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
+            centralAddress: new PollerAddress('10.0.0.1'),
         ));
 
         self::assertCount(3, $poller->globalMacros);
@@ -253,11 +259,32 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
+            centralAddress: new PollerAddress('10.0.0.1'),
         ));
 
         self::assertCount(2, $poller->globalMacros);
         self::assertCount(1, $firstUser1->pollers);
         self::assertCount(0, $duplicateUser1->pollers);
         self::assertCount(1, $user2->pollers);
+    }
+
+    public function testCentralAddressIsSetOnPoller(): void
+    {
+        $repository = new FakePollerRepository();
+        $eventBus = new EventBusSpy();
+        $uidGenerator = new FakePollerUidGenerator();
+        $globalMacroRepository = new FakeGlobalMacroRepository();
+        $handler = new CreatePollerCommandHandler($repository, $eventBus, $uidGenerator, $globalMacroRepository);
+
+        $poller = $handler(new CreatePollerCommand(
+            name: new PollerName('MyPoller'),
+            pollerType: PollerTypeEnum::VM,
+            address: new PollerAddress('192.168.1.1'),
+            creatorId: 1,
+            centralAddress: new PollerAddress('10.0.0.1'),
+        ));
+
+        self::assertNotNull($poller->centralAddress);
+        self::assertSame('10.0.0.1', $poller->centralAddress->value);
     }
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
@@ -85,6 +85,20 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
         self::assertSame(GorgoneCommunicationTypeEnum::ZMQ, $capturedCommand->gorgoneCommunicationType);
     }
 
+    public function testCentralAddressIsPassedToCommand(): void
+    {
+        $capturedCommand = null;
+        $processor = $this->buildProcessor(isCloudPlatform: false, capturedCommand: $capturedCommand);
+
+        $processor->process(
+            $this->buildInput(),
+            new Post(),
+        );
+
+        self::assertInstanceOf(CreatePollerCommand::class, $capturedCommand);
+        self::assertSame('192.168.1.254', $capturedCommand->centralAddress->value);
+    }
+
     private function buildProcessor(bool $isCloudPlatform, ?object &$capturedCommand): CreatePollerProcessor
     {
         $poller = new Poller(
@@ -103,6 +117,7 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             connectorConfiguration: new ConnectorConfiguration(),
             trapConfiguration: new TrapConfiguration(),
             pollerCommands: new Collection([], PollerCommand::class),
+            centralAddress: new PollerAddress('192.168.1.254'),
         );
 
         $commandBus = $this->createMock(CommandBus::class);
@@ -156,6 +171,7 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             pollerType: 'vm',
             address: '192.168.1.1',
             pollerTokenName: 'test-token',
+            centralAddress: '192.168.1.254',
         );
     }
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
@@ -82,6 +82,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => $address,
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -116,6 +117,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => $address,
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -136,6 +138,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'docker',
                 'address' => '10.' . mt_rand(0, 255) . '.' . mt_rand(0, 255) . '.' . mt_rand(1, 254),
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -156,6 +159,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '10.' . mt_rand(0, 255) . '.' . mt_rand(0, 255) . '.' . mt_rand(1, 254),
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
         self::assertResponseIsSuccessful();
@@ -166,6 +170,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '10.' . mt_rand(0, 255) . '.' . mt_rand(0, 255) . '.' . mt_rand(1, 254),
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
         self::assertResponseStatusCodeSame(409);
@@ -181,6 +186,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'invalid',
                 'address' => '192.168.1.1',
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -197,6 +203,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '192.168.1.1',
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -213,6 +220,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '192.168.1.1',
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -228,6 +236,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'name' => $this->uniqueName('NoToken'),
                 'poller_type' => 'vm',
                 'address' => '192.168.1.1',
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -244,6 +253,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '192.168.1.1',
                 'poller_token_name' => 'non-existent-token-' . bin2hex(random_bytes(4)),
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -258,6 +268,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '192.168.1.1',
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -283,6 +294,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '10.' . mt_rand(0, 255) . '.' . mt_rand(0, 255) . '.' . mt_rand(1, 254),
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -307,6 +319,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
                 'poller_type' => 'vm',
                 'address' => '192.168.1.1',
                 'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
             ],
         ]);
 
@@ -314,6 +327,73 @@ final class CreatePollerProcessorTest extends ApiTestCase
         self::assertJsonContains([
             'message' => 'You are not allowed to create pollers',
         ]);
+    }
+
+    public function testCannotCreatePollerWithoutCentralAddress(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('NoCentral'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCannotCreatePollerWithEmptyCentralAddress(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('EmptyCentral'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => '',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCannotCreatePollerWithWhitespaceCentralAddress(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('WsCentral'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => '   ',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCannotCreatePollerWithCentralAddressTooLong(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('LongCentral'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => str_repeat('a', 256),
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
     }
 
     private function uniqueName(string $prefix = 'Poller'): string

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
@@ -87,7 +87,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL https://<CENTRAL_URL>/poller/install.sh | bash -s -- --poller_token test-token-default:%s --uid %s --name %s --type %s --central_url <CENTRAL_URL> --appsecret test-app-secret --salt test-salt',
+            'curl -fsSL https://192.168.1.1/poller/install.sh | bash -s -- --poller_token test-token-default:%s --uid %s --name %s --type %s --central_url 192.168.1.1 --appsecret test-app-secret --salt test-salt',
             $tokenValue,
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
@@ -108,7 +108,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL https://<CENTRAL_URL>/poller/install.sh | bash -s -- --poller_token named-token:%s --uid %s --name %s --type %s --central_url <CENTRAL_URL> --appsecret test-app-secret --salt test-salt',
+            'curl -fsSL https://192.168.1.1/poller/install.sh | bash -s -- --poller_token named-token:%s --uid %s --name %s --type %s --central_url 192.168.1.1 --appsecret test-app-secret --salt test-salt',
             $namedTokenValue,
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
@@ -130,7 +130,17 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
             'ns_activate' => '1',
         ]);
 
-        return (int) $connection->lastInsertId();
+        $pollerId = (int) $connection->lastInsertId();
+
+        $connection->insert('platform_topology', [
+            'address' => '127.0.0.1',
+            'central_address' => '192.168.1.1',
+            'name' => $name,
+            'type' => 'poller',
+            'server_id' => $pollerId,
+        ]);
+
+        return $pollerId;
     }
 
     private function insertPollerToken(string $tokenName): string

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepositoryTest.php
@@ -28,7 +28,17 @@ use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroComment;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroExpression;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroId;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroName;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\BrokerConfiguration;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\ConnectorConfiguration;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\EngineInformation;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneConfiguration;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerCommand;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\TrapConfiguration;
 use App\MonitoringConfiguration\Infrastructure\Dbal\DbalPollerRepository;
 use App\Shared\Domain\Collection;
 use Doctrine\DBAL\Connection;
@@ -36,6 +46,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class DbalPollerRepositoryTest extends KernelTestCase
 {
+    private Connection $connection;
+
     private DbalPollerRepository $repository;
 
     protected function setUp(): void
@@ -46,11 +58,65 @@ final class DbalPollerRepositoryTest extends KernelTestCase
 
         /** @var Connection $connection */
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
         $connection->insert('nagios_server', ['id' => 1, 'name' => 'Central', 'localhost' => '1', 'ns_activate' => '1', 'ns_ip_address' => '127.0.0.1', 'uid' => 100000000000001]);
         $connection->insert('cfg_resource', ['resource_id' => 1, 'resource_name' => '$USER1$', 'resource_line' => '/usr/lib64/nagios/plugins/', 'resource_comment' => 'path to plugins', 'resource_activate' => '1', 'is_password' => 0]);
         $connection->insert('cfg_resource', ['resource_id' => 2, 'resource_name' => '$CENTREONPLUGINS$', 'resource_line' => '/usr/lib64/nagios/plugins/', 'resource_comment' => 'Centreon Plugin Path', 'resource_activate' => '1', 'is_password' => 0]);
         $connection->insert('cfg_resource_instance_relations', ['resource_id' => 1, 'instance_id' => 1]);
         $connection->insert('cfg_resource_instance_relations', ['resource_id' => 2, 'instance_id' => 1]);
+    }
+
+    public function testAddCreatesPlatformTopologyEntry(): void
+    {
+        $this->connection->insert('platform_topology', [
+            'address' => '127.0.0.1',
+            'name' => 'Central',
+            'type' => 'central',
+            'server_id' => 1,
+            'pending' => '0',
+        ]);
+
+        $poller = new Poller(
+            id: null,
+            name: new PollerName('MyPoller'),
+            address: new PollerAddress('192.168.1.10'),
+            isCentral: false,
+            isDefault: false,
+            isActivated: true,
+            pollerType: PollerTypeEnum::VM,
+            uid: new PollerUid(100000000000002),
+            globalMacros: new Collection([], GlobalMacro::class),
+            gorgoneConfiguration: new GorgoneConfiguration(),
+            engineInformation: new EngineInformation(),
+            brokerConfiguration: new BrokerConfiguration(),
+            connectorConfiguration: new ConnectorConfiguration(),
+            trapConfiguration: new TrapConfiguration(),
+            pollerCommands: new Collection([], PollerCommand::class),
+            centralAddress: new PollerAddress('10.0.0.1'),
+        );
+
+        $this->repository->add($poller);
+
+        $topology = $this->connection->fetchAssociative(
+            'SELECT * FROM platform_topology WHERE server_id = :serverId',
+            ['serverId' => $poller->id()->value],
+        );
+
+        self::assertIsArray($topology);
+        self::assertSame('192.168.1.10', $topology['address']);
+        self::assertSame('10.0.0.1', $topology['central_address']);
+        self::assertSame('MyPoller', $topology['name']);
+        self::assertSame('poller', $topology['type']);
+        self::assertSame('0', $topology['pending']);
+
+        $centralTopology = $this->connection->fetchAssociative(
+            "SELECT id FROM platform_topology WHERE type = 'central'",
+        );
+        self::assertIsArray($centralTopology);
+        self::assertIsScalar($centralTopology['id']);
+        self::assertIsScalar($topology['parent_id']);
+        self::assertSame((int) $centralTopology['id'], (int) $topology['parent_id']);
     }
 
     public function testItFindAllByGlobalMacro(): void

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2360,6 +2360,7 @@ CREATE TABLE `user_filter` (
 CREATE TABLE `platform_topology` (
     `id` int(11) NOT NULL AUTO_INCREMENT,
     `address` varchar(255) NOT NULL,
+    `central_address` varchar(255) NULL,
     `hostname` varchar(255) NULL,
     `name` varchar(255) NOT NULL,
     `type` varchar(255) NOT NULL,

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -19,8 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ConnectionInterface;
 use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Adaptation\Log\LoggerUpgrade;
 
 require_once __DIR__ . '/../../../bootstrap.php';
@@ -36,22 +38,190 @@ $errorMessage = '';
 
 // TODO add your functions here
 
+$addCentralAddressColumn = function () use ($pearDB, &$errorMessage, $version): void {
+    if ($pearDB->columnExists(
+        $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+        'platform_topology',
+        'central_address'
+    )) {
+        LoggerUpgrade::create()->info($version, 'central_address column already exists, skipping');
+
+        return;
+    }
+
+    $errorMessage = 'Unable to add central_address column to platform_topology';
+    LoggerUpgrade::create()->info($version, 'Adding central_address column to platform_topology');
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            ALTER TABLE `platform_topology`
+            ADD COLUMN `central_address` varchar(255) NULL AFTER `address`
+            SQL
+    );
+
+    LoggerUpgrade::create()->info($version, 'Successfully added central_address column');
+};
+
+/**
+ * Resolve central address from /etc/centreon/poller_installation (cloud only).
+ * Builds address as: {orga}.{region}.{domain}/{site}
+ */
+$resolveCloudCentralAddress = function () use ($version): ?string {
+    $filePath = _CENTREON_ETC_ . '/poller_installation';
+
+    if (! is_readable($filePath)) {
+        LoggerUpgrade::create()->warning(
+            $version,
+            "Cloud platform: {$filePath} not found or not readable"
+        );
+
+        return null;
+    }
+
+    $content = file_get_contents($filePath);
+
+    if ($content === false) {
+        LoggerUpgrade::create()->warning(
+            $version,
+            "Cloud platform: could not read {$filePath}"
+        );
+
+        return null;
+    }
+
+    $hasAllFields = preg_match('/CLOUD_REGION="([^"]+)"/', $content, $regionMatch)
+        && preg_match('/CLOUD_DOMAIN="([^"]+)"/', $content, $domainMatch)
+        && preg_match('/\binstall\b.*-o\s+([^\s;]+)/s', $content, $orgaMatch)
+        && preg_match('/\binstall\b.*-s\s+([^\s;]+)/s', $content, $siteMatch);
+
+    if (! $hasAllFields) {
+        LoggerUpgrade::create()->warning(
+            $version,
+            "Cloud platform: could not extract CLOUD_REGION, CLOUD_DOMAIN, -o or -s from {$filePath}"
+        );
+
+        return null;
+    }
+
+    return "{$orgaMatch[1]}.{$regionMatch[1]}.{$domainMatch[1]}/{$siteMatch[1]}";
+};
+
+/**
+ * Resolve central address from broker output configs (on-prem).
+ * Looks for IPv4 or BBDO Client outputs with a non-empty host.
+ * When multiple outputs exist, takes the most recent one (highest id).
+ *
+ * @param array{server_id: ?int} $platform
+ */
+$resolveOnPremCentralAddress = function (array $platform) use ($pearDB): ?string {
+    if ($platform['server_id'] === null) {
+        return null;
+    }
+
+    $host = $pearDB->fetchOne(
+        <<<'SQL'
+            SELECT cbi_host.config_value
+            FROM cfg_centreonbroker_info cbi_host
+            JOIN cfg_centreonbroker_info cbi_type
+                ON cbi_type.config_id = cbi_host.config_id
+                AND cbi_type.config_group = cbi_host.config_group
+                AND cbi_type.config_group_id = cbi_host.config_group_id
+                AND cbi_type.config_key = 'type'
+                AND cbi_type.config_value IN ('ipv4', 'bbdo_client')
+            JOIN cfg_centreonbroker cb
+                ON cb.config_id = cbi_host.config_id
+            WHERE cb.ns_nagios_server = :serverId
+                AND cbi_host.config_group = 'output'
+                AND cbi_host.config_key = 'host'
+                AND TRIM(cbi_host.config_value) != ''
+            ORDER BY cbi_host.id DESC
+            LIMIT 1
+            SQL,
+        QueryParameters::create([
+            QueryParameter::int('serverId', (int) $platform['server_id']),
+        ])
+    );
+
+    return is_string($host) && trim($host) !== '' ? trim($host) : null;
+};
+
+$populateCentralAddress = function () use ($pearDB, &$errorMessage, $version, $resolveCloudCentralAddress, $resolveOnPremCentralAddress): void {
+    $isCloudPlatform = filter_var(
+        $_ENV['IS_CLOUD_PLATFORM'] ?? null,
+        FILTER_VALIDATE_BOOL,
+        FILTER_NULL_ON_FAILURE
+    ) === true;
+
+    $errorMessage = 'Unable to populate central_address for central servers';
+    LoggerUpgrade::create()->info($version, 'Setting central_address = address for central servers');
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            UPDATE `platform_topology`
+            SET `central_address` = `address`
+            WHERE `type` = 'central'
+            SQL
+    );
+
+    $errorMessage = 'Unable to fetch non-central platforms';
+    $platforms = $pearDB->fetchAllAssociative(
+        <<<'SQL'
+            SELECT `id`, `server_id`, `address`, `type`
+            FROM `platform_topology`
+            WHERE `type` != 'central'
+            SQL
+    );
+
+    $cloudCentralAddress = $isCloudPlatform ? $resolveCloudCentralAddress() : null;
+
+    foreach ($platforms as $platform) {
+        if ($isCloudPlatform) {
+            $centralAddress = $cloudCentralAddress ?? $platform['address'];
+        } else {
+            $centralAddress = $resolveOnPremCentralAddress($platform) ?? $platform['address'];
+        }
+
+        if ($centralAddress === $platform['address']) {
+            $reason = $isCloudPlatform
+                ? 'Could not resolve central address from /etc/centreon/poller_installation'
+                : "No broker output host found (server_id={$platform['server_id']})";
+
+            LoggerUpgrade::create()->warning(
+                $version,
+                "{$reason} for platform id={$platform['id']}, "
+                . "falling back to address '{$centralAddress}'. "
+                . 'Please verify this value is correct.'
+            );
+        }
+
+        $errorMessage = "Unable to update central_address for platform id={$platform['id']}";
+        $pearDB->executeStatement(
+            <<<'SQL'
+                UPDATE `platform_topology`
+                SET `central_address` = :centralAddress
+                WHERE `id` = :platformId
+                SQL,
+            QueryParameters::create([
+                QueryParameter::string('centralAddress', $centralAddress),
+                QueryParameter::int('platformId', (int) $platform['id']),
+            ])
+        );
+    }
+
+    LoggerUpgrade::create()->info($version, 'Successfully populated central_address for all platforms');
+};
+
 try {
     LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
 
-    // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
+    $addCentralAddressColumn();
 
-    // DDL statements for configuration database
-    // TODO add your function calls to update the configuration database structure here
-
-    // Transactional queries for configuration database
     $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {
         $pearDB->startTransaction();
     }
 
-    // TODO add your function calls to update the configuration database data here
+    $populateCentralAddress();
 
     $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();

--- a/centreon/www/install/steps/process/insertBaseConf.php
+++ b/centreon/www/install/steps/process/insertBaseConf.php
@@ -109,6 +109,7 @@ if ($row = $centralServerQuery->fetch()) {
     $stmt = $link->prepare("
         INSERT INTO `platform_topology` (
             `address`,
+            `central_address`,
             `hostname`,
             `name`,
             `type`,
@@ -116,6 +117,7 @@ if ($row = $centralServerQuery->fetch()) {
             `server_id`,
             `pending`
         ) VALUES (
+            :centralAddress,
             :centralAddress,
             :hostname,
             :name,


### PR DESCRIPTION
## Description

Add `centralAddress` to the Poller domain: a mandatory field on the create-poller endpoint (`POST /configuration/pollers`) that is persisted in `platform_topology.central_address` and used to generate the poller installation command.

Backport of https://github.com/centreon/centreon/pull/11164

**Fixes** MON-206297

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.10.x
- [ ] master

## How this pull request can be tested ?

1. Create a poller via `POST /api/latest/configuration/pollers` with a valid `central_address`:
   - With a valid value → expect 201 with `central_address` in the response
   - Omit `central_address` → expect 400
   - Send empty or whitespace-only → expect 400
   - Send value longer than 255 characters → expect 400
2. Fetch the installation command via `GET /api/latest/configuration/pollers/installation-command/{id}`:
   - The `central_url` in the generated command should use the `central_address` value from `platform_topology`, not a placeholder

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).