### PR TITLE
feat(gorgone): add pull and pullwss config generation in popup

### DIFF
--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -141,7 +141,7 @@
                 </a>
                 {/if}
 
-                {if ($elemArr[elem].RowMenu_gorgone_protocol == 1 && $elemArr[elem].RowMenu_statusVal == 1)
+                {if (($elemArr[elem].RowMenu_gorgone_protocol == 1 || $elemArr[elem].RowMenu_gorgone_protocol == 3 || $elemArr[elem].RowMenu_gorgone_protocol == 4) && $elemArr[elem].RowMenu_statusVal == 1)
                 || $elemArr[elem].RowMenu_type == 'Central'}
                 <!-- Link for edit poller monitoring engine configuration -->
                 <span  {literal}onclick="displayPopup('{/literal}{$elemArr[elem].RowMenu_server_id}{literal}'){/literal}" >

--- a/centreon/www/include/configuration/configServers/popup/poller_pull.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller_pull.yaml
@@ -1,0 +1,19 @@
+name: gorgoned-__SERVERNAME__
+description: Configuration for poller __SERVERNAME__
+gorgone:
+  gorgonecore:
+    id: __SERVERID__
+    authorized_clients: __THUMBPRINT__
+    privkey: "/var/lib/centreon-gorgone/.keys/rsakey.priv.pem"
+    pubkey: "/var/lib/centreon-gorgone/.keys/rsakey.pub.pem"
+  modules:
+    - name: engine
+      package: gorgone::modules::centreon::engine::hooks
+      enable: true
+      command_file: "__COMMAND__"
+
+    - name: pull
+      package: "gorgone::modules::core::pull::hooks"
+      enable: true
+      target_type: tcp
+      target_path: "__CENTRALADDRESS__:__GORGONEPORT__"

--- a/centreon/www/include/configuration/configServers/popup/poller_pullwss.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller_pullwss.yaml
@@ -1,0 +1,21 @@
+name: gorgoned-__SERVERNAME__
+description: Configuration for poller __SERVERNAME__
+gorgone:
+  gorgonecore:
+    id: __SERVERID__
+    privkey: "/var/lib/centreon-gorgone/.keys/rsakey.priv.pem"
+    pubkey: "/var/lib/centreon-gorgone/.keys/rsakey.pub.pem"
+  modules:
+    - name: engine
+      package: gorgone::modules::centreon::engine::hooks
+      enable: true
+      command_file: "__COMMAND__"
+
+    - name: pullwss
+      package: "gorgone::modules::core::pullwss::hooks"
+      enable: true
+      ssl: true
+      token: "__TOKEN__"
+      port: __GORGONEPORT__
+      address: "__CENTRALADDRESS__"
+      central_uri: "/centreon/gorgone/pullwss/websocket"

--- a/centreon/www/include/configuration/configServers/popup/popup.ihtml
+++ b/centreon/www/include/configuration/configServers/popup/popup.ihtml
@@ -1,11 +1,11 @@
 <h3 style="text-align: center;"> Gorgone configuration file :</h3>
 <br>
 <div class="gorgone_config_file">
-    <pre id='configuration_file' style="overflow-x: auto;">{$args}</pre>
+    <pre id='configuration_file' style="overflow-x: auto;">{$args|escape}</pre>
     <br>
     <pre id='command_configuration_file' style="overflow-x: auto; display: none">
 cat &lt;&lt;EOF &gt; /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-{$args}
+{$args|escape}
 EOF</pre>
     {if $gorgoneError == '0'}
     <div style="text-align: center;">

--- a/centreon/www/include/configuration/configServers/popup/popup.php
+++ b/centreon/www/include/configuration/configServers/popup/popup.php
@@ -19,6 +19,9 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 require_once realpath(__DIR__ . '/../../../../../config/centreon.config.php');
 require_once _CENTREON_PATH_ . 'www/class/centreonDB.class.php';
 require_once _CENTREON_PATH_ . 'bootstrap.php';
@@ -26,6 +29,17 @@ require_once _CENTREON_PATH_ . 'www/include/common/common-Func.php';
 require_once _CENTREON_PATH_ . '/www/class/centreonRestHttp.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreonSession.class.php';
 $pearDB = $dependencyInjector['configuration_db'];
+
+/**
+ * Make a value safe for a double-quoted YAML scalar: strip control characters
+ * (a newline or a trailing #-comment would otherwise inject keys into the
+ * document the operator is told to paste on the poller), escape backslashes
+ * and double quotes.
+ */
+function escapeYamlQuotedScalar(string $value): string
+{
+    return addcslashes((string) preg_replace('/[\x00-\x1F\x7F]/', '', $value), '\\"');
+}
 
 // Check Session
 CentreonSession::start(1);
@@ -66,11 +80,15 @@ $dbResult->closeCursor();
 // get poller informations
 $statement = $pearDB->prepare(
     "SELECT ns.`id`, ns.`name`, ns.`gorgone_port`, ns.`ns_ip_address`, ns.`localhost`, ns.remote_id,
-      remote_server_use_as_proxy, cn.`command_file`, GROUP_CONCAT( pr.`remote_server_id` ) AS list_remote_server_id
+      ns.`gorgone_communication_type`,
+      remote_server_use_as_proxy, cn.`command_file`,
+      GROUP_CONCAT(DISTINCT pr.`remote_server_id`) AS list_remote_server_id,
+      MAX(pt.`central_address`) AS `central_address`
     FROM nagios_server AS ns
     LEFT JOIN remote_servers AS rs ON rs.server_id = ns.id
     LEFT JOIN cfg_nagios AS cn ON cn.`nagios_id` = ns.`id`
     LEFT JOIN rs_poller_relation AS pr ON pr.`poller_server_id` = ns.`id`
+    LEFT JOIN platform_topology AS pt ON pt.`server_id` = ns.`id`
     WHERE ns.ns_activate = '1'
     AND ns.`id` = :server_id"
 );
@@ -130,6 +148,63 @@ if ($server['localhost'] === '1') {
         ],
         $config
     );
+} elseif (
+    $server['gorgone_communication_type'] === '4'
+    && ! in_array($server['ns_ip_address'], $remotesServerIPs)
+) {
+    // config for poller in pullwss mode (no thumbprints needed);
+    // remote servers keep the remote template below, whatever their communication type.
+    // Mirrors DbalPollerTokenRepository::getFirstValidPollerToken(): oldest valid token first,
+    // deliberately. Keep both in sync.
+    $tokenRow = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT `token_name`, `token_string`
+            FROM `authentication_tokens`
+            WHERE `type` = 'poller'
+            AND `is_revoked` = 0
+            AND (`expiration_date` IS NULL OR `expiration_date` > :nowEpoch)
+            ORDER BY `creation_date` ASC
+            LIMIT 1
+            SQL,
+        QueryParameters::create([QueryParameter::int('nowEpoch', time())])
+    );
+
+    $centralAddress = $server['central_address'] ?? '';
+
+    if ($tokenRow === false) {
+        $gorgoneError = true;
+        $config = 'No valid poller token found. Please create one before generating the configuration.';
+    } elseif ($centralAddress === '') {
+        $gorgoneError = true;
+        $config = 'No central address is configured for this poller.'
+            . ' Please set the central address reachable from the poller before generating the configuration.';
+    } else {
+        $template = file_get_contents(__DIR__ . '/poller_pullwss.yaml');
+        if ($template === false) {
+            $gorgoneError = true;
+            $config = 'Unable to read the pullwss configuration template.';
+        } else {
+            $config = str_replace(
+                [
+                    '__SERVERNAME__',
+                    '__SERVERID__',
+                    '__GORGONEPORT__',
+                    '__COMMAND__',
+                    '__TOKEN__',
+                    '__CENTRALADDRESS__',
+                ],
+                [
+                    $server['name'],
+                    $server['id'],
+                    $server['gorgone_port'],
+                    $server['command_file'],
+                    escapeYamlQuotedScalar($tokenRow['token_name'] . ':' . $tokenRow['token_string']),
+                    escapeYamlQuotedScalar($centralAddress),
+                ],
+                $template
+            );
+        }
+    }
 } else {
     $gorgoneService = $kernel->getContainer()->get(Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface::class);
     $thumbprints = '';
@@ -202,8 +277,43 @@ if ($server['localhost'] === '1') {
             ],
             $config
         );
+    } elseif ($server['gorgone_communication_type'] === '3') {
+        // config for poller in pull mode
+        $centralAddress = $server['central_address'] ?? '';
+
+        if ($centralAddress === '') {
+            $gorgoneError = true;
+            $config = 'No central address is configured for this poller.'
+                . ' Please set the central address reachable from the poller before generating the configuration.';
+        } else {
+            $template = file_get_contents(__DIR__ . '/poller_pull.yaml');
+            if ($template === false) {
+                $gorgoneError = true;
+                $config = 'Unable to read the pull configuration template.';
+            } else {
+                $config = str_replace(
+                    [
+                        '__SERVERNAME__',
+                        '__SERVERID__',
+                        '__GORGONEPORT__',
+                        '__THUMBPRINT__',
+                        '__COMMAND__',
+                        '__CENTRALADDRESS__',
+                    ],
+                    [
+                        $server['name'],
+                        $server['id'],
+                        $server['gorgone_port'],
+                        $thumbprints,
+                        $server['command_file'],
+                        escapeYamlQuotedScalar($centralAddress),
+                    ],
+                    $template
+                );
+            }
+        }
     } else {
-        // config for poller
+        // config for poller (zmq/ssh)
         $config = file_get_contents('./poller.yaml');
         $config = str_replace(
             [


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/11231

Adapt gorgone configuration generation in the legacy popup (Configuration > Pollers > gorgone config icon) to support the new pull and pullwss communication modes.

- Add YAML template for pull mode gorgone config (thumbprints, pull module, central address)
- Add YAML template for pullwss mode (token-based auth, pullwss module, central address, no thumbprints)
- Update popup.php to fetch `gorgone_communication_type` and `central_address` via LEFT JOIN on `platform_topology`, branch on type '3' (pull) and type '4' (pullwss)
- Extend gorgone config icon visibility in listServers.ihtml to also show for pull and pullwss communication types

Fixes: [MON-206503](https://centreon.atlassian.net/browse/MON-206503)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

Note: this pull request targets `dev-26.10.x`, which is not listed in the template above, so no box is checked to avoid indicating a wrong serie.

## How this pull request can be tested ?

1. Configure a poller with pullwss communication mode
2. Go to Configuration > Pollers
3. Click the gorgone config icon — it should now appear for pull/pullwss pollers
4. Verify the generated YAML contains the correct pullwss module config with token and central address
5. Repeat with a poller in pull mode and verify the pull template with thumbprints

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (dev-26.10.x).


[MON-206503]: https://centreon.atlassian.net/browse/MON-206503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ