### PR TITLE
fix(resources): route Check column through translate() guard

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
@@ -153,7 +153,7 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
                 _('Monitoring server') => $resource->getMonitoringServerName(),
                 _('Notif') => $resource->isNotificationEnabled()
                     ? _('Notifications enabled') : _('Notifications disabled'),
-                _('Check') => _($this->getResourceCheck($resource)),
+                _('Check') => $this->translate($this->getResourceCheck($resource)),
                 _('Host ID') => $this->getHostId($resource),
                 _('Service ID') => $this->getServiceId($resource),
             ];


### PR DESCRIPTION
## Description

- Route the `Check` column through the existing `translate()` guard in `ExportResourcesPresenterCsv`
- Prevents the gettext catalog header from leaking into the CSV export when the column value is empty — the same guard already protects `Resource Type`, `Status`, `Parent Resource Type`, `Parent Resource Status` and `State`

**Fixes** MON-207195

## How to test

1. On a Debian-based platform with `en_US` locale active, log in to Centreon
2. Go to Resources Status and export the CSV
3. Verify that the `Check` column contains the expected value (e.g. "All checks are enabled") and never the gettext catalog header (`Project-Id-Version: Centreon web…`)

## Links

### Jira ticket

Resolves: [MON-207195](https://centreon.atlassian.net/browse/MON-207195)


[MON-207195]: https://centreon.atlassian.net/browse/MON-207195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ