### PR TITLE
test(e2e): web: install update/upgrade DB from the CI matrix (dev-26.10.x)

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -96,33 +96,82 @@ const getCentreonStableMinorVersions = (
   });
 };
 
-const installDatabase = (): void => {
-  if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
-    cy.execInContainer({
-      command: [
-        'dnf module enable -y mariadb:11.8',
-        'dnf install -y mariadb-server mariadb'
-      ],
-      name: 'web'
-    });
-  } else {
-    let osType = 'debian';
-    let osVersion = '12';
-    if (Cypress.env('WEB_IMAGE_OS') === 'jammy') {
-      osType = 'ubuntu';
-      osVersion = 'jammy';
-    }
-    cy.execInContainer({
-      command: [
-        `bash -e <<EOF
-          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --os-type=${osType} --skip-check-installed --skip-maxscale --os-version=${osVersion} --mariadb-server-version="mariadb-11.8"
-EOF`,
-        'apt-get update',
-        'apt-get install -y mariadb-server mariadb-client'
-      ],
-      name: 'web'
-    });
+interface DatabaseEngine {
+  type: 'mariadb' | 'mysql';
+  version: string;
+}
+
+const getDatabaseEngine = (): DatabaseEngine => {
+  const image = Cypress.env('DATABASE_IMAGE') || '';
+  const match = image.match(/(mariadb|mysql):([\d.]+)/);
+
+  if (match === null) {
+    throw new Error(
+      `Cannot determine the database from DATABASE_IMAGE "${image}". Expected a value like ".../mariadb:11.8" or ".../mysql:8.0".`
+    );
   }
+
+  return { type: match[1] as DatabaseEngine['type'], version: match[2] };
+};
+
+const isAlma = (): boolean => Cypress.env('WEB_IMAGE_OS').includes('alma');
+
+const mysqlRootGrant = `mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'centreon'; GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION"`;
+const mariadbRootGrant = `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`;
+
+const rootGrantCommand = (engine: DatabaseEngine): string =>
+  engine.type === 'mysql' ? mysqlRootGrant : mariadbRootGrant;
+
+const getDebianRepoTarget = (): { osType: string; osVersion: string } => {
+  switch (Cypress.env('WEB_IMAGE_OS')) {
+    case 'trixie':
+      return { osType: 'debian', osVersion: '13' };
+    default:
+      throw new Error(
+        `Unsupported OS "${Cypress.env('WEB_IMAGE_OS')}" for the database APT repository.`
+      );
+  }
+};
+
+const installDatabase = (): void => {
+  const { type, version } = getDatabaseEngine();
+  let command: Array<string>;
+
+  if (type === 'mysql') {
+    if (isAlma()) {
+      command = ['dnf install -y mysql-server mysql'];
+    } else {
+      command = [
+        'curl -fsSLO https://dev.mysql.com/get/mysql-apt-config_0.8.34-1_all.deb',
+        `echo "mysql-apt-config mysql-apt-config/select-server select mysql-${version}-lts" | debconf-set-selections`,
+        'DEBIAN_FRONTEND=noninteractive apt-get install -y ./mysql-apt-config_0.8.34-1_all.deb',
+        'curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | gpg --dearmor > /usr/share/keyrings/mysql-apt-config.gpg',
+        'apt-get update',
+        'apt-get install -y mysql-server mysql-common'
+      ];
+    }
+  } else if (isAlma()) {
+    // el10+ dropped DNF modules; MariaDB ships as versioned packages instead.
+    const almaMajor = Number(Cypress.env('WEB_IMAGE_OS').replace('alma', ''));
+    command =
+      almaMajor >= 10
+        ? [`dnf install -y mariadb${version}-server mariadb${version}`]
+        : [
+            `dnf module enable -y mariadb:${version}`,
+            'dnf install -y mariadb-server mariadb'
+          ];
+  } else {
+    const { osType, osVersion } = getDebianRepoTarget();
+    command = [
+      `bash -e <<EOF
+          curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --os-type=${osType} --skip-check-installed --skip-maxscale --os-version=${osVersion} --mariadb-server-version="mariadb-${version}"
+EOF`,
+      'apt-get update',
+      'apt-get install -y mariadb-server mariadb-client'
+    ];
+  }
+
+  cy.execInContainer({ command, name: 'web' });
 };
 
 const installCentreon = (version: string): Cypress.Chainable => {
@@ -133,6 +182,15 @@ const installCentreon = (version: string): Cypress.Chainable => {
     throw new Error('Cannot parse version number.');
   }
 
+  const databaseEngine = getDatabaseEngine();
+  // Below 24.10 the dependencies container ships MariaDB (we don't install it).
+  const databaseInstalled =
+    Number(versionMatches[1]) > 24 ||
+    (Number(versionMatches[1]) === 24 && Number(versionMatches[2]) >= 10);
+  const activeEngine: DatabaseEngine = databaseInstalled
+    ? databaseEngine
+    : { type: 'mariadb', version: databaseEngine.version };
+
   cy.execInContainer({
     command: [
       'mkdir -p /usr/lib/centreon/plugins',
@@ -141,11 +199,7 @@ const installCentreon = (version: string): Cypress.Chainable => {
     name: 'web'
   });
 
-  if (
-    Number(versionMatches[1]) > 24 ||
-    (Number(versionMatches[1]) === 24 && Number(versionMatches[2]) >= 10)
-  ) {
-    // database is not installed in dependencies containers > 24.10
+  if (databaseInstalled) {
     installDatabase();
   }
 
@@ -156,11 +210,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
         `dnf install -y centreon-web-${version}`,
         'dnf install -y centreon-broker-cbd',
         "echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini",
-        'systemctl start mariadb',
+        `systemctl start ${activeEngine.type === 'mysql' ? 'mysqld' : 'mariadb'}`,
         'mkdir -p /run/php-fpm',
         'systemctl restart php-fpm',
         'systemctl restart httpd',
-        "mysql -e \"GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION\"",
+        rootGrantCommand(activeEngine),
         "dnf config-manager --set-enabled 'centreon-*'"
       ],
       name: 'web'
@@ -223,12 +277,11 @@ const installCentreon = (version: string): Cypress.Chainable => {
         'mkdir -p /usr/lib/centreon-connector',
         `echo "date.timezone = Europe/Paris" > /etc/php/${phpVersion}/mods-available/timezone.ini`,
         `phpenmod -v ${phpVersion} timezone`,
-        // upstream MariaDB packages only ship /etc/init.d/mariadb
-        'systemctl start mariadb',
+        `systemctl start ${activeEngine.type === 'mysql' ? 'mysql' : 'mariadb'}`,
         'mkdir -p /run/php',
         `systemctl restart php${phpVersion}-fpm`,
         'systemctl restart apache2',
-        `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`,
+        rootGrantCommand(activeEngine),
         'mv /etc/apt/sources.list.d/centreon-unstable.list.bak /etc/apt/sources.list.d/centreon-unstable.list',
         'mv /etc/apt/sources.list.d/centreon-testing.list.bak /etc/apt/sources.list.d/centreon-testing.list',
         'apt-get update',


### PR DESCRIPTION
Fixes: [MON-207317](https://centreon.atlassian.net/browse/MON-207317)

Backport of centreon/centreon#11234 to `dev-26.10.x` (same matrix as develop: alma10↔mariadb:11.8, alma9↔mysql:8.0, trixie↔mysql:8.4).

The `Platform-upgrade-update` test installed MariaDB in the web container and ignored `CYPRESS_DATABASE_IMAGE`. `installDatabase()` now derives the engine/version from the matrix and installs MariaDB or MySQL accordingly (RHEL: DNF module on el9, versioned package on el10; Debian 13 via MySQL APT repo with GPG key refresh). Engine-aware service start and MySQL-8 compatible root grant; below 24.10 it keeps the legacy MariaDB from the dependencies container. Install paths validated locally in Docker.

[MON-207317]: https://centreon.atlassian.net/browse/MON-207317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
