### PR TITLE
style(dashboards): optimize the Metrics graphs widget's layout and spacing

### DIFF
--- a/centreon/packages/ui/src/Graph/BarChart/ResponsiveBarChart.tsx
+++ b/centreon/packages/ui/src/Graph/BarChart/ResponsiveBarChart.tsx
@@ -127,7 +127,8 @@ const ResponsiveBarChart = ({
       height,
       legendDisplay: legend?.display,
       legendPlacement: legend?.placement,
-      maxAxisCharacters: maxRightAxisCharacters || maxLeftAxisCharacters,
+      maxLeftAxisCharacters,
+      maxRightAxisCharacters,
       title,
       units: allUnits,
       width

--- a/centreon/packages/ui/src/Graph/Chart/Chart.styles.ts
+++ b/centreon/packages/ui/src/Graph/Chart/Chart.styles.ts
@@ -1,7 +1,8 @@
 import { makeStyles } from 'tss-react/mui';
 
-export const useChartStyles = makeStyles()({
+export const useChartStyles = makeStyles()(() => ({
   baseWrapper: {
+    border: '1px solid transparent',
     position: 'relative'
   },
   tooltipChildren: { height: '100%', width: '100%' },
@@ -10,4 +11,4 @@ export const useChartStyles = makeStyles()({
     overflow: 'hidden',
     width: '100%'
   }
-});
+}));

--- a/centreon/packages/ui/src/Graph/Chart/Chart.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/Chart.tsx
@@ -165,7 +165,8 @@ const Chart = ({
       legendDisplay: legend?.display,
       legendHeight: legend?.height,
       legendPlacement: legend?.placement,
-      maxAxisCharacters: maxRightAxisCharacters || maxLeftAxisCharacters,
+      maxLeftAxisCharacters,
+      maxRightAxisCharacters,
       title,
       units: allUnits,
       width

--- a/centreon/packages/ui/src/Graph/Chart/Legend/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/Legend/index.tsx
@@ -74,6 +74,7 @@ const MainLegend = ({
   const getMetricValue = ({ value, unit }: GetMetricValueProps): string =>
     formatMetricValue({
       base,
+      decimalPlaces: 1,
       unit,
       value
     }) || 'N/A';
@@ -119,7 +120,7 @@ const MainLegend = ({
 
   return (
     <div
-      className={`overflow-x-hidden overflow-y-auto ${!equals(placement, 'bottom') ? 'h-full mt-[15px]' : 'ml-[50px] mr-[40px]'}`}
+      className={`overflow-x-hidden overflow-y-auto ${!equals(placement, 'bottom') ? 'h-full mt-[15px]' : 'ml-[8px] mr-[8px]'}`}
       data-display-side={!equals(placement, 'bottom')}
     >
       <ul

--- a/centreon/packages/ui/src/Graph/Chart/common/index.ts
+++ b/centreon/packages/ui/src/Graph/Chart/common/index.ts
@@ -9,7 +9,7 @@ const commonTickLabelProps = {
   textAnchor: 'middle'
 };
 
-const margin = { bottom: 30, left: 50, right: 50, top: 30 };
+const margin = { bottom: 30, left: 20, right: 20, top: 30 };
 
 interface FillColor {
   areaColor: string;

--- a/centreon/packages/ui/src/Graph/common/Axes/index.tsx
+++ b/centreon/packages/ui/src/Graph/common/Axes/index.tsx
@@ -87,7 +87,7 @@ const Axes = ({
         top={isHorizontal ? height - margin.bottom : 0}
       />
 
-      {axisLeft.displayUnit && (
+      {axisLeft.displayUnit && data.axisYLeft?.onUnitChange && (
         <UnitLabel
           onUnitChange={data.axisYLeft?.onUnitChange}
           unit={axisLeft.unit}
@@ -128,7 +128,7 @@ const Axes = ({
           top={isHorizontal ? 0 : height - margin.bottom}
         />
       )}
-      {axisRight.displayUnit && (
+      {axisRight.displayUnit && data.axisYRight?.onUnitChange && (
         <UnitLabel
           onUnitChange={data.axisYRight?.onUnitChange}
           unit={axisRight.unit}

--- a/centreon/packages/ui/src/Graph/common/Axes/useAxisY.ts
+++ b/centreon/packages/ui/src/Graph/common/Axes/useAxisY.ts
@@ -67,11 +67,16 @@ const useAxisY = ({
         return '';
       }
 
-      return formatMetricValueWithUnit({
+      const formattedValue = formatMetricValueWithUnit({
         base: data.baseAxis,
+        decimalPlaces: 1,
         unit,
         value: value as number
       }) as string;
+
+      // The unit is already conveyed via the legend; strip it from every
+      // individual tick value instead of repeating it on each one.
+      return formattedValue.replace(/[a-zA-Z%]+$/, '').trimEnd();
     };
 
   const labelProps = ({

--- a/centreon/packages/ui/src/Graph/common/BaseChart/useComputeBaseChartDimensions.ts
+++ b/centreon/packages/ui/src/Graph/common/BaseChart/useComputeBaseChartDimensions.ts
@@ -2,9 +2,8 @@ import { equals, isNil } from 'ramda';
 import type { RefCallback } from 'react';
 import useResizeObserver from 'use-resize-observer';
 
-import { margin } from '../../Chart/common';
-import { margins } from '../margins';
 import { useMarginTop } from '../useMarginTop';
+import { computeGElementMarginLeft } from '../utils';
 
 export const extraMargin = 10;
 
@@ -15,7 +14,8 @@ interface UseComputeBaseChartDimensionsProps {
   legendHeight?: number;
   legendPlacement?: string;
   width: number;
-  maxAxisCharacters: number;
+  maxLeftAxisCharacters: number;
+  maxRightAxisCharacters: number;
   title?: string;
   units: Array<string>;
 }
@@ -34,7 +34,8 @@ export const useComputeBaseChartDimensions = ({
   legendPlacement,
   hasSecondUnit,
   legendHeight,
-  maxAxisCharacters,
+  maxLeftAxisCharacters,
+  maxRightAxisCharacters,
   units,
   title
 }: UseComputeBaseChartDimensionsProps): UseComputeBaseChartDimensionsState => {
@@ -60,12 +61,17 @@ export const useComputeBaseChartDimensions = ({
       ? legendRefWidth || 0
       : 0;
 
+  const leftMargin = computeGElementMarginLeft({
+    hasSecondUnit,
+    maxCharacters: maxLeftAxisCharacters
+  });
+  const rightAxisLabelWidth = hasSecondUnit
+    ? maxRightAxisCharacters * 4 + 2
+    : 0;
+
   const graphWidth =
     width > 0
-      ? width -
-        (hasSecondUnit ? maxAxisCharacters * 2 : maxAxisCharacters) * 6 -
-        (hasSecondUnit ? margins.left * 0.8 : margin.left) -
-        legendBoundingWidth
+      ? width - leftMargin - rightAxisLabelWidth - legendBoundingWidth
       : 0;
   const graphHeight =
     (height || 0) > 0

--- a/centreon/packages/ui/src/Graph/common/margins.ts
+++ b/centreon/packages/ui/src/Graph/common/margins.ts
@@ -1,1 +1,1 @@
-export const margins = { bottom: 20, left: 20, right: 20, top: 20 };
+export const margins = { bottom: 20, left: 10, right: 10, top: 20 };

--- a/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
+++ b/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
@@ -761,7 +761,8 @@ const getBase1024 = ({
 const formatMetricValue = ({
   value,
   unit,
-  base = 1000
+  base = 1000,
+  decimalPlaces = 2
 }: FormatMetricValueProps): string | null => {
   if (isNil(value)) {
     return null;
@@ -775,8 +776,10 @@ const formatMetricValue = ({
     [T, always(base1024 ? ' ib' : 'a')]
   ])(unit);
 
+  const decimalFormat = '0'.repeat(decimalPlaces);
+
   const formattedMetricValue = numeral(Math.abs(value))
-    .format(`0.[00]${formatSuffix}`)
+    .format(`0.[${decimalFormat}]${formatSuffix}`)
     .replace(/B/, unit);
 
   if (lt(value, 0)) {
@@ -790,6 +793,7 @@ const formatMetricValueWithUnit = ({
   value,
   unit,
   base = 1000,
+  decimalPlaces = 2,
   isRaw = false
 }: FormatMetricValueProps & { isRaw?: boolean }): string | null => {
   if (isNil(value)) {
@@ -803,10 +807,17 @@ const formatMetricValueWithUnit = ({
   }
 
   if (equals('%', unit)) {
-    return `${numeral(value).format('0.[00]')}%`;
+    const decimalFormat = '0'.repeat(decimalPlaces);
+
+    return `${numeral(value).format(`0.[${decimalFormat}]`)}%`;
   }
 
-  const formattedMetricValue = formatMetricValue({ base, unit, value });
+  const formattedMetricValue = formatMetricValue({
+    base,
+    decimalPlaces,
+    unit,
+    value
+  });
 
   return formattedMetricValue;
 };

--- a/centreon/packages/ui/src/Graph/common/timeSeries/models.ts
+++ b/centreon/packages/ui/src/Graph/common/timeSeries/models.ts
@@ -122,6 +122,7 @@ export interface NewLines {
 
 export interface FormatMetricValueProps {
   base?: number;
+  decimalPlaces?: number;
   unit: string;
   value: number | null;
 }

--- a/centreon/packages/ui/src/Graph/common/useMarginTop.ts
+++ b/centreon/packages/ui/src/Graph/common/useMarginTop.ts
@@ -1,21 +1,14 @@
-import { identity } from 'ramda';
 import { useMemo } from 'react';
 
 import { margin } from '../Chart/common';
 
 export const useMarginTop = ({
-  title,
-  units
+  title
 }: {
   title?: string;
   units: Array<string>;
 }): number => {
-  const hasUnits = useMemo(() => units.some(identity), [units]);
-
-  const marginTop = useMemo(
-    () => (title || hasUnits ? margin.top : 4),
-    [title, hasUnits]
-  );
+  const marginTop = useMemo(() => (title ? margin.top : 4), [title]);
 
   return marginTop;
 };

--- a/centreon/packages/ui/src/Graph/common/utils.ts
+++ b/centreon/packages/ui/src/Graph/common/utils.ts
@@ -22,7 +22,6 @@ import {
 } from 'ramda';
 
 import type { BarStyle } from '../BarChart/models';
-import { margin } from '../Chart/common';
 import type { LineStyle } from '../Chart/models';
 import type { Threshold, Thresholds } from './models';
 import { formatMetricValueWithUnit } from './timeSeries';
@@ -272,7 +271,7 @@ export const computeGElementMarginLeft = ({
   maxCharacters,
   hasSecondUnit
 }: ComputeGElementMarginLeftProps): number =>
-  maxCharacters * 5 + (hasSecondUnit ? margin.top * 0.8 : margin.top * 0.6);
+  maxCharacters * 4 + (hasSecondUnit ? 10 : 6);
 
 export const computPixelsToShiftMouse = (
   xScale: import('d3-scale').ScaleTime<number, number>


### PR DESCRIPTION
## Summary
- Tighten the chart's left/right margins and legend spacing so the graph makes better use of the widget frame
- Drop the redundant unit label above the Y axis and the duplicated per-tick unit suffix
- Cap displayed decimals to a single digit across the legend and axis ticks
- Fix two bugs causing the plot area to reserve more width than needed (a character-count fallback that ignored the left axis, and a width reservation for a right axis that isn't always rendered)

## Test plan
- [ ] Verify a single-axis Metrics graphs widget fills its frame with no wasted margin on either side
- [ ] Verify a dual-axis Metrics graphs widget renders correctly (both axes, correct tick spacing, no clipped labels)
- [ ] Verify the legend and axis tick values show at most one decimal
- [ ] Verify a non-dashboard graph (e.g. Resources page) is unaffected/still looks correct, since this touches the shared chart engine