### PR TITLE
fix(broker): do not export event_script logger to pollers older than 25.10.3

### DIFF
--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -36,6 +36,7 @@ class Broker extends AbstractObjectJSON
     use VaultTrait;
     private const STREAM_BBDO_SERVER = 'bbdo_server';
     private const STREAM_BBDO_CLIENT = 'bbdo_client';
+    private const EVENT_SCRIPT_LOGGER_MINIMUM_VERSION = '25.10.3';
 
     /** @var array|null */
     protected $engine = null;
@@ -110,6 +111,12 @@ class Broker extends AbstractObjectJSON
 
     /** @var CentreonDBStatement|null */
     protected $stmt_engine_parameters = null;
+
+    /** @var CentreonDBStatement|null */
+    protected $stmt_poller_version = null;
+
+    /** @var array<int, string|null> */
+    protected $cachePollerVersion = [];
 
     /** @var array|null */
     protected $cacheExternalValue = null;
@@ -206,6 +213,34 @@ class Broker extends AbstractObjectJSON
     }
 
     /**
+     * @param int $pollerId
+     * @param int|null $pollerUid
+     *
+     * @throws PDOException
+     * @return string|null
+     */
+    private function getPollerVersion(int $pollerId, ?int $pollerUid): ?string
+    {
+        if (! array_key_exists($pollerId, $this->cachePollerVersion)) {
+            if (is_null($this->stmt_poller_version)) {
+                $this->stmt_poller_version = $this->backend_instance->db_cs->prepare(
+                    "SELECT `version` FROM instances
+                    WHERE instance_id IN (:poller_id, :poller_uid)
+                    AND `version` IS NOT NULL AND `version` <> ''
+                    ORDER BY last_alive DESC LIMIT 1"
+                );
+            }
+            $this->stmt_poller_version->bindValue(':poller_id', $pollerId, PDO::PARAM_INT);
+            $this->stmt_poller_version->bindValue(':poller_uid', $pollerUid ?? $pollerId, PDO::PARAM_INT);
+            $this->stmt_poller_version->execute();
+            $version = $this->stmt_poller_version->fetchColumn();
+            $this->cachePollerVersion[$pollerId] = is_string($version) && $version !== '' ? $version : null;
+        }
+
+        return $this->cachePollerVersion[$pollerId];
+    }
+
+    /**
      * @param $poller_id
      * @param $localhost
      * @param mixed $pollerId
@@ -293,6 +328,21 @@ class Broker extends AbstractObjectJSON
             $object['log']['max_size'] = filter_var($row['log_max_size'], FILTER_VALIDATE_INT);
             $this->getLogsValues();
             $logs = $this->cacheLogValue[$object['broker_id']];
+
+            // brokers < 25.10.3 reject unknown loggers
+            if (isset($logs['event_script'])) {
+                $pollerVersion = $this->getPollerVersion(
+                    (int) $pollerId,
+                    $this->engine['uid'] !== null ? (int) $this->engine['uid'] : null
+                );
+                if (
+                    $pollerVersion === null
+                    || version_compare($pollerVersion, self::EVENT_SCRIPT_LOGGER_MINIMUM_VERSION, '<')
+                ) {
+                    unset($logs['event_script']);
+                }
+            }
+
             $object['log']['loggers'] = $logs;
 
             $reindexedObjectKeys = [];


### PR DESCRIPTION
Linked ticket: [MON-207438](https://centreon.atlassian.net/browse/MON-207438)

## Description

MON-195786 added the `event_script` logger to every exported broker configuration. Broker binaries older than 25.10.3 reject unknown loggers, so after a configuration export any poller still running an older broker fails to load its configuration and loses its connection to the central (MON-207047).

## Fix

At export time, the `event_script` entry is skipped from `log.loggers` when the target poller's broker version is below 25.10.3 or unknown (poller never connected yet). The version is read from `centreon_storage.instances`, matching the row by legacy poller id or poller uid (newer brokers register under their uid) and taking the most recent heartbeat that reports a version. The broker log form is unchanged; only the export is version-aware.

## Tests performed

On a fresh develop CDE (fixtures, MariaDB 11.8), generating the central poller configuration with `POLLERGENERATE` and checking `log.loggers` in the generated `central-broker.json` / `central-rrd.json` / `central-module.json`:

| # | `centreon_storage.instances` state | Expected | Result |
|---|---|---|---|
| 1 | Reported version `26.11.0` (row keyed by poller **uid**) | `"event_script": "error"` present in all 3 configs | ✅ |
| 2 | Version spoofed to `24.10.9` | `event_script` removed from all 3 configs, other loggers (`core`, `sql`, …) untouched, export succeeds | ✅ |
| 3 | Version unknown (`NULL` — poller never connected) | `event_script` removed | ✅ |
| 4 | Old-style row keyed by **legacy poller id** (`instance_id = 1`) | Row matched, version honored | ✅ |
| 5 | Boundary: version `25.10.3` | `event_script` kept | ✅ |
| 6 | Boundary: version `25.10.2` | `event_script` removed | ✅ |
| 7 | Row with `NULL` version but fresher `last_alive` than a versioned row (broker heartbeats bump `last_alive` without rewriting `version`) | Versioned row wins, no false "unknown" | ✅ |

[MON-207438]: https://centreon.atlassian.net/browse/MON-207438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ