### PR TITLE
fix(kernel): MON-207440 invalidate symfony cache when module config files change

### DIFF
--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -43,6 +43,9 @@ class Kernel extends BaseKernel
     /** @var string cache path */
     private string $cacheDir = '/var/cache/centreon/symfony';
 
+    /** @var string|null memoized config file set fingerprint */
+    private ?string $configFingerprint = null;
+
     /**
      * Kernel constructor.
      */
@@ -105,7 +108,7 @@ class Kernel extends BaseKernel
     #[\Override]
     public function getCacheDir(): string
     {
-        return $this->cacheDir;
+        return $this->cacheDir . '/' . $this->getConfigFingerprint();
     }
 
     #[\Override]
@@ -123,5 +126,35 @@ class Kernel extends BaseKernel
             $compilerPass = new $class();
             $container->addCompilerPass($compilerPass);
         }
+    }
+
+    /**
+     * Modules drop yaml files under config/routes and config/packages after the container
+     * may already have been compiled. Keying the cache directory on the config file set
+     * makes such a stale container unreachable instead of fatal.
+     *
+     * The shared kernel computes its own fingerprint the same way. Sharing the code is not an
+     * option: the deptrac Legacy layer must not depend on App\Shared.
+     */
+    private function getConfigFingerprint(): string
+    {
+        if ($this->configFingerprint === null) {
+            // filemtime() and filesize() read PHP's stat cache, which must not hand back
+            // pre-write values to a process that just wrote a configuration file.
+            clearstatcache();
+
+            $files = array_merge(
+                glob($this->getProjectDir() . '/config/{routes,packages}/{*,*/*}.yaml', \GLOB_BRACE) ?: [],
+                glob($this->getProjectDir() . '/config/bundles.php') ?: []
+            );
+            sort($files);
+            $entries = array_map(
+                static fn (string $file): string => $file . ':' . (filemtime($file) ?: 0) . ':' . (filesize($file) ?: 0),
+                $files
+            );
+            $this->configFingerprint = mb_substr(md5(implode('|', $entries)), 0, 8);
+        }
+
+        return $this->configFingerprint;
     }
 }

--- a/centreon/src/App/Shared/Infrastructure/Symfony/ConfigFingerprint.php
+++ b/centreon/src/App/Shared/Infrastructure/Symfony/ConfigFingerprint.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Symfony;
+
+/**
+ * Modules drop configuration files after the Symfony container may already have been
+ * compiled. Keying the cache directory on the configuration file set makes such a stale
+ * container unreachable instead of fatal.
+ *
+ * The Kernel itself is final and resolves its project directory from its own location, so
+ * holding the file set rules here is what makes them testable.
+ */
+final class ConfigFingerprint
+{
+    /**
+     * Fingerprints every file the shared kernel imports from the given configuration directory.
+     */
+    public static function ofConfigDir(string $configDir): string
+    {
+        return self::of(
+            $configDir . '/{routes,packages,services}/{*,*/*}.{yaml,php}',
+            $configDir . '/bundles.php'
+        );
+    }
+
+    private static function of(string ...$globPatterns): string
+    {
+        // filemtime() and filesize() read PHP's stat cache. Booting the kernel from the very
+        // process that just wrote a configuration file must not reuse pre-write values, and
+        // relying on glob() to evict them is not a documented guarantee.
+        clearstatcache();
+
+        $files = [];
+        foreach ($globPatterns as $globPattern) {
+            $files = array_merge($files, glob($globPattern, \GLOB_BRACE) ?: []);
+        }
+        sort($files);
+
+        $entries = array_map(
+            static fn (string $file): string => $file . ':' . (filemtime($file) ?: 0) . ':' . (filesize($file) ?: 0),
+            $files
+        );
+
+        return mb_substr(md5(implode('|', $entries)), 0, 8);
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Symfony/Kernel.php
+++ b/centreon/src/App/Shared/Infrastructure/Symfony/Kernel.php
@@ -36,9 +36,11 @@ final class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
+    private ?string $configFingerprint = null;
+
     public function getCacheDir(): string
     {
-        return '/var/cache/centreon/symfony.new';
+        return '/var/cache/centreon/symfony.new/' . $this->getConfigFingerprint();
     }
 
     public function getLogDir(): string
@@ -103,5 +105,10 @@ final class Kernel extends BaseKernel
     private function getConfigDir(): string
     {
         return $this->getProjectDir() . '/config.new';
+    }
+
+    private function getConfigFingerprint(): string
+    {
+        return $this->configFingerprint ??= ConfigFingerprint::ofConfigDir($this->getConfigDir());
     }
 }

--- a/centreon/tests/php/App/Double/FakeKernel.php
+++ b/centreon/tests/php/App/Double/FakeKernel.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Double;
+
+use App\Kernel;
+
+class FakeKernel extends Kernel
+{
+    public function __construct(private string $fakeProjectDir)
+    {
+        parent::__construct('test', false);
+    }
+
+    #[\Override]
+    public function getProjectDir(): string
+    {
+        return $this->fakeProjectDir;
+    }
+}

--- a/centreon/tests/php/App/Double/TemporaryConfigDirectory.php
+++ b/centreon/tests/php/App/Double/TemporaryConfigDirectory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Double;
+
+trait TemporaryConfigDirectory
+{
+    /**
+     * @param string ...$subDirectories directories to create inside the temporary directory
+     */
+    private function createTemporaryDirectory(string ...$subDirectories): string
+    {
+        $path = sys_get_temp_dir() . '/centreon-config-fingerprint-' . bin2hex(random_bytes(4));
+        mkdir($path, 0755, true);
+
+        foreach ($subDirectories as $subDirectory) {
+            mkdir($path . '/' . $subDirectory, 0755, true);
+        }
+
+        return $path;
+    }
+
+    /**
+     * A fixed modification time keeps the fingerprint assertions deterministic without
+     * having to wait for the next second.
+     */
+    private function writeFile(string $path, string $content, int $mtime = 1700000000): void
+    {
+        $directory = \dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($path, $content);
+        touch($path, $mtime);
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            assert($item instanceof \SplFileInfo);
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/centreon/tests/php/App/KernelConfigFingerprintTest.php
+++ b/centreon/tests/php/App/KernelConfigFingerprintTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App;
+
+use App\Shared\Infrastructure\Symfony\Kernel as SharedKernel;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Double\FakeKernel;
+use Tests\App\Double\TemporaryConfigDirectory;
+
+/**
+ * Covers the file set the legacy kernel imports from its config directory, and the fact that
+ * both kernels key their cache directory on it. The shared kernel is final and resolves its
+ * project directory from its own location, so the file set it imports is covered by
+ * {@see Shared\Infrastructure\Symfony\ConfigFingerprintTest}.
+ */
+final class KernelConfigFingerprintTest extends TestCase
+{
+    use TemporaryConfigDirectory;
+    private const MTIME = 1700000000;
+
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = $this->createTemporaryDirectory('config/routes', 'config/packages');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tmpDir);
+    }
+
+    /**
+     * The cache directory prefix comes from _CENTREON_CACHEDIR_, which the test bootstrap
+     * overrides, so only the /symfony/<fingerprint> suffix is asserted here.
+     */
+    public function testLegacyCacheDirEndsWithHexFingerprint(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/test.yaml', "resource: test\n");
+
+        self::assertMatchesRegularExpression('#/symfony/[0-9a-f]{8}$#', (new FakeKernel($this->tmpDir))->getCacheDir());
+    }
+
+    public function testSharedCacheDirEndsWithHexFingerprint(): void
+    {
+        $kernel = new SharedKernel('test', false);
+
+        self::assertMatchesRegularExpression('#^/var/cache/centreon/symfony\.new/[0-9a-f]{8}$#', $kernel->getCacheDir());
+    }
+
+    public function testFingerprintIsComputedOnlyOncePerKernel(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml', "resource: a\n");
+        $kernel = new FakeKernel($this->tmpDir);
+        $cacheDir = $kernel->getCacheDir();
+
+        $this->writeFile($this->tmpDir . '/config/routes/b.yaml', "resource: b\n");
+
+        self::assertSame($cacheDir, $kernel->getCacheDir());
+    }
+
+    public function testFingerprintIsStableWhileNothingChanges(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/z.yaml', "resource: z\n");
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml', "resource: a\n");
+
+        self::assertSame(
+            (new FakeKernel($this->tmpDir))->getCacheDir(),
+            (new FakeKernel($this->tmpDir))->getCacheDir()
+        );
+    }
+
+    public function testFingerprintChangesWhenAFileIsAdded(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml', "resource: a\n");
+        $before = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        $this->writeFile($this->tmpDir . '/config/routes/b.yaml', "resource: b\n");
+
+        self::assertNotSame($before, (new FakeKernel($this->tmpDir))->getCacheDir());
+    }
+
+    public function testFingerprintChangesWhenAFileIsRemoved(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml', "resource: a\n");
+        $this->writeFile($this->tmpDir . '/config/routes/b.yaml', "resource: b\n");
+        $before = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        unlink($this->tmpDir . '/config/routes/b.yaml');
+
+        self::assertNotSame($before, (new FakeKernel($this->tmpDir))->getCacheDir());
+    }
+
+    /**
+     * Both contents have the same length, so only the modification time can tell them apart.
+     */
+    public function testFingerprintChangesWhenContentChangesWithoutSizeChange(): void
+    {
+        $file = $this->tmpDir . '/config/packages/framework.yaml';
+        $this->writeFile($file, "framework:\n    secret: aaa\n");
+        $before = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        $this->writeFile($file, "framework:\n    secret: bbb\n", self::MTIME + 60);
+
+        self::assertNotSame($before, (new FakeKernel($this->tmpDir))->getCacheDir());
+    }
+
+    /**
+     * The modification time is preserved, as `cp -p` or `rsync -a` would, so only the file
+     * size can tell both contents apart.
+     */
+    public function testFingerprintChangesWhenSizeChangesWithoutMtimeChange(): void
+    {
+        $file = $this->tmpDir . '/config/packages/framework.yaml';
+        $this->writeFile($file, "framework:\n    secret: aaa\n");
+        $before = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        $this->writeFile($file, "framework:\n    secret: aaa_longer\n");
+
+        self::assertNotSame($before, (new FakeKernel($this->tmpDir))->getCacheDir());
+    }
+
+    public function testFingerprintCoversNestedDirectoriesAndBundles(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml', "resource: a\n");
+        $cacheDirs = [(new FakeKernel($this->tmpDir))->getCacheDir()];
+
+        $this->writeFile($this->tmpDir . '/config/routes/Centreon/module.yaml', "resource: module\n");
+        $cacheDirs[] = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        $this->writeFile($this->tmpDir . '/config/packages/prod/cache.yaml', "framework:\n    cache: ~\n");
+        $cacheDirs[] = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        $this->writeFile($this->tmpDir . '/config/bundles.php', "<?php\n\nreturn [];\n");
+        $cacheDirs[] = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        self::assertSame($cacheDirs, array_unique($cacheDirs));
+    }
+
+    public function testFingerprintIgnoresFilesThatAreNotImported(): void
+    {
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml', "resource: a\n");
+        $before = (new FakeKernel($this->tmpDir))->getCacheDir();
+
+        $this->writeFile($this->tmpDir . '/config/routes/a.yaml.bak', "resource: a\n");
+        $this->writeFile($this->tmpDir . '/config/packages/notes.md', "# notes\n");
+
+        self::assertSame($before, (new FakeKernel($this->tmpDir))->getCacheDir());
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Symfony/ConfigFingerprintTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Symfony/ConfigFingerprintTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Symfony;
+
+use App\Shared\Infrastructure\Symfony\ConfigFingerprint;
+use PHPUnit\Framework\TestCase;
+use Tests\App\Double\TemporaryConfigDirectory;
+
+/**
+ * Covers the file set the shared kernel imports from config.new. The legacy kernel keeps its
+ * own copy of this computation, exercised by {@see \Tests\App\KernelConfigFingerprintTest}.
+ */
+final class ConfigFingerprintTest extends TestCase
+{
+    use TemporaryConfigDirectory;
+    private const MTIME = 1700000000;
+
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = $this->createTemporaryDirectory('routes', 'packages', 'services');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tmpDir);
+    }
+
+    public function testFingerprintIsAShortHexadecimalDigestForAnEmptyConfigDir(): void
+    {
+        self::assertMatchesRegularExpression('/^[0-9a-f]{8}$/', ConfigFingerprint::ofConfigDir($this->tmpDir));
+    }
+
+    public function testFingerprintIsStableWhileNothingChanges(): void
+    {
+        $this->writeFile($this->tmpDir . '/routes/a.yaml', "resource: a\n");
+        $this->writeFile($this->tmpDir . '/routes/z.yaml', "resource: z\n");
+
+        self::assertSame(
+            ConfigFingerprint::ofConfigDir($this->tmpDir),
+            ConfigFingerprint::ofConfigDir($this->tmpDir)
+        );
+    }
+
+    public function testFingerprintChangesWhenAFileIsAdded(): void
+    {
+        $this->writeFile($this->tmpDir . '/routes/a.yaml', "resource: a\n");
+        $before = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/routes/b.yaml', "resource: b\n");
+
+        self::assertNotSame($before, ConfigFingerprint::ofConfigDir($this->tmpDir));
+    }
+
+    public function testFingerprintChangesWhenAFileIsRemoved(): void
+    {
+        $this->writeFile($this->tmpDir . '/routes/a.yaml', "resource: a\n");
+        $this->writeFile($this->tmpDir . '/routes/b.yaml', "resource: b\n");
+        $before = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        unlink($this->tmpDir . '/routes/b.yaml');
+
+        self::assertNotSame($before, ConfigFingerprint::ofConfigDir($this->tmpDir));
+    }
+
+    /**
+     * Both contents have the same length, so only the modification time can tell them apart.
+     */
+    public function testFingerprintChangesWhenContentChangesWithoutSizeChange(): void
+    {
+        $this->writeFile($this->tmpDir . '/packages/framework.yaml', "framework:\n    secret: aaa\n");
+        $before = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/packages/framework.yaml', "framework:\n    secret: bbb\n", self::MTIME + 60);
+
+        self::assertNotSame($before, ConfigFingerprint::ofConfigDir($this->tmpDir));
+    }
+
+    /**
+     * The modification time is preserved, as `cp -p` or `rsync -a` would, so only the file
+     * size can tell both contents apart.
+     */
+    public function testFingerprintChangesWhenSizeChangesWithoutMtimeChange(): void
+    {
+        $this->writeFile($this->tmpDir . '/packages/framework.yaml', "framework:\n    secret: aaa\n");
+        $before = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/packages/framework.yaml', "framework:\n    secret: aaa_longer\n");
+
+        self::assertNotSame($before, ConfigFingerprint::ofConfigDir($this->tmpDir));
+    }
+
+    public function testFingerprintCoversNestedDirectoriesServicesAndBundles(): void
+    {
+        $this->writeFile($this->tmpDir . '/routes/a.yaml', "resource: a\n");
+        $fingerprints = [ConfigFingerprint::ofConfigDir($this->tmpDir)];
+
+        $this->writeFile($this->tmpDir . '/packages/prod/cache.yaml', "framework:\n    cache: ~\n");
+        $fingerprints[] = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/services/handlers.php', "<?php\n\nreturn static function (): void {};\n");
+        $fingerprints[] = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/services/prod/handlers.php', "<?php\n\nreturn static function (): void {};\n");
+        $fingerprints[] = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/bundles.php', "<?php\n\nreturn [];\n");
+        $fingerprints[] = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        self::assertSame($fingerprints, array_unique($fingerprints));
+    }
+
+    public function testFingerprintIgnoresFilesThatAreNotImported(): void
+    {
+        $this->writeFile($this->tmpDir . '/services/handlers.php', "<?php\n\nreturn static function (): void {};\n");
+        $before = ConfigFingerprint::ofConfigDir($this->tmpDir);
+
+        $this->writeFile($this->tmpDir . '/services/handlers.php.bak', "<?php\n\nreturn static function (): void {};\n");
+        $this->writeFile($this->tmpDir . '/packages/notes.md', "# notes\n");
+
+        self::assertSame($before, ConfigFingerprint::ofConfigDir($this->tmpDir));
+    }
+}


### PR DESCRIPTION
## Description

On platforms shipping a pre-warmed Symfony cache, a module's config files (`config/routes/*.yaml`, `config/packages/*.yaml`, `config.new/**`) can land on disk **after** the container was compiled. The compiled route-loader service locator then misses the module's `RouteLoader` while its route yaml is present, and every `/api/latest/*` request fails with HTTP 500 (`Service "X\Routing\RouteLoader" not found: the container ... is a smaller service locator`). On cloud this dead-locks upgrades: compliance calls `GET /api/latest/platform/installation/status` before any step that would clear the cache, so the platform stays down until a manual `cache:clear`.

Both kernels now key their cache directory on a fingerprint of the module-facing config file set — file names, modification times and sizes, hashed and truncated to 8 hex characters. When a module lands, changes or is removed, the fingerprint changes and the kernel compiles a fresh container in a new subdirectory instead of fatally reusing the stale one. Packaging purge/warmup scriptlets are unaffected: they `rm -rf` / warm the parent directories (`/var/cache/centreon/symfony`, `/var/cache/centreon/symfony.new`).

Sizes are part of the fingerprint so that a file copied with its modification time preserved (`cp -p`, `rsync -a`) is still detected, and the computation clears PHP's stat cache so that a process which just wrote a configuration file cannot be handed pre-write values.

### Where the code lives

The two kernels track different trees, and each fingerprints only what it imports:

| Kernel | Config directory | Cache directory | Imported file set |
| --- | --- | --- | --- |
| `App\Kernel` | `config/` | `/var/cache/centreon/symfony/<fingerprint>` | `{routes,packages}/{*,*/*}.yaml` + `bundles.php` |
| `App\Shared\Infrastructure\Symfony\Kernel` | `config.new/` | `/var/cache/centreon/symfony.new/<fingerprint>` | `{routes,packages,services}/{*,*/*}.{yaml,php}` + `bundles.php` |

The shared kernel delegates to a dedicated `ConfigFingerprint` class, which is what makes its file set testable: that kernel is `final` and resolves its project directory from its own location, so it cannot be doubled. The legacy kernel keeps its own copy of the computation on purpose — deptrac places `App\Kernel` in the `Legacy` layer, which must not depend on `App\Shared` — and a comment in the code says so.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.09.x
- [ ] 26.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

### Unit tests

```
php vendor/bin/pest --do-not-cache-result tests/php/App/KernelConfigFingerprintTest.php tests/php/App/Shared/Infrastructure/Symfony/ConfigFingerprintTest.php
```

18 tests cover, for both file sets: a stable fingerprint while nothing changes, a change when a file is added or removed, a change when the content changes at constant size (proving modification times count), a change when the size changes at constant modification time (the `cp -p` case), coverage of nested and environment subdirectories, of `bundles.php`, of `config.new/services/*.php`, and the fact that files which are not imported are ignored.

### Manual scenario

Reproduce the stale-container state on a platform with an installed module (e.g. it-edition), with `APP_DEBUG=0`:

1. Move the module's yamls away: `mv /usr/share/centreon/config/routes/CentreonItEdition.yaml /usr/share/centreon/config/packages/CentreonItEdition.yaml /tmp/`
2. `rm -rf /var/cache/centreon/symfony` then hit `GET /api/latest/platform/installation/status` (compiles a container without the module) → 200
3. Restore both yamls **without** clearing the cache
4. Hit the endpoint again:
   - without this patch → HTTP 500 `Service "CentreonItEdition\Routing\RouteLoader" not found ... smaller service locator`
   - with this patch → HTTP 200, and a new fingerprinted cache directory appears under `/var/cache/centreon/symfony/`

Same scenario applies to the new kernel (`bin/console.new` / `/var/cache/centreon/symfony.new`).

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have added **unit tests** covering the new behaviour

## Links

### Jira ticket

Resolves: [MON-207614](https://centreon.atlassian.net/browse/MON-207614)

### PR Github

Backports: #11389

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MON-207614]: https://centreon.atlassian.net/browse/MON-207614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ