### PR TITLE
fix(resources): route Check column through translate() guard

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
@@ -153,7 +153,7 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
                 _('Monitoring server') => $resource->getMonitoringServerName(),
                 _('Notif') => $resource->isNotificationEnabled()
                     ? _('Notifications enabled') : _('Notifications disabled'),
-                _('Check') => _($this->getResourceCheck($resource)),
+                _('Check') => $this->translate($this->getResourceCheck($resource)),
                 _('Host ID') => $this->getHostId($resource),
                 _('Service ID') => $this->getServiceId($resource),
             ];


### PR DESCRIPTION
## Description

- Route the `Check` column through the existing `translate()` guard in `ExportResourcesPresenterCsv`, which returns `''` instead of calling `_()` on an empty value
- Defensive alignment only: `getResourceCheck()` cannot currently return `''` — `getActiveChecks()` / `getPassiveChecks()` are non-nullable `bool` and the four combinations are all covered — so no user-visible corruption was reachable through this column. The columns where the leak *was* reachable (`State`, `Parent Resource *`, `Resource Type`, `Status`) were already guarded on this series
- Value of the change: the column list becomes homogeneous and the file byte-identical to develop's, so the guard cannot be dropped again by a future edit

Strict cherry-pick of the develop commit, applied without conflict.

## How to test

1. On a Debian-based platform with `en_US` locale active, log in to Centreon
2. Go to Resources Status and export the CSV
3. Verify that the `Check` column contains the expected value (e.g. "All checks are enabled") and never the gettext catalog header (`Project-Id-Version: Centreon web…`)

## Links

### Jira ticket

Resolves: [MON-207522](https://centreon.atlassian.net/browse/MON-207522)

### PR Github

- Backports: #11367


[MON-207522]: https://centreon.atlassian.net/browse/MON-207522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ