### PR TITLE
fix(clapi) - Change the condition for specific period in recurrent downtimes

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonDowntime.class.php
+++ b/centreon/www/class/centreon-clapi/centreonDowntime.class.php
@@ -892,7 +892,7 @@ class CentreonDowntime extends CentreonObject
             } elseif (! $row['dtp_day_of_week'] && $row['dtp_month_cycle'] == 'none') { // monthly
                 $periodType = 'ADDMONTHLYPERIOD';
                 $extraData[] = $row['dtp_day_of_month'];
-            } elseif ($row['dtp_month_cycle'] == 'last' || $row['dtp_month_cycle'] == 'first') { // specific
+            } elseif (in_array($row['dtp_month_cycle'], $this->availableCycles, true)) { // specific
                 $periodType = 'ADDSPECIFICPERIOD';
                 $extraData[] = $row['dtp_day_of_week'];
                 $extraData[] = $row['dtp_month_cycle'];


### PR DESCRIPTION
## Description

A specific period in a recurrent dowtime can have these values:

- first
- second
- third
- fourth
- last

Before the fix, we only checked first and last.

**Fixes** # MON-207655

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
