### PR TITLE
test(e2e): web: parse the resource status CSV export with a quote-aware parser

### DIFF
--- a/centreon/tests/e2e/commons.ts
+++ b/centreon/tests/e2e/commons.ts
@@ -61,9 +61,12 @@ const getStatusTypeNumberFromString = (statusType: string): number => {
   throw new Error(`Status type ${statusType} does not exist`);
 };
 
-// Quote-aware CSV parser: the fields exported by the backend are enclosed in
-// double quotes as soon as they hold the delimiter, a quote or a line break, so
-// splitting on the raw delimiter shifts every following column of that record.
+// Splits CSV content into records of unquoted field values, header row first.
+// Enclosures have to be honoured: the exporter wraps in double quotes any field
+// holding the delimiter, a double quote (then doubled) or a line break, so a raw
+// split on the delimiter would cut such a field into several cells and shift
+// every column after it:
+//   Critical;"OK: 5% | cpu=5%;80;90";1/1 (H)   ->   3 fields, not 5
 const parseCsv = (content: string, delimiter = ';'): Array<Array<string>> => {
   const records: Array<Array<string>> = [];
   let fields: Array<string> = [];

--- a/centreon/tests/e2e/commons.ts
+++ b/centreon/tests/e2e/commons.ts
@@ -61,6 +61,53 @@ const getStatusTypeNumberFromString = (statusType: string): number => {
   throw new Error(`Status type ${statusType} does not exist`);
 };
 
+// Quote-aware CSV parser: the fields exported by the backend are enclosed in
+// double quotes as soon as they hold the delimiter, a quote or a line break, so
+// splitting on the raw delimiter shifts every following column of that record.
+const parseCsv = (content: string, delimiter = ';'): Array<Array<string>> => {
+  const records: Array<Array<string>> = [];
+  let fields: Array<string> = [];
+  let field = '';
+  let isQuoted = false;
+  let index = 0;
+
+  while (index < content.length) {
+    const character = content[index];
+    index += 1;
+
+    if (isQuoted) {
+      if (character !== '"') {
+        field += character;
+      } else if (content[index] === '"') {
+        // an escaped quote inside an enclosed field
+        field += '"';
+        index += 1;
+      } else {
+        isQuoted = false;
+      }
+    } else if (character === '"') {
+      isQuoted = true;
+    } else if (character === delimiter) {
+      fields.push(field);
+      field = '';
+    } else if (character === '\n') {
+      fields.push(field);
+      records.push(fields);
+      fields = [];
+      field = '';
+    } else if (character !== '\r') {
+      field += character;
+    }
+  }
+
+  if (field !== '' || fields.length > 0) {
+    fields.push(field);
+    records.push(fields);
+  }
+
+  return records;
+};
+
 interface MonitoredHost {
   name: string;
   output?: string;
@@ -474,6 +521,7 @@ export {
   checkServicesAreMonitored,
   getStatusNumberFromString,
   getStatusTypeNumberFromString,
+  parseCsv,
   submitResultsViaClapi,
   updateFixturesResult,
   apiBase,

--- a/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
@@ -3,7 +3,8 @@ import { INTERCEPTORS } from 'fixtures/shared/constants/interceptors';
 
 import {
   checkMetricsAreMonitored,
-  checkServicesAreMonitored
+  checkServicesAreMonitored,
+  parseCsv
 } from '../../../commons';
 
 const serviceOk = 'service_test_ok';
@@ -66,9 +67,6 @@ const UpdatedColumns = [
 
 const downloadsFolder = Cypress.config('downloadsFolder');
 
-const normalize = (text: string) =>
-  text.trim().replace(/^"|"$/g, '').replace(/\\"/g, '').replace(/"/g, '');
-
 // Host ID / Service ID values are runtime-generated, so instead of comparing
 // them against a static fixture we assert the type-based contract on every row:
 // a host has only Host ID, a service has both identifiers.
@@ -76,9 +74,9 @@ const assertIdentifierContract = (
   rows: Array<Record<string, string>>
 ): void => {
   rows.forEach((row, index) => {
-    const type = (row['Resource Type'] ?? '').replace(/"/g, '');
-    const hostId = (row['Host ID'] ?? '').replace(/"/g, '');
-    const serviceId = (row['Service ID'] ?? '').replace(/"/g, '');
+    const type = row['Resource Type'] ?? '';
+    const hostId = row['Host ID'] ?? '';
+    const serviceId = row['Service ID'] ?? '';
 
     if (type === 'Service') {
       expect(hostId, `Row ${index + 1} (service) Host ID`).to.match(/^\d+$/);
@@ -292,22 +290,15 @@ Then(
   () => {
     cy.task('getExportedFile', { downloadsFolder }).then((filePath) => {
       cy.task('readCsvFile', { filePath }).then((csvContent) => {
-        const rows = (csvContent as string)
-          .trim()
-          .split('\n')
-          .map((row) => row.split(';').map((cell) => cell.trim()));
+        const [headers, ...dataRows] = parseCsv(csvContent as string);
 
-        const rawHeaders = rows[0];
-        const headers = rawHeaders.map(normalize);
-        cy.log('Normalized CSV Headers:', headers.join(' | '));
+        cy.log('CSV Headers:', headers.join(' | '));
         expect(headers).to.deep.equal(AllColumns);
-
-        const dataRows = rows.slice(1);
 
         const rowObjects = dataRows.map((row) =>
           headers.reduce(
             (obj, header, i) => {
-              obj[header.replace(/"/g, '')] = row[i];
+              obj[header] = row[i];
               return obj;
             },
             {} as Record<string, string>
@@ -387,22 +378,15 @@ Then(
   () => {
     cy.task('getExportedFile', { downloadsFolder }).then((filePath) => {
       cy.task('readCsvFile', { filePath }).then((csvContent) => {
-        const rows = (csvContent as string)
-          .trim()
-          .split('\n')
-          .map((row) => row.split(';').map((cell) => cell.trim()));
+        const [headers, ...dataRows] = parseCsv(csvContent as string);
 
-        const rawHeaders = rows[0];
-        const headers = rawHeaders.map(normalize);
-        cy.log('Normalized CSV Headers:', headers.join(' | '));
+        cy.log('CSV Headers:', headers.join(' | '));
         expect(headers).to.deep.equal(UpdatedColumns);
-
-        const dataRows = rows.slice(1);
 
         const rowObjects = dataRows.map((row) =>
           headers.reduce(
             (obj, header, i) => {
-              obj[header.replace(/"/g, '')] = row[i];
+              obj[header] = row[i];
               return obj;
             },
             {} as Record<string, string>

--- a/centreon/tests/e2e/fixtures/resources/csvFIleWithAllPagesAndColumns.json
+++ b/centreon/tests/e2e/fixtures/resources/csvFIleWithAllPagesAndColumns.json
@@ -6,10 +6,10 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Duration": "\"1m 9s\"",
-    "Last Check": "\"1m 9s\"",
+    "Duration": "1m 9s",
+    "Last Check": "1m 9s",
     "Information": "submit_status_2",
-    "Tries": "\"1/1 (H)\"",
+    "Tries": "1/1 (H)",
     "Severity": "",
     "Notes": "",
     "Action": "",
@@ -18,8 +18,8 @@
     "Parent alias": "host1",
     "FQDN / Address": "",
     "Monitoring server": "Central",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -28,10 +28,10 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Duration": "\"1m 9s\"",
-    "Last Check": "\"1m 9s\"",
+    "Duration": "1m 9s",
+    "Last Check": "1m 9s",
     "Information": "submit_status_2",
-    "Tries": "\"1/1 (H)\"",
+    "Tries": "1/1 (H)",
     "Severity": "",
     "Notes": "",
     "Action": "",
@@ -40,8 +40,8 @@
     "Parent alias": "host1",
     "FQDN / Address": "",
     "Monitoring server": "Central",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -50,10 +50,10 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Duration": "\"1m 9s\"",
-    "Last Check": "\"1m 9s\"",
+    "Duration": "1m 9s",
+    "Last Check": "1m 9s",
     "Information": "submit_status_2",
-    "Tries": "\"1/1 (H)\"",
+    "Tries": "1/1 (H)",
     "Severity": "",
     "Notes": "",
     "Action": "",
@@ -62,7 +62,7 @@
     "Parent alias": "host1",
     "FQDN / Address": "",
     "Monitoring server": "Central",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   }
 ]

--- a/centreon/tests/e2e/fixtures/resources/csvFIleWithOnlyVisiblePagesAndColumns.json
+++ b/centreon/tests/e2e/fixtures/resources/csvFIleWithOnlyVisiblePagesAndColumns.json
@@ -6,13 +6,13 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Last Check": "\"1m 27s\"",
+    "Last Check": "1m 27s",
     "Information": "submit_status_2",
     "Notes": "",
     "Action": "",
     "FQDN / Address": "",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -21,13 +21,13 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Last Check": "\"1m 27s\"",
+    "Last Check": "1m 27s",
     "Information": "submit_status_2",
     "Notes": "",
     "Action": "",
     "FQDN / Address": "",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -36,12 +36,12 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Last Check": "\"1m 27s\"",
+    "Last Check": "1m 27s",
     "Information": "submit_status_2",
     "Notes": "",
     "Action": "",
     "FQDN / Address": "",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   }
 ]


### PR DESCRIPTION
Fixes: [MON-207171](https://centreon.atlassian.net/browse/MON-207171)

## What

Test-only fix. The e2e test of the Resource Status CSV export parsed the downloaded file with a naive `String.split`, which cannot survive a quoted field. It now uses a quote-aware parser.

## Why it was failing

The backend emits standards-compliant CSV — `CsvEncoder` with `DELIMITER_KEY => ';'`, `fputcsv($handle, $columnValues, ';')` — so any field containing the delimiter, a quote or a line break is enclosed in double quotes, with inner quotes doubled. The test did:

```ts
const rows = (csvContent as string)
  .trim()
  .split('\n')
  .map((row) => row.split(';').map((cell) => cell.trim()));
```

As soon as one field is legitimately enclosed, `split(';')` shreds it into several cells and `split('\n')` breaks the record into several fake rows. Every column after the offending one shifts, and the assertions land on empty or garbage values — which is why `release-25.10-next` reported `Row 1 (service) Host ID: expected '' to match /^\d+$/` while `release-24.10-next` reported `Line 1 - Key: Parent alias: expected undefined to equal 'host1'`: same cause, different column, because 24.10 has no `Host ID` / `Service ID` columns.

The gap is latent on every branch including develop: a single `;` in the `Information` column — standard plugin perfdata such as `OK: 5.00% | cpu=5.00%;80;90;0;100` — is enough to trigger it.

## Changes

- `tests/e2e/commons.ts` — new `parseCsv(content, delimiter = ';')` helper, an RFC 4180 state machine: enclosed fields, `""` escaped quotes, delimiter and line breaks kept as data inside quotes, CRLF tolerated. Placed in the shared helpers rather than the domain file so any future export test reuses it.
- `07-csv-export/index.ts` — both scenarios consume the parser. The ad hoc de-quoting it makes useless is gone: the `normalize()` helper (whose `.replace(/\\"/g, '')` was dead code — `fputcsv` never emits backslash-quotes — and whose blanket `.replace(/"/g, '')` destroyed legitimate quotes) and the `.replace(/"/g, '')` calls on cells and header keys.
- `fixtures/resources/csvFIleWith*.json` — the two fixtures no longer carry the raw enclosures (`"\"1m 9s\""` → `"1m 9s"`), since values now come out already unquoted.

No product code touched, no assertion added or removed.

## Test done

- Parser exercised against a synthetic payload reproducing the exact failing export: a quoted multi-line cell, a `;`-bearing `Information` value, a doubled `""`, CRLF separators — 22 fields per record and correct `Host ID` / `Service ID` in every case.
- `tsc --noEmit`: clean on the changed files.
- Reviewed on each target branch: the cherry-picks are already prepared and verified for `dev-26.10.x`, `dev-25.10.x`, `dev-24.10.x`, `release-25.10-next` and `release-24.10-next`.

## Notes for review

The failure that surfaced this was triggered by a **separate product bug**, tracked in [MON-207195](https://centreon.atlassian.net/browse/MON-207195): on 25.10 and 24.10 the `State` column contains the whole gettext translation catalog header, because the presenter calls `_()` on a value that is empty in the nominal case. `develop` and `dev-26.10.x` have been guarded since #9940, which is why only the release branches are red. That is out of scope here — this PR only makes the test read a valid CSV correctly. The assertion that keeps the leak visible (no cell may contain `Project-Id-Version`, plus the comparison of the `State` column) belongs to MON-207195 and will land with its fix.


[MON-207171]: https://centreon.atlassian.net/browse/MON-207171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-207195]: https://centreon.atlassian.net/browse/MON-207195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ