### PR TITLE
test(e2e): web: start mariadb with systemd during platform update tests (dev-26.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -223,8 +223,8 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        `sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql`,
-        'service mysql start',
+        // upstream MariaDB packages only ship /etc/init.d/mariadb
+        'systemctl start mariadb',
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',
@@ -412,9 +412,10 @@ const updatePlatformPackages = (): Cypress.Chainable => {
 };
 
 const checkPlatformVersion = (platformVersion: string): Cypress.Chainable => {
+  // stderr is merged into the output, drop the apt CLI stability warning
   const command = Cypress.env('WEB_IMAGE_OS').includes('alma')
     ? `rpm -qa | grep centreon-web | cut -d '-' -f3 | tr -d '\n'`
-    : `apt list --installed centreon-web | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
+    : `apt list --installed centreon-web 2>/dev/null | awk '{ print $2 }' | cut -d '-' -f1 | tr -d '\n'`;
 
   return cy
     .execInContainer({


### PR DESCRIPTION
Fixes: [MON-207202](https://centreon.atlassian.net/browse/MON-207202)

Backport of #11333.

## Description

`Platform-upgrade-update/*.feature` fails on every Debian target because the test patches `/etc/init.d/mysql` before starting the database: upstream MariaDB packages only ship `/etc/init.d/mariadb`, and their postinst recreates the `mysql` script only when it already exists, so on a fresh install both that `sed` and the following `service mysql start` are broken. The service is now started through systemd, as the Alma branch already does.

The second hunk fixes the check that immediately followed: `execInContainer` merges stderr into the output, so the "apt does not have a stable CLI interface" warning landed in the parsed version and the platform version check failed while the installed version was correct.

## Why this branch was missed

The TargetBranches field of [MON-206824](https://centreon.atlassian.net/browse/MON-206824) listed `dev-25.10.x`, `dev-24.10.x` and both `release-*-next`, but not `dev-26.10.x`, so no clone was created for this branch and the backport never happened. Meanwhile `dev-26.10.x` did receive the follow-up fixes ([MON-207110](https://centreon.atlassian.net/browse/MON-207110), unpinning centreon-perl-libs, and the Xray import fix), which left it as the only branch still carrying the original failure.

No functional impact today — this series is at 26.10.0, so the feature skips itself for lack of a published stable version — but the failure would resurface as soon as a minor version is released on it.

## Validation

The same change was validated on bookworm with the full OS/database matrix on the release branches: `01-platform-update` and `02-platform-upgrade` both passed on `bookworm-mysql:8.4` (see #11336 for the 24.10 series).


[MON-207202]: https://centreon.atlassian.net/browse/MON-207202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-206824]: https://centreon.atlassian.net/browse/MON-206824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-207110]: https://centreon.atlassian.net/browse/MON-207110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ