### PR TITLE
fix(open-tickets): use canonical ITILCategory itemtype casing for GLPI REST API

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
@@ -1240,7 +1240,8 @@ class GlpiRestApiProvider extends AbstractProvider
     protected function getItilCategories()
     {
         // add the api endpoint and method to our info array
-        $info['query_endpoint'] = '/itilCategory';
+        // ITILCategory is the canonical itemtype casing accepted by every GLPI version (9.1 -> 11)
+        $info['query_endpoint'] = '/ITILCategory';
         $info['method'] = 0;
         // set headers
         $info['headers'] = ['App-Token: ' . $this->getFormValue('app_token'), 'Content-Type: application/json'];


### PR DESCRIPTION
Fixes: [MON-206863](https://centreon.atlassian.net/browse/MON-206863)

Backport of https://github.com/centreon/centreon/pull/11265

> Note: this repository does not currently ship a `.github/PULL_REQUEST_TEMPLATE.md` on `dev-26.10.x` (nor on `develop`), so the sections below follow the structure used by the original PR, with the type of change and target serie stated explicitly.

## Description

GLPI's REST API routes itemtypes case-sensitively to internal PHP class names. The `GlpiRestApi` open-tickets provider queried the ITIL Category endpoint as `/itilCategory`, which no longer matches the class name on GLPI ≥ 9.5.0, so the **ITIL Category** dropdown failed on recent GLPI versions.

The fix is to use `/ITILCategory`, the **canonical itemtype casing accepted by every GLPI version from 9.1 to 11**:
- **≤ 9.4** — the autoloader lowercases the itemtype and resolves `inc/itilcategory.class.php`
- **9.5.x** — exact PSR-4 match on `ITILCategory`
- **10.0.0+** — normalized through `fixItemtypeCase()`

The **Group** endpoint already used the canonical `/Group` casing, so it needed no change.

This intentionally replaces an earlier version-selector approach: **no new form field, no default value to manage, no migration of existing rules, and nothing new to document.**

## Changes

- `GlpiRestApiProvider::getItilCategories()`: `/itilCategory` → `/ITILCategory`.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactoring

## Target serie

- [x] 26.10.x

## How to test

Configure a GlpiRestApi open-tickets rule against a GLPI instance and open a ticket using ITIL Category / Group mappings. The **ITIL Category** and **GLPI Group** dropdowns should populate without error on:
- GLPI ≤ 9.4
- GLPI 9.5.x
- GLPI 10.0.0+

## Checklist

- [x] I have followed the coding style guidelines of this project
- [x] I have rebased my commits on the target branch (`dev-26.10.x`)
- [x] The commit is a clean cherry-pick of `6ce5b6e7f2a74ae3959f3b10ef4dc082a6b96499` (recorded with `-x`), with no manual conflict resolution
- [x] The change is identical to the one already reviewed and merged on `develop` (1 file, 2 insertions, 1 deletion)
- [ ] I have added tests that prove my fix is effective (not applicable: legacy open-tickets provider without existing test coverage; the change is a single endpoint casing correction validated manually against GLPI)
- [ ] I have added the necessary documentation (not applicable: no user-facing configuration change)


[MON-206863]: https://centreon.atlassian.net/browse/MON-206863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ