### PR TITLE
enh(delivery): merge pulp domains and split deb repositories per stability

### DIFF
--- a/.github/actions/package-delivery-pulp/action.yml
+++ b/.github/actions/package-delivery-pulp/action.yml
@@ -39,11 +39,11 @@ inputs:
   pulp_url:
     description: "The pulp server api url"
     required: false
-    default: "https://pulp-api.apps.centreon.com"
+    default: "https://pulp-api.int.centreon.com"
   pulp_content_url:
     description: "The pulp server content url"
     required: false
-    default: "https://packages.apps.centreon.com"
+    default: "https://packages.int.centreon.com"
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
     required: false

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -8,8 +8,8 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
 # an unset org variable is forwarded as an empty string, overriding the default
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 PULP_DOMAIN="${PULP_DOMAIN:-default}"
 # read through the public content-app, no auth/grant needed (see api.sh's content_curl)
 PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -8,8 +8,8 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
 # an unset org variable is forwarded as an empty string, overriding the default
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 PULP_DOMAIN="${PULP_DOMAIN:-default}"
 # read-only grant into the stable domain, used by assert_not_in_stable below
 PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -90,7 +90,7 @@ runs:
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
-        # testing and stable tiers live in different Pulp Domains; promote-rpm.sh switches between them
+        # stable shares the domain since the domain merge; kept distinct for the scripts that address the stable tier
         PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
         PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
       run: ${{ github.action_path }}/promote-rpm.sh
@@ -102,8 +102,10 @@ runs:
       env:
         MODULE_NAME: ${{ inputs.module_name }}
         DISTRIB: ${{ inputs.distrib }}
-        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
-        BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        # the promotion source is the testing repository (one deb repository per
+        # stability), not the repository matching the requested stability
+        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.testing_repository_name }}
+        BASE_PATH: ${{ steps.pulp-properties.outputs.testing_base_path }}
         TESTING_POOL_PATH: ${{ steps.pulp-properties.outputs.testing_pool_path }}
         TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
@@ -114,7 +116,7 @@ runs:
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
-        # testing and stable tiers live in different Pulp Domains; promote-deb.sh switches between them
+        # stable shares the domain since the domain merge; kept distinct for the scripts that address the stable tier
         PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
         PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
       run: ${{ github.action_path }}/promote-deb.sh

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -31,11 +31,11 @@ inputs:
   pulp_url:
     description: "The pulp server api url"
     required: false
-    default: "https://pulp-api.apps.centreon.com"
+    default: "https://pulp-api.int.centreon.com"
   pulp_content_url:
     description: "The pulp server content url"
     required: false
-    default: "https://packages.apps.centreon.com"
+    default: "https://packages.int.centreon.com"
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
     required: false

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -7,8 +7,8 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
 # an unset org variable is forwarded as an empty string, overriding the default
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 # stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
 # now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
 PULP_DOMAIN="${PULP_DOMAIN:-default}"

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -9,8 +9,8 @@ source "$(dirname "$0")/../../scripts/pulp/api.sh"
 # an unset org variable is forwarded as an empty string, overriding the default
 PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
 PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
-# testing and stable repositories live in different Pulp Domains; PULP_DOMAIN
-# covers the read phase, switch_pulp_domain moves to PULP_STABLE_DOMAIN for the write phase
+# stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
+# now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
 PULP_DOMAIN="${PULP_DOMAIN:-default}"
 PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
 # switch_pulp_domain overwrites PULP_DOMAIN itself once the write phase

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -250,11 +250,13 @@ if ((${#UNPROMOTED_HREFS[@]} == 0)); then
   exit 0
 fi
 
-# batched promote, mirroring the batched delivery: Pulp Domains share no
-# content across domains, so promoting means re-downloading each package from
-# testing's published distribution and re-uploading it into the stable domain
-# (see deliver-deb.sh for why the FIRST package of each arch goes through the
-# legacy path to establish the release component).
+# batched promote, mirroring the batched delivery. Since the domain merge,
+# testing and stable share their domain (and content): the re-download/
+# re-upload below is deduplicated server-side by sha256, kept only because the
+# battle-tested flow predates the merge — a direct href association would skip
+# the transfers entirely (follow-up optimization). The FIRST package of each
+# arch still goes through the legacy path to establish the release component
+# (see deliver-deb.sh).
 declare -A ARCH_SEEN=()
 LEGACY_PACKAGES=()
 BATCH_PACKAGES=()

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -7,8 +7,8 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
 # an unset org variable is forwarded as an empty string, overriding the default
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 # stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
 # now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
 PULP_DOMAIN="${PULP_DOMAIN:-default}"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -9,8 +9,8 @@ source "$(dirname "$0")/../../scripts/pulp/api.sh"
 # an unset org variable is forwarded as an empty string, overriding the default
 PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
 PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
-# testing and stable repositories live in different Pulp Domains; PULP_DOMAIN
-# covers the read phase, switch_pulp_domain moves to PULP_STABLE_DOMAIN for the write phase
+# stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
+# now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
 PULP_DOMAIN="${PULP_DOMAIN:-default}"
 PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
 # switch_pulp_domain overwrites PULP_DOMAIN itself once the write phase

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -180,10 +180,11 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
 
-  # Pulp Domains share no content across domains (RepositoryVersion.add_content
-  # requires a matching pulp_domain), so promoting re-downloads each package
-  # from testing's published distribution and re-uploads it into the stable
-  # domain -- same as the JFrog promote job always did.
+  # Since the domain merge, testing and stable share their domain (and
+  # content): this re-download/re-upload is deduplicated server-side by
+  # sha256, kept only because the battle-tested flow predates the merge — a
+  # direct href association would skip the transfers entirely (follow-up
+  # optimization). Same shape as the JFrog promote job always had.
   echo "[INFO] Re-uploading $ARCH_PACKAGES_COUNT package(s) from $TESTING_BASE_PATH into the stable domain"
   DOWNLOAD_DIR=$(mktemp -d)
   UPLOAD_DIR=$(mktemp -d)

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -69,6 +69,12 @@ outputs:
   stable_base_path_prefix:
     description: "Base path prefix of stable rpm distributions"
     value: ${{ steps.properties.outputs.stable_base_path_prefix }}
+  testing_repository_name:
+    description: "Repository name of the testing deb repository, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_repository_name }}
+  testing_base_path:
+    description: "Base path of the testing deb distribution, used to download promotion source content"
+    value: ${{ steps.properties.outputs.testing_base_path }}
   testing_suite:
     description: "Apt suite of testing deb packages"
     value: ${{ steps.properties.outputs.testing_suite }}
@@ -76,7 +82,7 @@ outputs:
     description: "Apt suite of stable deb packages"
     value: ${{ steps.properties.outputs.stable_suite }}
   stable_repository_name:
-    description: "Repository holding the stable packages (dedicated for deb plugins, the delivery repository otherwise)"
+    description: "Repository holding the stable deb packages (one deb repository per stability)"
     value: ${{ steps.properties.outputs.stable_repository_name }}
   stable_base_path:
     description: "Base path serving the stable packages"

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -30,29 +30,31 @@ fi
 # parse-distrib emits the el family either generically ("el") or per version
 # ("el7"/"el8"/"el9"/"el10" on centreon-collect); normalize it to "el" so the
 # family checks below are portable across both conventions.
+DEB_PREFIX=""
 case "$DISTRIB_FAMILY" in
   el | el[0-9]*)
-    FAMILY_PREFIX="rpm-"
     DISTRIB_FAMILY="el"
     ;;
-  debian) FAMILY_PREFIX="apt-" ;;
-  ubuntu) FAMILY_PREFIX="ubuntu-" ;;
+  debian) DEB_PREFIX="apt-" ;;
+  ubuntu) DEB_PREFIX="ubuntu-" ;;
   *)
     echo "::error::Unsupported distribution family: $DISTRIB_FAMILY"
     exit 1
     ;;
 esac
 
-ROOT_REPO="${FAMILY_PREFIX}${REPO_BASE}"
-
 # business (paid) rpm content is served under an opaque path segment, mirroring
 # the Artifactory layout; only rpm business repos use it (deb business does not).
+# The segment is path-only: repository NAMES never contain it (they are unique
+# per Domain, and the Domain already identifies the edition).
 BUSINESS_HASH="1a97ff9985262bf3daf7a0919f9c59a6"
 HASH_SEGMENT=""
 if [[ "$REPO_BASE" == "business" && "$DISTRIB_FAMILY" == "el" ]]; then
   HASH_SEGMENT="/$BUSINESS_HASH"
 fi
 
+# uniform stability segments across every edition (plugins included):
+# unstable, testing-release, testing-hotfix, stable
 TESTING_SEGMENT="testing"
 TESTING_POOL_SEGMENT="testing"
 if [[ "$RELEASE_TYPE" == "release" || "$RELEASE_TYPE" == "hotfix" ]]; then
@@ -76,6 +78,8 @@ STABLE_BASE_PATH_PREFIX=""
 REPOSITORY_NAME=""
 BASE_PATH=""
 SUITE=""
+TESTING_REPOSITORY_NAME=""
+TESTING_BASE_PATH=""
 TESTING_SUITE=""
 STABLE_SUITE=""
 POOL_PATH=""
@@ -83,48 +87,32 @@ TESTING_POOL_PATH=""
 STABLE_POOL_PATH=""
 
 if [[ "$REPO_BASE" == "plugins" ]]; then
-  # plugins repositories are not versioned and use their own testing layout: a
-  # bare "testing" segment for releases and "testing-hotfix" for hotfixes,
-  # mirroring the artifactory rpm-plugins/<distrib>/<stability> layout. deb
-  # plugins share one apt-plugins/ubuntu-plugins repo with <distrib>-<stability>
-  # suites.
+  # plugins repositories are not versioned: rpm paths carry no version segment
+  # and deb suites are the plain distribution codename.
   if [[ "$DELIVERY_TYPE" == "feature" ]]; then
     echo "::notice::Feature delivery is not supported for plugins packages, skipping delivery."
     echo "skip_delivery=true" >> "$GITHUB_OUTPUT"
     exit 0
   fi
 
-  TESTING_SEGMENT="testing"
-  TESTING_POOL_SEGMENT="testing"
-  if [[ "$RELEASE_TYPE" == "hotfix" ]]; then
-    TESTING_SEGMENT="testing-hotfix"
-    TESTING_POOL_SEGMENT="testing/hotfix"
-  fi
-
-  STABILITY_SEGMENT="$STABILITY"
-  POOL_SEGMENT="$STABILITY"
-  if [[ "$STABILITY" == "testing" ]]; then
-    STABILITY_SEGMENT="$TESTING_SEGMENT"
-    POOL_SEGMENT="$TESTING_POOL_SEGMENT"
-  fi
-
   if [[ "$DISTRIB_FAMILY" == "el" ]]; then
-    REPOSITORY_PREFIX="$ROOT_REPO-$DISTRIB-$STABILITY_SEGMENT"
-    BASE_PATH_PREFIX="$ROOT_REPO/$DISTRIB/$STABILITY_SEGMENT"
-    TESTING_REPOSITORY_PREFIX="$ROOT_REPO-$DISTRIB-$TESTING_SEGMENT"
-    TESTING_BASE_PATH_PREFIX="$ROOT_REPO/$DISTRIB/$TESTING_SEGMENT"
-    STABLE_REPOSITORY_PREFIX="$ROOT_REPO-$DISTRIB-stable"
-    STABLE_BASE_PATH_PREFIX="$ROOT_REPO/$DISTRIB/stable"
+    REPOSITORY_PREFIX="rpm-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="rpm/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="rpm-$DISTRIB-$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="rpm/$DISTRIB/$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="rpm-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="rpm/$DISTRIB/stable"
   else
-    REPOSITORY_NAME="$ROOT_REPO"
-    BASE_PATH="$ROOT_REPO"
-    SUITE="$DISTRIB-$STABILITY_SEGMENT"
-    TESTING_SUITE="$DISTRIB-$TESTING_SEGMENT"
-    # stable lives in a DEDICATED repository with plain-codename suites, so
-    # the client apt configuration stays identical to the artifactory one
-    # (deb .../apt-plugins-stable <codename> main)
-    STABLE_REPOSITORY_NAME="$ROOT_REPO-stable"
-    STABLE_BASE_PATH="$ROOT_REPO-stable"
+    # one deb repository per stability (base path = repository name), suites
+    # carry the plain codename only
+    REPOSITORY_NAME="${DEB_PREFIX}${STABILITY_SEGMENT}"
+    BASE_PATH="$REPOSITORY_NAME"
+    SUITE="$DISTRIB"
+    TESTING_REPOSITORY_NAME="${DEB_PREFIX}${TESTING_SEGMENT}"
+    TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
+    TESTING_SUITE="$DISTRIB"
+    STABLE_REPOSITORY_NAME="${DEB_PREFIX}stable"
+    STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB"
     POOL_PATH="pool/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$TESTING_POOL_SEGMENT/$MODULE_NAME"
@@ -143,32 +131,35 @@ elif [[ "$DELIVERY_TYPE" == "feature" ]]; then
     exit 1
   fi
 
-  REPOSITORY_PREFIX="$ROOT_REPO-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
-  BASE_PATH_PREFIX="$ROOT_REPO-feature$HASH_SEGMENT/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  REPOSITORY_PREFIX="rpm-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
+  BASE_PATH_PREFIX="rpm-feature$HASH_SEGMENT/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
 else
+  RPM_ROOT="rpm"
+  DEB_INFIX=""
   if [[ "$IS_CLOUD" == "true" || "$REPOSITORY_TYPE" == *-internal ]]; then
-    ROOT_REPO="$ROOT_REPO-internal"
+    RPM_ROOT="rpm-internal"
+    DEB_INFIX="internal-"
   fi
 
   if [[ "$DISTRIB_FAMILY" == "el" ]]; then
-    REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
-    BASE_PATH_PREFIX="$ROOT_REPO$HASH_SEGMENT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
-    TESTING_REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-$TESTING_SEGMENT"
-    TESTING_BASE_PATH_PREFIX="$ROOT_REPO$HASH_SEGMENT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
-    STABLE_REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-stable"
-    STABLE_BASE_PATH_PREFIX="$ROOT_REPO$HASH_SEGMENT/$VERSION/$DISTRIB/stable"
+    REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/stable"
   else
-    REPOSITORY_NAME="$ROOT_REPO"
-    BASE_PATH="$ROOT_REPO"
-    SUITE="$DISTRIB-$VERSION-$STABILITY_SEGMENT"
-    TESTING_SUITE="$DISTRIB-$VERSION-$TESTING_SEGMENT"
-    # stable is a dedicated repository (its own Domain, standard-stable/business-stable,
-    # is the write-protection boundary), but shares its NAME with the non-stable one --
-    # Pulp scopes name uniqueness per Domain, and the Domain already says "stable", so
-    # there's no need to also repeat that (or the version) in the repository name: the
-    # version lives in the suite name only, like the non-stable suites above.
-    STABLE_REPOSITORY_NAME="$ROOT_REPO"
-    STABLE_BASE_PATH="$ROOT_REPO"
+    # one deb repository per stability (base path = repository name), shared by
+    # every major version: the version lives in the suite name only
+    # (e.g. "trixie-26.09")
+    REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${STABILITY_SEGMENT}"
+    BASE_PATH="$REPOSITORY_NAME"
+    SUITE="$DISTRIB-$VERSION"
+    TESTING_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${TESTING_SEGMENT}"
+    TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
+    TESTING_SUITE="$DISTRIB-$VERSION"
+    STABLE_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}stable"
+    STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB-$VERSION"
     POOL_PATH="pool/$VERSION/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$VERSION/$TESTING_POOL_SEGMENT/$MODULE_NAME"
@@ -177,19 +168,19 @@ else
 fi
 
 # unless a dedicated stable repository was selected above, stable shares the
-# delivery repository
+# delivery repository (rpm resolves stable through the *_PREFIX variables)
 STABLE_REPOSITORY_NAME="${STABLE_REPOSITORY_NAME:-$REPOSITORY_NAME}"
 STABLE_BASE_PATH="${STABLE_BASE_PATH:-$BASE_PATH}"
 
-# one Pulp Domain per edition/channel; "-internal"/cloud repos share the
-# domain of their non-internal sibling, so REPO_BASE alone is enough
+# one Pulp Domain per edition; stable and non-stable repositories share it
+# ("-internal"/cloud repos too). The stable/non-stable write boundary is the
+# repository name, enforced server-side by name-scoped grants. stable_domain
+# is kept as a distinct output for the scripts that address the stable tier,
+# even though it now always equals domain.
 DOMAIN="$REPO_BASE"
-# stable is always a separate repository object, never a suite inside
-# testing's, so it gets its own "-stable" domain
-STABLE_DOMAIN="$REPO_BASE-stable"
+STABLE_DOMAIN="$DOMAIN"
 
 echo "[DEBUG] - repository_type: $REPOSITORY_TYPE"
-echo "[DEBUG] - root_repo: $ROOT_REPO"
 echo "[DEBUG] - repository_prefix: $REPOSITORY_PREFIX"
 echo "[DEBUG] - base_path_prefix: $BASE_PATH_PREFIX"
 echo "[DEBUG] - testing_repository_prefix: $TESTING_REPOSITORY_PREFIX"
@@ -199,6 +190,8 @@ echo "[DEBUG] - stable_base_path_prefix: $STABLE_BASE_PATH_PREFIX"
 echo "[DEBUG] - repository_name: $REPOSITORY_NAME"
 echo "[DEBUG] - base_path: $BASE_PATH"
 echo "[DEBUG] - suite: $SUITE"
+echo "[DEBUG] - testing_repository_name: $TESTING_REPOSITORY_NAME"
+echo "[DEBUG] - testing_base_path: $TESTING_BASE_PATH"
 echo "[DEBUG] - testing_suite: $TESTING_SUITE"
 echo "[DEBUG] - stable_suite: $STABLE_SUITE"
 echo "[DEBUG] - pool_path: $POOL_PATH"
@@ -218,6 +211,8 @@ echo "[DEBUG] - stable_domain: $STABLE_DOMAIN"
   echo "repository_name=$REPOSITORY_NAME"
   echo "base_path=$BASE_PATH"
   echo "suite=$SUITE"
+  echo "testing_repository_name=$TESTING_REPOSITORY_NAME"
+  echo "testing_base_path=$TESTING_BASE_PATH"
   echo "testing_suite=$TESTING_SUITE"
   echo "stable_suite=$STABLE_SUITE"
   echo "stable_repository_name=$STABLE_REPOSITORY_NAME"

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -4,7 +4,7 @@ inputs:
   pulp_url:
     description: "The pulp server api url"
     required: false
-    default: "https://pulp-api.apps.centreon.com"
+    default: "https://pulp-api.int.centreon.com"
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
     required: false
@@ -88,7 +88,7 @@ runs:
 
         # fall back to the default when the caller passes an empty value (unset
         # org variable forwarded as "" would otherwise override the default).
-        PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+        PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
         DOMAIN="${DOMAIN:-default}"
 
         # keep the pulp-cli config (which stores the OIDC token) under the per-job

--- a/.github/scripts/docker-push-to-pulp.sh
+++ b/.github/scripts/docker-push-to-pulp.sh
@@ -21,7 +21,7 @@
 # full provenance; only the Pulp copy omits it.
 #
 # Expected env vars:
-#   PULP_URL             e.g. https://pulp-api.apps.centreon.com
+#   PULP_URL             e.g. https://pulp-api.int.centreon.com
 #   PULP_OIDC_AUDIENCE   e.g. https://pulp.dev.centreon.io
 #   BASE_PATH            Pulp container path, e.g. centreon/centreon-centreontrapd-trixie
 #   HARBOR_IMAGE         source image ref on Harbor, no tag
@@ -31,7 +31,7 @@
 #   ACTIONS_ID_TOKEN_REQUEST_TOKEN / ACTIONS_ID_TOKEN_REQUEST_URL (injected by GitHub Actions when the job has `id-token: write`)
 set -euo pipefail
 
-PULP_IMAGE="pulp-api.apps.centreon.com/$BASE_PATH"
+PULP_IMAGE="pulp-api.int.centreon.com/$BASE_PATH"
 
 echo "::group::Fetch GitHub OIDC token for Pulp"
 OIDC_TOKEN=$(curl -sS \
@@ -84,7 +84,7 @@ echo "::endgroup::"
 echo "::group::Login to Pulp registry via OIDC"
 PULP_JWT=$(curl -sS \
   -H "Authorization: Bearer $OIDC_TOKEN" \
-  "$PULP_URL/token/?service=pulp-api.apps.centreon.com&scope=repository:${BASE_PATH}:push,pull" \
+  "$PULP_URL/token/?service=pulp-api.int.centreon.com&scope=repository:${BASE_PATH}:push,pull" \
   | jq -r '.token // empty')
 if [[ -z "$PULP_JWT" ]]; then
   echo "::error::Failed to fetch Pulp JWT (token service returned empty)"
@@ -94,7 +94,7 @@ echo "::add-mask::$PULP_JWT"
 mkdir -p ~/.docker
 EXISTING_CONFIG=$(cat ~/.docker/config.json 2>/dev/null || echo '{}')
 echo "$EXISTING_CONFIG" | jq --arg jwt "$PULP_JWT" \
-  '.auths["pulp-api.apps.centreon.com"] = {"registrytoken": $jwt}' \
+  '.auths["pulp-api.int.centreon.com"] = {"registrytoken": $jwt}' \
   > ~/.docker/config.json
 echo "::endgroup::"
 

--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -11,8 +11,8 @@
 # shellcheck source=.github/scripts/pulp/api.sh
 source "$(dirname "${BASH_SOURCE[0]}")/api.sh"
 
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 
 switch_pulp_domain "$PULP_DOMAIN" || exit 1
 # 900s: the published indexes can lag a finished publication by up to the

--- a/.github/workflows/docker-trapd.yml
+++ b/.github/workflows/docker-trapd.yml
@@ -429,7 +429,7 @@ jobs:
         continue-on-error: true
         id: promote-pulp
         env:
-          PULP_URL: https://pulp-api.apps.centreon.com
+          PULP_URL: https://pulp-api.int.centreon.com
           PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
           BASE_PATH: centreon/${{ matrix.component }}-${{ matrix.operating_system }}
           HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}


### PR DESCRIPTION
Fixes: [MON-207474](https://centreon.atlassian.net/browse/MON-207474)

Companion of centreon/delivery-tooling#279 (merged Pulp domains, one deb repository per stability). Pulp-only change — the Artifactory delivery path is untouched.

- `pulp-repository-properties`: one Domain per edition (`stable_domain` now equals `domain`); deb targets one repository per stability (`apt-stable` / `apt-testing-release` / `apt-testing-hotfix` / `apt-unstable`, `ubuntu-*` and `*-internal-*` variants) with `codename[-major]` suites (no stability in suite names); rpm base paths rooted at `rpm[/token]`, token-free repository names; uniform stability segments (plugins/connectors move from bare `testing` to `testing-release`).
- `promote-to-stable-pulp`: the deb promotion source is now explicitly the testing repository (new `testing_repository_name` / `testing_base_path` outputs) since the requested stability resolves to `apt-stable`.
- `deliver-*.sh` / `promote-*.sh` logic unchanged (cross-repo promotion already covered the new scheme); only stale domain comments updated.

Repositories must be provisioned by delivery-tooling `create-repos` (new layout) before this is used; the dev stack migration is tracked in MON-207474.


[MON-207474]: https://centreon.atlassian.net/browse/MON-207474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ