### PR TITLE
test(e2e): web: start mariadb with systemd during platform update tests (release-25.10-next)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -212,8 +212,8 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        `sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql`,
-        'service mysql start',
+        // upstream MariaDB packages only ship /etc/init.d/mariadb
+        'systemctl start mariadb',
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -392,9 +392,10 @@ const updatePlatformPackages = (): Cypress.Chainable => {
 };
 
 const checkPlatformVersion = (platformVersion: string): Cypress.Chainable => {
+  // stderr is merged into the output, drop the apt CLI stability warning
   const command = Cypress.env('WEB_IMAGE_OS').includes('alma')
     ? `rpm -qa | grep centreon-web | cut -d '-' -f3 | tr -d '\n'`
-    : `apt list --installed centreon-web | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
+    : `apt list --installed centreon-web 2>/dev/null | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
 
   return cy
     .execInContainer({


### PR DESCRIPTION
**CI validation only — not meant to be merged as is.** The ticket reference will be added later, on the real backport PR, to avoid creating a misleading link from this throwaway branch.

## Purpose

Check on `release-25.10-next` whether `Platform-upgrade-update/01-platform-update.feature` gets past its first step (`Given a running platform in '<version>' version`) on bookworm, where it currently aborts with:

```
Execution of "sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql" failed
Exit code: 2
sed: can't read /etc/init.d/mysql: No such file or directory
```

The database these features use is installed **inside the `web` container** by `installDatabase()`: MariaDB from the upstream `dlm.mariadb.com` repository. Those packages only ship `/etc/init.d/mariadb` — their postinst recreates `/etc/init.d/mysql` only when it already exists — so on a fresh install both the `sed` and the following `service mysql start` are broken. This change starts the service through systemd instead, exactly as the Alma branch already does.

## Expected outcome

* The `first minor` example should now proceed past the database step.
* Two examples (`penultimate stable`, `antepenultimate stable`) are expected to **stay red for an unrelated reason**: the test pins `centreon-perl-libs` to the `centreon-web` version, but that package is only published up to 25.10.8 while `centreon-web` goes up to 25.10.16 (`E: Version '25.10.15-*+deb12u1' for 'centreon-perl-libs' was not found`). That one needs its own decision and is not addressed here.
