### PR TITLE
test(e2e): web: stabilize the agent configuration delete steps (release-25.10-next)

### DIFF
--- a/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions.feature
+++ b/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions.feature
@@ -65,5 +65,5 @@ Feature: Check permissions on Agent Configuration
   Scenario: Delete an agent configuration with a non-admin user with filters on Pollers
     Given a non-admin user is in the Agents Configuration page
     And an already existing agent configuration is displayed
-    When the user deletes the Agents Configuration
-    Then the first Agents Configuration is no longer displayed in the listing page
+    When the non-admin user deletes an Agent Configuration
+    Then the deleted agent Configuration is no longer displayed in the listing page

--- a/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions/index.ts
+++ b/centreon/tests/e2e/features/Agent-configuration/05-agent-configuration-check-permissions/index.ts
@@ -200,15 +200,17 @@ Then(
 );
 
 When('the user deletes the Agents Configuration', () => {
-  cy.getByTestId({ testId: 'Delete' }).eq(1).click();
+  cy.contains('[role="row"]', agentsConfiguration.telegraf2.name).within(() => {
+    cy.getByTestId({ testId: 'Delete' }).click();
+  });
   cy.contains('button', 'Delete').click();
-  cy.wait('@deleteAgents');
+  cy.wait('@deleteAgents').its('response.statusCode').should('eq', 204);
 });
 
 Then(
   'the Agents Configuration is no longer displayed in the listing page',
   () => {
-    cy.contains('telegraf-001-updated').should('not.exist');
+    cy.contains(agentsConfiguration.telegraf2.name).should('not.exist');
   }
 );
 
@@ -426,7 +428,8 @@ Given('a non-admin user is in the Agents Configuration page', () => {
     loginViaApi: false
   });
   cy.visit(PAGES.configuration.agentConfigurations);
-  cy.wait('@getAgentsPage');
+  cy.wait('@getNavigationList');
+  cy.wait('@getAgentsPage').its('response.statusCode').should('eq', 200);
 });
 
 Given('an already existing agent configuration is displayed', () => {
@@ -479,14 +482,17 @@ Then(
   }
 );
 
+When('the non-admin user deletes an Agent Configuration', () => {
+  cy.contains('[role="row"]', agentsConfiguration.telegraf2.name).within(() => {
+    cy.getByTestId({ testId: 'Delete' }).click();
+  });
+  cy.contains('button', 'Delete').click();
+  cy.wait('@deleteAgents').its('response.statusCode').should('eq', 204);
+});
+
 Then(
-  'the first Agents Configuration is no longer displayed in the listing page',
+  'the deleted agent Configuration is no longer displayed in the listing page',
   () => {
-    cy.contains('telegraf-001-updated').should('not.exist');
-    cy.get('*[role="rowgroup"]').should(
-      'contain',
-      agentsConfiguration.telegraf2.name
-    );
-    cy.get('*[role="rowgroup"]').should('contain', 'Telegraf');
+    cy.contains(agentsConfiguration.telegraf2.name).should('not.exist');
   }
 );


### PR DESCRIPTION
Fixes: [MON-207363](https://centreon.atlassian.net/browse/MON-207363)

Cherry-pick of #11378 on `release-25.10-next`, itself a cherry-pick of #10379 which was only applied to `develop`.

The delete step targeted the row by a fixed index while the listing is sorted by name, so it removed `telegraf-001-1` and the final assertion then required that same row to still be displayed. It now targets the row by name and asserts the deleted configuration is gone.

This is the failure currently red on the release pipeline of this branch: `bookworm-mysql:8.4 / Agent-configuration/05-agent-configuration-check-permissions.feature`.

[MON-207359]: https://centreon.atlassian.net/browse/MON-207359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MON-207363]: https://centreon.atlassian.net/browse/MON-207363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ