### PR TITLE
fix(token): keep listing tokens after a creator is deleted

### DIFF
--- a/centreon/cypress/fixtures/authenticationTokens/listTokensWithDeletedCreator.json
+++ b/centreon/cypress/fixtures/authenticationTokens/listTokensWithDeletedCreator.json
@@ -1,0 +1,56 @@
+{
+  "result": [
+    {
+      "name": "a-token",
+      "type": "api",
+      "user": {
+        "id": 23,
+        "name": "Jane Doe"
+      },
+      "creator": {
+        "id": 23,
+        "name": "Jane Doe"
+      },
+      "creation_date": "2023-08-31T15:46:00+02:00",
+      "expiration_date": null,
+      "is_revoked": false
+    },
+    {
+      "name": "b-token",
+      "type": "api",
+      "user": {
+        "id": 24,
+        "name": "John Doe"
+      },
+      "creator": {
+        "id": null,
+        "name": "Deleted Creator"
+      },
+      "creation_date": "2023-08-31T15:46:00+02:00",
+      "expiration_date": "2028-08-31T00:00:00+00:00",
+      "is_revoked": false
+    },
+    {
+      "name": "c-token",
+      "type": "api",
+      "user": {
+        "id": 23,
+        "name": "Jane Doe"
+      },
+      "creator": {
+        "id": 23,
+        "name": "Kevin B"
+      },
+      "creation_date": "2023-08-31T15:46:00+02:00",
+      "expiration_date": "2028-08-31T00:00:00+00:00",
+      "is_revoked": false
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "search": {},
+    "sort_by": { "token_name": "ASC" },
+    "total": 3
+  }
+}

--- a/centreon/www/front_src/src/AuthenticationTokens/Filters/useFilters.ts
+++ b/centreon/www/front_src/src/AuthenticationTokens/Filters/useFilters.ts
@@ -69,7 +69,9 @@ const useFilters = (): UseFiltersState => {
   const filterCreators = (options): Array<NamedEntity> => {
     const creatorsData = options?.map(({ creator }) => creator);
 
-    return getUniqData(creatorsData);
+    // Creators without an id have been deleted: filtering on them would send
+    // creator.id $eq null and always return an empty listing.
+    return reject(({ id }) => isNil(id), getUniqData(creatorsData));
   };
 
   const deleteCreator = (_, item): void => {

--- a/centreon/www/front_src/src/AuthenticationTokens/Listing/models.ts
+++ b/centreon/www/front_src/src/AuthenticationTokens/Listing/models.ts
@@ -15,9 +15,14 @@ export interface NamedEntity {
   name: string;
 }
 
+export interface Creator {
+  id: number | null;
+  name: string;
+}
+
 export interface Token {
   creationDate: string;
-  creator: NamedEntity;
+  creator: Creator;
   expirationDate: string | null;
   isRevoked: boolean;
   name: string;

--- a/centreon/www/front_src/src/AuthenticationTokens/Specs/AuthenticationTokens.cypress.spec.tsx
+++ b/centreon/www/front_src/src/AuthenticationTokens/Specs/AuthenticationTokens.cypress.spec.tsx
@@ -1,6 +1,7 @@
 import {
   labelAdd,
   labelCreateAuthenticationToken,
+  labelCreator,
   labelDeleteToken,
   labelDisableToken,
   labelDisabled,
@@ -218,5 +219,32 @@ describe('Authentication tokens', () => {
     cy.contains(labelDone).click();
 
     cy.findByText(labelCreateAuthenticationToken).should('not.exist');
+  });
+});
+
+describe('Authentication tokens with a deleted creator', () => {
+  beforeEach(() => {
+    initilize('authenticationTokens/listTokensWithDeletedCreator');
+  });
+
+  it('lists every token when the creator of one of them has been deleted', () => {
+    cy.waitForRequest('@listToken');
+
+    cy.contains('a-token');
+    cy.contains('b-token');
+    cy.contains('c-token');
+
+    cy.contains('Deleted Creator');
+  });
+
+  it('does not offer a deleted creator in the creator filter', () => {
+    cy.waitForRequest('@listToken');
+
+    cy.findByTestId(labelFilters).click();
+
+    cy.findByTestId(labelCreator).click();
+
+    cy.findByRole('option', { name: 'Jane Doe' }).should('exist');
+    cy.findByRole('option', { name: 'Deleted Creator' }).should('not.exist');
   });
 });

--- a/centreon/www/front_src/src/AuthenticationTokens/Specs/initialize.tsx
+++ b/centreon/www/front_src/src/AuthenticationTokens/Specs/initialize.tsx
@@ -9,8 +9,10 @@ import Page from '../Page';
 import { listTokensEndpoint } from '../api';
 import { listUsers } from '../api/endpoints';
 
-const interceptRequests = () => {
-  cy.fixture('authenticationTokens/listTokens').then((data) => {
+const defaultListTokensFixture = 'authenticationTokens/listTokens';
+
+const interceptRequests = (listTokensFixture: string) => {
+  cy.fixture(listTokensFixture).then((data) => {
     cy.interceptAPIRequest({
       alias: 'listToken',
       method: Method.GET,
@@ -61,7 +63,9 @@ const interceptRequests = () => {
   });
 };
 
-export const initilize = (): void => {
+export const initilize = (
+  listTokensFixture: string = defaultListTokensFixture
+): void => {
   i18next.use(initReactI18next).init({
     lng: 'en',
     resources: {}
@@ -80,7 +84,7 @@ export const initilize = (): void => {
     cy.stub(win.navigator.clipboard, 'writeText').as('writeText');
   });
 
-  interceptRequests();
+  interceptRequests(listTokensFixture);
 
   cy.mount({
     Component: (

--- a/centreon/www/front_src/src/AuthenticationTokens/api/decoder.ts
+++ b/centreon/www/front_src/src/AuthenticationTokens/api/decoder.ts
@@ -3,7 +3,7 @@ import { JsonDecoder } from 'ts.data.json';
 import { buildListingDecoder } from '@centreon/ui';
 
 import { equals } from 'ramda';
-import { NamedEntity, Token } from '../Listing/models';
+import { Creator, NamedEntity, Token } from '../Listing/models';
 import { CreatedToken } from '../Modal/models';
 import { TokenType } from '../models';
 
@@ -16,11 +16,23 @@ const getNamedEntityDecoder = (decoderName): JsonDecoder.Decoder<NamedEntity> =>
     decoderName
   );
 
+// Deleting a contact sets creator_id to NULL and keeps the token, while
+// creator_name stays denormalized on the token row. A user id is never null:
+// its column is NOT NULL and the token is deleted along with its user.
+const getCreatorDecoder = (): JsonDecoder.Decoder<Creator> =>
+  JsonDecoder.object<Creator>(
+    {
+      id: JsonDecoder.nullable(JsonDecoder.number),
+      name: JsonDecoder.string
+    },
+    'creator'
+  );
+
 const tokenDecoder = JsonDecoder.object<Token>(
   {
     name: JsonDecoder.string,
     creationDate: JsonDecoder.string,
-    creator: getNamedEntityDecoder('creator'),
+    creator: getCreatorDecoder(),
     expirationDate: JsonDecoder.nullable(JsonDecoder.string),
     isRevoked: JsonDecoder.boolean,
     user: JsonDecoder.optional(getNamedEntityDecoder('user')),
@@ -50,7 +62,7 @@ export const listTokensDecoder = buildListingDecoder<Token>({
 export const createdTokenDecoder = JsonDecoder.object<CreatedToken>(
   {
     creationDate: JsonDecoder.string,
-    creator: getNamedEntityDecoder('creator'),
+    creator: getCreatorDecoder(),
     expirationDate: JsonDecoder.nullable(JsonDecoder.string),
     isRevoked: JsonDecoder.boolean,
     name: JsonDecoder.string,


### PR DESCRIPTION
Fixes: [MON-206866](https://centreon.atlassian.net/browse/MON-206866)

Backport of https://github.com/centreon/centreon/pull/11274

## Description

Deleting a contact keeps their tokens and sets `creator_id` to `NULL`
(the FK is already `ON DELETE SET NULL`), so the API correctly returns
`creator.id: null`. The listing decoder typed that field as a
non-nullable number and rejected the entry — and since one invalid
entry fails the whole payload, the token page rendered **empty** with:

> decoder failed at key "result" ... at key "creator" ... "id" ...
> null is not a valid number

The fix is frontend-only; the API, the schema and the OpenAPI contract
already handle a null creator.

## Changes

- `api/decoder.ts` — new `getCreatorDecoder()` with a nullable id, used by
  both `tokenDecoder` and `createdTokenDecoder`. `getNamedEntityDecoder`
  stays strict for `user`: its column is `NOT NULL` and the token is
  deleted along with its user.
- `Listing/models.ts` — new `Creator` interface (`id: number | null`).
- `Filters/useFilters.ts` — drop deleted creators from the creator filter
  options; selecting one would emit `creator.id $eq null` and never match.
- Regression test + fixture covering a listing with a null-id creator.
  `initilize()` now takes an optional listing fixture, defaulting to the
  existing one so the current snapshots are unchanged.

The Creator column keeps showing the stored `creator_name`, which is
denormalised on the token row and survives the contact deletion — the
listing looks exactly as it did before the user was removed.

## Backport note

The cherry-pick needed a **manual conflict resolution in the import block**
of `api/decoder.ts`, so this branch is not byte-identical to the
`dev-26.10.x` backport (#11327) — please give that import block a look.

`dev-25.10.x` puts the `ts.data.json` import on line 1, while `dev-26.10.x`
places it after `ramda` and additionally carries a `// @ts-nocheck` header
that does not exist on 25.10. The incoming hunk rewrote that region to add
`Creator`, which collided. The resolution keeps the existing 25.10 import
layout and only adds `Creator` to the `../Listing/models` import; taking the
incoming side verbatim would have duplicated the `ts.data.json` import.

Verified afterwards that every added and removed line of this commit is
identical to the original commit `81670d7d21` — only line offsets differ. The
remaining differences against #11327 are the pre-existing `@ts-nocheck` header
and the decoder key ordering, both inherited from the respective baselines and
left untouched.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

1. Create an API token for user B while logged in as user A.
2. Delete user A.
3. Open Administration > Authentication tokens — the listing must still show
   every token, with the Creator column displaying user A's stored name.
4. Confirm the token still authenticates.

Cypress component spec: `AuthenticationTokens.cypress.spec.tsx`.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).


[MON-206866]: https://centreon.atlassian.net/browse/MON-206866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ