### PR TITLE
fix(host): detail hostgroup link-change action log

### DIFF
--- a/centreon/phpstan.core.test.baseline.neon
+++ b/centreon/phpstan.core.test.baseline.neon
@@ -1407,7 +1407,7 @@ parameters:
 		-
 			message: '#^Call to protected method any\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 3
+			count: 7
 			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
 
 		-
@@ -1419,13 +1419,13 @@ parameters:
 		-
 			message: '#^Call to protected method exactly\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 2
+			count: 5
 			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
 
 		-
 			message: '#^Call to protected method once\(\) of class PHPUnit\\Framework\\TestCase\.$#'
 			identifier: method.protected
-			count: 22
+			count: 30
 			path: tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
 
 		-

--- a/centreon/src/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroup.php
+++ b/centreon/src/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroup.php
@@ -222,15 +222,26 @@ final class UpdateHostGroup
 
         sort($linkedBefore);
         sort($linkedAfter);
-        if ($linkedBefore !== $linkedAfter) {
-            $this->writeActionLogRepository->addAction(new ActionLog(
-                ActionLog::OBJECT_TYPE_HOSTGROUP,
-                $request->id,
-                $existingHostGroup->getName(),
-                ActionLog::ACTION_TYPE_CHANGE,
-                $this->user->getId(),
-            ));
+        if ($linkedBefore === $linkedAfter) {
+            return;
         }
+
+        $actionLog = new ActionLog(
+            ActionLog::OBJECT_TYPE_HOSTGROUP,
+            $request->id,
+            $existingHostGroup->getName(),
+            ActionLog::ACTION_TYPE_CHANGE,
+            $this->user->getId(),
+        );
+        $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
+        $actionLog->setId($actionLogId);
+
+        $added = array_values(array_diff($linkedAfter, $linkedBefore));
+        $removed = array_values(array_diff($linkedBefore, $linkedAfter));
+        $this->writeActionLogRepository->addActionDetails($actionLog, [
+            'hosts_added' => implode(',', $added),
+            'hosts_removed' => implode(',', $removed),
+        ]);
     }
 
     /**

--- a/centreon/tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
+++ b/centreon/tests/php/Core/HostGroup/Application/UseCase/UpdateHostGroup/UpdateHostGroupTest.php
@@ -26,6 +26,7 @@ namespace Tests\Core\HostGroup\Application\UseCase\UpdateHostGroup;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Core\ActionLog\Application\Repository\WriteActionLogRepositoryInterface;
+use Core\ActionLog\Domain\Model\ActionLog;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
@@ -368,5 +369,143 @@ it(
         dump($response);
         expect($response)
             ->toBeInstanceOf(NoContentResponse::class);
+    }
+);
+
+it(
+    'should log a CHANGE action with added/removed host ids when links change',
+    function (): void {
+        $this->adminResolver
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(true);
+        $this->user
+            ->expects($this->any())
+            ->method('getId')
+            ->willReturn(42);
+        $this->readHostGroupRepository
+            ->expects($this->once())
+            ->method('findOne')
+            ->willReturn(new HostGroup(
+                id: 1,
+                name: 'existing_name',
+                alias: 'alias',
+                geoCoords: GeoCoords::fromString('-10,10'),
+                comment: 'comment',
+            ));
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findByHostGroup')
+            ->willReturn([]);
+        $this->readHostGroupRepository
+            ->expects($this->exactly(2))
+            ->method('findLinkedHosts')
+            ->willReturnOnConsecutiveCalls([3, 5], [1, 2]);
+
+        $capturedActionLog = null;
+        $capturedDetails = null;
+        $this->writeActionLogRepository
+            ->expects($this->once())
+            ->method('addAction')
+            ->willReturnCallback(function (ActionLog $actionLog) use (&$capturedActionLog): int {
+                $capturedActionLog = $actionLog;
+
+                return 99;
+            });
+        $this->writeActionLogRepository
+            ->expects($this->once())
+            ->method('addActionDetails')
+            ->willReturnCallback(function (ActionLog $log, array $details) use (&$capturedDetails): void {
+                $capturedDetails = ['id' => $log->getId(), 'details' => $details];
+            });
+
+        $response = ($this->useCase)($this->updateHostGroupRequest);
+
+        expect($response)->toBeInstanceOf(NoContentResponse::class)
+            ->and($capturedActionLog)->not->toBeNull()
+            ->and($capturedActionLog->getObjectType())->toBe(ActionLog::OBJECT_TYPE_HOSTGROUP)
+            ->and($capturedActionLog->getObjectId())->toBe(1)
+            ->and($capturedActionLog->getObjectName())->toBe('existing_name')
+            ->and($capturedActionLog->getActionType())->toBe(ActionLog::ACTION_TYPE_CHANGE)
+            ->and($capturedActionLog->getContactId())->toBe(42)
+            ->and($capturedDetails)->toBe([
+                'id' => 99,
+                'details' => ['hosts_added' => '1,2', 'hosts_removed' => '3,5'],
+            ]);
+    }
+);
+
+it(
+    'should not log any action when the host links do not change',
+    function (): void {
+        $this->adminResolver
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(true);
+        $this->readHostGroupRepository
+            ->expects($this->once())
+            ->method('findOne')
+            ->willReturn(new HostGroup(
+                id: 1,
+                name: 'existing_name',
+                alias: 'alias',
+                geoCoords: GeoCoords::fromString('-10,10'),
+                comment: 'comment',
+            ));
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findByHostGroup')
+            ->willReturn([]);
+        $this->readHostGroupRepository
+            ->expects($this->exactly(2))
+            ->method('findLinkedHosts')
+            ->willReturnOnConsecutiveCalls([1, 2], [1, 2]);
+
+        $this->writeActionLogRepository
+            ->expects($this->never())
+            ->method('addAction');
+        $this->writeActionLogRepository
+            ->expects($this->never())
+            ->method('addActionDetails');
+
+        $response = ($this->useCase)($this->updateHostGroupRequest);
+
+        expect($response)->toBeInstanceOf(NoContentResponse::class);
+    }
+);
+
+it(
+    'should treat the same host ids in different order as unchanged',
+    function (): void {
+        $this->adminResolver
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(true);
+        $this->readHostGroupRepository
+            ->expects($this->once())
+            ->method('findOne')
+            ->willReturn(new HostGroup(
+                id: 1,
+                name: 'existing_name',
+                alias: 'alias',
+                geoCoords: GeoCoords::fromString('-10,10'),
+                comment: 'comment',
+            ));
+        $this->readHostRepository
+            ->expects($this->once())
+            ->method('findByHostGroup')
+            ->willReturn([]);
+        $this->readHostGroupRepository
+            ->expects($this->exactly(2))
+            ->method('findLinkedHosts')
+            ->willReturnOnConsecutiveCalls([2, 1], [1, 2]);
+
+        $this->writeActionLogRepository
+            ->expects($this->never())
+            ->method('addAction');
+
+        $response = ($this->useCase)($this->updateHostGroupRequest);
+
+        expect($response)->toBeInstanceOf(NoContentResponse::class);
     }
 );

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -30,6 +30,8 @@ require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
 use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger as AdaptationLogger;
 use App\Kernel;
 use Centreon\Domain\Log\Logger;
 use Core\ActionLog\Domain\Model\ActionLog;
@@ -2885,8 +2887,7 @@ function updateHostInAPI(int $hostId, array $formData): bool
         try {
             $relationsBefore = getHostRelationsSnapshot($hostId);
         } catch (Throwable $ex) {
-            CentreonLog::create()->error(
-                CentreonLog::TYPE_BUSINESS_LOG,
+            AdaptationLogger::create(LogChannelEnum::WEB)->error(
                 'Failed to snapshot host relations before update',
                 [
                     'hostId' => $hostId,
@@ -2929,8 +2930,7 @@ function updateHostInAPI(int $hostId, array $formData): bool
                 );
             }
         } catch (Throwable $ex) {
-            CentreonLog::create()->error(
-                CentreonLog::TYPE_BUSINESS_LOG,
+            AdaptationLogger::create(LogChannelEnum::WEB)->error(
                 'Failed to record host relation-change action log',
                 [
                     'hostId' => $hostId,


### PR DESCRIPTION
## Description

Record the added/removed host IDs alongside the CHANGE audit entry so the audit trail lists which hosts joined or left the group, aligning with the existing decorator pattern for other hostgroup mutations.
Swap the deprecated CentreonLog error calls in the legacy host form for Adaptation\Log\Logger.
Cover the UpdateHostGroup link-change branch with tests for change detection, no-op runs, and sort-order independence.

MON-206638

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
