### PR TITLE
fix(ha): rpm packages signature restored

### DIFF
--- a/centreon-ha/packaging/centreon-ha-common.yaml
+++ b/centreon-ha/packaging/centreon-ha-common.yaml
@@ -99,3 +99,9 @@ overrides:
       - systemd
     recommends:
       - logrotate
+
+rpm:
+  summary: Centreon HA common files for database and central nodes
+  signature:
+    key_file: ${RPM_SIGNING_KEY_FILE}
+    key_id: ${RPM_SIGNING_KEY_ID}

--- a/centreon-ha/packaging/centreon-ha-web.yaml
+++ b/centreon-ha/packaging/centreon-ha-web.yaml
@@ -115,3 +115,9 @@ overrides:
       - "centreon-ha-common (>= ${MAJOR_VERSION}~)"
       - "centreon-ha-common (<< ${NEXT_MAJOR_VERSION}~)"
       - resource-agents
+
+rpm:
+  summary: Centreon HA scripts and config files for central servers
+  signature:
+    key_file: ${RPM_SIGNING_KEY_FILE}
+    key_id: ${RPM_SIGNING_KEY_ID}


### PR DESCRIPTION
## Description

HA RPM packages weren't signed since we moved from rpmbuild to nfpm due to an error in conf migration. This PR restores the signing process in the build action.

Backport of #11289 to `dev-25.10.x`.

**Fixes** [MON-206461](https://centreon.atlassian.net/browse/MON-206461)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] 26.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Once merged, a full rebuild is required to get new signed packages. On a produced package, `rpm -qp --qf '%{SIGPGP:pgpsig}\n' centreon-ha-*.rpm` must return the Centreon signing key instead of `(none)`.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-206461]: https://centreon.atlassian.net/browse/MON-206461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ