### PR TITLE
chore(docker): add reverse-proxy TLS test profile (dev-24.10.x)

### DIFF
--- a/.github/docker/docker-compose.proxy.yml
+++ b/.github/docker/docker-compose.proxy.yml
@@ -1,0 +1,38 @@
+# Reverse-proxy overlay: run Centreon behind a TLS-terminating reverse proxy.
+#
+# Combine with the base compose and enable the `proxy` profile:
+#   docker compose -f docker-compose.yml -f docker-compose.proxy.yml --profile proxy up -d
+#
+# This overlay:
+#   - overrides the `web` service so apache trusts the X-Forwarded-Proto header
+#     sent by the proxy (apache snippet) — a no-op when no proxy is in front;
+#   - adds an `nginx-proxy` service terminating TLS on 4443 and forwarding to
+#     web:80 with X-Forwarded-Proto: https.
+#
+# Access the UI over HTTPS at: https://localhost:4443/centreon
+# The web container stays reachable directly over HTTP at http://localhost:4000/centreon
+# for comparison. See reverse-proxy/README.md for scenarios and verification.
+#
+# Per-scenario knobs (set as needed, not hard-coded here): e.g. an internal API
+# base URL with an explicit scheme —
+#   CENTREON_INTERNAL_API_BASE_URL=http://127.0.0.1:80 docker compose ... up -d
+services:
+  web:
+    volumes:
+      - ./reverse-proxy/apache-forwarded-proto.conf:/etc/httpd/conf.d/zz-forwarded-proto.conf:ro
+      # Diagnostic header (X-Effective-Scheme) so the wiring can be checked with
+      # curl alone — see reverse-proxy/verify.sh. Harmless extra response header.
+      - ./reverse-proxy/apache-debug-scheme.conf:/etc/httpd/conf.d/zz-debug-scheme.conf:ro
+
+  nginx-proxy:
+    image: nginx:stable-alpine
+    container_name: web-proxy
+    profiles: ["proxy"]
+    depends_on:
+      web:
+        condition: service_healthy
+    ports:
+      - "4443:443"
+    volumes:
+      - ./reverse-proxy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./reverse-proxy/certs:/etc/nginx/certs:ro

--- a/.github/docker/reverse-proxy/README.md
+++ b/.github/docker/reverse-proxy/README.md
@@ -1,0 +1,130 @@
+> **Languages / Langues** — [English](#-english) · [Français](#-français)
+
+<a name="-english"></a>
+
+## 🇬🇧 English
+
+# Reverse-proxy test stack (TLS termination)
+
+Runs the Centreon `web` container behind a TLS-terminating reverse proxy
+(external HTTPS, internal HTTP). A reusable building block to test connection
+scenarios the standard e2e/API stack cannot cover: `X-Forwarded-Proto` handling,
+auth/cookies behind a proxy, redirections.
+
+```
+browser --HTTPS--> web-proxy (nginx, TLS) --HTTP + X-Forwarded-Proto: https--> web (apache :80)
+```
+
+`apache-forwarded-proto.conf` makes apache trust `X-Forwarded-Proto`, so php-fpm
+sees `REQUEST_SCHEME=https` while the real connection stays HTTP.
+
+## Usage
+
+```sh
+cd .github/docker
+
+# 1. one-time: self-signed cert for the proxy (git-ignored)
+reverse-proxy/create-certs.sh
+
+# 2. start (web image defaults to centreon-web-alma9:develop, override with WEB_IMAGE=…)
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml --profile proxy up -d
+
+# 3. verify the wiring (expects https via proxy, http direct)
+reverse-proxy/verify.sh
+```
+
+Expected output of step 3:
+
+```
+» Through the proxy (HTTPS) — expect https
+  PASS proxy → X-Effective-Scheme: https
+» Direct to web (HTTP) — expect http
+  PASS direct → X-Effective-Scheme: http
+```
+
+Then use Centreon through either entry point:
+
+- Through the proxy: <https://localhost:4443/centreon> — `admin` / `Centreon!2021`
+- Direct to `web` (HTTP, for comparison): <http://localhost:4000/centreon>
+
+Per-scenario config goes through env, e.g. `CENTREON_INTERNAL_API_BASE_URL=http://127.0.0.1:80`.
+
+```sh
+# stop when done
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml --profile proxy down -v
+```
+
+## Files
+
+- `../docker-compose.proxy.yml` — overlay: `web` override + `nginx-proxy` (profile `proxy`)
+- `nginx.conf` — proxy vhost (TLS 443 → `web:80`, sets `X-Forwarded-Proto: https`)
+- `apache-forwarded-proto.conf` — apache trusts `X-Forwarded-Proto`
+- `create-certs.sh` — generates the self-signed proxy certificate
+- `apache-debug-scheme.conf` + `verify.sh` — diagnostic `X-Effective-Scheme` header and its bash check (helpers)
+
+<br>
+
+---
+
+<a name="-français"></a>
+
+## 🇫🇷 Français
+
+# Stack de test reverse-proxy (terminaison TLS)
+
+Fait tourner le conteneur `web` de Centreon derrière un reverse proxy qui termine
+le TLS (HTTPS externe, HTTP interne). Un socle réutilisable pour tester des
+scénarios de connexion que la stack e2e/API standard ne couvre pas : gestion de
+`X-Forwarded-Proto`, authentification/cookies derrière un proxy, redirections.
+
+```
+navigateur --HTTPS--> web-proxy (nginx, TLS) --HTTP + X-Forwarded-Proto: https--> web (apache :80)
+```
+
+`apache-forwarded-proto.conf` fait confiance à `X-Forwarded-Proto` côté apache,
+si bien que php-fpm voit `REQUEST_SCHEME=https` alors que la connexion réelle
+reste en HTTP.
+
+## Utilisation
+
+```sh
+cd .github/docker
+
+# 1. une fois : certificat auto-signé pour le proxy (non commité)
+reverse-proxy/create-certs.sh
+
+# 2. démarrer (image web par défaut : centreon-web-alma9:develop, surcharge via WEB_IMAGE=…)
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml --profile proxy up -d
+
+# 3. vérifier le câblage (attendu : https via le proxy, http en direct)
+reverse-proxy/verify.sh
+```
+
+Sortie attendue de l'étape 3 :
+
+```
+» Through the proxy (HTTPS) — expect https
+  PASS proxy → X-Effective-Scheme: https
+» Direct to web (HTTP) — expect http
+  PASS direct → X-Effective-Scheme: http
+```
+
+Ensuite, exploiter Centreon par l'une ou l'autre porte d'entrée :
+
+- Via le proxy : <https://localhost:4443/centreon> — `admin` / `Centreon!2021`
+- En direct sur `web` (HTTP, pour comparer) : <http://localhost:4000/centreon>
+
+La config par scénario passe par l'environnement, ex. `CENTREON_INTERNAL_API_BASE_URL=http://127.0.0.1:80`.
+
+```sh
+# arrêter une fois terminé
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml --profile proxy down -v
+```
+
+## Fichiers
+
+- `../docker-compose.proxy.yml` — overlay : surcharge `web` + service `nginx-proxy` (profil `proxy`)
+- `nginx.conf` — vhost du proxy (TLS 443 → `web:80`, pose `X-Forwarded-Proto: https`)
+- `apache-forwarded-proto.conf` — apache fait confiance à `X-Forwarded-Proto`
+- `create-certs.sh` — génère le certificat auto-signé du proxy
+- `apache-debug-scheme.conf` + `verify.sh` — en-tête diagnostic `X-Effective-Scheme` et sa vérification bash (helpers)

--- a/.github/docker/reverse-proxy/apache-debug-scheme.conf
+++ b/.github/docker/reverse-proxy/apache-debug-scheme.conf
@@ -1,0 +1,16 @@
+# Debug helper (not part of the runtime stack).
+#
+# Exposes, as response headers readable with curl, the scheme Centreon
+# effectively sees. Mirrors the exact condition used by
+# apache-forwarded-proto.conf (X-Forwarded-Proto == https -> https), so the
+# header value matches what php-fpm receives as REQUEST_SCHEME.
+#
+# Installed on demand by verify.sh, then removed again.
+<IfModule mod_headers.c>
+    # Default to the real connection scheme, override to https when the proxy
+    # forwards X-Forwarded-Proto: https.
+    SetEnvIf Request_URI ".*" MON_EFFECTIVE_SCHEME=http
+    SetEnvIf X-Forwarded-Proto "^https$" MON_EFFECTIVE_SCHEME=https
+
+    Header always set X-Effective-Scheme "%{MON_EFFECTIVE_SCHEME}e"
+</IfModule>

--- a/.github/docker/reverse-proxy/apache-forwarded-proto.conf
+++ b/.github/docker/reverse-proxy/apache-forwarded-proto.conf
@@ -1,0 +1,19 @@
+# Make the Centreon apache vhost trust the X-Forwarded-Proto header set by the
+# front TLS proxy, so PHP receives REQUEST_SCHEME=https even though the actual
+# connection to apache is plain HTTP.
+#
+# This mirrors a real "Centreon behind a TLS-terminating reverse proxy" setup.
+# Without it REQUEST_SCHEME stays "http" and the HTTPS case cannot be exercised.
+#
+# ProxyFCGISetEnvIf runs late and overrides the REQUEST_SCHEME/HTTPS fastcgi
+# params computed by apache before they are sent to php-fpm.
+#
+# NOTE: the header is trusted unconditionally on purpose. This is a local test
+# stack, so a client hitting the direct HTTP port could spoof
+# X-Forwarded-Proto: https. That is acceptable here and intentional; do NOT copy
+# this as-is into production, where the header must only be trusted from the
+# reverse proxy's address (e.g. mod_remoteip / a proxy-only network).
+<IfModule mod_proxy_fcgi.c>
+    ProxyFCGISetEnvIf "reqenv('HTTP_X_FORWARDED_PROTO') == 'https'" REQUEST_SCHEME "https"
+    ProxyFCGISetEnvIf "reqenv('HTTP_X_FORWARDED_PROTO') == 'https'" HTTPS "on"
+</IfModule>

--- a/.github/docker/reverse-proxy/create-certs.sh
+++ b/.github/docker/reverse-proxy/create-certs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Generate the self-signed certificate used by the reverse proxy.
+# Certificates land in reverse-proxy/certs/ and are git-ignored.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CERTS="$DIR/certs"
+
+mkdir -p "$CERTS"
+openssl req -x509 -nodes -newkey rsa:2048 \
+  -keyout "$CERTS/proxy.key" -out "$CERTS/proxy.crt" \
+  -days 825 -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+echo "Certificate written to $CERTS/{proxy.crt,proxy.key}"

--- a/.github/docker/reverse-proxy/nginx.conf
+++ b/.github/docker/reverse-proxy/nginx.conf
@@ -1,0 +1,27 @@
+# TLS-terminating reverse proxy in front of the Centreon web container.
+#
+# External protocol is HTTPS, the internal backend (web:80) is plain HTTP, and
+# X-Forwarded-Proto is set to https. Combined with the apache snippet that honors
+# that header (see apache-forwarded-proto.conf), the web container sees
+# REQUEST_SCHEME=https while serving over HTTP.
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/certs/proxy.crt;
+    ssl_certificate_key /etc/nginx/certs/proxy.key;
+
+    # Centreon may emit large config payloads on internal operations.
+    client_max_body_size 100m;
+    proxy_read_timeout 300s;
+
+    location / {
+        proxy_pass http://web:80;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  4443;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For   $remote_addr;
+        proxy_set_header X-Real-IP         $remote_addr;
+    }
+}

--- a/.github/docker/reverse-proxy/verify.sh
+++ b/.github/docker/reverse-proxy/verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Verify the reverse-proxy wiring from the client side, in pure bash.
+#
+# Relies on the X-Effective-Scheme diagnostic header exposed by apache
+# (apache-debug-scheme.conf, mounted by the proxy overlay). Curls Centreon
+# through the proxy (HTTPS, certificate validated with --cacert) and directly
+# (HTTP), and asserts the effective scheme is exactly https / http. Exits
+# non-zero if either check fails.
+#
+# Usage:
+#   ./verify.sh
+# Env overrides: PROXY_URL, DIRECT_URL, CACERT
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PROXY_URL="${PROXY_URL:-https://localhost:4443/centreon/}"
+DIRECT_URL="${DIRECT_URL:-http://localhost:4000/centreon/}"
+CACERT="${CACERT:-$DIR/certs/proxy.crt}"
+
+fail=0
+
+# check <label> <expected-scheme> <curl args...>
+check() {
+    local label="$1" expected="$2"
+    shift 2
+    local value
+    value="$(curl -sI "$@" 2>/dev/null | tr -d '\r' \
+        | awk -F': ' 'tolower($1) == "x-effective-scheme" { print $2 }')" || true
+    if [ "$value" = "$expected" ]; then
+        echo "  PASS ${label} → X-Effective-Scheme: ${value}"
+    else
+        echo "  FAIL ${label} → X-Effective-Scheme: ${value:-<absent>} (expected ${expected})"
+        fail=1
+    fi
+}
+
+echo "» Through the proxy (HTTPS) — expect https"
+check "proxy" "https" --cacert "$CACERT" "$PROXY_URL"
+
+echo "» Direct to web (HTTP) — expect http"
+check "direct" "http" "$DIRECT_URL"
+
+exit "$fail"

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ checkstyle.core.xml
 **/centreon-build/
 **/build/
 
+# locally generated self-signed certificates
+**/certs/
+
 # Mac Os cache files
 .DS_Store
 


### PR DESCRIPTION
## Description

Backport of #11227.

Adds a reusable dev/test building block to run Centreon behind a
TLS-terminating reverse proxy (external HTTPS, internal HTTP), letting QA
exercise connection scenarios the standard e2e/API stack cannot cover:
`X-Forwarded-Proto` handling, auth/cookies behind a proxy, redirections.

Ships as a compose overlay with an opt-in `proxy` profile, an apache snippet
making the `web` container trust `X-Forwarded-Proto`, helper scripts
(`create-certs.sh`, `verify.sh`) and a bilingual README. No product code is
touched; the default e2e stack is unaffected.

Fixes: [MON-206766](https://centreon.atlassian.net/browse/MON-206766)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x

## How to test

```sh
cd .github/docker
reverse-proxy/create-certs.sh
docker compose -f docker-compose.yml -f docker-compose.proxy.yml --profile proxy up -d
reverse-proxy/verify.sh
```

Expected: `X-Effective-Scheme: https` through the proxy, `http` in direct access.


[MON-206766]: https://centreon.atlassian.net/browse/MON-206766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ