### PR TITLE
style(dashboards): enlarge the Single Metric widget's Text mode font

### DIFF
--- a/centreon/packages/ui/src/Graph/Text/Text.tsx
+++ b/centreon/packages/ui/src/Graph/Text/Text.tsx
@@ -75,8 +75,8 @@ export const Text = ({
   return (
     <div className={classes.graphText} ref={ref}>
       <FluidTypography
-        max="40px"
-        pref={14}
+        max="150px"
+        pref={52}
         sx={{ color, fontWeight: 'bold', textAlign: 'center' }}
         text={
           formatMetricValueWithUnit({


### PR DESCRIPTION
## Summary
- The value displayed by the Single Metric widget in "Text" display mode was too small to read at a glance
- Bump its size roughly fourfold while keeping the existing centered layout

## Test plan
- [ ] Add/view a Single Metric widget with display type "Text": verify the value is significantly larger and still centered
- [ ] Verify the value still scales down gracefully in small/narrow widget sizes
- [ ] Verify threshold labels (warning/critical) still display correctly below the value