### PR TITLE
test(e2e): web: start mariadb with systemd during platform update tests (dev-24.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -197,8 +197,8 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        `sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql`,
-        'service mysql start',
+        // upstream MariaDB packages only ship /etc/init.d/mariadb
+        'systemctl start mariadb',
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',
@@ -384,9 +384,10 @@ const updatePlatformPackages = (): Cypress.Chainable => {
 };
 
 const checkPlatformVersion = (platformVersion: string): Cypress.Chainable => {
+  // stderr is merged into the output, drop the apt CLI stability warning
   const command = Cypress.env('WEB_IMAGE_OS').includes('alma')
     ? `rpm -qa | grep centreon-web | cut -d '-' -f3 | tr -d '\n'`
-    : `apt list --installed centreon-web | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
+    : `apt list --installed centreon-web 2>/dev/null | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
 
   return cy
     .execInContainer({


### PR DESCRIPTION
Fixes: [MON-206999](https://centreon.atlassian.net/browse/MON-206999)

Backport of #11333.

## Description

`Platform-upgrade-update/*.feature` failed on every Debian target because the test patched `/etc/init.d/mysql` before starting the database: upstream MariaDB packages only ship `/etc/init.d/mariadb`, and their postinst recreates the `mysql` script only when it already exists, so on a fresh install both that `sed` and the following `service mysql start` were broken. The service is now started through systemd, as the Alma branch already does.

The second hunk fixes the check that immediately followed: `execInContainer` merges stderr into the output, so the "apt does not have a stable CLI interface" warning landed in the parsed version and the platform version check failed while the installed version was correct.

## Validation

Verified on bookworm through the draft PRs opened on the release branches, which carry the same change:

* `release-24.10-next` (#11336): `01-platform-update` and `02-platform-upgrade` both pass on `bookworm-mysql:8.4`.
* `release-25.10-next` (#11335): `02-platform-upgrade` passes, `01-platform-update` reaches 3 passing tests. Its two remaining failures are unrelated to this change — the test pins `centreon-perl-libs` to the `centreon-web` version, and that package is only published up to 25.10.8.

`Resources-status/07-csv-export.feature` remains red on bookworm; it is a pre-existing failure, identical on the `dev-24.10.x` and `dev-25.10.x` nightly runs that actually played bookworm, and out of scope here.


[MON-206999]: https://centreon.atlassian.net/browse/MON-206999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ