### PR TITLE
chore(release) bump oss 24.10 2026-08-04

### DIFF
--- a/.version.centreon-dsm
+++ b/.version.centreon-dsm
@@ -1,1 +1,1 @@
-MINOR=7
+MINOR=8

--- a/.version.centreon-open-tickets
+++ b/.version.centreon-open-tickets
@@ -1,1 +1,1 @@
-MINOR=15
+MINOR=16

--- a/.version.centreon-web
+++ b/.version.centreon-web
@@ -1,1 +1,1 @@
-MINOR=29
+MINOR=30

--- a/centreon-dsm/www/modules/centreon-dsm/conf.php
+++ b/centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -22,7 +22,7 @@
 // Be Careful with internal_name, it's case sensitive (with directory module name)
 $module_conf['centreon-dsm']['name'] = 'centreon-dsm';
 $module_conf['centreon-dsm']['rname'] = 'Dynamic Services Management';
-$module_conf['centreon-dsm']['mod_release'] = '24.10.7';
+$module_conf['centreon-dsm']['mod_release'] = '24.10.8';
 $module_conf['centreon-dsm']['infos'] = 'Centreon Dynamic Service Management (Centreon-DSM) is a module to manage '
     . 'alarms with an event logs system. With DSM, Centreon can receive events such as SNMP traps resulting from the '
     . 'detection of a problem and assign events dynamically to a slot defined in Centreon, like a tray events.
@@ -37,7 +37,7 @@ The goal of this module is to overhead the basic trap management system of Centr
 $module_conf['centreon-dsm']['is_removeable'] = '1';
 $module_conf['centreon-dsm']['author'] = 'Centreon';
 $module_conf['centreon-dsm']['stability'] = 'stable';
-$module_conf['centreon-dsm']['last_update'] = '2026-06-01';
+$module_conf['centreon-dsm']['last_update'] = '2026-08-04';
 $module_conf['centreon-dsm']['images'] = [
     'images/dsm_snmp_events_tray.png',
 ];

--- a/centreon-open-tickets/widgets/open-tickets/configs.xml
+++ b/centreon-open-tickets/widgets/open-tickets/configs.xml
@@ -4,7 +4,7 @@
   <email>contact@centreon.com</email>
   <website>http://www.centreon.com</website>
   <description>This widget is associated to the Open Tickets Module and allows for selecting hosts or services events for which to create tickets in your favorite ITSM tools. This widget can also list already created tickets with their ID and datetime.</description>
-  <version>24.10.15</version>
+  <version>24.10.16</version>
   <keywords>centreon, widget, tickets</keywords>
   <screenshot></screenshot>
   <thumbnail>./widgets/open-tickets/resources/centreon-logo.png</thumbnail>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -21,7 +21,7 @@
 
 $module_conf['centreon-open-tickets']['rname'] = 'Centreon Open Tickets';
 $module_conf['centreon-open-tickets']['name'] = 'centreon-open-tickets';
-$module_conf['centreon-open-tickets']['mod_release'] = '24.10.15';
+$module_conf['centreon-open-tickets']['mod_release'] = '24.10.16';
 $module_conf['centreon-open-tickets']['infos'] = 'Centreon Open Tickets is a community module developed to '
     . 'create tickets to your favorite ITSM tools using API.
 
@@ -36,7 +36,7 @@ Regarding the widget configuration, it is possible to see the created tickets by
 $module_conf['centreon-open-tickets']['is_removeable'] = '1';
 $module_conf['centreon-open-tickets']['author'] = 'Centreon';
 $module_conf['centreon-open-tickets']['stability'] = 'stable';
-$module_conf['centreon-open-tickets']['last_update'] = '2026-07-02';
+$module_conf['centreon-open-tickets']['last_update'] = '2026-08-04';
 $module_conf['centreon-open-tickets']['images'] = [
     'images/image1.png',
     'images/image2.png',

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '24.10.29');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '24.10.30');
 
 --
 -- Contenu de la table `contact`


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-206329

Bump OSS versions to 24.10 (2026-08-04):
- centreon-dsm: 24.10.8
- centreon-open-tickets: 24.10.16
- centreon-web: 24.10.30


File change check (expected vs modified):
- centreon-dsm: expected 2, modified 2
- centreon-open-tickets: expected 3, modified 3
- centreon-web: expected 2, modified 2

Total: expected 7, modified 7