### PR TITLE
feat(pollers): add copy installation command icon to poller listing

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -25318,3 +25318,7 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
+
+#: www/include/configuration/configServers/listServers.ihtml
+msgid "Copy installation command"
+msgstr "Copier la commande d'installation"

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -98,7 +98,7 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         $model = $this->commandBus->execute($command);
         Assert::isInstanceOf($model, Poller::class);
 
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             $model,
             $token,
             $appSecret,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
@@ -63,7 +63,7 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
             ? $this->pollerTokenRepository->getValidPollerTokenByName($tokenName)
             : $this->pollerTokenRepository->getFirstValidPollerToken();
 
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             $poller,
             $token,
             $this->engineSecretsRepository->getAppSecret(),

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -24,13 +24,18 @@ declare(strict_types=1);
 namespace App\MonitoringConfiguration\Infrastructure;
 
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
 use App\MonitoringConfiguration\Domain\Model\PollerToken;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
 final readonly class PollerInstallationCommandFactory
 {
     public function __construct(
-        private Poller $poller,
+        private PollerUid $pollerUid,
+        private PollerName $pollerName,
+        private PollerTypeEnum $pollerType,
         private PollerToken $pollerToken,
         #[Sensitive] private string $appSecret,
         #[Sensitive] private string $salt,
@@ -39,20 +44,45 @@ final readonly class PollerInstallationCommandFactory
     ) {
     }
 
+    /**
+     * Preferred entry point when a full Poller aggregate is at hand: it guarantees
+     * uid, name and type all come from the same poller.
+     */
+    public static function fromPoller(
+        Poller $poller,
+        PollerToken $pollerToken,
+        string $appSecret,
+        string $salt,
+        bool $isCloudPlatform = false,
+        string $centralUrl = '<CENTRAL_URL>',
+    ): self {
+        return new self(
+            $poller->uid,
+            $poller->name,
+            $poller->pollerType,
+            $pollerToken,
+            $appSecret,
+            $salt,
+            $isCloudPlatform,
+            $centralUrl,
+        );
+    }
+
     public function generate(): string
     {
         // Only `name` is escaped with escapeshellarg(): it is the sole free-form,
         // user-provided value. The other parameters are controlled and cannot carry
         // shell metacharacters: pollerToken name+value are hex (bin2hex), uid is an int,
-        // pollerType is an enum, appSecret/salt are engine-generated, and centralUrl comes from config.
+        // pollerType is an enum, appSecret/salt are engine-generated, and centralUrl must be
+        // validated as an IP or hostname (PollerAddress) by every call site before reaching here.
         $command = sprintf(
             'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
             $this->centralUrl,
             $this->pollerToken->name,
             $this->pollerToken->value,
-            $this->poller->uid->value,
-            escapeshellarg($this->poller->name->value),
-            $this->poller->pollerType->value,
+            $this->pollerUid->value,
+            escapeshellarg($this->pollerName->value),
+            $this->pollerType->value,
             $this->centralUrl,
             $this->appSecret,
             $this->salt,

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
@@ -52,7 +52,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsCurlScript(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -69,7 +69,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsPollerToken(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -82,7 +82,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsPollerUid(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -95,7 +95,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsPollerName(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -108,7 +108,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsVmType(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -121,7 +121,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsDockerType(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::Docker),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -134,7 +134,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsCentralUrl(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -147,7 +147,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsAppSecret(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -160,7 +160,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsSalt(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -173,7 +173,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandHasExpectedFormat(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -197,7 +197,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandContainsCloudFlagWhenCloudPlatform(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -211,7 +211,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
 
     public function testGenerateCommandDoesNotContainCloudFlagWhenOnPremise(): void
     {
-        $factory = new PollerInstallationCommandFactory(
+        $factory = PollerInstallationCommandFactory::fromPoller(
             poller: $this->createPoller(PollerTypeEnum::VM),
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
@@ -221,6 +221,34 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         );
 
         self::assertStringNotContainsString('--cloud', $factory->generate());
+    }
+
+    public function testConstructorAndFromPollerShareTheSameDefaults(): void
+    {
+        $poller = $this->createPoller(PollerTypeEnum::Docker);
+        $token = new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false);
+
+        // isCloudPlatform and centralUrl are intentionally omitted: their defaults are
+        // duplicated in both signatures, and this test pins them to the same values.
+        $fromPoller = PollerInstallationCommandFactory::fromPoller(
+            poller: $poller,
+            pollerToken: $token,
+            appSecret: self::APP_SECRET,
+            salt: self::SALT,
+        );
+
+        $fromValueObjects = new PollerInstallationCommandFactory(
+            pollerUid: $poller->uid,
+            pollerName: $poller->name,
+            pollerType: $poller->pollerType,
+            pollerToken: $token,
+            appSecret: self::APP_SECRET,
+            salt: self::SALT,
+        );
+
+        self::assertSame($fromPoller->generate(), $fromValueObjects->generate());
+        self::assertStringContainsString('--central_url <CENTRAL_URL>', $fromValueObjects->generate());
+        self::assertStringNotContainsString('--cloud', $fromValueObjects->generate());
     }
 
     private function createPoller(PollerTypeEnum $type): Poller

--- a/centreon/www/include/configuration/configServers/copyInstallCommand.php
+++ b/centreon/www/include/configuration/configServers/copyInstallCommand.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+require_once realpath(__DIR__ . '/../../../../config/centreon.config.php');
+require_once _CENTREON_PATH_ . 'www/class/centreonDB.class.php';
+require_once _CENTREON_PATH_ . 'bootstrap.php';
+require_once _CENTREON_PATH_ . 'www/include/common/common-Func.php';
+require_once _CENTREON_PATH_ . '/www/class/centreonSession.class.php';
+
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
+use App\MonitoringConfiguration\Domain\Model\PollerToken;
+use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
+use App\Shared\Infrastructure\FsEngineSecretsRepository;
+
+// Keep in sync with engine_context_path (config/services.yaml) and
+// upgrade.engine_context_path (config.new/services/upgrade.php): this endpoint
+// deliberately does not boot the Symfony kernel, so it cannot read the parameter.
+const ENGINE_CONTEXT_PATH = '/etc/centreon-engine/engine-context.json';
+
+header('Content-Type: application/json');
+// The response body carries the app secret, the salt and a live poller token.
+header('Cache-Control: no-store');
+
+/**
+ * Emit a JSON response with the given HTTP status code and stop the script.
+ *
+ * @param int $statusCode
+ * @param array<string, string> $payload
+ *
+ * @throws JsonException
+ */
+function sendJsonResponse(int $statusCode, array $payload): never
+{
+    http_response_code($statusCode);
+    echo json_encode($payload, JSON_THROW_ON_ERROR);
+
+    exit();
+}
+
+$pearDB = $dependencyInjector['configuration_db'];
+
+CentreonSession::start(1);
+if (! CentreonSession::checkSession(session_id(), $pearDB)) {
+    sendJsonResponse(403, ['error' => 'Invalid session']);
+}
+
+$centreon = $_SESSION['centreon'];
+$pollerId = filter_var($_GET['id'] ?? false, FILTER_VALIDATE_INT);
+if ($pollerId === false) {
+    sendJsonResponse(400, ['error' => 'Invalid poller id']);
+}
+
+$userId = (int) $centreon->user->user_id;
+$isAdmin = (bool) $centreon->user->admin;
+
+if ($isAdmin === false) {
+    $acl = new CentreonACL($userId, $isAdmin);
+    if (
+        ! $acl->checkAction('create_edit_poller_cfg')
+        || ! array_key_exists($pollerId, $acl->getPollers())
+    ) {
+        sendJsonResponse(403, ['error' => 'Access denied']);
+    }
+}
+
+try {
+    $poller = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT ns.uid, ns.name, ns.poller_type, pt.central_address
+            FROM nagios_server ns
+            LEFT JOIN platform_topology pt ON pt.server_id = ns.id
+            WHERE ns.id = :id
+            SQL,
+        QueryParameters::create([QueryParameter::int('id', $pollerId)]),
+    );
+
+    if ($poller === false) {
+        sendJsonResponse(404, ['error' => 'Poller not found']);
+    }
+
+    $pollerUid = new PollerUid((int) $poller['uid']);
+    $pollerType = PollerTypeEnum::from($poller['poller_type']);
+    $isCloudPlatform = filter_var(
+        $_ENV['IS_CLOUD_PLATFORM'] ?? $_SERVER['IS_CLOUD_PLATFORM'] ?? getenv('IS_CLOUD_PLATFORM'),
+        FILTER_VALIDATE_BOOLEAN,
+    );
+
+    if ($poller['central_address'] === null || $poller['central_address'] === '') {
+        sendJsonResponse(400, ['error' => 'No central address configured for this poller']);
+    }
+
+    try {
+        // central_address is written by the remote-server wizard without format validation;
+        // PollerAddress enforces the same IP-or-hostname invariant as the API endpoint,
+        // so no value able to alter the generated shell command can get through.
+        $centralAddress = new PollerAddress($poller['central_address']);
+    } catch (InvalidArgumentException) {
+        sendJsonResponse(400, ['error' => 'Invalid central address configured for this poller']);
+    }
+
+    // Mirrors DbalPollerTokenRepository::getFirstValidPollerToken(): oldest valid token first,
+    // deliberately. Keep both in sync — this endpoint and
+    // GET /configuration/pollers/installation-command/{id} must return the same command.
+    $tokenRow = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT token_string, token_name, creation_date, expiration_date, is_revoked
+            FROM authentication_tokens
+            WHERE type = 'poller'
+            AND is_revoked = 0
+            AND (expiration_date IS NULL OR expiration_date > :nowEpoch)
+            ORDER BY creation_date ASC
+            LIMIT 1
+            SQL,
+        QueryParameters::create([QueryParameter::int('nowEpoch', time())]),
+    );
+
+    if ($tokenRow === false) {
+        sendJsonResponse(404, ['error' => 'No valid poller token found']);
+    }
+
+    $token = new PollerToken(
+        name: $tokenRow['token_name'],
+        value: $tokenRow['token_string'],
+        creationDate: new DateTimeImmutable('@' . (int) $tokenRow['creation_date']),
+        expirationDate: $tokenRow['expiration_date'] !== null
+            ? new DateTimeImmutable('@' . (int) $tokenRow['expiration_date'])
+            : null,
+        isRevoked: (bool) $tokenRow['is_revoked'],
+    );
+
+    $engineSecrets = new FsEngineSecretsRepository(ENGINE_CONTEXT_PATH);
+
+    $factory = new PollerInstallationCommandFactory(
+        pollerUid: $pollerUid,
+        pollerName: new PollerName($poller['name']),
+        pollerType: $pollerType,
+        pollerToken: $token,
+        appSecret: $engineSecrets->getAppSecret(),
+        salt: $engineSecrets->getSalt(),
+        isCloudPlatform: $isCloudPlatform,
+        centralUrl: $centralAddress->value,
+    );
+
+    sendJsonResponse(200, ['command' => $factory->generate()]);
+} catch (Throwable $exception) {
+    Logger::create(LogChannelEnum::WEB)->error(
+        'Failed to generate poller installation command',
+        ['poller_id' => $pollerId, 'exception' => $exception],
+    );
+    sendJsonResponse(500, ['error' => 'Failed to generate installation command']);
+}

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -148,6 +148,12 @@
                     <img src="./img/icons/show_template.png" class="ico-16" style="cursor: pointer" title="Gorgone configuration">
                 </span>
                 {/if}
+
+                {if $can_create_edit == 1 && $elemArr[elem].RowMenu_isPoller && $elemArr[elem].RowMenu_statusVal == 1 && !$isRemote}
+                <span {literal}onclick="copyInstallCommand('{/literal}{$elemArr[elem].RowMenu_server_id}{literal}', this){/literal}">
+                    <img src="./img/icons/content_copy.png" class="ico-16" style="cursor: pointer" title="{t}Copy installation command{/t}">
+                </span>
+                {/if}
             </td>
             <td class="ListColRight">{if $can_create_edit == 1 && !$isRemote }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
         </tr>
@@ -167,6 +173,83 @@
 </form>
 {literal}
 <script type='text/javascript'>
+    // Copy through a temporary textarea + execCommand('copy'). Used when
+    // navigator.clipboard is unavailable (non-secure context: plain HTTP) or rejects
+    // (document not focused, permission denied).
+    function legacyCopyToClipboard(text) {
+        return new Promise(function(resolve, reject) {
+            var textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            textarea.style.opacity = '0';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                // execCommand can throw (SecurityError); the finally block guarantees the
+                // textarea holding the token and secrets never outlives the attempt.
+                var succeeded = document.execCommand('copy');
+                if (succeeded) {
+                    resolve();
+                } else {
+                    reject(new Error('execCommand copy failed'));
+                }
+            } finally {
+                textarea.value = '';
+                document.body.removeChild(textarea);
+            }
+        });
+    }
+
+    function writeToClipboard(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            return navigator.clipboard.writeText(text).catch(function() {
+                return legacyCopyToClipboard(text);
+            });
+        }
+
+        return legacyCopyToClipboard(text);
+    }
+
+    function copyInstallCommand(id, element) {
+        var url = './include/configuration/configServers/copyInstallCommand.php?id=' + id;
+        jQuery.ajax({
+            url: url,
+            type: 'GET',
+            dataType: 'json',
+            success: function(data) {
+                if (!data.command) {
+                    console.error('Installation command response is empty', data);
+                    clToast('Could not retrieve the installation command', 'error');
+                    return;
+                }
+                writeToClipboard(data.command).then(function() {
+                    var img = jQuery(element).find('img');
+                    // Capture the copy icon once: on quick successive clicks the live
+                    // src may already be the check mark, and the stale restore timer
+                    // would otherwise leave the check mark on screen permanently.
+                    if (!img.data('originalSrc')) {
+                        img.data('originalSrc', img.attr('src'));
+                    }
+                    img.attr('src', './img/icons/checked.png');
+                    clearTimeout(img.data('restoreTimer'));
+                    img.data('restoreTimer', setTimeout(function() {
+                        img.attr('src', img.data('originalSrc'));
+                    }, 1500));
+                }).catch(function(error) {
+                    console.error('Failed to copy installation command to clipboard', error);
+                    clToast('Could not copy the installation command to the clipboard', 'error');
+                });
+            },
+            error: function(xhr) {
+                var message = (xhr.responseJSON && xhr.responseJSON.error)
+                    ? xhr.responseJSON.error
+                    : 'Could not retrieve the installation command';
+                console.error('Failed to fetch installation command', message);
+                clToast(message, 'error');
+            }
+        });
+    }
+
     function displayPopup(id) {
         let popin = jQuery(
             '<div id="config-popin">' +
@@ -182,7 +265,7 @@
             ajaxType: 'GET',
             ajaxDataType: 'html'
         });
-    };
+    }
 
     setDisabledRowStyle();
     //formatting the tags containing a class isTimestamp

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -212,10 +212,9 @@ foreach ($servers as $config) {
         && $nagiosInfo[$runtimeKey]['last_alive'])
         ? $nagiosInfo[$runtimeKey]['last_alive']
         : '-';
+    $isRemoteServer = in_array($config['ns_ip_address'], $remotesServerIPs);
     $serverType = $config['localhost'] ? _('Central') : _('Poller');
-    $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
-        ? _('Remote Server')
-        : $serverType;
+    $serverType = $isRemoteServer ? _('Remote Server') : $serverType;
 
     if (
         isset($nagiosInfo[$runtimeKey]['is_currently_running'])
@@ -257,6 +256,7 @@ foreach ($servers as $config) {
         'RowMenu_gorgone_protocol' => $config['gorgone_communication_type'],
         'RowMenu_link' => $serverLink,
         'RowMenu_type' => $serverType,
+        'RowMenu_isPoller' => ! $config['localhost'] && ! $isRemoteServer,
         'RowMenu_is_running' => $isRunning ? _('Yes') : _('No'),
         'RowMenu_is_runningFlag' => $nagiosInfo[$runtimeKey]['is_currently_running'],
         'RowMenu_is_default' => $config['is_default'] ? _('Yes') : _('No'),


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the copy-installation-command icon in the legacy poller listing (Configuration > Pollers). The icon fetches the poller installation command through a dedicated AJAX endpoint and copies it to the clipboard.

The endpoint reuses the App domain value objects and `PollerInstallationCommandFactory` directly (no Symfony kernel boot), which required refactoring the factory to accept value objects, with a `fromPoller()` named constructor kept for App callers. Access requires the `create_edit_poller_cfg` ACL action, matching the API endpoint's voter.

Original PR (develop): https://github.com/centreon/centreon/pull/11273

**Fixes** [MON-206870](https://centreon.atlassian.net/browse/MON-206870)

### Conflicts resolved during the cherry-pick

- `lang/fr_FR.UTF-8/LC_MESSAGES/messages.po`: `develop` carries a trailing block of translations absent from `dev-26.10.x`; only the 4 lines belonging to this commit were applied.
- `GetInstallationCommandProvider.php`: the `centralAddress` guard present on `develop` comes from another commit and does not exist on `dev-26.10.x`; only the `new PollerInstallationCommandFactory(...)` → `PollerInstallationCommandFactory::fromPoller(...)` change was applied, keeping `dev-26.10.x` behaviour unchanged.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.10.x
- [ ] master

## How this pull request can be tested ?

1. Go to Configuration > Pollers with an admin user: each enabled poller row (not the Central, not a Remote Server) shows a copy icon in the Actions column.
2. Click the icon: the full installation command (`curl ... install.sh ... --poller_token ... --uid ...`) is copied to the clipboard and the icon briefly turns into a check mark.
3. Compare with `GET /configuration/pollers/installation-command/{id}`: the command must be identical.
4. With a poller that has no `central_address` in `platform_topology`: the click logs an error in the browser console (400, no crash).
5. With a non-admin user whose access group lacks the `create_edit_poller_cfg` action: the icon is not displayed, and calling `copyInstallCommand.php?id=X` directly returns 403.
6. Disabled pollers, the Central and Remote Servers rows must not show the icon.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).


[MON-206870]: https://centreon.atlassian.net/browse/MON-206870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ