### PR TITLE
fix(install-poller): resolve stable poller images from ghcr.io, not Harbor

### DIFF
--- a/centreon/install-poller/src/commands/docker.sh
+++ b/centreon/install-poller/src/commands/docker.sh
@@ -87,8 +87,9 @@ function _generateDotEnv() {
   local dir=$1
   logInfo "Generating .env in ${dir} (stability: ${STABILITY})"
 
-  # NOTE: unstable tag reachability on docker.centreon.com is unverified for
-  # centreon-engine/centreon-gorgone/centreon-snmptrapd/centreon-centreontrapd.
+  # Registry/repo selection (ghcr.io for stable, Harbor otherwise) happens in
+  # _pollerImageRepo, used by _generateDockerCompose. Only the tag is decided
+  # here (MON-207531 verified these tag conventions end-to-end).
   local image_tag
   case "${STABILITY}" in
   stable)
@@ -141,6 +142,19 @@ EOF
   logInfo ".env written"
 }
 
+# Registry + repo (no tag) for one of the 5 poller component images, per
+# stability. Only 'stable' is published to ghcr.io (MON-207531); testing and
+# unstable stay on Harbor, as neither ever gets a validated stable-equivalent
+# tag there.
+function _pollerImageRepo() {
+  local component=$1
+  if [ "${STABILITY}" = "stable" ]; then
+    echo "ghcr.io/centreon/centreon-${component}"
+  else
+    echo "docker.centreon.com/centreon/centreon-${component}-trixie"
+  fi
+}
+
 function _generateDockerCompose() {
   local dir=$1
   local out="${dir}/docker-compose.yaml"
@@ -150,7 +164,9 @@ function _generateDockerCompose() {
   cat > "${out}" <<'EOF'
 services:
   centengine:
-    image: "docker.centreon.com/centreon/centreon-engine-trixie:${ENGINE_TAG:-${TAG}}"
+EOF
+  printf '    image: "%s:${ENGINE_TAG:-${TAG}}"\n' "$(_pollerImageRepo engine)" >> "${out}"
+  cat >> "${out}" <<'EOF'
     container_name: "${NAME}-centengine"
     hostname: centengine
     restart: unless-stopped
@@ -194,7 +210,9 @@ EOF
   # gorgone base volumes (always)
   cat >> "${out}" <<'EOF'
   gorgone:
-    image: "docker.centreon.com/centreon/centreon-gorgone-trixie:${GORGONE_TAG:-${TAG}}"
+EOF
+  printf '    image: "%s:${GORGONE_TAG:-${TAG}}"\n' "$(_pollerImageRepo gorgone)" >> "${out}"
+  cat >> "${out}" <<'EOF'
     container_name: "${NAME}-gorgone"
     hostname: gorgone
     restart: unless-stopped
@@ -265,7 +283,9 @@ EOF
   if [ "${WITH_SNMPTRAP}" = "1" ]; then
     cat >> "${out}" <<'EOF'
   snmptrapd:
-    image: "docker.centreon.com/centreon/centreon-snmptrapd-trixie:${SNMPTRAPD_TAG:-${TAG}}"
+EOF
+    printf '    image: "%s:${SNMPTRAPD_TAG:-${TAG}}"\n' "$(_pollerImageRepo snmptrapd)" >> "${out}"
+    cat >> "${out}" <<'EOF'
     container_name: "${NAME}-snmptrap"
     hostname: snmptrapd
     restart: unless-stopped
@@ -286,7 +306,9 @@ EOF
       retries: 3
 
   centreontrapd:
-    image: "docker.centreon.com/centreon/centreon-centreontrapd-trixie:${CENTREONTRAPD_TAG:-${TAG}}"
+EOF
+    printf '    image: "%s:${CENTREONTRAPD_TAG:-${TAG}}"\n' "$(_pollerImageRepo centreontrapd)" >> "${out}"
+    cat >> "${out}" <<'EOF'
     container_name: "${NAME}-centreontrap"
     hostname: centreontrapd
     restart: unless-stopped


### PR DESCRIPTION
## Description
Backport of #11416 to `dev-26.10.x`.

`install-poller`'s docker mode hardcoded every stability to pull the 5 poller images (gorgone, centengine, centreon-broker, snmptrapd, centreontrapd) from Harbor, including `stable` — which never gets a stable tag on Harbor for these images (per MON-207531). Adds `_pollerImageRepo()` in `centreon/install-poller/src/commands/docker.sh` to resolve `ghcr.io/centreon/centreon-<component>` for `stable`, unchanged Harbor path otherwise. `testing`/`unstable` behavior is untouched.

Ref: MON-207741

**Fixes** MON-207741

## Type of change
- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master
- [x] 26.10.x

## How this pull request can be tested ?
Same testing procedure as #11416.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).