### PR TITLE
fix(resources): route Check column through translate() guard

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
@@ -122,12 +122,12 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
         /** @var ResourceEntity $resource */
         foreach ($resources as $resource) {
             $resource = [
-                _('Resource Type') => _($this->formatLabel($resource->getType() ?? '')),
-                _('Resource Name') => _($resource->getName() ?? ''),
-                _('Status') => _($this->formatLabel($resource->getStatus()?->getName() ?? '')),
-                _('Parent Resource Type') => _($this->formatLabel($resource->getParent()?->getType() ?? '')),
-                _('Parent Resource Name') => _($resource->getParent()?->getName() ?? ''),
-                _('Parent Resource Status') => _(
+                _('Resource Type') => $this->translate($this->formatLabel($resource->getType() ?? '')),
+                _('Resource Name') => $resource->getName() ?? '',
+                _('Status') => $this->translate($this->formatLabel($resource->getStatus()?->getName() ?? '')),
+                _('Parent Resource Type') => $this->translate($this->formatLabel($resource->getParent()?->getType() ?? '')),
+                _('Parent Resource Name') => $resource->getParent()?->getName() ?? '',
+                _('Parent Resource Status') => $this->translate(
                     $this->formatLabel($resource->getParent()?->getStatus()?->getName() ?? '')
                 ),
                 _('Duration') => $resource->getDuration() ?? '',
@@ -139,14 +139,14 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
                 _('Action') => $this->formatUrl(
                     $resource->getLinks()->getExternals()->getActionUrl() ?? '', $resource
                 ),
-                _('State') => _($this->getResourceState($resource)),
+                _('State') => $this->translate($this->getResourceState($resource)),
                 _('Alias') => $resource->getAlias() ?? '',
                 _('Parent alias') => $resource->getParent()?->getAlias() ?? '',
                 _('FQDN / Address') => $resource->getFqdn() ?? '',
                 _('Monitoring server') => $resource->getMonitoringServerName(),
                 _('Notif') => $resource->isNotificationEnabled()
                     ? _('Notifications enabled') : _('Notifications disabled'),
-                _('Check') => _($this->getResourceCheck($resource)),
+                _('Check') => $this->translate($this->getResourceCheck($resource)),
             ];
 
             $line = array_map(
@@ -232,6 +232,16 @@ final class ExportResourcesPresenterCsv extends AbstractPresenter implements Exp
         });
 
         return $csvHeader;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    private function translate(string $value): string
+    {
+        return $value !== '' ? _($value) : '';
     }
 
     /**


### PR DESCRIPTION
## Description

Aligns `ExportResourcesPresenterCsv` on the develop version, so the CSV export never leaks the gettext catalog header into an empty column.

- Add the `translate()` helper — `_()` on an empty `msgid` returns the catalog metadata entry (`Project-Id-Version: Centreon web…`), not an empty string
- Route `Resource Type`, `Status`, `Parent Resource Type`, `Parent Resource Status`, `State` and `Check` through it
- Stop translating `Resource Name` and `Parent Resource Name`: they hold user data, which has no place in a translation catalog. The shipped catalogs really do contain entries such as `Load`, `Host` or `Central`, so a resource named `Load` was being rendered as the French verb `Charger` — the de-translation fixes that too

Nominal rows were affected: `State` is empty whenever the resource is neither acknowledged, in downtime nor flapping, and the `Parent Resource *` columns are empty on every Host row.

Not a plain cherry-pick: this series never received the guard, which reached develop as a side effect of #9940 (deb13 / EL10 packaging). Cherry-picking the develop commit alone applies textually but calls a `translate()` method that does not exist here. The change was therefore rebuilt from #9940 plus #11367. The guard is identical to the 25.10 one; the remaining differences with that series are pre-existing and untouched — this series has no `Host ID` / `Service ID` columns (nor their helpers), and its `_('Action')` call is wrapped on a single line.

## How to test

1. On a Debian-based platform with `en_US` locale active, log in to Centreon
2. Go to Resources Status and export the CSV
3. Verify that no cell contains `Project-Id-Version`, that `State` is empty on a nominal resource, and that `Check` holds its expected value (e.g. "All checks are enabled")

## Links

### Jira ticket

Resolves: [MON-207524](https://centreon.atlassian.net/browse/MON-207524)

### PR Github

- Backports: #11367


[MON-207524]: https://centreon.atlassian.net/browse/MON-207524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ