### PR TITLE
fix(logging): disable deprecation channel in prod by default (#11257)

### DIFF
--- a/centreon/config/packages/monolog.yaml
+++ b/centreon/config/packages/monolog.yaml
@@ -145,18 +145,9 @@ when@prod:
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!deprecation"]
                 formatter: monolog.formatter.line
-            # Never let a failing deprecation write break the request; fall back to error_log if the primary handler throws.
             deprecation:
-                type: fallbackgroup
+                type: 'null'
                 channels: [deprecation]
-                members: [deprecation_file, deprecation_error_log]
-            deprecation_file:
-                type: stream
-                path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
-                formatter: monolog.formatter.line
-            deprecation_error_log:
-                type: error_log
-                formatter: monolog.formatter.line
             authentication:
                 type: stream
                 channels: [authentication]

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -68,7 +68,7 @@ lands in the catch-all (`%env%.web.log`).
 | Excluded channel | Reason |
 |------------------|--------|
 | `event`, `doctrine`, `console` | Internal Symfony / DBAL noise. |
-| `deprecation` | Dedicated file `%env%.deprecations.log`. |
+| `deprecation` | Disabled in prod (`NullHandler`); dev writes `dev.deprecations.log`. Override the handler in a local `monolog.yaml` to re-enable — `prod.deprecations.log` is still declared in `logrotate/centreon`. |
 | `authentication` | Dedicated file `%env%.access.log`. |
 | `token` | Dedicated file `%env%.token.log`. |
 | `password`, `plugin-pack-manager`, `upgrade` | Dedicated files. |
@@ -157,12 +157,12 @@ In production the `prod.*.log` files are rotated by **logrotate**
 (`centreon/logrotate/centreon`, deployed to `/etc/logrotate.d/centreon`):
 
 - `prod.web.log` (catch-all)
-- `prod.deprecations.log`
 - `prod.access.log` (authentication)
 - `prod.token.log`
 - `prod.password.log`
 - `prod.upgrade.log`
 - `prod.plugin-pack-manager.log`
+- `prod.deprecations.log` — not created by default (`NullHandler`); declared so an override re-enabling the handler inherits rotation (`missingok` covers the absent-file case).
 
 Default retention: `weekly` × `rotate 52` (1 year), with `compress` +
 `delaycompress` + `copytruncate`.


### PR DESCRIPTION
## Description

Backport of #11257

[MON-206326](https://centreon.atlassian.net/browse/MON-206326)

[MON-206326]: https://centreon.atlassian.net/browse/MON-206326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ