### PR TITLE
chore(deps): upgrade react-router to 7.14.2

### DIFF
--- a/centreon/package.json
+++ b/centreon/package.json
@@ -153,7 +153,7 @@
     "react-i18next": "^15.4.1",
     "react-material-ui-carousel": "^3.4.2",
     "react-resizable": "^3.0.5",
-    "react-router": "7.12.0",
+    "react-router": "7.14.2",
     "react-select": "^5.10.1",
     "react-spring": "^9.7.5",
     "string-argv": "^0.3.2",

--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -162,7 +162,7 @@
     "ramda": "0.30.1",
     "react-grid-layout": "^2.2.2",
     "react-resizable": "^3.0.5",
-    "react-router": "7.12.0",
+    "react-router": "7.14.2",
     "react-transition-group": "^4.4.5",
     "sanitize-html": "^2.14.0",
     "ulog": "^2.0.0-beta.19"

--- a/centreon/pnpm-lock.yaml
+++ b/centreon/pnpm-lock.yaml
@@ -199,8 +199,8 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
-        specifier: 7.12.0
-        version: 7.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 7.14.2
+        version: 7.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-select:
         specifier: ^5.10.1
         version: 5.10.1(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -674,8 +674,8 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
-        specifier: 7.12.0
-        version: 7.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 7.14.2
+        version: 7.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -5108,14 +5108,12 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.13.3':
     resolution: {integrity: sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.14.0':
     resolution: {integrity: sha512-quTTx1Olm05fBfv66DEBuOsOgqdypnZ/1Bh3yGXWY7ANLFeeRpCDZpljD9BSjdsNdPOlwJmEUZXMHtGm3v1TZQ==}
@@ -12687,8 +12685,8 @@ packages:
     peerDependencies:
       react: '>= 16.3'
 
-  react-router@7.12.0:
-    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -21085,7 +21083,7 @@ snapshots:
       '@usebruno/js': 0.47.0(debug@4.4.3)
       '@usebruno/lang': 0.36.0
       '@usebruno/requests': 0.17.0
-      aws4-axios: 3.4.0(axios@1.13.6)
+      aws4-axios: 3.4.0(axios@1.13.6(debug@4.4.3))
       axios: 1.13.6(debug@4.4.3)
       axios-ntlm: 1.4.6(debug@4.4.3)
       chai: 4.5.0
@@ -22205,7 +22203,7 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  aws4-axios@3.4.0(axios@1.13.6):
+  aws4-axios@3.4.0(axios@1.13.6(debug@4.4.3)):
     dependencies:
       '@aws-sdk/client-sts': 3.1045.0
       aws4: 1.13.2
@@ -22650,7 +22648,7 @@ snapshots:
       duplexer2: 0.1.4
       events: 3.3.0
       glob: 7.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       htmlescape: 1.1.1
       https-browserify: 1.0.0
       inherits: 2.0.4
@@ -24309,7 +24307,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -24394,7 +24392,7 @@ snapshots:
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -25395,7 +25393,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -26100,7 +26098,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   internmap@1.0.1: {}
@@ -26287,7 +26285,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-regexp@1.0.0: {}
 
@@ -29700,7 +29698,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  react-router@7.12.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router@7.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       cookie: 1.0.2
       react: 19.1.0


### PR DESCRIPTION
Fixes: [MON-206728](https://centreon.atlassian.net/browse/MON-206728)

Bumps `react-router` from 7.12.0 to **7.14.2** on the web side (the modules side is a separate PR under the same ticket).

## Changes
- `package.json` — `react-router` 7.12.0 → 7.14.2
- `packages/ui/package.json` (`@centreon/ui`) — same bump (it pins react-router directly)
- `pnpm-lock.yaml` — regenerated; fully on 7.14.2

## Validation (local)
- `pnpm install` clean — 7.12.0 fully gone
- `pnpm lint` (biome) clean — 1558 files
- `pnpm type-check` — no new errors (the 3 in `InstallationCommandButton.tsx` pre-exist on develop)
- `pnpm build` (rspack prod) OK

react-router is a production dependency, so routing behavior (route matching, lazy/nested routes, `useParams`/`useNavigate`/`useSearchParams`) is exercised by the Cypress component + e2e suite in CI. The 7.12 → 7.14.2 bump stays within the 7.x line.

[MON-206728]: https://centreon.atlassian.net/browse/MON-206728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ