### PR TITLE
fix(open-tickets): sanitize Dropzone.createElement output

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/lib/dropzone.js
@@ -26,7 +26,7 @@
  */
 
 (function() {
-  var Dropzone, Emitter, ExifRestore, camelize, contentLoaded, detectVerticalSquash, drawImageIOSFix, escapeHtml, noop, without,
+  var Dropzone, Emitter, ExifRestore, camelize, contentLoaded, detectVerticalSquash, drawImageIOSFix, escapeHtml, noop, sanitizeElement, without,
     slice = [].slice,
     extend1 = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
@@ -1669,10 +1669,36 @@
     });
   };
 
+  sanitizeElement = function(root) {
+    var attr, el, i, j, name, ref, scripts, value;
+    scripts = root.querySelectorAll("script");
+    for (i = 0; i < scripts.length; i++) {
+      scripts[i].parentNode.removeChild(scripts[i]);
+    }
+    ref = root.querySelectorAll("*");
+    for (j = 0; j < ref.length; j++) {
+      el = ref[j];
+      i = el.attributes.length - 1;
+      while (i >= 0) {
+        attr = el.attributes[i];
+        name = attr.name.toLowerCase();
+        value = attr.value.replace(/[\t\r\n]/g, "");
+        if (name.indexOf("on") === 0 || name === "srcdoc") {
+          el.removeAttribute(attr.name);
+        } else if ((name === "href" || name === "src" || name === "xlink:href") && /^\s*javascript:/i.test(value)) {
+          el.removeAttribute(attr.name);
+        }
+        i--;
+      }
+    }
+    return root;
+  };
+
   Dropzone.createElement = function(string) {
     var div;
     div = document.createElement("div");
     div.innerHTML = string;
+    sanitizeElement(div);
     return div.childNodes[0];
   };
 


### PR DESCRIPTION
Fixes: [MON-206630](https://centreon.atlassian.net/browse/MON-206630)

Backport of #11213 to `dev-26.10.x`.

`Dropzone.createElement()` assigns its input straight to `innerHTML`. #11084 (already on this branch) escaped the option values at the call sites, but left the sink itself trusting its caller — `previewTemplate` still flows through unescaped and cannot be escaped, since it is markup defining the DOM structure rather than text. This hardens the sink instead: after parsing, `<script>` elements, `on*` handler attributes, `srcdoc`, and `javascript:` URIs in `href`/`src`/`xlink:href` are stripped before the node is returned.

Clean cherry-pick of `13425be4b9`. `dropzone.js` on this branch is now identical to develop.

## Test plan

- [x] `node --check` passes on the modified file
- [ ] Open-tickets submit form: Dropzone preview/upload UI renders and behaves unchanged (drag-drop, remove file, default message)


[MON-206630]: https://centreon.atlassian.net/browse/MON-206630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ