### PR TITLE
test(e2e): web: stop pinning centreon-perl-libs in platform update tests (release-25.10-next)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -190,11 +190,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
     }
 
     const packageVersionSuffix = `${version}${packageDistribPrefix}${packageDistribName}`;
+    // centreon-perl-libs is left to apt: it follows the gorgone release cadence
     const packagesToInstall = [
       `centreon-poller='${packageVersionSuffix}'`,
       `centreon-web='${packageVersionSuffix}'`,
-      `centreon-trap='${packageVersionSuffix}'`,
-      `centreon-perl-libs='${packageVersionSuffix}'`
+      `centreon-trap='${packageVersionSuffix}'`
     ];
     if (Number(versionMatches[1]) < 24) {
       packagesToInstall.push(`centreon-web-apache=${packageVersionSuffix}`);


### PR DESCRIPTION
Fixes: [MON-207109](https://centreon.atlassian.net/browse/MON-207109)

Cherry-pick of #11350 on `dev-25.10.x`, itself a backport of #11348 on `develop`.

## Description

`Platform-upgrade-update` installs its "version A" platform by pinning the same exact version on four packages, which makes apt reject the whole command as soon as one of them is not published under that number:

```
E: Version '25.10.15-*+deb12u1' for 'centreon-perl-libs' was not found
```

`centreon-perl-libs` is delivered by the gorgone pipeline and follows its own release cadence — currently 25.10.8, while `centreon-web` is at 25.10.16. There is no publication gap: the two products simply stopped sharing numbering. And `centreon-web` never required equality, only a range (`>= 25.10~`, `<< 26.04~`), which 25.10.8 satisfies — a real 25.10.15 platform runs fine with that version.

This removes the pin and lets apt resolve the package through the `centreon-web` dependency, exactly as on a customer platform. The other three packages stay pinned, so the tested "version A" remains fully controlled.

## Why this branch needs it

On the release pipeline run of this branch, `bookworm-mysql:8.4 / Platform-upgrade-update/01-platform-update.feature` failed on the "penultimate stable" (25.10.15) and "antepenultimate stable" (25.10.14) examples for exactly this reason, so the update path from the versions currently deployed at customers is not covered.

`Resources-status/07-csv-export.feature` remains red on bookworm; it is a pre-existing failure, identical on the `dev-*` nightly runs that actually played bookworm, and out of scope here.


[MON-207109]: https://centreon.atlassian.net/browse/MON-207109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ