### PR TITLE
test(e2e): web: start mariadb with systemd during platform update tests

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -412,9 +412,10 @@ const updatePlatformPackages = (): Cypress.Chainable => {
 };
 
 const checkPlatformVersion = (platformVersion: string): Cypress.Chainable => {
+  // stderr is merged into the output, drop the apt CLI stability warning
   const command = Cypress.env('WEB_IMAGE_OS').includes('alma')
     ? `rpm -qa | grep centreon-web | cut -d '-' -f3 | tr -d '\n'`
-    : `apt list --installed centreon-web | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
+    : `apt list --installed centreon-web 2>/dev/null | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
 
   return cy
     .execInContainer({

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -223,8 +223,8 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        `sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql`,
-        'service mysql start',
+        // upstream MariaDB packages only ship /etc/init.d/mariadb
+        'systemctl start mariadb',
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',


### PR DESCRIPTION
Fixes: [MON-206824](https://centreon.atlassian.net/browse/MON-206824)

## Description

`Platform-upgrade-update/01-platform-update.feature` fails deterministically on Debian targets, on the very first step (`Given a running platform in '<version>' version`):

```
Execution of "sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql" failed
Exit code: 2
sed: can't read /etc/init.d/mysql: No such file or directory
```

The database used by these two features is the one `installDatabase()` installs **inside the `web` container**: MariaDB from the upstream `dlm.mariadb.com` repository. Those packages only ship `/etc/init.d/mariadb` — their postinst recreates `/etc/init.d/mysql` only when that file already exists (migration path from the legacy MySQL packages). On a fresh install it is therefore absent, so both the `sed` and the following `service mysql start` are broken. Verified against the three versions currently published for bookworm: 10.11.16, 10.11.17 and 10.11.18.

The service is now started through systemd, exactly as the Alma branch already does. The `datadir_set` workaround no longer has any purpose: that variable does not exist in `/etc/init.d/mariadb`, and the datadir is initialised by the package postinst.

## Validation

In a Debian 12 container running systemd, after installing `mariadb-server` from the upstream repository: `systemctl start mariadb` returns `active` and `mysql -e "SELECT VERSION()"` returns `10.11.18-MariaDB-deb12`, with no `sed` involved.

Failing runs before the fix:

* https://github.com/centreon/centreon/actions/runs/31188737107/job/93420428967 (release-25.10-next)
* https://github.com/centreon/centreon/actions/runs/31188820180/job/93466704255 (release-24.10-next)

## Notes for reviewers

* Draft PR #11234 ([MON-206072](https://centreon.atlassian.net/browse/MON-206072)) edits the same lines to make the DBMS follow the CI matrix. It keeps the `sed` behind a `mariadb` condition and keeps `service mysql start`, so it both conflicts with this change and still carries the bug. Once this is merged, #11234 should drop the `sed` altogether and derive the unit name from the engine (`mariadb` or `mysql` on Debian, `mysqld` on Alma).
* Unrelated and not addressed here: on the 25.10 series, two of the four scenario examples stay red because the test pins `centreon-perl-libs` to the `centreon-web` version, while that package is only published up to 25.10.8 (centreon-web goes up to 25.10.16).


[MON-206824]: https://centreon.atlassian.net/browse/MON-206824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-206072]: https://centreon.atlassian.net/browse/MON-206072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ