### PR TITLE
fix(export): stop broker crashing after export

### DIFF
--- a/centreon/www/class/config-generate/abstract/objectJSON.class.php
+++ b/centreon/www/class/config-generate/abstract/objectJSON.class.php
@@ -80,6 +80,7 @@ abstract class AbstractObjectJSON
                 throw new RuntimeException('/etc/centreon/engine-context.json does not exists or is empty');
             }
             $engineContext = json_decode($engineContext, true, flags: JSON_THROW_ON_ERROR);
+            $this->engineContextEncryption->setFirstKey($engineContext['app_secret']);
             $this->engineContextEncryption->setSecondKey($engineContext['salt']);
         } catch (JsonException|RuntimeException $ex) {
             CentreonLog::create()->error(


### PR DESCRIPTION
Fixes: [MON-202475](https://centreon.atlassian.net/browse/MON-202475)

## Description

After a configuration export, `cbd` fails to start and crash-loops under the watchdog, leaving the platform unmonitored until the password is put back in clear text by hand:

```
[config] [error] No usable encrypted password: Decryption finalization failed: error:1C800064:Provider routines::bad decrypt
```

Credentials on the export path are encrypted by `Security\Encryption::crypt()`, which uses two keys. The Symfony service definition pre-sets `firstKey` to `%env(APP_SECRET)%`, so any consumer that needs the Engine key has to override it.

`AbstractObjectJSON` reads and parses `/etc/centreon-engine/engine-context.json`, but only ever consumed its `salt`. The AES key stayed at the container default, so the JSON files were signed with the Engine salt and encrypted with the web `APP_SECRET` — while `cbd` decrypts with `app_secret` from `engine-context.json`.

`AbstractObject` (the Engine `.cfg` path) was aligned to `engine-context.json` in #9464; the symmetric change was never applied to the JSON path. The asymmetry has been there since #7925.

This adds the missing `setFirstKey($engineContext['app_secret'])`, mirroring `object.class.php` exactly.

### Why it only shows up on some platforms

`engine-context.json` is seeded *from* `APP_SECRET` at install, and both writers are write-once — so on a clean central the two values coincide and the bug is invisible. They drift when `APP_SECRET` is rotated, or on a Remote Server / poller, which pulls the central's secrets via `writeEngineSecrets.sh` while keeping its own distinct `.env`.

### Scope

One line, in the shared base class, so it covers every credential on the JSON export path:

| Location | Field |
|---|---|
| `broker.class.php:489` | `db_password` in `sql` / `storage` / `unified_sql` outputs |
| `broker.class.php:504` | Lua stream connector params of type `password` |
| `AdditionalConnectorVmWareV6.class.php:142` | vSphere server password in `centreon_vmware.json` |

Safe with respect to other consumers: `EncryptionInterface` is declared `shared: false`, so each `get()` returns a fresh instance and the override cannot leak elsewhere. No migration is needed either — these files are fully regenerated on every export, and PHP never decrypts these values.

## Type of change

- [x] Patch (non-breaking change which fixes an issue)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Target serie

- [x] master (develop)
- [ ] 25.10
- [ ] 24.10

Backport to `dev-25.10.x` will follow — that branch is confirmed to still carry the bug.

## How to test

Manual validation on a platform (reviewer / QA):

1. Make `APP_SECRET` in `/usr/share/centreon/.env` differ from `app_secret` in `/etc/centreon-engine/engine-context.json` — or simply use a Remote Server, where they differ by construction.
2. Confirm the poller has `is_encryption_ready = 1` in `instances`; the encryption branch is gated on it.
3. Export the configuration, then `systemctl restart cbd` — it now starts cleanly, with no `bad decrypt` in `/var/log/centreon-broker/`.
4. Regression check on the Engine side: a host password macro still produces a decryptable `encrypt::` value and `centengine` restarts cleanly.

## Notes for reviewers

- No unit test is included. `AbstractObjectJSON` is a legacy singleton that boots a full kernel and reads a hardcoded `/etc/centreon-engine/engine-context.json` in its constructor, so covering this would mean refactoring the constructor — out of scope for a Blocker. MON-192371 shipped the same way.

[MON-202475]: https://centreon.atlassian.net/browse/MON-202475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ