### PR TITLE
fix(MON-206523): escape IN clause values in centreonACL::constructReque…

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -3242,7 +3242,11 @@ class CentreonACL
                 if ($op == 'IN') {
                     $inValues = '';
                     if (is_array($value) && count($value)) {
-                        $inValues = implode("','", $value);
+                        $db = CentreonDBInstance::getDbCentreonInstance();
+                        $inValues = implode("','", array_map(
+                            fn($v) => trim($db->quoteString((string) $v), "'"),
+                            $value
+                        ));
                     }
                     $requests['conditions'] .= $clause . ' ' . $key . ' ' . $op . " ('" . $inValues . "') ";
                 } else {


### PR DESCRIPTION
…st()

The IN clause in constructRequest() concatenated user input directly into SQL without escaping, allowing blind time-based SQL injection via select2 form fields (e.g. hostElement on reporting dashboard).

Use quoteString() to sanitize each value before concatenation.

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
