### PR TITLE
fix(delivery): plain-codename suites for plugins/connectors deb deliveries

### DIFF
--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -110,24 +110,23 @@ if [[ "$REPO_BASE" == "plugins" ]]; then
     # carry the plain codename only
     REPOSITORY_NAME="${DEB_PREFIX}${STABILITY_SEGMENT}"
     BASE_PATH="$REPOSITORY_NAME"
-    # historical plugins suite names: plain codename for stable,
-    # codename-<stability> otherwise (bare "testing" segment)
+    # historical layout: one repository per stability with plain-codename
+    # suites; the legacy stability (bare "testing") lives in the front prefix
     LEGACY_SEGMENT="$STABILITY_SEGMENT"
     [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT="testing"
     LEGACY_TESTING_SEGMENT="$TESTING_SEGMENT"
     [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT="testing"
-    SUITE="$DISTRIB-$LEGACY_SEGMENT"
-    [[ "$STABILITY" == "stable" ]] && SUITE="$DISTRIB"
+    SUITE="$DISTRIB"
     TESTING_REPOSITORY_NAME="${DEB_PREFIX}${TESTING_SEGMENT}"
     TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
-    TESTING_SUITE="$DISTRIB-$LEGACY_TESTING_SEGMENT"
+    TESTING_SUITE="$DISTRIB"
     STABLE_REPOSITORY_NAME="${DEB_PREFIX}stable"
     STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB"
     # legacy (front) paths used by the content verifications: the CI exercises
     # the compatibility rewrites on every delivery
-    LEGACY_BASE_PATH="${DEB_PREFIX}${REPO_BASE}"
-    LEGACY_TESTING_BASE_PATH="${DEB_PREFIX}${REPO_BASE}"
+    LEGACY_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-${LEGACY_SEGMENT}"
+    LEGACY_TESTING_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-${LEGACY_TESTING_SEGMENT}"
     LEGACY_STABLE_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-stable"
     POOL_PATH="pool/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$TESTING_POOL_SEGMENT/$MODULE_NAME"


### PR DESCRIPTION
Related to: [MON-202540](https://centreon.atlassian.net/browse/MON-202540)

The real pre-migration layout (verified on packages.centreon.com) exposes plugins/connectors deb as **dedicated repositories per stability** (`apt-plugins-{stable,testing,unstable}`, same for connectors) with **plain-codename suites** — not the stability-suffixed suites this action produced for non-stable tiers. Since the pulp layout already has one deb repository per stability, the plain codename is unambiguous and becomes the canonical suite everywhere for these families:

- `suite`/`testing_suite` outputs: plain `$DISTRIB` for every plugins/connectors stability;
- legacy verification base paths: the dedicated per-stability front prefixes (`apt-plugins-unstable`, `apt-plugins-testing`, ...) instead of the shared form that never existed on artifactory.

To merge together with [delivery-tooling#297](https://github.com/centreon/delivery-tooling/pull/297) (front routes + create-repos suites) — same train.

[MON-202540]: https://centreon.atlassian.net/browse/MON-202540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ