### PR TITLE
fix(token): keep listing tokens after a creator is deleted

### DIFF
--- a/centreon/cypress/fixtures/authenticationTokens/listTokensWithDeletedCreator.json
+++ b/centreon/cypress/fixtures/authenticationTokens/listTokensWithDeletedCreator.json
@@ -1,0 +1,56 @@
+{
+  "result": [
+    {
+      "name": "a-token",
+      "type": "api",
+      "user": {
+        "id": 23,
+        "name": "Jane Doe"
+      },
+      "creator": {
+        "id": 23,
+        "name": "Jane Doe"
+      },
+      "creation_date": "2023-08-31T15:46:00+02:00",
+      "expiration_date": null,
+      "is_revoked": false
+    },
+    {
+      "name": "b-token",
+      "type": "api",
+      "user": {
+        "id": 24,
+        "name": "John Doe"
+      },
+      "creator": {
+        "id": null,
+        "name": "Deleted Creator"
+      },
+      "creation_date": "2023-08-31T15:46:00+02:00",
+      "expiration_date": "2028-08-31T00:00:00+00:00",
+      "is_revoked": false
+    },
+    {
+      "name": "c-token",
+      "type": "api",
+      "user": {
+        "id": 23,
+        "name": "Jane Doe"
+      },
+      "creator": {
+        "id": 23,
+        "name": "Kevin B"
+      },
+      "creation_date": "2023-08-31T15:46:00+02:00",
+      "expiration_date": "2028-08-31T00:00:00+00:00",
+      "is_revoked": false
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "search": {},
+    "sort_by": { "token_name": "ASC" },
+    "total": 3
+  }
+}

--- a/centreon/www/front_src/src/AuthenticationTokens/Filters/useFilters.ts
+++ b/centreon/www/front_src/src/AuthenticationTokens/Filters/useFilters.ts
@@ -70,7 +70,9 @@ const useFilters = (): UseFiltersState => {
   const filterCreators = (options): Array<NamedEntity> => {
     const creatorsData = options?.map(({ creator }) => creator);
 
-    return getUniqData(creatorsData);
+    // Creators without an id have been deleted: filtering on them would send
+    // creator.id $eq null and always return an empty listing.
+    return reject(({ id }) => isNil(id), getUniqData(creatorsData));
   };
 
   const deleteCreator = (_, item): void => {

--- a/centreon/www/front_src/src/AuthenticationTokens/Listing/models.ts
+++ b/centreon/www/front_src/src/AuthenticationTokens/Listing/models.ts
@@ -15,9 +15,14 @@ export interface NamedEntity {
   name: string;
 }
 
+export interface Creator {
+  id: number | null;
+  name: string;
+}
+
 export interface Token {
   creationDate: string;
-  creator: NamedEntity;
+  creator: Creator;
   expirationDate: string | null;
   isRevoked: boolean;
   name: string;

--- a/centreon/www/front_src/src/AuthenticationTokens/Specs/AuthenticationTokens.cypress.spec.tsx
+++ b/centreon/www/front_src/src/AuthenticationTokens/Specs/AuthenticationTokens.cypress.spec.tsx
@@ -1,6 +1,7 @@
 import {
   labelAdd,
   labelCreateAuthenticationToken,
+  labelCreator,
   labelDeleteToken,
   labelDisabled,
   labelDisableToken,
@@ -249,5 +250,32 @@ describe('Authentication tokens', () => {
     cy.contains(labelDone).click();
 
     cy.findByText(labelCreateAuthenticationToken).should('not.exist');
+  });
+});
+
+describe('Authentication tokens with a deleted creator', () => {
+  beforeEach(() => {
+    initilize('authenticationTokens/listTokensWithDeletedCreator');
+  });
+
+  it('lists every token when the creator of one of them has been deleted', () => {
+    cy.waitForRequest('@listToken');
+
+    cy.contains('a-token');
+    cy.contains('b-token');
+    cy.contains('c-token');
+
+    cy.contains('Deleted Creator');
+  });
+
+  it('does not offer a deleted creator in the creator filter', () => {
+    cy.waitForRequest('@listToken');
+
+    cy.findByTestId(labelFilters).click();
+
+    cy.findByTestId(labelCreator).click();
+
+    cy.findByRole('option', { name: 'Jane Doe' }).should('exist');
+    cy.findByRole('option', { name: 'Deleted Creator' }).should('not.exist');
   });
 });

--- a/centreon/www/front_src/src/AuthenticationTokens/Specs/initialize.tsx
+++ b/centreon/www/front_src/src/AuthenticationTokens/Specs/initialize.tsx
@@ -10,8 +10,10 @@ import { listTokensEndpoint } from '../api';
 import { listUsers } from '../api/endpoints';
 import Page from '../Page';
 
-const interceptRequests = () => {
-  cy.fixture('authenticationTokens/listTokens').then((data) => {
+const defaultListTokensFixture = 'authenticationTokens/listTokens';
+
+const interceptRequests = (listTokensFixture: string) => {
+  cy.fixture(listTokensFixture).then((data) => {
     cy.interceptAPIRequest({
       alias: 'listToken',
       method: Method.GET,
@@ -62,7 +64,9 @@ const interceptRequests = () => {
   });
 };
 
-export const initilize = (): void => {
+export const initilize = (
+  listTokensFixture: string = defaultListTokensFixture
+): void => {
   i18next.use(initReactI18next).init({
     lng: 'en',
     resources: {}
@@ -81,7 +85,7 @@ export const initilize = (): void => {
     cy.stub(win.navigator.clipboard, 'writeText').as('writeText');
   });
 
-  interceptRequests();
+  interceptRequests(listTokensFixture);
 
   cy.mount({
     Component: (

--- a/centreon/www/front_src/src/AuthenticationTokens/api/decoder.ts
+++ b/centreon/www/front_src/src/AuthenticationTokens/api/decoder.ts
@@ -5,7 +5,7 @@ import { buildListingDecoder } from '@centreon/ui';
 import { equals } from 'ramda';
 import { JsonDecoder } from 'ts.data.json';
 
-import { NamedEntity, Token } from '../Listing/models';
+import { Creator, NamedEntity, Token } from '../Listing/models';
 import { CreatedToken } from '../Modal/models';
 import { TokenType } from '../models';
 
@@ -18,10 +18,22 @@ const getNamedEntityDecoder = (decoderName): JsonDecoder.Decoder<NamedEntity> =>
     decoderName
   );
 
+// Deleting a contact sets creator_id to NULL and keeps the token, while
+// creator_name stays denormalized on the token row. A user id is never null:
+// its column is NOT NULL and the token is deleted along with its user.
+const getCreatorDecoder = (): JsonDecoder.Decoder<Creator> =>
+  JsonDecoder.object<Creator>(
+    {
+      id: JsonDecoder.nullable(JsonDecoder.number),
+      name: JsonDecoder.string
+    },
+    'creator'
+  );
+
 const tokenDecoder = JsonDecoder.object<Token>(
   {
     creationDate: JsonDecoder.string,
-    creator: getNamedEntityDecoder('creator'),
+    creator: getCreatorDecoder(),
     expirationDate: JsonDecoder.nullable(JsonDecoder.string),
     isRevoked: JsonDecoder.boolean,
     name: JsonDecoder.string,
@@ -52,7 +64,7 @@ export const listTokensDecoder = buildListingDecoder<Token>({
 export const createdTokenDecoder = JsonDecoder.object<CreatedToken>(
   {
     creationDate: JsonDecoder.string,
-    creator: getNamedEntityDecoder('creator'),
+    creator: getCreatorDecoder(),
     expirationDate: JsonDecoder.nullable(JsonDecoder.string),
     isRevoked: JsonDecoder.boolean,
     name: JsonDecoder.string,


### PR DESCRIPTION
Fixes: [MON-201990](https://centreon.atlassian.net/browse/MON-201990)

## Description

Deleting a contact keeps their tokens and sets `creator_id` to `NULL`
(the FK is already `ON DELETE SET NULL`), so the API correctly returns
`creator.id: null`. The listing decoder typed that field as a
non-nullable number and rejected the entry — and since one invalid
entry fails the whole payload, the token page rendered **empty** with:

> decoder failed at key "result" ... at key "creator" ... "id" ...
> null is not a valid number

The fix is frontend-only; the API, the schema and the OpenAPI contract
already handle a null creator.

## Changes

- `api/decoder.ts` — `getNamedEntityDecoder` now takes an optional id
  decoder, and `getCreatorDecoder()` reuses it with a nullable id. `user`
  stays strict: its column is `NOT NULL` and the token is deleted along
  with its user.
- `Listing/models.ts` — new `Creator` interface (`id: number | null`).
- `Filters/useFilters.ts` — drop deleted creators from the creator filter
  options; selecting one would emit `creator.id $eq null` and never match.
- Regression test + fixture covering a listing with a null-id creator.
  `initilize()` now takes an optional listing fixture, defaulting to the
  existing one so the current snapshots are unchanged.

The Creator column keeps showing the stored `creator_name`, which is
denormalised on the token row and survives the contact deletion — the
listing looks exactly as it did before the user was removed.

## Test

- `pnpm biome check ./www/front_src/src/AuthenticationTokens` — clean.
- Cypress component spec: `AuthenticationTokens.cypress.spec.tsx`.
- Manual: create an API token for user B as user A, delete user A, and
  confirm the listing still shows every token and the token still
  authenticates.


[MON-201990]: https://centreon.atlassian.net/browse/MON-201990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ