### PR TITLE
test(e2e): web: start mariadb with systemd during platform update tests (release-24.10-next)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -384,9 +384,10 @@ const updatePlatformPackages = (): Cypress.Chainable => {
 };
 
 const checkPlatformVersion = (platformVersion: string): Cypress.Chainable => {
+  // stderr is merged into the output, drop the apt CLI stability warning
   const command = Cypress.env('WEB_IMAGE_OS').includes('alma')
     ? `rpm -qa | grep centreon-web | cut -d '-' -f3 | tr -d '\n'`
-    : `apt list --installed centreon-web | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
+    : `apt list --installed centreon-web 2>/dev/null | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
 
   return cy
     .execInContainer({

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -197,8 +197,8 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        `sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql`,
-        'service mysql start',
+        // upstream MariaDB packages only ship /etc/init.d/mariadb
+        'systemctl start mariadb',
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',


### PR DESCRIPTION
**CI validation only — not meant to be merged as is.** The ticket reference will be added later, on the real backport PR, to avoid creating a misleading link from this throwaway branch.

## Purpose

Check on `release-24.10-next` whether `Platform-upgrade-update/01-platform-update.feature` passes on bookworm. Every example currently aborts on the first step (`Given a running platform in '<version>' version`) with:

```
Execution of "sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql" failed
Exit code: 2
sed: can't read /etc/init.d/mysql: No such file or directory
```

The database these features use is installed **inside the `web` container** by `installDatabase()`: MariaDB from the upstream `dlm.mariadb.com` repository. Those packages only ship `/etc/init.d/mariadb` — their postinst recreates `/etc/init.d/mysql` only when it already exists — so on a fresh install both the `sed` and the following `service mysql start` are broken. This change starts the service through systemd instead, exactly as the Alma branch already does.

## Expected outcome

All examples should now get past the database step. Unlike the 25.10 series, this one has no package-pinning issue: `centreon-perl-libs` is published for every 24.10 version, just like `centreon-web`.
