### PR TITLE
fix(resources): route Check column through translate() guard

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
@@ -128,12 +128,12 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
         /** @var ResourceEntity $resource */
         foreach ($resources as $resource) {
             $resource = [
-                _('Resource Type') => _($this->formatLabel($resource->getType() ?? '')),
-                _('Resource Name') => _($resource->getName() ?? ''),
-                _('Status') => _($this->formatLabel($resource->getStatus()?->getName() ?? '')),
-                _('Parent Resource Type') => _($this->formatLabel($resource->getParent()?->getType() ?? '')),
-                _('Parent Resource Name') => _($resource->getParent()?->getName() ?? ''),
-                _('Parent Resource Status') => _(
+                _('Resource Type') => $this->translate($this->formatLabel($resource->getType() ?? '')),
+                _('Resource Name') => $resource->getName() ?? '',
+                _('Status') => $this->translate($this->formatLabel($resource->getStatus()?->getName() ?? '')),
+                _('Parent Resource Type') => $this->translate($this->formatLabel($resource->getParent()?->getType() ?? '')),
+                _('Parent Resource Name') => $resource->getParent()?->getName() ?? '',
+                _('Parent Resource Status') => $this->translate(
                     $this->formatLabel($resource->getParent()?->getStatus()?->getName() ?? '')
                 ),
                 _('Duration') => $resource->getDuration() ?? '',
@@ -146,14 +146,14 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
                     $resource->getLinks()->getExternals()->getActionUrl() ?? '',
                     $resource
                 ),
-                _('State') => _($this->getResourceState($resource)),
+                _('State') => $this->translate($this->getResourceState($resource)),
                 _('Alias') => $resource->getAlias() ?? '',
                 _('Parent alias') => $resource->getParent()?->getAlias() ?? '',
                 _('FQDN / Address') => $resource->getFqdn() ?? '',
                 _('Monitoring server') => $resource->getMonitoringServerName(),
                 _('Notif') => $resource->isNotificationEnabled()
                     ? _('Notifications enabled') : _('Notifications disabled'),
-                _('Check') => _($this->getResourceCheck($resource)),
+                _('Check') => $this->translate($this->getResourceCheck($resource)),
                 _('Host ID') => $this->getHostId($resource),
                 _('Service ID') => $this->getServiceId($resource),
             ];
@@ -241,6 +241,16 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
         });
 
         return $csvHeader;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    private function translate(string $value): string
+    {
+        return $value !== '' ? _($value) : '';
     }
 
     /**


### PR DESCRIPTION
## Description

Aligns `ExportResourcesPresenterCsv` on the develop version, so the CSV export never leaks the gettext catalog header into an empty column.

- Add the `translate()` helper — `_()` on an empty `msgid` returns the catalog metadata entry (`Project-Id-Version: Centreon web…`), not an empty string
- Route `Resource Type`, `Status`, `Parent Resource Type`, `Parent Resource Status`, `State` and `Check` through it
- Stop translating `Resource Name` and `Parent Resource Name`: they hold user data, which has no place in a translation catalog

Nominal rows were affected: `State` is empty whenever the resource is neither acknowledged, in downtime nor flapping, and the `Parent Resource *` columns are empty on every Host row.

Not a plain cherry-pick: this series never received the guard, which reached develop as a side effect of #9940 (deb13 / EL10 packaging). Cherry-picking the develop commit alone applies textually but calls a `translate()` method that does not exist here. The change was therefore rebuilt from #9940 plus #11367, and the file is now byte-identical to develop's.

## How to test

1. On a Debian-based platform with `en_US` locale active, log in to Centreon
2. Go to Resources Status and export the CSV
3. Verify that no cell contains `Project-Id-Version`, that `State` is empty on a nominal resource, and that `Check` holds its expected value (e.g. "All checks are enabled")

## Links

### Jira ticket

Resolves: [MON-207523](https://centreon.atlassian.net/browse/MON-207523)

### PR Github

- Backports: #11367


[MON-207523]: https://centreon.atlassian.net/browse/MON-207523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ