### PR TITLE
fix(export): stop broker crashing after export (#11298)

### DIFF
--- a/centreon/www/class/config-generate/abstract/objectJSON.class.php
+++ b/centreon/www/class/config-generate/abstract/objectJSON.class.php
@@ -80,6 +80,7 @@ abstract class AbstractObjectJSON
                 throw new RuntimeException('/etc/centreon/engine-context.json does not exists or is empty');
             }
             $engineContext = json_decode($engineContext, true, flags: JSON_THROW_ON_ERROR);
+            $this->engineContextEncryption->setFirstKey($engineContext['app_secret']);
             $this->engineContextEncryption->setSecondKey($engineContext['salt']);
         } catch (JsonException|RuntimeException $ex) {
             CentreonLog::create()->error(


### PR DESCRIPTION
Backport of #11298 to `dev-25.10.x`, cherry-picked from the `dev-26.10.x` backport
#11307.

Fixes: [MON-206466](https://centreon.atlassian.net/browse/MON-206466)

## Description

Credentials on the JSON export path were encrypted with the Symfony `APP_SECRET` from
`.env`, while `cbd` decrypts them with `app_secret` from
`/etc/centreon-engine/engine-context.json`. When the two values differ — after an
`APP_SECRET` rotation, or on a Remote Server / poller that pulls the central's secrets
while keeping its own `.env` — `cbd` fails with `bad decrypt` and crash-loops after every
configuration export, leaving the platform unmonitored.

`AbstractObjectJSON` already read `engine-context.json` but only consumed its `salt`, so
the AES first key stayed at the container default (`%env(APP_SECRET)%`). It now also sets
`app_secret` as the first key, mirroring `AbstractObject` (the Engine `.cfg` path), which
was aligned in #9464.

One line in the shared base class, so it covers every credential on the JSON export path:
the broker `db_password`, the Lua stream connector passwords, and the vSphere password of
the VMware connector.

## Type of change

- [x] Patch (non-breaking change which fixes an issue)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Target serie

- [ ] master (develop)
- [ ] 26.10
- [x] 25.10
- [ ] 24.10

## How to test

Clean cherry-pick, no conflict — the diff is byte-identical to #11298.

Manual validation on a platform (reviewer / QA):

1. Make `APP_SECRET` in `/usr/share/centreon/.env` differ from `app_secret` in
   `/etc/centreon-engine/engine-context.json` — or simply use a Remote Server, where they
   differ by construction.
2. Confirm the poller has `is_encryption_ready = 1` in `instances`; the encryption branch
   is gated on it.
3. Export the configuration, then `systemctl restart cbd` — it now starts cleanly, with no
   `bad decrypt` in `/var/log/centreon-broker/`.
4. Regression check on the Engine side: a host password macro still produces a decryptable
   `encrypt::` value and `centengine` restarts cleanly.

## Notes for reviewers

No unit test, same as #11298: `AbstractObjectJSON` is a legacy singleton that boots a full
kernel and reads a hardcoded `/etc/centreon-engine/engine-context.json` in its constructor,
so covering this would mean refactoring the constructor — out of scope for a Blocker
backport.


[MON-206466]: https://centreon.atlassian.net/browse/MON-206466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ