### PR TITLE
test(e2e): web: restore centreon-perl-libs pinning in platform update tests

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -230,11 +230,13 @@ const installCentreon = (version: string): Cypress.Chainable => {
     });
   } else {
     const packageVersionSuffix = `${version}-1*`;
-    // centreon-perl-libs is left to apt: it follows the gorgone release cadence
+    // on this series centreon-web requires centreon-perl-libs at strict
+    // equality, so pinning it is what allows apt to downgrade it
     const packagesToInstall = [
       `centreon-poller='${packageVersionSuffix}'`,
       `centreon-web='${packageVersionSuffix}'`,
-      `centreon-trap='${packageVersionSuffix}'`
+      `centreon-trap='${packageVersionSuffix}'`,
+      `centreon-perl-libs='${packageVersionSuffix}'`
     ];
     if (
       Number(versionMatches[1]) < 24 ||


### PR DESCRIPTION
Fixes: [MON-207351](https://centreon.atlassian.net/browse/MON-207351)

Reverts #11349.

On 24.10 `centreon-perl-libs` is packaged by this repository (`centreon/packaging/centreon-perl-libs.yaml`) and `centreon-web` requires it at strict equality, so it has to stay pinned along with the other packages — otherwise apt resolves it to the latest published version and refuses the downgrade.

From 25.10 on it is packaged in centreon-collect (`perl-libs/`) and `centreon-web` only declares a version range, so the change is valid there but not on this series.

[MON-207351]: https://centreon.atlassian.net/browse/MON-207351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ