### PR TITLE
dev-26.10.x enh(apache-gorgone): allows apache to be reverse proxy for gorgone

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,3 @@ We want to thank all [reporters and pentesters](https://github.com/centreon/.git
 <h2> License </h2>
 
 This project is licensed under the Apache 2.0 License - see the [LICENSE.md](LICENSE.md) file for details.
-

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -325,6 +325,15 @@ contents:
     dst: "/usr/share/centreon/examples/centreon-apache-https.conf"
     file_info:
       mode: 0644
+  - src: "./src/centreon-apache-gorgone.conf"
+    dst: "/usr/share/centreon/examples/centreon-apache-gorgone.conf"
+    file_info:
+      mode: 0644
+
+  - src: "./src/centreon-apache-https-gorgone.conf"
+    dst: "/usr/share/centreon/examples/centreon-apache-https-gorgone.conf"
+    file_info:
+      mode: 0644
 
   - src: "../GPL_LIB"
     dst: "/usr/share/centreon/GPL_LIB"

--- a/centreon/packaging/src/centreon-apache-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-gorgone.conf
@@ -1,0 +1,13 @@
+#
+# Section added by Centreon Install Setup
+# Disabled by default. Can be enabled by the administrator if they already had activated pullwss on the previous Centreon version
+# if gorgone was manually configured by the user to listen to the websocket connection on port 8086
+
+ServerTokens Prod
+Listen 8086
+<VirtualHost *:8086>
+    <IfModule mod_proxy_wstunnel.c>
+        ProxyPass "/"  "ws://localhost:8087/"
+        ProxyPassReverse "/"  "ws://localhost:8087/"
+    </IfModule>
+</VirtualHost>

--- a/centreon/packaging/src/centreon-apache-https-gorgone.conf
+++ b/centreon/packaging/src/centreon-apache-https-gorgone.conf
@@ -1,0 +1,34 @@
+#
+# Section added by Centreon Install Setup
+# Disabled by default. Can be enabled by the administrator if they already had activated pullwss on the previous Centreon version
+# if gorgone was manually configured by the user to listen to the websocket connection on port 8086.
+
+ServerTokens Prod
+Listen 8086
+<VirtualHost *:8086>
+    #####################
+    # SSL configuration #
+    #####################
+    SSLEngine On
+    SSLProtocol All -SSLv3 -SSLv2 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ADH:!IDEA
+    SSLHonorCipherOrder On
+    SSLCompression Off
+    SSLCertificateFile /etc/pki/tls/certs/ca.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/ca.key
+
+    Header set X-Frame-Options: "sameorigin"
+    Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;SameSite=Strict
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    ServerSignature Off
+    TraceEnable Off
+
+    <IfModule mod_proxy_wstunnel.c>
+        # gorgone have multiples communication mode, one of them is websocket.
+        # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
+        ProxyPass "/"  "ws://localhost:8087/"
+        ProxyPassReverse "/"  "ws://localhost:8087/"
+
+    </IfModule>
+
+</VirtualHost>

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -40,6 +40,12 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
+    <IfModule mod_proxy_wstunnel.c>
+        # gorgone has multiple communication modes, one of them is websocket.
+        # this allow to use apache as a proxy for the websocket. Doing so, gorgone don't have to manage another certificate.
+        ProxyPass "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPassReverse "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+    </IfModule>
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -22,6 +22,13 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
+    <IfModule mod_proxy_wstunnel.c>
+        # gorgone have multiples communication mode, one of them is websocket.
+        # this allows it to use apache as a proxy for the websocket. By doing so, gorgone doesn't have to manage another certificate if the client set it up.
+        ProxyPass "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+        ProxyPassReverse "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
+    </IfModule>
+
     <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>


### PR DESCRIPTION
## Description


backport to 26.10 the apache configuration allowing to reverse proxy for gorgone when needed

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
