### PR TITLE
fix(dashboards): hide the Text widget when its description is empty

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-generictext/src/index.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-generictext/src/index.tsx
@@ -1,5 +1,7 @@
 import { RichTextEditor } from '@centreon/ui';
 
+import { makeStyles } from 'tss-react/mui';
+
 import { isRichTextEditorEmpty } from '../../../utils';
 
 interface Props {
@@ -11,19 +13,30 @@ interface Props {
   };
 }
 
+const useStyles = makeStyles()(() => ({
+  content: {
+    marginTop: '-8px'
+  }
+}));
+
 const GenericText = ({ panelOptions }: Props): JSX.Element | null => {
+  const { classes } = useStyles();
+
   const displayDescription =
     panelOptions?.description?.enabled &&
     panelOptions?.description?.content &&
     !isRichTextEditorEmpty(panelOptions?.description?.content);
 
+  if (!displayDescription) {
+    return null;
+  }
+
   return (
     <RichTextEditor
+      contentClassName={classes.content}
       disabled
       editable={false}
-      editorState={
-        (displayDescription && panelOptions?.description?.content) || undefined
-      }
+      editorState={panelOptions?.description?.content}
     />
   );
 };

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/widgets.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/widgets.ts
@@ -54,7 +54,12 @@ const internalWidgets: Array<
     panelDefaultHeight: 3,
     panelDefaultWidth: 6
   },
-  { name: 'generictext', panelDefaultHeight: 3, panelDefaultWidth: 6 },
+  {
+    name: 'generictext',
+    panelDefaultHeight: 2,
+    panelDefaultWidth: 6,
+    panelMinHeight: 1
+  },
   {
     name: 'graph',
     panelDefaultHeight: 4,


### PR DESCRIPTION
## Summary
- Render nothing instead of an empty rich text box when the Text widget's description is disabled or empty, so it doesn't take up visible space
- Allow the widget to be resized down to a single row (lower default height, new minimum height)
- Tighten the gap between the widget's title and its content when a description is displayed

## Test plan
- [ ] Add a Text widget with no description configured: verify it renders as an empty box with no content, resizable down to 1 row
- [ ] Enable/fill in a description: verify the text renders with a tight gap below the title
- [ ] Disable the description after having content: verify content disappears with no visual gap left behind
- [ ] Verify adding a new Text widget from the widget gallery still works as expected