### PR TITLE
test(e2e): web: stop pinning centreon-perl-libs in platform update tests

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -191,11 +191,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
     }
 
     const packageVersionSuffix = `${version}${packageDistribPrefix}${packageDistribName}`;
+    // centreon-perl-libs is left to apt: it follows the gorgone release cadence
     const packagesToInstall = [
       `centreon-poller='${packageVersionSuffix}'`,
       `centreon-web='${packageVersionSuffix}'`,
-      `centreon-trap='${packageVersionSuffix}'`,
-      `centreon-perl-libs='${packageVersionSuffix}'`
+      `centreon-trap='${packageVersionSuffix}'`
     ];
     if (
       Number(versionMatches[1]) < 24 ||


### PR DESCRIPTION
Fixes: [MON-207063](https://centreon.atlassian.net/browse/MON-207063)

## Description

`Platform-upgrade-update` installs its "version A" platform by pinning the same exact version on four packages. On the 25.10 series that makes apt reject the whole command:

```
E: Version '25.10.15-*+deb12u1' for 'centreon-perl-libs' was not found
```

`centreon-perl-libs` is delivered by the gorgone pipeline, which has its own release cadence. Versions currently published in `apt-standard bookworm-25.10-stable`:

| Package | Latest published |
| --- | --- |
| centreon-gorgone | 25.10.8 |
| centreon-perl-libs | 25.10.8 |
| centreon-perl-libs-common | 25.10.8 |
| centreon-web | 25.10.16 |

There is no publication gap: the two products just stopped sharing numbering. And centreon-web never required equality — only a range:

```
Depends: centreon-perl-libs (>= 25.10~), centreon-perl-libs (<< 26.04~)
```

25.10.8 satisfies it, so a real 25.10.15 platform runs fine with that version. This change removes the pin and lets apt resolve the package through the centreon-web dependency, exactly as it happens on a customer platform. The other three packages stay pinned, so the tested "version A" remains fully controlled.

## Impact

Restores coverage of the update path **from the versions actually deployed at customers**: two of the four scenario examples ("penultimate stable" 25.10.15 and "antepenultimate stable" 25.10.14) currently fail before installing anything, leaving only 25.10.0 to 25.10.2 testable.

The 24.10 series is not affected yet — perl-libs still follows centreon-web there version for version — but the change is harmless on it (apt resolves the same version it installs today) and keeps the file identical across branches for future backports.

Previously masked by #11333: on bookworm the test aborted earlier, when starting the database.


[MON-207063]: https://centreon.atlassian.net/browse/MON-207063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ