### PR TITLE
fix(poller): keep freshest instance row and clean up stale legacy rows after 26.07 upgrade

### DIFF
--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -709,7 +709,7 @@ class CentreonTopCounter extends CentreonWebService
         while ($row = $res->fetch()) {
             $pollerId = $uidToId[$row['instance_id']];
             // Only trust the latency of the freshest instances row so a stale legacy
-            // row cannot raise a false latency alert (MON-206900).
+            // row cannot raise a false latency alert.
             if (
                 ! isset($freshestByPoller[$pollerId])
                 || $row['instance_id'] != $freshestByPoller[$pollerId]['instance_id']

--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -664,7 +664,7 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         // Keep the freshest instances row per poller so a stale legacy row cannot
-        // override the fresh Snowflake-uid one after a 26.07 upgrade (MON-206900).
+        // override the fresh Snowflake-uid one after a 26.07 upgrade.
         $freshestByPoller = [];
         while ($row = $res->fetch()) {
             $pollerId = $uidToId[$row['instance_id']];

--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -692,7 +692,7 @@ class CentreonTopCounter extends CentreonWebService
             }
         }
         // Get latency
-        $query = 'SELECT 1 AS REALTIME, n.stat_value, i.instance_id, i.last_alive
+        $query = 'SELECT 1 AS REALTIME, n.stat_value, i.instance_id
             FROM nagios_stats n, instances i
             WHERE n.stat_label = "Service Check Latency"
                 AND n.stat_key = "Average"
@@ -706,19 +706,16 @@ class CentreonTopCounter extends CentreonWebService
             throw new RestInternalServerErrorException($e);
         }
 
-        // Same freshest-row protection as above (MON-206900).
-        $freshestLatencyByPoller = [];
         while ($row = $res->fetch()) {
             $pollerId = $uidToId[$row['instance_id']];
+            // Only trust the latency of the freshest instances row so a stale legacy
+            // row cannot raise a false latency alert (MON-206900).
             if (
-                ! isset($freshestLatencyByPoller[$pollerId])
-                || (int) $row['last_alive'] > (int) $freshestLatencyByPoller[$pollerId]['last_alive']
+                ! isset($freshestByPoller[$pollerId])
+                || $row['instance_id'] != $freshestByPoller[$pollerId]['instance_id']
             ) {
-                $freshestLatencyByPoller[$pollerId] = $row;
+                continue;
             }
-        }
-
-        foreach ($freshestLatencyByPoller as $pollerId => $row) {
             if ($row['stat_value'] >= 120) {
                 $listPoller[$pollerId]['latency']['state'] = 2;
                 $listPoller[$pollerId]['latency']['time'] = $row['stat_value'];

--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -663,8 +663,20 @@ class CentreonTopCounter extends CentreonWebService
             throw new RestInternalServerErrorException($e);
         }
 
+        // Keep the freshest instances row per poller so a stale legacy row cannot
+        // override the fresh Snowflake-uid one after a 26.07 upgrade (MON-206900).
+        $freshestByPoller = [];
         while ($row = $res->fetch()) {
             $pollerId = $uidToId[$row['instance_id']];
+            if (
+                ! isset($freshestByPoller[$pollerId])
+                || (int) $row['last_alive'] > (int) $freshestByPoller[$pollerId]['last_alive']
+            ) {
+                $freshestByPoller[$pollerId] = $row;
+            }
+        }
+
+        foreach ($freshestByPoller as $pollerId => $row) {
             // Test if poller running and activity
             if (time() - $row['last_alive'] >= $this->timeUnit * 10) {
                 $listPoller[$pollerId]['stability'] = 2;
@@ -680,7 +692,7 @@ class CentreonTopCounter extends CentreonWebService
             }
         }
         // Get latency
-        $query = 'SELECT 1 AS REALTIME, n.stat_value, i.instance_id
+        $query = 'SELECT 1 AS REALTIME, n.stat_value, i.instance_id, i.last_alive
             FROM nagios_stats n, instances i
             WHERE n.stat_label = "Service Check Latency"
                 AND n.stat_key = "Average"
@@ -694,8 +706,19 @@ class CentreonTopCounter extends CentreonWebService
             throw new RestInternalServerErrorException($e);
         }
 
+        // Same freshest-row protection as above (MON-206900).
+        $freshestLatencyByPoller = [];
         while ($row = $res->fetch()) {
             $pollerId = $uidToId[$row['instance_id']];
+            if (
+                ! isset($freshestLatencyByPoller[$pollerId])
+                || (int) $row['last_alive'] > (int) $freshestLatencyByPoller[$pollerId]['last_alive']
+            ) {
+                $freshestLatencyByPoller[$pollerId] = $row;
+            }
+        }
+
+        foreach ($freshestLatencyByPoller as $pollerId => $row) {
             if ($row['stat_value'] >= 120) {
                 $listPoller[$pollerId]['latency']['state'] = 2;
                 $listPoller[$pollerId]['latency']['time'] = $row['stat_value'];

--- a/centreon/www/install/php/Update-26.07.1.php
+++ b/centreon/www/install/php/Update-26.07.1.php
@@ -39,7 +39,7 @@ $errorMessage = '';
  * Soft-delete stale legacy centreon_storage.instances rows (deleted = 0, frozen last_alive)
  * left after the 26.07 Snowflake UID migration, which make the poller "database updates"
  * indicator turn red. Only when the fresh uid row is strictly newer, so it is safe and
- * idempotent for platforms already upgraded (MON-206900).
+ * idempotent for platforms already upgraded.
  */
 $softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMessage, $version): void {
     $errorMessage = 'Unable to fetch pollers for the stale instances cleanup';

--- a/centreon/www/install/php/Update-26.07.1.php
+++ b/centreon/www/install/php/Update-26.07.1.php
@@ -68,7 +68,7 @@ $softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMes
         // Atomic soft-delete: remove the legacy row only when a live UID row is strictly
         // newer, evaluated at write time so a legacy heartbeat between check and update
         // cannot delete an active row. A downgrade (active legacy, stale UID) and a
-        // poller with no fresh UID row both yield a zero-row update (MON-206900).
+        // poller with no fresh UID row both yield a zero-row update.
         $errorMessage = "Unable to soft-delete the stale legacy instances row for poller id={$legacyId}";
         $softDeleted += $pearDBO->update(
             <<<'SQL'

--- a/centreon/www/install/php/Update-26.07.1.php
+++ b/centreon/www/install/php/Update-26.07.1.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ConnectionInterface;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\LoggerUpgrade;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+$version = '26.07.1';
+
+$errorMessage = '';
+
+/**
+ * @var ConnectionInterface $pearDB
+ * @var ConnectionInterface $pearDBO
+ */
+
+/**
+ * Soft-delete stale legacy centreon_storage.instances rows (deleted = 0, frozen last_alive)
+ * left after the 26.07 Snowflake UID migration, which make the poller "database updates"
+ * indicator turn red. Only when the fresh uid row is strictly newer, so it is safe and
+ * idempotent for platforms already upgraded (MON-206900).
+ */
+$softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to fetch pollers for the stale instances cleanup';
+    $pollers = $pearDB->fetchAllAssociative(
+        <<<'SQL'
+            SELECT `id`, `uid`
+            FROM `nagios_server`
+            WHERE `uid` IS NOT NULL AND `uid` <> `id`
+            SQL
+    );
+
+    if ($pollers === []) {
+        LoggerUpgrade::create()->info(
+            $version,
+            'No poller with a distinct Snowflake UID, skipping stale instances cleanup'
+        );
+
+        return;
+    }
+
+    $softDeleted = 0;
+    foreach ($pollers as $poller) {
+        $legacyId = (int) $poller['id'];
+        $uid = (int) $poller['uid'];
+
+        // Atomic soft-delete: remove the legacy row only when a live UID row is strictly
+        // newer, evaluated at write time so a legacy heartbeat between check and update
+        // cannot delete an active row. A downgrade (active legacy, stale UID) and a
+        // poller with no fresh UID row both yield a zero-row update (MON-206900).
+        $errorMessage = "Unable to soft-delete the stale legacy instances row for poller id={$legacyId}";
+        $softDeleted += $pearDBO->update(
+            <<<'SQL'
+                UPDATE `instances` AS legacy
+                INNER JOIN `instances` AS fresh
+                    ON fresh.`instance_id` = :uid AND fresh.`deleted` = 0
+                SET legacy.`deleted` = 1
+                WHERE legacy.`instance_id` = :legacyId
+                    AND legacy.`deleted` = 0
+                    AND fresh.`last_alive` > legacy.`last_alive`
+                SQL,
+            QueryParameters::create([
+                QueryParameter::int('legacyId', $legacyId),
+                QueryParameter::int('uid', $uid),
+            ])
+        );
+    }
+
+    LoggerUpgrade::create()->info(
+        $version,
+        "Stale legacy instances cleanup completed, {$softDeleted} row(s) soft-deleted"
+    );
+};
+
+try {
+    LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
+
+    $softDeleteStaleLegacyInstances();
+
+    LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
+
+} catch (Throwable $throwable) {
+    LoggerUpgrade::create()->stepFailure(
+        $version,
+        'php_script',
+        "UPGRADE - {$version}: {$errorMessage}",
+        $throwable
+    );
+
+    throw new RuntimeException(
+        message: "UPGRADE - {$version}: " . $errorMessage,
+        previous: $throwable
+    );
+}

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -240,46 +240,24 @@ $softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMes
         $legacyId = (int) $poller['id'];
         $uid = (int) $poller['uid'];
 
-        // Soft-delete the legacy row only when the UID row is strictly newer, so an
-        // active legacy row is never removed (e.g. a 26.07 -> legacy downgrade keeps a
-        // stale UID row alive) and a poller never loses its only live row (MON-206900).
-        $errorMessage = "Unable to read the instances last_alive for poller id={$legacyId}";
-        $uidLastAlive = $pearDBO->fetchOne(
-            <<<'SQL'
-                SELECT `last_alive`
-                FROM `instances`
-                WHERE `instance_id` = :uid AND `deleted` = 0
-                SQL,
-            QueryParameters::create([QueryParameter::int('uid', $uid)])
-        );
-        $legacyLastAlive = $pearDBO->fetchOne(
-            <<<'SQL'
-                SELECT `last_alive`
-                FROM `instances`
-                WHERE `instance_id` = :legacyId AND `deleted` = 0
-                SQL,
-            QueryParameters::create([QueryParameter::int('legacyId', $legacyId)])
-        );
-
-        if ($uidLastAlive === false || $uidLastAlive === null) {
-            continue;
-        }
-        if ($legacyLastAlive === false || $legacyLastAlive === null) {
-            continue;
-        }
-        if ((int) $uidLastAlive <= (int) $legacyLastAlive) {
-            continue;
-        }
-
+        // Atomic soft-delete: remove the legacy row only when a live UID row is strictly
+        // newer, evaluated at write time so a legacy heartbeat between check and update
+        // cannot delete an active row. A downgrade (active legacy, stale UID) and a
+        // poller with no fresh UID row both yield a zero-row update (MON-206900).
         $errorMessage = "Unable to soft-delete the stale legacy instances row for poller id={$legacyId}";
         $softDeleted += $pearDBO->update(
             <<<'SQL'
-                UPDATE `instances`
-                SET `deleted` = 1
-                WHERE `instance_id` = :legacyId AND `deleted` = 0
+                UPDATE `instances` AS legacy
+                INNER JOIN `instances` AS fresh
+                    ON fresh.`instance_id` = :uid AND fresh.`deleted` = 0
+                SET legacy.`deleted` = 1
+                WHERE legacy.`instance_id` = :legacyId
+                    AND legacy.`deleted` = 0
+                    AND fresh.`last_alive` > legacy.`last_alive`
                 SQL,
             QueryParameters::create([
                 QueryParameter::int('legacyId', $legacyId),
+                QueryParameter::int('uid', $uid),
             ])
         );
     }

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -211,63 +211,6 @@ $populateCentralAddress = function () use ($pearDB, &$errorMessage, $version, $r
     LoggerUpgrade::create()->info($version, 'Successfully populated central_address for all platforms');
 };
 
-/**
- * Soft-delete stale legacy centreon_storage.instances rows (deleted = 0, frozen last_alive)
- * left after the 26.07 Snowflake UID migration, which make the poller "database updates"
- * indicator turn red. Only when the fresh uid row exists, so it is safe and idempotent (MON-206900).
- */
-$softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMessage, $version): void {
-    $errorMessage = 'Unable to fetch pollers for the stale instances cleanup';
-    $pollers = $pearDB->fetchAllAssociative(
-        <<<'SQL'
-            SELECT `id`, `uid`
-            FROM `nagios_server`
-            WHERE `uid` IS NOT NULL AND `uid` <> `id`
-            SQL
-    );
-
-    if ($pollers === []) {
-        LoggerUpgrade::create()->info(
-            $version,
-            'No poller with a distinct Snowflake UID, skipping stale instances cleanup'
-        );
-
-        return;
-    }
-
-    $softDeleted = 0;
-    foreach ($pollers as $poller) {
-        $legacyId = (int) $poller['id'];
-        $uid = (int) $poller['uid'];
-
-        // Atomic soft-delete: remove the legacy row only when a live UID row is strictly
-        // newer, evaluated at write time so a legacy heartbeat between check and update
-        // cannot delete an active row. A downgrade (active legacy, stale UID) and a
-        // poller with no fresh UID row both yield a zero-row update (MON-206900).
-        $errorMessage = "Unable to soft-delete the stale legacy instances row for poller id={$legacyId}";
-        $softDeleted += $pearDBO->update(
-            <<<'SQL'
-                UPDATE `instances` AS legacy
-                INNER JOIN `instances` AS fresh
-                    ON fresh.`instance_id` = :uid AND fresh.`deleted` = 0
-                SET legacy.`deleted` = 1
-                WHERE legacy.`instance_id` = :legacyId
-                    AND legacy.`deleted` = 0
-                    AND fresh.`last_alive` > legacy.`last_alive`
-                SQL,
-            QueryParameters::create([
-                QueryParameter::int('legacyId', $legacyId),
-                QueryParameter::int('uid', $uid),
-            ])
-        );
-    }
-
-    LoggerUpgrade::create()->info(
-        $version,
-        "Stale legacy instances cleanup completed, {$softDeleted} row(s) soft-deleted"
-    );
-};
-
 try {
     LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
 
@@ -282,9 +225,6 @@ try {
 
     $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();
-
-    // Realtime (centreon_storage) cleanup, run outside the configuration DB transaction.
-    $softDeleteStaleLegacyInstances();
 
     LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -240,20 +240,34 @@ $softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMes
         $legacyId = (int) $poller['id'];
         $uid = (int) $poller['uid'];
 
-        // Only when the fresh UID row is live, so we never remove a poller's only row.
-        $errorMessage = "Unable to check the fresh instances row for poller id={$legacyId}";
-        $freshRowExists = $pearDBO->fetchOne(
+        // Soft-delete the legacy row only when the UID row is strictly newer, so an
+        // active legacy row is never removed (e.g. a 26.07 -> legacy downgrade keeps a
+        // stale UID row alive) and a poller never loses its only live row (MON-206900).
+        $errorMessage = "Unable to read the instances last_alive for poller id={$legacyId}";
+        $uidLastAlive = $pearDBO->fetchOne(
             <<<'SQL'
-                SELECT 1
+                SELECT `last_alive`
                 FROM `instances`
                 WHERE `instance_id` = :uid AND `deleted` = 0
                 SQL,
-            QueryParameters::create([
-                QueryParameter::int('uid', $uid),
-            ])
+            QueryParameters::create([QueryParameter::int('uid', $uid)])
+        );
+        $legacyLastAlive = $pearDBO->fetchOne(
+            <<<'SQL'
+                SELECT `last_alive`
+                FROM `instances`
+                WHERE `instance_id` = :legacyId AND `deleted` = 0
+                SQL,
+            QueryParameters::create([QueryParameter::int('legacyId', $legacyId)])
         );
 
-        if (! $freshRowExists) {
+        if ($uidLastAlive === false || $uidLastAlive === null) {
+            continue;
+        }
+        if ($legacyLastAlive === false || $legacyLastAlive === null) {
+            continue;
+        }
+        if ((int) $uidLastAlive <= (int) $legacyLastAlive) {
             continue;
         }
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -211,6 +211,71 @@ $populateCentralAddress = function () use ($pearDB, &$errorMessage, $version, $r
     LoggerUpgrade::create()->info($version, 'Successfully populated central_address for all platforms');
 };
 
+/**
+ * Soft-delete stale legacy centreon_storage.instances rows (deleted = 0, frozen last_alive)
+ * left after the 26.07 Snowflake UID migration, which make the poller "database updates"
+ * indicator turn red. Only when the fresh uid row exists, so it is safe and idempotent (MON-206900).
+ */
+$softDeleteStaleLegacyInstances = function () use ($pearDB, $pearDBO, &$errorMessage, $version): void {
+    $errorMessage = 'Unable to fetch pollers for the stale instances cleanup';
+    $pollers = $pearDB->fetchAllAssociative(
+        <<<'SQL'
+            SELECT `id`, `uid`
+            FROM `nagios_server`
+            WHERE `uid` IS NOT NULL AND `uid` <> `id`
+            SQL
+    );
+
+    if ($pollers === []) {
+        LoggerUpgrade::create()->info(
+            $version,
+            'No poller with a distinct Snowflake UID, skipping stale instances cleanup'
+        );
+
+        return;
+    }
+
+    $softDeleted = 0;
+    foreach ($pollers as $poller) {
+        $legacyId = (int) $poller['id'];
+        $uid = (int) $poller['uid'];
+
+        // Only when the fresh UID row is live, so we never remove a poller's only row.
+        $errorMessage = "Unable to check the fresh instances row for poller id={$legacyId}";
+        $freshRowExists = $pearDBO->fetchOne(
+            <<<'SQL'
+                SELECT 1
+                FROM `instances`
+                WHERE `instance_id` = :uid AND `deleted` = 0
+                SQL,
+            QueryParameters::create([
+                QueryParameter::int('uid', $uid),
+            ])
+        );
+
+        if (! $freshRowExists) {
+            continue;
+        }
+
+        $errorMessage = "Unable to soft-delete the stale legacy instances row for poller id={$legacyId}";
+        $softDeleted += $pearDBO->update(
+            <<<'SQL'
+                UPDATE `instances`
+                SET `deleted` = 1
+                WHERE `instance_id` = :legacyId AND `deleted` = 0
+                SQL,
+            QueryParameters::create([
+                QueryParameter::int('legacyId', $legacyId),
+            ])
+        );
+    }
+
+    LoggerUpgrade::create()->info(
+        $version,
+        "Stale legacy instances cleanup completed, {$softDeleted} row(s) soft-deleted"
+    );
+};
+
 try {
     LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
 
@@ -225,6 +290,9 @@ try {
 
     $errorMessage = 'Unable to commit the configuration database transaction';
     $pearDB->commitTransaction();
+
+    // Realtime (centreon_storage) cleanup, run outside the configuration DB transaction.
+    $softDeleteStaleLegacyInstances();
 
     LoggerUpgrade::create()->info($version, "Upgrade script for version {$version} completed");
 


### PR DESCRIPTION
## Ticket

https://centreon.atlassian.net/browse/MON-206900

## Problem

After upgrading a platform to 26.07, the Pollers top-counter shows a red **"Database updates are not active"** icon even though the poller is running fine. This affects all upgraded platforms and has been reported as a blocker by several customers.

26.07 replaced the poller identifier with a Snowflake UID. After the upgrade, Broker registers the poller under its new UID and inserts a fresh row in `centreon_storage.instances`, but the old legacy row (keyed by the legacy id) is left behind with `deleted = 0` and a frozen `last_alive`. Since the top counter also matches pollers by legacy id, the stale row overrides the fresh one and the indicator turns red.

## Changes

**1. Harden the top-counter legacy fallback** — `centreon_topcounter.class.php`

`pollersStatusList()` previously processed *every* matching `instances` row and only ever escalated the state, so a stale legacy row's frozen `last_alive` made the indicator sticky-red and the fresh row could not clear it. It now collapses to the **freshest row per poller** (max `last_alive`) before computing state, for both the database and latency indicators. Genuine outages are still reported.

**2. Idempotent cleanup for upgraded platforms** — `Update-next.php`

New `$softDeleteStaleLegacyInstances` step soft-deletes stale legacy `centreon_storage.instances` rows, but **only** when the fresh UID row exists — so it is safe (never removes a poller's only live row) and idempotent for platforms already upgraded.

## Tests

Verified on a 26.09-dev CDE with an injected stale legacy row:

| Scenario | Result |
|---|---|
| Buggy code + stale row | indicator RED (repro) |
| Fixed code + stale row still present | GREEN |
| Fixed code, genuine outage (fresh row also stale) | RED |
| Migration run 1 | stale legacy row soft-deleted, fresh row untouched |
| Migration run 2 | 0 rows (idempotent) |
| Poller with no live fresh row | legacy row kept (skipped) |
