### PR TITLE
fix(api): error in shortname

### DIFF
--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -105,8 +105,20 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
         $generatedRoute = $this->router->generate($name, $parameters, $referenceType);
         $generatedRoute = $this->cleanPrefixUrl($generatedRoute);
 
-        // remove double identical prefixes due to progressive migration
-        $generatedRoute = str_replace($doubleBaseUri, $parameters['base_uri'], $generatedRoute);
+        // Anchored to path start or right after the authority so a short-name host
+        // matching the base path (https://centreon/centreon/...) is not consumed.
+        if ($doubleBaseUri !== '') {
+            $singleBaseUri = $parameters['base_uri'];
+            $generatedRoute = preg_replace_callback(
+                '#(^|://[^/]*)' . preg_quote($doubleBaseUri, '#') . '#',
+                static fn (array $matches): string => $matches[1] . $singleBaseUri,
+                $generatedRoute,
+                1
+            );
+            if ($generatedRoute === null) {
+                throw new \RuntimeException('Error occurred during regular expression search and replace.');
+            }
+        }
 
         // remove double slashes
         return $this->cleanPrefixUrl($generatedRoute);

--- a/centreon/tests/php/Core/Infrastructure/Common/Api/RouterTest.php
+++ b/centreon/tests/php/Core/Infrastructure/Common/Api/RouterTest.php
@@ -183,6 +183,12 @@ it(
         '/centreon/centreon/api/latest/configuration/hosts/7013',
         '/centreon/api/latest/configuration/hosts/7013',
     ],
+    'short-name host with duplicated default base path' => [
+        '/centreon',
+        Router::ABSOLUTE_URL,
+        'https://centreon/centreon/centreon/api/latest/configuration/hosts/7013',
+        'https://centreon/centreon/api/latest/configuration/hosts/7013',
+    ],
 ]);
 
 it('leaves URLs without a doubled base path untouched', function (): void {

--- a/centreon/tests/php/Core/Infrastructure/Common/Api/RouterTest.php
+++ b/centreon/tests/php/Core/Infrastructure/Common/Api/RouterTest.php
@@ -30,6 +30,7 @@ beforeEach(function (): void {
     $_SERVER['HTTP_HOST'] = 'localhost';
     $_SERVER['SERVER_ADDR'] = '127.0.0.1';
     $_SERVER['SERVER_PORT'] = '80';
+    unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
 
     $request = new Request(server: [
         'HTTP_HOST' => 'localhost',
@@ -37,8 +38,10 @@ beforeEach(function (): void {
         'SERVER_PORT' => '80',
     ]);
 
+    $this->mockRouter = $this->createMock(Symfony\Component\Routing\RouterInterface::class);
+
     $this->router = new Router(
-        $this->createMock(Symfony\Component\Routing\RouterInterface::class),
+        $this->mockRouter,
         $this->createMock(Symfony\Component\Routing\Matcher\RequestMatcherInterface::class)
     );
     $requestStack = $this->createMock(Symfony\Component\HttpFoundation\RequestStack::class);
@@ -115,4 +118,82 @@ it('should restore the original routing context after generating a local URL', f
     expect($context->getHost())->toBe('my-server.example.com')
         ->and($context->getScheme())->toBe('https')
         ->and($context->getHttpPort())->toBe(443);
+});
+
+it(
+    'preserves generated URLs when the short-name host collides with the base path',
+    function (string $baseUri, string $rawUrl, string $expected): void {
+        $this->mockRouter->method('generate')->willReturn($rawUrl);
+
+        $result = $this->router->generate(
+            'any_route',
+            ['base_uri' => $baseUri],
+            Router::ABSOLUTE_URL
+        );
+
+        expect($result)->toBe($expected);
+    }
+)->with([
+    'short-name host equal to default base path' => [
+        '/centreon',
+        'https://centreon/centreon/api/latest/configuration/hosts/7013',
+        'https://centreon/centreon/api/latest/configuration/hosts/7013',
+    ],
+    'short-name host equal to custom base path /snc' => [
+        '/snc',
+        'https://snc/snc/api/latest/configuration/hosts/7013',
+        'https://snc/snc/api/latest/configuration/hosts/7013',
+    ],
+    'domain suffix colliding with custom base path /com' => [
+        '/com',
+        'https://centreon.com/com/api/latest/configuration/hosts/7013',
+        'https://centreon.com/com/api/latest/configuration/hosts/7013',
+    ],
+]);
+
+it(
+    'still collapses the double base path in legitimate URLs',
+    function (string $baseUri, int $referenceType, string $rawUrl, string $expected): void {
+        $this->mockRouter->method('generate')->willReturn($rawUrl);
+
+        $result = $this->router->generate(
+            'any_route',
+            ['base_uri' => $baseUri],
+            $referenceType
+        );
+
+        expect($result)->toBe($expected);
+    }
+)->with([
+    'FQDN with duplicated default base path' => [
+        '/centreon',
+        Router::ABSOLUTE_URL,
+        'https://my-server.example.com/centreon/centreon/api/latest/configuration/hosts/7013',
+        'https://my-server.example.com/centreon/api/latest/configuration/hosts/7013',
+    ],
+    'FQDN with duplicated custom base path /snc' => [
+        '/snc',
+        Router::ABSOLUTE_URL,
+        'https://snc.mj.gouv.fr/snc/snc/api/latest/configuration/hosts/7013',
+        'https://snc.mj.gouv.fr/snc/api/latest/configuration/hosts/7013',
+    ],
+    'relative URL with duplicated default base path' => [
+        '/centreon',
+        Router::ABSOLUTE_PATH,
+        '/centreon/centreon/api/latest/configuration/hosts/7013',
+        '/centreon/api/latest/configuration/hosts/7013',
+    ],
+]);
+
+it('leaves URLs without a doubled base path untouched', function (): void {
+    $this->mockRouter->method('generate')
+        ->willReturn('https://centreon.test.local/centreon/api/latest/configuration/hosts/7013');
+
+    $result = $this->router->generate(
+        'any_route',
+        ['base_uri' => '/centreon'],
+        Router::ABSOLUTE_URL
+    );
+
+    expect($result)->toBe('https://centreon.test.local/centreon/api/latest/configuration/hosts/7013');
 });


### PR DESCRIPTION
## Description

Reaching Centreon through a short hostname equal to the base path (e.g. https://centreon/centreon/...) broke URL generation: the double-base-URI collapse in Router::generate() matched anywhere in the string and stripped the base path, producing unroutable URLs like https://centreon/api/.... Users saw silent failures such as ERROR : Error while deleting host by API : Unknown error in centreon-web.log.

The fix anchors the replacement to the start of the path or right after the authority, so the host is never touched.

[MON-192954](https://centreon.atlassian.net/browse/MON-192954)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-192954]: https://centreon.atlassian.net/browse/MON-192954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ