### PR TITLE
fix(pollers): remove double protocol in the generated installation command

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Application/Command/CreatePollerCommand.php
+++ b/centreon/src/App/MonitoringConfiguration/Application/Command/CreatePollerCommand.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Application\Command;
 
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
@@ -35,7 +36,7 @@ final readonly class CreatePollerCommand
         public PollerTypeEnum $pollerType,
         public PollerAddress $address,
         public int $creatorId,
-        public PollerAddress $centralAddress,
+        public CentralAddress $centralAddress,
         public GorgoneCommunicationTypeEnum $gorgoneCommunicationType = GorgoneCommunicationTypeEnum::ZMQ,
     ) {
     }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\Poller;
+
+use App\Shared\Domain\Assert\Assert as CentreonAssert;
+use Webmozart\Assert\Assert;
+
+/**
+ * Client-visible entry point of the central server: hostname or IP address,
+ * optional port, optional base path — e.g. "central.example.com",
+ * "10.0.0.1:8443" or "orga.region.example.com/platform". Unlike PollerAddress,
+ * it may carry a base path: on cloud platforms the whole application
+ * (including /poller/install.sh) is served under the platform path. No scheme.
+ *
+ * Behind proxies and NAT, only the browser knows the client-reachable form of
+ * this address, so the value is provided by the frontend and stored verbatim
+ * (minus trailing slash).
+ */
+final readonly class CentralAddress
+{
+    public const MIN_LENGTH = 1;
+    public const MAX_LENGTH = 255;
+    private const HOST_PORT_PATTERN = '/^(?<host>.+):(?<port>\d{1,5})$/';
+    private const BASE_PATH_PATTERN = '~^[A-Za-z0-9._\-]+(?:/[A-Za-z0-9._\-]+)*$~';
+    private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
+
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        $normalized = rtrim(trim($value), '/');
+        Assert::lengthBetween($normalized, self::MIN_LENGTH, self::MAX_LENGTH);
+
+        $slashPosition = mb_strpos($normalized, '/');
+        $authority = $slashPosition === false ? $normalized : mb_substr($normalized, 0, $slashPosition);
+        $basePath = $slashPosition === false ? null : mb_substr($normalized, $slashPosition + 1);
+
+        $this->assertAuthority($authority);
+        if ($basePath !== null) {
+            Assert::regex(
+                $basePath,
+                self::BASE_PATH_PATTERN,
+                sprintf('[CentralAddress::value] The base path "%s" contains invalid characters', $basePath)
+            );
+            // "." and ".." match BASE_PATH_PATTERN but would make the generated URL
+            // resolve outside the configured base path.
+            Assert::false(
+                (bool) preg_match(self::DOT_SEGMENT_PATTERN, $basePath),
+                sprintf('[CentralAddress::value] The base path "%s" must not contain dot segments', $basePath)
+            );
+        }
+
+        $this->value = $normalized;
+    }
+
+    private function assertAuthority(string $authority): void
+    {
+        // A bare IP address (IPv4, or IPv6 whose colons would confuse port detection).
+        if (filter_var($authority, FILTER_VALIDATE_IP) !== false) {
+            return;
+        }
+
+        if (preg_match(self::HOST_PORT_PATTERN, $authority, $matches) === 1) {
+            Assert::range(
+                (int) $matches['port'],
+                1,
+                65535,
+                sprintf('[CentralAddress::value] The port in "%s" is out of range', $authority)
+            );
+            CentreonAssert::ipOrHostname($matches['host'], 'CentralAddress::value');
+
+            return;
+        }
+
+        CentreonAssert::ipOrHostname($authority, 'CentralAddress::value');
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/Poller.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/Poller.php
@@ -52,7 +52,7 @@ final class Poller extends AggregateRoot
         public readonly ConnectorConfiguration $connectorConfiguration,
         public readonly TrapConfiguration $trapConfiguration,
         public readonly Collection $pollerCommands,
-        public readonly ?PollerAddress $centralAddress = null,
+        public readonly ?CentralAddress $centralAddress = null,
         public ?PollerCMACertificates $cmaCertificates = null,
         public readonly ?PollerRemoteAttachment $remoteAttachment = null,
     ) {

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Dto/CreatePollerInput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Dto/CreatePollerInput.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Dto;
 
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
@@ -40,6 +41,7 @@ final readonly class CreatePollerInput
 
         #[Assert\NotBlank(normalizer: 'trim')]
         #[Assert\Length(min: PollerAddress::MIN_LENGTH, max: PollerAddress::MAX_LENGTH)]
+        #[Assert\Regex(pattern: '~://~', match: false, message: 'This value must be an IP address or a hostname, without a protocol scheme.')]
         public string $address,
 
         #[Assert\NotBlank(normalizer: 'trim')]
@@ -48,7 +50,8 @@ final readonly class CreatePollerInput
         public string $pollerTokenName,
 
         #[Assert\NotBlank(normalizer: 'trim')]
-        #[Assert\Length(min: PollerAddress::MIN_LENGTH, max: PollerAddress::MAX_LENGTH)]
+        #[Assert\Length(min: CentralAddress::MIN_LENGTH, max: CentralAddress::MAX_LENGTH)]
+        #[Assert\Regex(pattern: '~://~', match: false, message: 'This value must be an IP address or a hostname with an optional base path, without a protocol scheme.')]
         public string $centralAddress,
     ) {
     }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -26,6 +26,7 @@ namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\MonitoringConfiguration\Application\Command\CreatePollerCommand;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
@@ -81,12 +82,14 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         $credentialUser = $this->security->getUser();
         Assert::isInstanceOf($credentialUser, CredentialUser::class);
 
+        $centralAddress = new CentralAddress($data->centralAddress);
+
         $command = new CreatePollerCommand(
             name: $pollerName,
             pollerType: PollerTypeEnum::from($data->pollerType),
             address: new PollerAddress($data->address),
             creatorId: $credentialUser->credential->userId->value,
-            centralAddress: new PollerAddress($data->centralAddress),
+            centralAddress: $centralAddress,
             gorgoneCommunicationType: $this->isCloudPlatform
                 ? GorgoneCommunicationTypeEnum::PullWss
                 : GorgoneCommunicationTypeEnum::ZMQ,
@@ -99,13 +102,15 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         $model = $this->commandBus->execute($command);
         Assert::isInstanceOf($model, Poller::class);
 
+        // Use the normalized value, not the raw input: the stored poller and the
+        // returned command must match what GET /installation-command/{id} generates.
         $factory = PollerInstallationCommandFactory::fromPoller(
             $model,
             $token,
             $appSecret,
             $salt,
             $this->isCloudPlatform,
-            $data->centralAddress,
+            $centralAddress->value,
         );
 
         $resource = $this->transformer->transform($model);

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
@@ -25,7 +25,7 @@ namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
-use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
@@ -64,7 +64,7 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
             ? $this->pollerTokenRepository->getValidPollerTokenByName($tokenName)
             : $this->pollerTokenRepository->getFirstValidPollerToken();
 
-        if (! $poller->centralAddress instanceof PollerAddress) {
+        if (! $poller->centralAddress instanceof CentralAddress) {
             throw new BadRequestHttpException(sprintf('No central address configured for poller #%d.', $pollerId->value));
         }
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerTransformer.php
@@ -25,6 +25,7 @@ namespace App\MonitoringConfiguration\Infrastructure\Dbal;
 
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\BrokerConfiguration;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\ConnectorConfiguration;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\EngineInformation;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
@@ -60,7 +61,7 @@ final readonly class DbalPollerTransformer implements TransformerInterface
             uid: new PollerUid((int) $from['poller_uid']),
             globalMacros: new Collection([], GlobalMacro::class),
             pollerCommands: new Collection([], PollerCommand::class),
-            centralAddress: is_string($from['central_address'] ?? null) ? new PollerAddress($from['central_address']) : null,
+            centralAddress: $this->centralAddressFromDatabase($from['central_address'] ?? null),
             brokerConfiguration: new BrokerConfiguration(
                 reloadCommand: $from['broker_reload_command'],
                 configurationPath: $from['centreonbroker_cfg_path'],
@@ -91,6 +92,35 @@ final readonly class DbalPollerTransformer implements TransformerInterface
             ),
             cmaCertificates: null,
         );
+    }
+
+    /**
+     * Rows written before the scheme rejection (MON-206245) may carry a full URL:
+     * the modal used to send window.location.href on cloud platforms. Reduce them
+     * to host[:port] so hydration keeps working — their base path cannot be told
+     * apart from the page path of the stored URL. Unreadable values become null,
+     * which downstream reports as "no central address configured".
+     */
+    private function centralAddressFromDatabase(mixed $value): ?CentralAddress
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        if (str_contains($value, '://')) {
+            $host = parse_url($value, PHP_URL_HOST);
+            if (! is_string($host) || $host === '') {
+                return null;
+            }
+            $port = parse_url($value, PHP_URL_PORT);
+            $value = is_int($port) ? sprintf('%s:%d', $host, $port) : $host;
+        }
+
+        try {
+            return new CentralAddress($value);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
     }
 
     private function communicationTypeFromDatabase(string $value): GorgoneCommunicationTypeEnum

--- a/centreon/tests/php/App/MonitoringConfiguration/Application/Command/CreatePollerCommandHandlerTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Application/Command/CreatePollerCommandHandlerTest.php
@@ -29,6 +29,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroExpression;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroId;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroName;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
@@ -57,7 +58,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         );
 
         $poller = $handler($command);
@@ -86,7 +87,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
             gorgoneCommunicationType: GorgoneCommunicationTypeEnum::PullWss,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         );
 
         $poller = $handler($command);
@@ -107,7 +108,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::Docker,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         );
 
         $poller = $handler($command);
@@ -128,7 +129,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 42,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         ));
 
         $events = $eventBus->getDispatchedEvents(PollerCreated::class);
@@ -160,7 +161,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         ));
 
         self::assertCount(1, $poller->globalMacros);
@@ -209,7 +210,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         ));
 
         self::assertCount(3, $poller->globalMacros);
@@ -259,7 +260,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         ));
 
         self::assertCount(2, $poller->globalMacros);
@@ -281,7 +282,7 @@ final class CreatePollerCommandHandlerTest extends TestCase
             pollerType: PollerTypeEnum::VM,
             address: new PollerAddress('192.168.1.1'),
             creatorId: 1,
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         ));
 
         self::assertNotNull($poller->centralAddress);

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddressTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddressTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Domain\Aggregate\Poller;
+
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CentralAddressTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function validAddressProvider(): iterable
+    {
+        yield 'hostname' => ['central.example.com', 'central.example.com'];
+
+        yield 'IPv4 address' => ['10.0.0.1', '10.0.0.1'];
+
+        yield 'IPv6 address' => ['2001:db8::1', '2001:db8::1'];
+
+        yield 'hostname with port' => ['central.example.com:8443', 'central.example.com:8443'];
+
+        yield 'hostname with base path' => ['orga.euwest1.example.com/platform', 'orga.euwest1.example.com/platform'];
+
+        yield 'hostname with port and multi-segment base path' => [
+            'central.example.com:8443/base/path',
+            'central.example.com:8443/base/path',
+        ];
+
+        yield 'IPv4 with base path' => ['10.0.0.1/centreon', '10.0.0.1/centreon'];
+
+        yield 'surrounding whitespace is trimmed' => ['  central.example.com  ', 'central.example.com'];
+
+        yield 'trailing slash is removed' => ['central.example.com/platform/', 'central.example.com/platform'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidAddressProvider(): iterable
+    {
+        yield 'empty' => [''];
+
+        yield 'protocol scheme' => ['https://central.example.com'];
+
+        yield 'query string' => ['central.example.com/path?foo=bar'];
+
+        yield 'fragment' => ['central.example.com/path#anchor'];
+
+        yield 'invalid host characters' => ['central_bad!.example.com/path'];
+
+        yield 'empty path segment' => ['central.example.com//path'];
+
+        yield 'invalid path characters' => ['central.example.com/pa th'];
+
+        yield 'port out of range' => ['central.example.com:70000'];
+
+        yield 'single-dot path segment' => ['central.example.com/.'];
+
+        yield 'double-dot path segment' => ['central.example.com/..'];
+
+        yield 'dot segment inside base path' => ['central.example.com/platform/../admin'];
+
+        yield 'leading dot segment' => ['central.example.com/./platform'];
+
+        yield 'longer than 255 characters' => [str_repeat('a', 250) . '.example.com'];
+    }
+
+    #[DataProvider('validAddressProvider')]
+    public function testAcceptsValidAddress(string $rawValue, string $expectedValue): void
+    {
+        $address = new CentralAddress($rawValue);
+
+        self::assertSame($expectedValue, $address->value);
+    }
+
+    #[DataProvider('invalidAddressProvider')]
+    public function testRejectsInvalidAddress(string $rawValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new CentralAddress($rawValue);
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
@@ -27,6 +27,7 @@ use ApiPlatform\Metadata\Post;
 use App\MonitoringConfiguration\Application\Command\CreatePollerCommand;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\BrokerConfiguration;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\ConnectorConfiguration;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\EngineInformation;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
@@ -117,7 +118,7 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             connectorConfiguration: new ConnectorConfiguration(),
             trapConfiguration: new TrapConfiguration(),
             pollerCommands: new Collection([], PollerCommand::class),
-            centralAddress: new PollerAddress('192.168.1.254'),
+            centralAddress: new CentralAddress('192.168.1.254'),
         );
 
         $commandBus = $this->createMock(CommandBus::class);

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
@@ -396,6 +396,95 @@ final class CreatePollerProcessorTest extends ApiTestCase
         self::assertResponseStatusCodeSame(400);
     }
 
+    public function testCannotCreatePollerWithProtocolSchemeInCentralAddress(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('SchemeCentral'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => 'https://central.example.com',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCannotCreatePollerWithProtocolSchemeInAddress(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('SchemeAddress'),
+                'poller_type' => 'vm',
+                'address' => 'http://192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.1',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testCreatePollerWithBasePathInCentralAddress(): void
+    {
+        $this->login();
+
+        $response = $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('BasePath'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => 'staging.euwest1.centreon.click/funky-donkey',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        self::assertArrayHasKey('installation_command', $responseData);
+        self::assertIsString($responseData['installation_command']);
+        self::assertStringContainsString(
+            'https://staging.euwest1.centreon.click/funky-donkey/poller/install.sh',
+            $responseData['installation_command']
+        );
+    }
+
+    public function testCreatePollerWithTrailingSlashInCentralAddressUsesNormalizedValue(): void
+    {
+        $this->login();
+
+        $response = $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('TrailingSlash'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => 'staging.euwest1.centreon.click/funky-donkey/',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        self::assertArrayHasKey('installation_command', $responseData);
+        self::assertIsString($responseData['installation_command']);
+        self::assertStringContainsString(
+            'https://staging.euwest1.centreon.click/funky-donkey/poller/install.sh',
+            $responseData['installation_command']
+        );
+        self::assertStringNotContainsString('funky-donkey//', $responseData['installation_command']);
+        self::assertStringContainsString(
+            '--central_url staging.euwest1.centreon.click/funky-donkey ',
+            $responseData['installation_command']
+        );
+    }
+
     private function uniqueName(string $prefix = 'Poller'): string
     {
         return $prefix . '_' . bin2hex(random_bytes(4));

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepositoryTest.php
@@ -29,6 +29,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroExpressi
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroId;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\BrokerConfiguration;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\ConnectorConfiguration;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\EngineInformation;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneConfiguration;
@@ -93,7 +94,7 @@ final class DbalPollerRepositoryTest extends KernelTestCase
             connectorConfiguration: new ConnectorConfiguration(),
             trapConfiguration: new TrapConfiguration(),
             pollerCommands: new Collection([], PollerCommand::class),
-            centralAddress: new PollerAddress('10.0.0.1'),
+            centralAddress: new CentralAddress('10.0.0.1'),
         );
 
         $this->repository->add($poller);

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerTransformerTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerTransformerTest.php
@@ -131,6 +131,33 @@ final class DbalPollerTransformerTest extends TestCase
         self::assertSame(PollerTypeEnum::Docker, $poller->pollerType);
     }
 
+    public function testTransformKeepsValidCentralAddress(): void
+    {
+        $row = $this->buildRow(['central_address' => 'central.example.com:8443/platform']);
+
+        $poller = $this->transformer->transform($row);
+
+        self::assertSame('central.example.com:8443/platform', $poller->centralAddress?->value);
+    }
+
+    public function testTransformReducesLegacySchemeCentralAddressToHostAndPort(): void
+    {
+        $row = $this->buildRow(['central_address' => 'https://central.example.com:8443/centreon/monitoring/resources?tab=details']);
+
+        $poller = $this->transformer->transform($row);
+
+        self::assertSame('central.example.com:8443', $poller->centralAddress?->value);
+    }
+
+    public function testTransformNullsUnreadableLegacyCentralAddress(): void
+    {
+        $row = $this->buildRow(['central_address' => 'not a valid address!']);
+
+        $poller = $this->transformer->transform($row);
+
+        self::assertNull($poller->centralAddress);
+    }
+
     /**
      * @param array<string, mixed> $overrides
      *

--- a/centreon/www/front_src/src/Header/Poller/PollerSubMenu/CloudInstallCommand/CloudInstallCommand.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Header/Poller/PollerSubMenu/CloudInstallCommand/CloudInstallCommand.cypress.spec.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../translatedLabels';
 import { generatedCommandAtom, isModalOpenAtom, pollerIdAtom } from './atoms';
 import CloudInstallCommand from './CloudInstallCommand';
-import { webUrl } from './Modal/useInstallCommand';
+import { centralWebAddress } from './Modal/useInstallCommand';
 
 const createPollerSuccessResponse = {
   '@context': '/centreon/api/latest/contexts/Poller',
@@ -44,12 +44,6 @@ const createPollerSuccessResponse = {
   name: 'poller-docker_07',
   poller_type: 'docker',
   uuid: '019dcf18-bdb1-7f89-a61f-45b8fcfb27e6'
-};
-
-const createPollerResponseWithPlaceholder = {
-  ...createPollerSuccessResponse,
-  installation_command:
-    'installcma.ps /FINGERPRINT=lllllll /ENDPOINT=<CENTRAL_URL>/api/latest'
 };
 
 const initializeI18n = (): void => {
@@ -577,8 +571,8 @@ describe('CloudInstallCommand', () => {
       });
 
       it('sends a value of centreon central address based on the web url in the API payload if the enviromment is cloud', () => {
-        cy.stub(webUrl, 'get').returns(
-          'https://staging.euwest1.centreon.click/funky-donkey'
+        cy.stub(centralWebAddress, 'get').returns(
+          'staging.euwest1.centreon.click/funky-donkey'
         );
 
         initialize({ isCloudPlatform: true, isModalOpen: true });
@@ -596,20 +590,19 @@ describe('CloudInstallCommand', () => {
           expect(request.body.name).to.equal('my-poller');
           expect(request.body.address).to.equal('192.168.1.1');
           expect(request.body.central_address).to.equal(
-            'https://staging.euwest1.centreon.click/funky-donkey'
+            'staging.euwest1.centreon.click/funky-donkey'
           );
         });
       });
 
-      it('replaces <CENTRAL_URL> placeholder in the generated command with the actual central URL', () => {
-        initialize({
-          createPollerResponse: createPollerResponseWithPlaceholder,
-          isModalOpen: true
-        });
+      it('strips the protocol scheme but keeps the base path from the central address typed by the user', () => {
+        initialize({ isModalOpen: true });
 
         cy.findByLabelText(`${labelPollerName} *`).type('my-poller');
         cy.findByLabelText(`${labelPollerAddress} *`).type('192.168.1.1');
-        cy.findByLabelText(`${labelCentralAddress} *`).type('192.168.1.1');
+        cy.findByLabelText(`${labelCentralAddress} *`).type(
+          'https://central.example.com/centreon'
+        );
 
         cy.findByLabelText(labelSelectTokenPlaceholder).click();
         cy.waitForRequest('@getTokens');
@@ -617,17 +610,11 @@ describe('CloudInstallCommand', () => {
 
         cy.findByTestId('Install command').closest('button').click();
 
-        cy.waitForRequest('@createPoller');
-
-        const expectedUrl = `${window.location.origin}`;
-
-        cy.findByTestId('Command')
-          .scrollIntoView()
-          .should(
-            'contain.text',
-            `installcma.ps /FINGERPRINT=lllllll /ENDPOINT=${expectedUrl}/api/latest`
+        cy.waitForRequest('@createPoller').then(({ request }) => {
+          expect(request.body.central_address).to.equal(
+            'central.example.com/centreon'
           );
-        cy.findByTestId('Command').should('not.contain.text', '<CENTRAL_URL>');
+        });
       });
 
       it('submits with Docker environment when Docker is selected', () => {

--- a/centreon/www/front_src/src/Header/Poller/PollerSubMenu/CloudInstallCommand/Modal/useInstallCommand.ts
+++ b/centreon/www/front_src/src/Header/Poller/PollerSubMenu/CloudInstallCommand/Modal/useInstallCommand.ts
@@ -15,8 +15,28 @@ import { labelFailedToCreatePoller } from '../../../translatedLabels';
 import { generatedCommandAtom, isModalOpenAtom, pollerIdAtom } from '../atoms';
 import type { CloudInstallCommandFormValues } from '../models';
 
-export const webUrl = {
-  get: (): string => window.location.href
+// On cloud, the whole application (including /poller/install.sh) is served
+// under the platform base path, and behind proxies/NAT only the browser knows
+// the client-reachable address — so the central address is host + <base href>,
+// never derived server-side.
+export const centralWebAddress = {
+  get: (): string => `${window.location.host}${centreonBaseURL}`
+};
+
+const normalizeAddress = (address?: string): string | undefined => {
+  const trimmed = address?.trim();
+
+  if (!trimmed?.includes('://')) {
+    return trimmed?.replace(/\/+$/, '');
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    return `${url.host}${url.pathname}`.replace(/\/+$/, '');
+  } catch {
+    return trimmed;
+  }
 };
 
 interface PollerResponse {
@@ -51,9 +71,11 @@ export const useInstallCommand = (): UseInstallCommandState => {
 
   const submit = useCallback(async (values: CloudInstallCommandFormValues) => {
     try {
-      const centralAddress = platformFeatures?.isCloudPlatform
-        ? webUrl.get()
-        : values?.centralAddress?.trim();
+      const centralAddress = normalizeAddress(
+        platformFeatures?.isCloudPlatform
+          ? centralWebAddress.get()
+          : values?.centralAddress
+      );
 
       const pollerResponse = await createPoller({
         payload: {
@@ -76,12 +98,7 @@ export const useInstallCommand = (): UseInstallCommandState => {
 
       setPollerId(pollerId);
 
-      const centralUrl = `${window.location.origin}${centreonBaseURL}`;
-      const command = (response?.installation_command || '')
-        .split('<CENTRAL_URL>')
-        .join(centralUrl);
-
-      setGeneratedCommand(command);
+      setGeneratedCommand(response?.installation_command || '');
     } catch {
       showErrorMessage(t(labelFailedToCreatePoller));
     }


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the fix for the double protocol in the poller installation command.

The Create Poller modal generated an installation command containing a double protocol (`https://http://...`) in the install.sh URL.

Two root causes, both fixed:
- On Cloud platforms, the frontend sent the full `window.location.href` (scheme included) as `central_address`. It now sends the hostname only, and the address typed by on-prem users is normalized the same way (scheme and path stripped through URL parsing).
- The frontend replaced the `<CENTRAL_URL>` placeholder with `window.location.origin` (scheme included) while the backend command template already hardcodes `https://`. This replacement mechanism is dead since `central_address` became required, and has been removed.

As a safety net for direct API calls, `POST /configuration/pollers` now returns an explicit 400 (instead of an opaque 500) when `address` or `central_address` contains a protocol scheme.

Original PR (develop): https://github.com/centreon/centreon/pull/11279

Clean cherry-pick: the resulting diff is byte-identical to the upstream commit, no conflict to resolve.

**Fixes** [MON-207304](https://centreon.atlassian.net/browse/MON-207304)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.10.x
- [ ] master

## How this pull request can be tested ?

1. On a Cloud platform, open the top-banner Create Poller modal, fill in the form and generate the command: the install.sh URL must contain a single `https://` followed by the central hostname (no path, no duplicated scheme), and `--central_url` must hold the bare hostname.
2. On an on-prem platform, type a central address WITH a protocol (e.g. `https://central.example.com/centreon`) in the modal: the generated command must contain `central.example.com` only.
3. Call `POST /configuration/pollers` directly with `"central_address": "http://foo.bar"`: the API must return a 400 with a clear validation message (same for `address`).
4. Nominal case: create a poller with a plain hostname or IP as central address — the command must be identical to the one returned by `GET /configuration/pollers/installation-command/{id}`.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially new classes, functions or any legacy code modified.
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (master, maintenance).


[MON-207304]: https://centreon.atlassian.net/browse/MON-207304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ