### PR TITLE
fix(delivery-feature): fix feature repository creation issue with 'pulp' default value

### DIFF
--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -70,12 +70,14 @@ runs:
               --arg major_version "$major_version" \
               --arg repo_type "feature" \
               --arg feature_ticket "$feature_ticket" \
+              --arg target "jfrog" \
               '{
                 event_type: "create-feature-repositories",
                 client_payload: {
                   major_version: $major_version,
                   repo_type: $repo_type,
-                  feature_ticket: $feature_ticket
+                  feature_ticket: $feature_ticket,
+                  target: $target
                 }
               }'
             )"


### PR DESCRIPTION
## Description

basically switch the feature repository creation repository dispatch workflow call to jfrog: there's an input that was added two weeks ago over on delivery-tooling that has not been taken into account, so it falls over to pulp and fails because there's no signing service available
**Fixes** # MON-206334

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
