### PR TITLE
test(e2e): web: parse the resource status CSV export with a quote-aware parser (dev-24.10.x)

### DIFF
--- a/centreon/tests/e2e/commons.ts
+++ b/centreon/tests/e2e/commons.ts
@@ -62,6 +62,53 @@ const getStatusTypeNumberFromString = (statusType: string): number => {
   throw new Error(`Status type ${statusType} does not exist`);
 };
 
+// Quote-aware CSV parser: the fields exported by the backend are enclosed in
+// double quotes as soon as they hold the delimiter, a quote or a line break, so
+// splitting on the raw delimiter shifts every following column of that record.
+const parseCsv = (content: string, delimiter = ';'): Array<Array<string>> => {
+  const records: Array<Array<string>> = [];
+  let fields: Array<string> = [];
+  let field = '';
+  let isQuoted = false;
+  let index = 0;
+
+  while (index < content.length) {
+    const character = content[index];
+    index += 1;
+
+    if (isQuoted) {
+      if (character !== '"') {
+        field += character;
+      } else if (content[index] === '"') {
+        // an escaped quote inside an enclosed field
+        field += '"';
+        index += 1;
+      } else {
+        isQuoted = false;
+      }
+    } else if (character === '"') {
+      isQuoted = true;
+    } else if (character === delimiter) {
+      fields.push(field);
+      field = '';
+    } else if (character === '\n') {
+      fields.push(field);
+      records.push(fields);
+      fields = [];
+      field = '';
+    } else if (character !== '\r') {
+      field += character;
+    }
+  }
+
+  if (field !== '' || fields.length > 0) {
+    fields.push(field);
+    records.push(fields);
+  }
+
+  return records;
+};
+
 interface MonitoredHost {
   name: string;
   output?: string;
@@ -477,6 +524,7 @@ export {
   checkServicesAreMonitored,
   getStatusNumberFromString,
   getStatusTypeNumberFromString,
+  parseCsv,
   submitResultsViaClapi,
   updateFixturesResult,
   apiBase,

--- a/centreon/tests/e2e/commons.ts
+++ b/centreon/tests/e2e/commons.ts
@@ -62,9 +62,12 @@ const getStatusTypeNumberFromString = (statusType: string): number => {
   throw new Error(`Status type ${statusType} does not exist`);
 };
 
-// Quote-aware CSV parser: the fields exported by the backend are enclosed in
-// double quotes as soon as they hold the delimiter, a quote or a line break, so
-// splitting on the raw delimiter shifts every following column of that record.
+// Splits CSV content into records of unquoted field values, header row first.
+// Enclosures have to be honoured: the exporter wraps in double quotes any field
+// holding the delimiter, a double quote (then doubled) or a line break, so a raw
+// split on the delimiter would cut such a field into several cells and shift
+// every column after it:
+//   Critical;"OK: 5% | cpu=5%;80;90";1/1 (H)   ->   3 fields, not 5
 const parseCsv = (content: string, delimiter = ';'): Array<Array<string>> => {
   const records: Array<Array<string>> = [];
   let fields: Array<string> = [];

--- a/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/07-csv-export/index.ts
@@ -3,7 +3,8 @@ import { INTERCEPTORS } from 'e2e/fixtures/shared/constants/interceptors';
 
 import {
   checkMetricsAreMonitored,
-  checkServicesAreMonitored
+  checkServicesAreMonitored,
+  parseCsv
 } from '../../../commons';
 
 const serviceOk = 'service_test_ok';
@@ -61,9 +62,6 @@ const UPDATED_COLUMNS = [
 ];
 
 const downloadsFolder = Cypress.config('downloadsFolder');
-
-const normalize = (text: string) =>
-  text.trim().replace(/^"|"$/g, '').replace(/\\"/g, '').replace(/"/g, '');
 
 before(() => {
   cy.intercept({
@@ -265,22 +263,15 @@ Then(
   () => {
     cy.task('getExportedFile', { downloadsFolder }).then((filePath) => {
       cy.task('readCsvFile', { filePath }).then((csvContent) => {
-        const rows = (csvContent as string)
-          .trim()
-          .split('\n')
-          .map((row) => row.split(';').map((cell) => cell.trim()));
+        const [headers, ...dataRows] = parseCsv(csvContent as string);
 
-        const rawHeaders = rows[0];
-        const headers = rawHeaders.map(normalize);
-        cy.log('Normalized CSV Headers:', headers.join(' | '));
+        cy.log('CSV Headers:', headers.join(' | '));
         expect(headers).to.deep.equal(ALL_COLUMNS);
-
-        const dataRows = rows.slice(1);
 
         const rowObjects = dataRows.map((row) =>
           headers.reduce(
             (obj, header, i) => {
-              obj[header.replace(/"/g, '')] = row[i];
+              obj[header] = row[i];
               return obj;
             },
             {} as Record<string, string>
@@ -358,22 +349,15 @@ Then(
   () => {
     cy.task('getExportedFile', { downloadsFolder }).then((filePath) => {
       cy.task('readCsvFile', { filePath }).then((csvContent) => {
-        const rows = (csvContent as string)
-          .trim()
-          .split('\n')
-          .map((row) => row.split(';').map((cell) => cell.trim()));
+        const [headers, ...dataRows] = parseCsv(csvContent as string);
 
-        const rawHeaders = rows[0];
-        const headers = rawHeaders.map(normalize);
-        cy.log('Normalized CSV Headers:', headers.join(' | '));
+        cy.log('CSV Headers:', headers.join(' | '));
         expect(headers).to.deep.equal(UPDATED_COLUMNS);
-
-        const dataRows = rows.slice(1);
 
         const rowObjects = dataRows.map((row) =>
           headers.reduce(
             (obj, header, i) => {
-              obj[header.replace(/"/g, '')] = row[i];
+              obj[header] = row[i];
               return obj;
             },
             {} as Record<string, string>

--- a/centreon/tests/e2e/fixtures/resources/csvFIleWithAllPagesAndColumns.json
+++ b/centreon/tests/e2e/fixtures/resources/csvFIleWithAllPagesAndColumns.json
@@ -6,10 +6,10 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Duration": "\"1m 9s\"",
-    "Last Check": "\"1m 9s\"",
+    "Duration": "1m 9s",
+    "Last Check": "1m 9s",
     "Information": "submit_status_2",
-    "Tries": "\"1/1 (H)\"",
+    "Tries": "1/1 (H)",
     "Severity": "",
     "Notes": "",
     "Action": "",
@@ -18,8 +18,8 @@
     "Parent alias": "host1",
     "FQDN / Address": "",
     "Monitoring server": "Central",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -28,10 +28,10 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Duration": "\"1m 9s\"",
-    "Last Check": "\"1m 9s\"",
+    "Duration": "1m 9s",
+    "Last Check": "1m 9s",
     "Information": "submit_status_2",
-    "Tries": "\"1/1 (H)\"",
+    "Tries": "1/1 (H)",
     "Severity": "",
     "Notes": "",
     "Action": "",
@@ -40,8 +40,8 @@
     "Parent alias": "host1",
     "FQDN / Address": "",
     "Monitoring server": "Central",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -50,10 +50,10 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Duration": "\"1m 9s\"",
-    "Last Check": "\"1m 9s\"",
+    "Duration": "1m 9s",
+    "Last Check": "1m 9s",
     "Information": "submit_status_2",
-    "Tries": "\"1/1 (H)\"",
+    "Tries": "1/1 (H)",
     "Severity": "",
     "Notes": "",
     "Action": "",
@@ -62,7 +62,7 @@
     "Parent alias": "host1",
     "FQDN / Address": "",
     "Monitoring server": "Central",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   }
 ]

--- a/centreon/tests/e2e/fixtures/resources/csvFIleWithOnlyVisiblePagesAndColumns.json
+++ b/centreon/tests/e2e/fixtures/resources/csvFIleWithOnlyVisiblePagesAndColumns.json
@@ -6,13 +6,13 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Last Check": "\"1m 27s\"",
+    "Last Check": "1m 27s",
     "Information": "submit_status_2",
     "Notes": "",
     "Action": "",
     "FQDN / Address": "",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -21,13 +21,13 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Last Check": "\"1m 27s\"",
+    "Last Check": "1m 27s",
     "Information": "submit_status_2",
     "Notes": "",
     "Action": "",
     "FQDN / Address": "",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   },
   {
     "Status": "Critical",
@@ -36,12 +36,12 @@
     "Parent Resource Type": "Host",
     "Parent Resource Name": "host1",
     "Parent Resource Status": "Pending",
-    "Last Check": "\"1m 27s\"",
+    "Last Check": "1m 27s",
     "Information": "submit_status_2",
     "Notes": "",
     "Action": "",
     "FQDN / Address": "",
-    "Notif": "\"Notifications disabled\"",
-    "Check": "\"Only passive checks are enabled\""
+    "Notif": "Notifications disabled",
+    "Check": "Only passive checks are enabled"
   }
 ]


### PR DESCRIPTION
Fixes: [MON-207298](https://centreon.atlassian.net/browse/MON-207298)

Backport of #11358 on `dev-24.10.x`.

Test-only fix: the e2e test of the Resource Status CSV export parsed the downloaded file with a naive `String.split`, which shreds any field the exporter legitimately encloses in double quotes (delimiter, quote or line break inside the value) and shifts every column after it. It now goes through a quote-aware parser.

This is the branch whose pipeline surfaced the bug, as `Line 1 - Key: Parent alias: expected undefined to equal 'host1'` on the `bookworm-mysql:8.4` leg — same cause as 25.10, different column reported because this series has no `Host ID` / `Service ID` columns.

## Adaptations

Two conflicts, resolved:

- this series names the expected-column constants `ALL_COLUMNS` / `UPDATED_COLUMNS` where develop still has `AllColumns` / `UpdatedColumns`;
- develop's `assertIdentifierContract()` helper was **not** imported, since `Host ID` / `Service ID` do not exist here. Only the obsolete `normalize()` helper was removed.

## Test done

- Parser exercised against a payload reproducing the failing export: quoted multi-line cell, `;`-bearing `Information` value, doubled `""`, CRLF separators.
- `tsc --noEmit`: clean on the changed files.


[MON-207298]: https://centreon.atlassian.net/browse/MON-207298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ