### PR TITLE
fix(install-poller): resolve stable poller images from ghcr.io, not Harbor

### DIFF
--- a/centreon/install-poller/src/commands/docker.sh
+++ b/centreon/install-poller/src/commands/docker.sh
@@ -87,8 +87,9 @@ function _generateDotEnv() {
   local dir=$1
   logInfo "Generating .env in ${dir} (stability: ${STABILITY})"
 
-  # NOTE: unstable tag reachability on docker.centreon.com is unverified for
-  # centreon-engine/centreon-gorgone/centreon-snmptrapd/centreon-centreontrapd.
+  # Registry/repo selection (ghcr.io for stable, Harbor otherwise) happens in
+  # _pollerImageRepo, used by _generateDockerCompose. Only the tag is decided
+  # here (MON-207531 verified these tag conventions end-to-end).
   local image_tag
   case "${STABILITY}" in
   stable)
@@ -141,6 +142,19 @@ EOF
   logInfo ".env written"
 }
 
+# Registry + repo (no tag) for one of the 5 poller component images, per
+# stability. Only 'stable' is published to ghcr.io (MON-207531); testing and
+# unstable stay on Harbor, as neither ever gets a validated stable-equivalent
+# tag there.
+function _pollerImageRepo() {
+  local component=$1
+  if [ "${STABILITY}" = "stable" ]; then
+    echo "ghcr.io/centreon/centreon-${component}"
+  else
+    echo "docker.centreon.com/centreon/centreon-${component}-trixie"
+  fi
+}
+
 function _generateDockerCompose() {
   local dir=$1
   local out="${dir}/docker-compose.yaml"
@@ -150,7 +164,9 @@ function _generateDockerCompose() {
   cat > "${out}" <<'EOF'
 services:
   centengine:
-    image: "docker.centreon.com/centreon/centreon-engine-trixie:${ENGINE_TAG:-${TAG}}"
+EOF
+  printf '    image: "%s:${ENGINE_TAG:-${TAG}}"\n' "$(_pollerImageRepo engine)" >> "${out}"
+  cat >> "${out}" <<'EOF'
     container_name: "${NAME}-centengine"
     hostname: centengine
     restart: unless-stopped
@@ -194,7 +210,9 @@ EOF
   # gorgone base volumes (always)
   cat >> "${out}" <<'EOF'
   gorgone:
-    image: "docker.centreon.com/centreon/centreon-gorgone-trixie:${GORGONE_TAG:-${TAG}}"
+EOF
+  printf '    image: "%s:${GORGONE_TAG:-${TAG}}"\n' "$(_pollerImageRepo gorgone)" >> "${out}"
+  cat >> "${out}" <<'EOF'
     container_name: "${NAME}-gorgone"
     hostname: gorgone
     restart: unless-stopped
@@ -265,7 +283,9 @@ EOF
   if [ "${WITH_SNMPTRAP}" = "1" ]; then
     cat >> "${out}" <<'EOF'
   snmptrapd:
-    image: "docker.centreon.com/centreon/centreon-snmptrapd-trixie:${SNMPTRAPD_TAG:-${TAG}}"
+EOF
+    printf '    image: "%s:${SNMPTRAPD_TAG:-${TAG}}"\n' "$(_pollerImageRepo snmptrapd)" >> "${out}"
+    cat >> "${out}" <<'EOF'
     container_name: "${NAME}-snmptrap"
     hostname: snmptrapd
     restart: unless-stopped
@@ -286,7 +306,9 @@ EOF
       retries: 3
 
   centreontrapd:
-    image: "docker.centreon.com/centreon/centreon-centreontrapd-trixie:${CENTREONTRAPD_TAG:-${TAG}}"
+EOF
+    printf '    image: "%s:${CENTREONTRAPD_TAG:-${TAG}}"\n' "$(_pollerImageRepo centreontrapd)" >> "${out}"
+    cat >> "${out}" <<'EOF'
     container_name: "${NAME}-centreontrap"
     hostname: centreontrapd
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- MON-207531 made the producer side correct: `centreon-engine`/`centreon-broker`/`centreon-gorgone`/`centreon-snmptrapd`/`centreon-centreontrapd` images are only ever copied to `ghcr.io` on `stability == stable`. `install-poller`'s docker mode never caught up: it hardcoded every stability to pull from Harbor (`docker.centreon.com/centreon/<component>-trixie`), including `stable` — which, per MON-207531, never gets a stable tag on Harbor for these images.
- Adds `_pollerImageRepo()` in `centreon/install-poller/src/commands/docker.sh` to resolve the registry+repo prefix per `${STABILITY}`: `ghcr.io/centreon/centreon-<component>` for `stable`, unchanged Harbor `docker.centreon.com/centreon/centreon-<component>-trixie` otherwise.
- `testing`/`unstable` behavior is unchanged (already correct: `unstable` → Harbor `develop`, `testing` → per-component placeholder instructing the user to edit `.env`).
- Tag resolution (`_generateDotEnv`) is untouched — `${major}` (e.g. `26.11`) was already the right value, and is confirmed to be a valid ghcr tag (verified against `.github/actions/promote-docker-to-ghcr` callers in `web.yml`/`collect.yml`/`centreon-collect/gorgone.yml`).

Ref: [MON-207617](https://centreon.atlassian.net/browse/MON-207617)

## Test plan
- [x] `bash -n` on the modified `docker.sh` — syntax OK
- [x] Sourced `docker.sh` and generated `docker-compose.yaml`/`.env` for `STABILITY=stable/unstable/testing` — confirmed `stable` resolves all 4 images to `ghcr.io/centreon/centreon-<component>:26.11`, `unstable`/`testing` unchanged (Harbor, `-trixie` suffix)
- [x] Validated all 3 generated compose files with `docker compose config -q`
- [ ] Manual `--type docker` install on a real host, confirm anonymous `docker pull ghcr.io/centreon/centreon-gorgone:<major>.<minor>` succeeds (ghcr.io package public visibility, per MON-207531)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-207617]: https://centreon.atlassian.net/browse/MON-207617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ