### PR TITLE
fix(upgrade): use CentreonDB instead of DbalConnectionAdapter for module scripts

### DIFF
--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalModuleRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalModuleRepository.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Infrastructure\Dbal;
 
-use Adaptation\Database\Connection\Adapter\Dbal\DbalConnectionAdapter;
 use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Domain\Repository\ModuleRepository;
 use Doctrine\DBAL\Connection;
@@ -45,8 +44,6 @@ final class DbalModuleRepository implements ModuleRepository
     public function __construct(
         #[Autowire(service: 'doctrine.dbal.default_connection')]
         private readonly Connection $configConnection,
-        #[Autowire(service: 'doctrine.dbal.realtime_connection')]
-        private readonly Connection $realtimeConnection,
         #[Autowire(param: 'upgrade.modules_dir')]
         private readonly string $modulesDir,
         private readonly ConnectionConfig $connectionConfig,
@@ -295,8 +292,18 @@ final class DbalModuleRepository implements ModuleRepository
             return;
         }
 
-        $pearDB = DbalConnectionAdapter::createFromDbalConnection($this->configConnection, $this->connectionConfig);
-        $pearDBO = DbalConnectionAdapter::createFromDbalConnection($this->realtimeConnection, $this->connectionConfig);
+        // TODO: temporary bridge — replace with proper ConnectionInterface injection once module upgrade scripts are migrated
+        $pearDB = new \CentreonDB(connectionConfig: $this->connectionConfig);
+        $pearDBO = new \CentreonDB(connectionConfig: new ConnectionConfig(
+            host: $this->connectionConfig->getHost(),
+            user: $this->connectionConfig->getUser(),
+            password: $this->connectionConfig->getPassword(),
+            databaseNameConfiguration: $this->connectionConfig->getDatabaseNameRealTime(),
+            databaseNameRealTime: $this->connectionConfig->getDatabaseNameRealTime(),
+            port: $this->connectionConfig->getPort(),
+            charset: $this->connectionConfig->getCharset(),
+            driver: $this->connectionConfig->getDriver(),
+        ));
         $centreon_path = $this->centreonPath;
 
         require_once $filePath;

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalModuleRepositoryTest.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalModuleRepositoryTest.php
@@ -35,8 +35,6 @@ final class DbalModuleRepositoryTest extends TestCase
 {
     private Connection&MockObject $configConnection;
 
-    private Connection&MockObject $realtimeConnection;
-
     private Filesystem $filesystem;
 
     private string $modulesDir;
@@ -46,7 +44,6 @@ final class DbalModuleRepositoryTest extends TestCase
     protected function setUp(): void
     {
         $this->configConnection = $this->createMock(Connection::class);
-        $this->realtimeConnection = $this->createMock(Connection::class);
         $this->filesystem = new Filesystem();
 
         $baseTmpDir = sys_get_temp_dir() . '/centreon-module-test-' . uniqid();
@@ -56,7 +53,6 @@ final class DbalModuleRepositoryTest extends TestCase
 
         $this->repository = new DbalModuleRepository(
             $this->configConnection,
-            $this->realtimeConnection,
             $this->modulesDir,
             new ConnectionConfig('localhost', 'centreon', 'password', 'centreon', 'centreon_storage'),
             '/usr/share/centreon/',


### PR DESCRIPTION
## Description

- Replace `DbalConnectionAdapter` with `CentreonDB` in `DbalModuleRepository::executeModulePhpFile()` to restore backward compatibility with module upgrade scripts
- `DbalConnectionAdapter` only implements `ConnectionInterface`, missing PDO methods (`inTransaction()`, `beginTransaction()`, `commit()`, `rollBack()`, `query()`, `prepare()`...) used by legacy scripts
- `CentreonDB` (`extends PDO implements ConnectionInterface` + `ConnectionTrait`) covers both legacy PDO API and new `ConnectionInterface` API — no module scripts need modification
- Removes the `Adaptation` dependency from `App\Upgrade` (deptrac alignment)

## How to test

1. Deploy on a test environment with module upgrades pending (e.g. centreon-pp-manager from 25.01.0)
2. Trigger upgrade via `POST /api/latest/platform/updates`
3. Verify no `Call to undefined method` errors in `prod.upgrade.log`
4. Verify modules are upgraded to their target versions in `modules_informations` table
5. Verify both legacy scripts (using `inTransaction()`, `beginTransaction()`) and recent scripts (using `isTransactionActive()`, `startTransaction()`) execute without errors

## Links

### Jira ticket

Resolves: [MON-207743](https://centreon.atlassian.net/browse/MON-207743)

### PR Github

Backports: #11420

[MON-207743]: https://centreon.atlassian.net/browse/MON-207743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
