### PR TITLE
test(e2e): web: install update/upgrade DB from the CI matrix (dev-25.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -160,10 +160,15 @@ const installDatabase = (): void => {
       ];
     }
   } else if (isAlma()) {
-    command = [
-      `dnf module enable -y mariadb:${version}`,
-      'dnf install -y mariadb-server mariadb'
-    ];
+    // el10+ dropped DNF modules; MariaDB ships as versioned packages instead.
+    const almaMajor = Number(Cypress.env('WEB_IMAGE_OS').replace('alma', ''));
+    command =
+      almaMajor >= 10
+        ? [`dnf install -y mariadb${version}-server mariadb${version}`]
+        : [
+            `dnf module enable -y mariadb:${version}`,
+            'dnf install -y mariadb-server mariadb'
+          ];
   } else {
     const { osType, osVersion } = getDebianRepoTarget();
     command = [

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -95,33 +95,87 @@ const getCentreonStableMinorVersions = (
   });
 };
 
-const installDatabase = (): void => {
-  if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
-    cy.execInContainer({
-      command: [
-        'dnf module enable -y mariadb:10.11',
-        'dnf install -y mariadb-server mariadb'
-      ],
-      name: 'web'
-    });
-  } else {
-    let osType = 'debian';
-    let osVersion = '12';
-    if (Cypress.env('WEB_IMAGE_OS') === 'jammy') {
-      osType = 'ubuntu';
-      osVersion = 'jammy';
-    }
-    cy.execInContainer({
-      command: [
-        `bash -e <<EOF
-          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --os-type=${osType} --skip-check-installed --skip-maxscale --os-version=${osVersion} --mariadb-server-version="mariadb-10.11"
-EOF`,
-        'apt-get update',
-        'apt-get install -y mariadb-server mariadb-client'
-      ],
-      name: 'web'
-    });
+interface DatabaseEngine {
+  type: 'mariadb' | 'mysql';
+  version: string;
+}
+
+const getDatabaseEngine = (): DatabaseEngine => {
+  const image = Cypress.env('DATABASE_IMAGE') || '';
+  const match = image.match(/(mariadb|mysql):([\d.]+)/);
+
+  if (match === null) {
+    throw new Error(
+      `Cannot determine the database from DATABASE_IMAGE "${image}". Expected a value like ".../mariadb:10.11" or ".../mysql:8.0".`
+    );
   }
+
+  return { type: match[1] as DatabaseEngine['type'], version: match[2] };
+};
+
+const isAlma = (): boolean => Cypress.env('WEB_IMAGE_OS').includes('alma');
+
+const getDatabaseService = (engine: DatabaseEngine): string => {
+  if (engine.type === 'mariadb') {
+    return 'mariadb';
+  }
+
+  return isAlma() ? 'mysqld' : 'mysql';
+};
+
+const mysqlRootGrant = `mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'centreon'; GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION"`;
+const mariadbRootGrant = `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`;
+
+const rootGrantCommand = (engine: DatabaseEngine): string =>
+  engine.type === 'mysql' ? mysqlRootGrant : mariadbRootGrant;
+
+const getDebianRepoTarget = (): { osType: string; osVersion: string } => {
+  switch (Cypress.env('WEB_IMAGE_OS')) {
+    case 'jammy':
+      return { osType: 'ubuntu', osVersion: 'jammy' };
+    case 'bookworm':
+      return { osType: 'debian', osVersion: '12' };
+    default:
+      throw new Error(
+        `Unsupported OS "${Cypress.env('WEB_IMAGE_OS')}" for the database APT repository.`
+      );
+  }
+};
+
+const installDatabase = (): void => {
+  const { type, version } = getDatabaseEngine();
+  let command: Array<string>;
+
+  if (type === 'mysql') {
+    if (isAlma()) {
+      command = ['dnf install -y mysql-server mysql'];
+    } else {
+      command = [
+        'curl -fsSLO https://dev.mysql.com/get/mysql-apt-config_0.8.34-1_all.deb',
+        `echo "mysql-apt-config mysql-apt-config/select-server select mysql-${version}-lts" | debconf-set-selections`,
+        'DEBIAN_FRONTEND=noninteractive apt-get install -y ./mysql-apt-config_0.8.34-1_all.deb',
+        'curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | gpg --dearmor > /usr/share/keyrings/mysql-apt-config.gpg',
+        'apt-get update',
+        'apt-get install -y mysql-server mysql-common'
+      ];
+    }
+  } else if (isAlma()) {
+    command = [
+      `dnf module enable -y mariadb:${version}`,
+      'dnf install -y mariadb-server mariadb'
+    ];
+  } else {
+    const { osType, osVersion } = getDebianRepoTarget();
+    command = [
+      `bash -e <<EOF
+          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --os-type=${osType} --skip-check-installed --skip-maxscale --os-version=${osVersion} --mariadb-server-version="mariadb-${version}"
+EOF`,
+      'apt-get update',
+      'apt-get install -y mariadb-server mariadb-client'
+    ];
+  }
+
+  cy.execInContainer({ command, name: 'web' });
 };
 
 const installCentreon = (version: string): Cypress.Chainable => {
@@ -132,6 +186,15 @@ const installCentreon = (version: string): Cypress.Chainable => {
     throw new Error('Cannot parse version number.');
   }
 
+  const databaseEngine = getDatabaseEngine();
+  // Below 24.10 the dependencies container ships MariaDB (we don't install it).
+  const databaseInstalled =
+    Number(versionMatches[1]) > 24 ||
+    (Number(versionMatches[1]) === 24 && Number(versionMatches[2]) >= 10);
+  const activeEngine: DatabaseEngine = databaseInstalled
+    ? databaseEngine
+    : { type: 'mariadb', version: databaseEngine.version };
+
   cy.execInContainer({
     command: [
       'mkdir -p /usr/lib/centreon/plugins',
@@ -140,11 +203,7 @@ const installCentreon = (version: string): Cypress.Chainable => {
     name: 'web'
   });
 
-  if (
-    Number(versionMatches[1]) > 24 ||
-    (Number(versionMatches[1]) === 24 && Number(versionMatches[2]) >= 10)
-  ) {
-    // database is not installed in dependencies containers > 24.10
+  if (databaseInstalled) {
     installDatabase();
   }
 
@@ -155,11 +214,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
         `dnf install -y centreon-web-${version}`,
         'dnf install -y centreon-broker-cbd',
         "echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini",
-        'systemctl start mariadb',
+        `systemctl start ${getDatabaseService(activeEngine)}`,
         'mkdir -p /run/php-fpm',
         'systemctl restart php-fpm',
         'systemctl restart httpd',
-        "mysql -e \"GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION\"",
+        rootGrantCommand(activeEngine),
         "dnf config-manager --set-enabled 'centreon-*'"
       ],
       name: 'web'
@@ -212,12 +271,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        // upstream MariaDB packages only ship /etc/init.d/mariadb
-        'systemctl start mariadb',
+        `systemctl start ${getDatabaseService(activeEngine)}`,
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',
-        `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`,
+        rootGrantCommand(activeEngine),
         'for i in $( ls /etc/apt/sources.list.d/centreon*{unstable,testing}*.disabled ); do mv $i "$(echo $i | sed -r \'s/.disabled//\')"; done',
         'apt-get update',
         'usermod -a -G centreon-broker www-data' // temporary fix (MON-20769)


### PR DESCRIPTION
Fixes: [MON-207316](https://centreon.atlassian.net/browse/MON-207316)

Backport of centreon/centreon#11234 to `dev-25.10.x`.

The `Platform-upgrade-update` test installed MariaDB in the web container and ignored `CYPRESS_DATABASE_IMAGE`, even though this series' CI matrix declares mysql:8.0 and mysql:8.4 legs. `installDatabase()` now derives the engine/version from the matrix and installs MariaDB or MySQL accordingly (engine-aware service start and MySQL-8 compatible root grant; below 24.10 it keeps the legacy MariaDB from the dependencies container).

Adapted to this series (MariaDB 10.11 default, alma8/alma9 DNF module stream, bookworm APT repo). Install paths validated locally in Docker.

[MON-207316]: https://centreon.atlassian.net/browse/MON-207316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
