### PR TITLE
enh(delivery): drop the opaque path tokens from pulp base paths

### DIFF
--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -43,16 +43,6 @@ case "$DISTRIB_FAMILY" in
     ;;
 esac
 
-# business (paid) rpm content is served under an opaque path segment, mirroring
-# the Artifactory layout; only rpm business repos use it (deb business does not).
-# The segment is path-only: repository NAMES never contain it (they are unique
-# per Domain, and the Domain already identifies the edition).
-BUSINESS_HASH="1a97ff9985262bf3daf7a0919f9c59a6"
-HASH_SEGMENT=""
-if [[ "$REPO_BASE" == "business" && "$DISTRIB_FAMILY" == "el" ]]; then
-  HASH_SEGMENT="/$BUSINESS_HASH"
-fi
-
 # uniform stability segments across every edition (plugins included):
 # unstable, testing-release, testing-hotfix, stable
 TESTING_SEGMENT="testing"
@@ -132,7 +122,7 @@ elif [[ "$DELIVERY_TYPE" == "feature" ]]; then
   fi
 
   REPOSITORY_PREFIX="rpm-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
-  BASE_PATH_PREFIX="rpm-feature$HASH_SEGMENT/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  BASE_PATH_PREFIX="rpm-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
 else
   RPM_ROOT="rpm"
   DEB_INFIX=""
@@ -143,11 +133,11 @@ else
 
   if [[ "$DISTRIB_FAMILY" == "el" ]]; then
     REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
-    BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
     TESTING_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$TESTING_SEGMENT"
-    TESTING_BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
     STABLE_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-stable"
-    STABLE_BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/stable"
+    STABLE_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/stable"
   else
     # one deb repository per stability (base path = repository name), shared by
     # every major version: the version lives in the suite name only


### PR DESCRIPTION
Fixes: [MON-202540](https://centreon.atlassian.net/browse/MON-202540)

Companion of the delivery-tooling change (create-repos base-path reconcile). The business/connectors distributions are hidden from the pulp content listings since MON-202523, which is the actual discovery barrier: the opaque path segments no longer serve a purpose and leave the served base paths (`rpm/<major>/…`, `rpm-feature/<ticket>/…`, connectors `rpm/<distrib>/…`).

- `pulp-repository-properties`: the token constants and the `HASH_SEGMENT` interpolation are gone; repository/distribution names are unchanged (they never carried the token), so no grant or repo rename is involved.
- Client-facing: the business rpm base URLs lose their token segment; the `.repo` files are regenerated by create-repos with the new baseurl. Dev stack only — the migration happens through the create-repos base-path reconcile.


[MON-202540]: https://centreon.atlassian.net/browse/MON-202540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ