### PR TITLE
test(e2e): web: stop pinning centreon-perl-libs in platform update tests (dev-24.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -166,11 +166,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
     });
   } else {
     const packageVersionSuffix = `${version}-1*`;
+    // centreon-perl-libs is left to apt: it follows the gorgone release cadence
     const packagesToInstall = [
       `centreon-poller='${packageVersionSuffix}'`,
       `centreon-web='${packageVersionSuffix}'`,
-      `centreon-trap='${packageVersionSuffix}'`,
-      `centreon-perl-libs='${packageVersionSuffix}'`
+      `centreon-trap='${packageVersionSuffix}'`
     ];
     if (
       Number(versionMatches[1]) < 24 ||


### PR DESCRIPTION
Fixes: [MON-207107](https://centreon.atlassian.net/browse/MON-207107)

Backport of #11348.

## Description

`Platform-upgrade-update` installs its "version A" platform by pinning the same exact version on four packages, which makes apt reject the whole command as soon as one of them is not published under that number:

```
E: Version '25.10.15-*+deb12u1' for 'centreon-perl-libs' was not found
```

`centreon-perl-libs` is delivered by the gorgone pipeline and follows its own release cadence — currently 25.10.8, while `centreon-web` is at 25.10.16. There is no publication gap: the two products simply stopped sharing numbering. And `centreon-web` never required equality, only a range (`>= 25.10~`, `<< 26.04~`), which 25.10.8 satisfies.

This removes the pin and lets apt resolve the package through the `centreon-web` dependency, exactly as on a customer platform. The other three packages stay pinned, so the tested "version A" remains fully controlled.

## Impact

Restores coverage of the update path from the versions actually deployed at customers. On the 24.10 series the failure is not visible yet — perl-libs still follows centreon-web version for version there — but the change is harmless (apt resolves the same version it installs today) and keeps the file identical across branches for future backports.


[MON-207107]: https://centreon.atlassian.net/browse/MON-207107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ