### PR TITLE
fix(ci): xray: scope results-import artifact download per OS to fix flaky import (dev-26.10.x)

### DIFF
--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -358,7 +358,7 @@ jobs:
       type_test_execution: e2e
       result_format: cucumber
       enrich_tests: true
-      artifact_pattern: "*-xray-reports-*"
+      artifact_pattern: "${{ inputs.name }}-${{ inputs.os }}-${{ needs.cypress-e2e-test-list.outputs.db_id }}-xray-reports*"
     secrets:
       XRAY_CLIENT_ID: ${{ secrets.xray_client_id }}
       XRAY_CLIENT_SECRET: ${{ secrets.xray_client_secret }}


### PR DESCRIPTION
Fixes: [MON-206861](https://centreon.atlassian.net/browse/MON-206861)

Backport of the flaky Xray results-import fix to `dev-26.10.x`. Scopes the import `artifact_pattern` to the job own OS + database (and drops the trailing `-`), preventing the race with `regroup-artifacts` deletions.

Original PR (develop): https://github.com/centreon/centreon/pull/11318

[MON-206861]: https://centreon.atlassian.net/browse/MON-206861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ