### PR TITLE
fix(ldap): remove imported contact groups deleted from the LDAP server on sync

### DIFF
--- a/centreon/www/class/centreonContactgroup.class.php
+++ b/centreon/www/class/centreonContactgroup.class.php
@@ -389,7 +389,7 @@ class CentreonContactgroup
                             && ldap_errno($ldapConn->getDs()) != 3
                         ) {
                             $dn = $ldapConn->findGroupDn($row['cg_name']);
-                            if ($dn === false && ldap_errno($ldapConn->getDs()) != 3) {
+                            if (empty($dn) && ldap_errno($ldapConn->getDs()) != 3) {
                                 // Delete the ldap group in contactgroup
                                 try {
                                     $stmt = $this->db->prepare(

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -373,7 +373,9 @@ class CentreonLDAP
             return false;
         }
 
-        return $entries[0]['dn'];
+        $dn = $entries[0]['dn'] ?? null;
+
+        return is_string($dn) && trim($dn) !== '' ? $dn : false;
     }
 
     /**


### PR DESCRIPTION
## Description

Ref: MON-188055

Imported LDAP contact groups were never removed when they disappeared from the LDAP server (deleted, or excluded after tightening the *Search group base DN* filter). On the next synchronization the stale group was kept in `contactgroup` and, worse, its `cg_ldap_dn` was overwritten with an empty value.

## Root cause

The cleanup in `CentreonContactgroup::syncWithLdap()` deletes a group only when `CentreonLDAP::findGroupDn()` returns the boolean `false`. But `findGroupDn()` could return an **empty string** instead of `false` when the group was not found, so:

- the strict `$dn === false` check never matched → the delete branch never ran;
- execution fell through to the `UPDATE`, writing the empty `$dn` into `cg_ldap_dn`.

## Fix

- `CentreonLDAP::findGroupDn()` now honours its declared `string|false` contract: it returns `false` (never an empty string) when the entry has no usable DN. This also protects the other caller (`getContactGroupId()`), which would otherwise insert an empty DN.
- `CentreonContactgroup::syncWithLdap()` uses `empty($dn)` instead of the strict `=== false`, so a stray empty DN can never again block deletion.

## How to test

Requires an LDAP auth resource with groups imported for a test user.

1. Log in as the LDAP user so the LDAP groups are imported into `contactgroup`.
2. Delete one group on the LDAP server (`ldapdelete … "cn=<group>,ou=groups,…"`), or tighten the group filter so it no longer matches.
3. Force a sync on the next login (instead of waiting for the sync interval):
   ```sql
   UPDATE contact SET contact_ldap_last_sync = 0 WHERE contact_alias = '<ldap_user>';
   ```
4. Log in again as the LDAP user.
5. **Expected:** the deleted group is removed from `contactgroup`; the remaining groups keep their `cg_ldap_dn` intact.
   **Before this fix:** the group stayed in DB with an empty `cg_ldap_dn`.

> Dev-environment note: in `APP_ENV=dev` (`display_errors` on), the sync login may hang on the loading screen — a `getEntry()` `ldap_read: No such object` PHP warning is prepended to the JSON login response and breaks the redirect. This is pre-existing behaviour in unchanged code, does not occur in production (`display_errors` off), and is unrelated to this fix. Refresh to continue.
