### PR TITLE
fix(ci): xray: scope results-import artifact download per OS to fix flaky import

### DIFF
--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -358,7 +358,7 @@ jobs:
       type_test_execution: e2e
       result_format: cucumber
       enrich_tests: true
-      artifact_pattern: "*-xray-reports-*"
+      artifact_pattern: "${{ inputs.name }}-${{ inputs.os }}-${{ needs.cypress-e2e-test-list.outputs.db_id }}-xray-reports*"
     secrets:
       XRAY_CLIENT_ID: ${{ secrets.xray_client_id }}
       XRAY_CLIENT_SECRET: ${{ secrets.xray_client_secret }}


### PR DESCRIPTION
Fixes: [MON-206771](https://centreon.atlassian.net/browse/MON-206771)

## Description

The Xray results-import job (`xray-api-import-results.yml`) downloaded result artifacts with a **global** pattern `*-xray-reports-*`, so every OS import listed/downloaded the Xray artifacts of **all** OS in the run. Meanwhile each OS's `regroup-artifacts` job concurrently **deletes** its own `*-xray-reports-*` artifacts via the GitHub API. When a deletion lands between `download-artifact`'s *list* and *download-by-id* steps, the import crashes with `ArtifactNotFoundError` — a timing-dependent (flaky) failure.

This scopes the import's `artifact_pattern` to the job's own OS + database (and drops the trailing `-` so it also matches the merged, suffix-less artifact on re-runs), consistent with how the report jobs already scope their downloads in this workflow:

```yaml
artifact_pattern: "${{ inputs.name }}-${{ inputs.os }}-${{ needs.cypress-e2e-test-list.outputs.db_id }}-xray-reports*"
```

An import now only reads its own OS/db artifacts, which are deleted only by its own `regroup-artifacts` job (which runs *after* it), so the race is gone.

**Evidence** — observed in `centreon-modules` run [31373832523](https://github.com/centreon/centreon-modules/actions/runs/31373832523) (same pipeline): the `bookworm` import failed on all 4 attempts with `ArtifactNotFoundError`, while other OS succeeded depending on scheduling order.

Aligned with the same fix in the `centreon-modules` repo ([PR #9038](https://github.com/centreon/centreon-modules/pull/9038)).

[MON-206771]: https://centreon.atlassian.net/browse/MON-206771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ