### PR TITLE
fix(ci): xray: scope results-import artifact download per OS to fix flaky import (release-24.10-next)

### DIFF
--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -372,7 +372,7 @@ jobs:
       type_test_execution: e2e
       result_format: cucumber
       enrich_tests: true
-      artifact_pattern: "*-xray-reports-*"
+      artifact_pattern: "${{ inputs.name }}-${{ inputs.os }}-${{ needs.cypress-e2e-test-list.outputs.db_id }}-xray-reports*"
     secrets:
       XRAY_CLIENT_ID: ${{ secrets.xray_client_id }}
       XRAY_CLIENT_SECRET: ${{ secrets.xray_client_secret }}


### PR DESCRIPTION
Fixes: [MON-207061](https://centreon.atlassian.net/browse/MON-207061)

Cherry-pick of #11321 on `dev-24.10.x`, itself a backport of #11318 on `develop`.

## Description

The Xray results import downloads artifacts with a **global** pattern (`*-xray-reports-*`) instead of one scoped to its own OS, while each OS's `regroup-artifacts` job concurrently deletes `<name>-<os>-xray-reports-*`. `download-artifact` lists the matching artifacts first, then downloads each by ID, so a deletion happening between the list and the download makes the import crash with `ArtifactNotFoundError`. Scoping the pattern per OS removes the race.

## Why this branch needs it

The fix is already merged on `develop`, `dev-24.10.x`, `dev-25.10.x` and `dev-26.10.x`, but never reached the release branches, so they keep replaying a bug that is fixed everywhere else. On the release pipeline run of this branch, the following jobs failed for exactly this reason:

* `e2e-test alma9 / xray-api-import-results / Import test execution results to Xray`
* `e2e-test alma8 / xray-api-import-results / Import test execution results to Xray`
* `e2e-test alma9 / regroup-artifacts (xray-reports)`
* `e2e-test alma8 / regroup-artifacts (xray-reports)`

No functional test is involved: this only touches the CI artifact plumbing.


[MON-207061]: https://centreon.atlassian.net/browse/MON-207061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ