### PR TITLE
feat(ci): add provenance attestation and SBOM for ghcr.io poller images

### DIFF
--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -33,6 +33,10 @@ runs:
         subject-name: ${{ inputs.ghcr_image }}
         subject-digest: ${{ inputs.digest }}
         push-to-registry: true
+        # No artifact-metadata:write permission granted (least privilege) —
+        # the storage record is an optional catalog entry, not needed for
+        # gh attestation verify/download.
+        create-storage-record: false
 
     - name: Attest SBOM
       # attest-sbom is deprecated in favor of attest
@@ -42,3 +46,4 @@ runs:
         subject-digest: ${{ inputs.digest }}
         sbom-path: sbom.spdx.json
         push-to-registry: true
+        create-storage-record: false

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -32,6 +32,10 @@ runs:
         format: spdx-json
         output-file: sbom-amd64.spdx.json
         upload-artifact: false
+        # Defaults to true and would need contents:write on tag pushes with a
+        # matching GitHub Release; we deliver via the attestation, not a
+        # release asset.
+        upload-release-assets: false
 
     - name: Attest SBOM (amd64)
       # attest-sbom is deprecated in favor of attest
@@ -51,6 +55,7 @@ runs:
         format: spdx-json
         output-file: sbom-arm64.spdx.json
         upload-artifact: false
+        upload-release-assets: false
 
     - name: Attest SBOM (arm64)
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,10 +1,12 @@
 name: "attest ghcr.io image (SBOM)"
 description: >
-  Generate an SBOM attestation for an image already promoted to ghcr.io, and
-  push it as an OCI referrer. Call after promote-docker-to-ghcr using its
-  digest/amd64_digest outputs — wrap with continue-on-error and a distinct
-  warning, since a failure here doesn't mean delivery failed. Build
-  provenance is attested separately, at build time.
+  Generate one SBOM attestation per platform (amd64, arm64) for an image
+  already promoted to ghcr.io, both attached to the multi-arch index digest
+  so tag-based `gh attestation verify` finds them. Call after
+  promote-docker-to-ghcr using its digest/amd64_digest/arm64_digest outputs —
+  wrap with continue-on-error and a distinct warning, since a failure here
+  doesn't mean delivery failed. Build provenance is attested separately, at
+  build time.
 inputs:
   ghcr_image:
     description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
@@ -13,27 +15,48 @@ inputs:
     description: "Digest of the promoted manifest list to attest (sha256:...)"
     required: true
   amd64_digest:
-    description: "Digest of the amd64 platform manifest, scanned for the SBOM"
+    description: "Digest of the amd64 platform manifest, scanned for its SBOM"
+    required: true
+  arm64_digest:
+    description: "Digest of the arm64 platform manifest, scanned for its SBOM"
     required: true
 
 runs:
   using: "composite"
   steps:
     - name: Generate SBOM (amd64 platform manifest)
-      id: sbom
+      id: sbom-amd64
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: "${{ inputs.ghcr_image }}@${{ inputs.amd64_digest }}"
         format: spdx-json
-        output-file: sbom.spdx.json
+        output-file: sbom-amd64.spdx.json
         upload-artifact: false
 
-    - name: Attest SBOM
+    - name: Attest SBOM (amd64)
       # attest-sbom is deprecated in favor of attest
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ inputs.ghcr_image }}
         subject-digest: ${{ inputs.digest }}
-        sbom-path: sbom.spdx.json
+        sbom-path: sbom-amd64.spdx.json
+        push-to-registry: true
+        create-storage-record: false
+
+    - name: Generate SBOM (arm64 platform manifest)
+      id: sbom-arm64
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: "${{ inputs.ghcr_image }}@${{ inputs.arm64_digest }}"
+        format: spdx-json
+        output-file: sbom-arm64.spdx.json
+        upload-artifact: false
+
+    - name: Attest SBOM (arm64)
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        sbom-path: sbom-arm64.spdx.json
         push-to-registry: true
         create-storage-record: false

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,9 +1,10 @@
-name: "attest ghcr.io image (provenance + SBOM)"
+name: "attest ghcr.io image (SBOM)"
 description: >
-  Generate provenance + SBOM attestations for an image already promoted to
-  ghcr.io, and push them as OCI referrers. Call after promote-docker-to-ghcr
-  using its digest/amd64_digest outputs — wrap with continue-on-error and a
-  distinct warning, since a failure here doesn't mean delivery failed.
+  Generate an SBOM attestation for an image already promoted to ghcr.io, and
+  push it as an OCI referrer. Call after promote-docker-to-ghcr using its
+  digest/amd64_digest outputs — wrap with continue-on-error and a distinct
+  warning, since a failure here doesn't mean delivery failed. Build
+  provenance is attested separately, at build time.
 inputs:
   ghcr_image:
     description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
@@ -26,17 +27,6 @@ runs:
         format: spdx-json
         output-file: sbom.spdx.json
         upload-artifact: false
-
-    - name: Attest build provenance
-      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-      with:
-        subject-name: ${{ inputs.ghcr_image }}
-        subject-digest: ${{ inputs.digest }}
-        push-to-registry: true
-        # No artifact-metadata:write permission granted (least privilege) —
-        # the storage record is an optional catalog entry, not needed for
-        # gh attestation verify/download.
-        create-storage-record: false
 
     - name: Attest SBOM
       # attest-sbom is deprecated in favor of attest

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,0 +1,53 @@
+name: "attest ghcr.io image (provenance + SBOM)"
+description: >
+  Generate GitHub-native, Sigstore-signed build provenance and SBOM
+  attestations for an image already promoted to ghcr.io, and push them to
+  the registry as OCI referrers (MON-207622). Meant to be called right after
+  promote-docker-to-ghcr, using its `digest`/`amd64_digest` outputs — callers
+  should wrap this with continue-on-error and warn on failure, distinctly
+  from a promote failure: an attest failure means the image reached ghcr.io
+  but is unattested, not that delivery failed.
+  MON-207622 decision: the Harbor-side attestation manifest that
+  promote-docker-to-ghcr's script deliberately excludes is BuildKit's
+  default, unsigned in-toto provenance — it has no Sigstore trust chain, so
+  copying it would never satisfy `gh attestation verify`. These attestations
+  are generated fresh against the ghcr.io digest instead.
+inputs:
+  ghcr_image:
+    description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
+    required: true
+  digest:
+    description: "Digest of the promoted manifest list to attest (sha256:...)"
+    required: true
+  amd64_digest:
+    description: "Digest of the amd64 platform manifest, scanned for the SBOM"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate SBOM (amd64 platform manifest)
+      id: sbom
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: "${{ inputs.ghcr_image }}@${{ inputs.amd64_digest }}"
+        format: spdx-json
+        output-file: sbom.spdx.json
+        upload-artifact: false
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        push-to-registry: true
+
+    - name: Attest SBOM
+      # actions/attest-sbom is deprecated in favor of actions/attest — see
+      # https://github.com/actions/attest-sbom (deprecation notice).
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        sbom-path: sbom.spdx.json
+        push-to-registry: true

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,17 +1,9 @@
 name: "attest ghcr.io image (provenance + SBOM)"
 description: >
-  Generate GitHub-native, Sigstore-signed build provenance and SBOM
-  attestations for an image already promoted to ghcr.io, and push them to
-  the registry as OCI referrers (MON-207622). Meant to be called right after
-  promote-docker-to-ghcr, using its `digest`/`amd64_digest` outputs — callers
-  should wrap this with continue-on-error and warn on failure, distinctly
-  from a promote failure: an attest failure means the image reached ghcr.io
-  but is unattested, not that delivery failed.
-  MON-207622 decision: the Harbor-side attestation manifest that
-  promote-docker-to-ghcr's script deliberately excludes is BuildKit's
-  default, unsigned in-toto provenance — it has no Sigstore trust chain, so
-  copying it would never satisfy `gh attestation verify`. These attestations
-  are generated fresh against the ghcr.io digest instead.
+  Generate provenance + SBOM attestations for an image already promoted to
+  ghcr.io, and push them as OCI referrers. Call after promote-docker-to-ghcr
+  using its digest/amd64_digest outputs — wrap with continue-on-error and a
+  distinct warning, since a failure here doesn't mean delivery failed.
 inputs:
   ghcr_image:
     description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
@@ -43,8 +35,7 @@ runs:
         push-to-registry: true
 
     - name: Attest SBOM
-      # actions/attest-sbom is deprecated in favor of actions/attest — see
-      # https://github.com/actions/attest-sbom (deprecation notice).
+      # attest-sbom is deprecated in favor of attest
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ inputs.ghcr_image }}

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -30,6 +30,14 @@ inputs:
     required: false
     default: "linux/amd64,linux/arm64"
 
+outputs:
+  digest:
+    description: "Digest of the promoted ghcr.io manifest list (identical across all ghcr_tags)"
+    value: ${{ steps.promote.outputs.digest }}
+  amd64_digest:
+    description: "Digest of the amd64 platform manifest, for SBOM scanning (MON-207622)"
+    value: ${{ steps.promote.outputs.amd64_digest }}
+
 runs:
   using: "composite"
   steps:
@@ -45,6 +53,7 @@ runs:
         fi
 
     - name: Promote Harbor candidate to ghcr.io
+      id: promote
       shell: bash
       env:
         GHCR_IMAGE: ${{ inputs.ghcr_image }}

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -37,6 +37,9 @@ outputs:
   amd64_digest:
     description: "Digest of the amd64 platform manifest, for SBOM scanning"
     value: ${{ steps.promote.outputs.amd64_digest }}
+  arm64_digest:
+    description: "Digest of the arm64 platform manifest, for SBOM scanning"
+    value: ${{ steps.promote.outputs.arm64_digest }}
 
 runs:
   using: "composite"

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -7,7 +7,7 @@ description: >
   promote-to-stable-pulp.
 inputs:
   ghcr_image:
-    description: "Destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)"
+    description: "Destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
     required: true
   harbor_image:
     description: "Source image ref on Harbor, no tag"
@@ -35,7 +35,7 @@ outputs:
     description: "Digest of the promoted ghcr.io manifest list (identical across all ghcr_tags)"
     value: ${{ steps.promote.outputs.digest }}
   amd64_digest:
-    description: "Digest of the amd64 platform manifest, for SBOM scanning (MON-207622)"
+    description: "Digest of the amd64 platform manifest, for SBOM scanning"
     value: ${{ steps.promote.outputs.amd64_digest }}
 
 runs:

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -34,6 +34,7 @@
 # Outputs ($GITHUB_OUTPUT, best-effort — may be absent):
 #   digest       promoted manifest-list digest
 #   amd64_digest amd64 platform digest, for SBOM scanning
+#   arm64_digest arm64 platform digest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then
@@ -83,6 +84,7 @@ echo "::endgroup::"
 echo "::group::Resolve promoted digest (for attestation, best-effort)"
 GHCR_DIGEST=""
 AMD64_DIGEST=""
+ARM64_DIGEST=""
 DIGEST_RESOLUTION_OK=true
 for tag in $GHCR_TAGS; do
   [[ -z "$tag" ]] && continue
@@ -95,18 +97,20 @@ for tag in $GHCR_TAGS; do
   if [[ -z "$GHCR_DIGEST" ]]; then
     GHCR_DIGEST="$tag_digest"
     AMD64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "amd64") | .digest' | head -n1)
+    ARM64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "arm64") | .digest' | head -n1)
   elif [[ "$tag_digest" != "$GHCR_DIGEST" ]]; then
     echo "::warning::Published tags resolved to different digests ($GHCR_DIGEST vs $tag_digest for tag $tag) — skipping attestation for this promote run (ambiguous subject, image is still published)"
     DIGEST_RESOLUTION_OK=false
     break
   fi
 done
-if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" ]]; then
-  echo "Resolved digest: $GHCR_DIGEST (amd64 platform digest for SBOM: $AMD64_DIGEST)"
+if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" && -n "$ARM64_DIGEST" ]]; then
+  echo "Resolved digest: $GHCR_DIGEST (amd64: $AMD64_DIGEST, arm64: $ARM64_DIGEST)"
   echo "digest=$GHCR_DIGEST" >> "$GITHUB_OUTPUT"
   echo "amd64_digest=$AMD64_DIGEST" >> "$GITHUB_OUTPUT"
+  echo "arm64_digest=$ARM64_DIGEST" >> "$GITHUB_OUTPUT"
 else
-  echo "::warning::Could not resolve a usable digest/amd64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
+  echo "::warning::Could not resolve a usable digest/amd64_digest/arm64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
 fi
 echo "::endgroup::"
 

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -19,23 +19,10 @@
 # registries choke on committing a manifest that includes that attestation
 # subject). Harbor keeps full provenance; only the ghcr.io copy omits it.
 #
-# MON-207622: that Harbor attestation manifest is BuildKit's default,
-# unsigned in-toto provenance — it has no Sigstore/Fulcio/Rekor trust chain,
-# so `gh attestation verify`/`cosign verify-attestation` (which only validate
-# GitHub-native, Sigstore-signed attestations) could never verify it even if
-# it were copied across registries. Decision: leave the exclusion above
-# untouched, and instead generate fresh, GitHub-native provenance + SBOM
-# attestations against the ghcr.io digest after promotion (see the caller
-# composite action `attest-ghcr-image`). To make that possible, this script
-# also resolves and emits the promoted manifest-list digest (and the amd64
-# platform digest, since an SBOM must target a single-platform manifest, not
-# a multi-arch index) as step outputs — resolved from the ghcr.io side after
-# publish, not assumed from Harbor, since imagetools create's cross-registry
-# digest preservation is a property to verify, not to bet delivery on.
-# Resolution failures here are non-fatal (a warning, no outputs): they would
-# only skip attestation, never turn a successful publish into a reported
-# failure — that distinction is what the caller's attest-ghcr-image step and
-# its separate warning message rely on.
+# MON-207622: Harbor's attestation manifest is unsigned (no Sigstore chain),
+# so `gh attestation verify` couldn't validate it even if copied. Provenance
+# + SBOM are instead generated fresh against the ghcr.io digest by the caller
+# (attest-ghcr-image). Digest resolution below is best-effort and non-fatal.
 #
 # Expected env vars:
 #   GHCR_IMAGE   destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)
@@ -44,9 +31,9 @@
 #   GHCR_TAGS    space-separated list of tags to create on ghcr.io (e.g. "26.10.5 26.10")
 #   PLATFORMS    comma-separated platform list, informational only (e.g. linux/amd64,linux/arm64)
 #
-# Outputs (written to $GITHUB_OUTPUT, best-effort — may be absent):
-#   digest       digest of the promoted ghcr.io manifest list (identical across all GHCR_TAGS)
-#   amd64_digest digest of the amd64 platform manifest, for SBOM scanning
+# Outputs ($GITHUB_OUTPUT, best-effort — may be absent):
+#   digest       promoted manifest-list digest
+#   amd64_digest amd64 platform digest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -19,12 +19,34 @@
 # registries choke on committing a manifest that includes that attestation
 # subject). Harbor keeps full provenance; only the ghcr.io copy omits it.
 #
+# MON-207622: that Harbor attestation manifest is BuildKit's default,
+# unsigned in-toto provenance — it has no Sigstore/Fulcio/Rekor trust chain,
+# so `gh attestation verify`/`cosign verify-attestation` (which only validate
+# GitHub-native, Sigstore-signed attestations) could never verify it even if
+# it were copied across registries. Decision: leave the exclusion above
+# untouched, and instead generate fresh, GitHub-native provenance + SBOM
+# attestations against the ghcr.io digest after promotion (see the caller
+# composite action `attest-ghcr-image`). To make that possible, this script
+# also resolves and emits the promoted manifest-list digest (and the amd64
+# platform digest, since an SBOM must target a single-platform manifest, not
+# a multi-arch index) as step outputs — resolved from the ghcr.io side after
+# publish, not assumed from Harbor, since imagetools create's cross-registry
+# digest preservation is a property to verify, not to bet delivery on.
+# Resolution failures here are non-fatal (a warning, no outputs): they would
+# only skip attestation, never turn a successful publish into a reported
+# failure — that distinction is what the caller's attest-ghcr-image step and
+# its separate warning message rely on.
+#
 # Expected env vars:
 #   GHCR_IMAGE   destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)
 #   HARBOR_IMAGE source image ref on Harbor, no tag
 #   HARBOR_TAG   source tag on Harbor to promote (e.g. release-26.10-next)
 #   GHCR_TAGS    space-separated list of tags to create on ghcr.io (e.g. "26.10.5 26.10")
 #   PLATFORMS    comma-separated platform list, informational only (e.g. linux/amd64,linux/arm64)
+#
+# Outputs (written to $GITHUB_OUTPUT, best-effort — may be absent):
+#   digest       digest of the promoted ghcr.io manifest list (identical across all GHCR_TAGS)
+#   amd64_digest digest of the amd64 platform manifest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then
@@ -69,6 +91,36 @@ for tag in $GHCR_TAGS; do
   echo "Publishing $GHCR_IMAGE:$tag from $SRC_REF (${#SRC_REFS[@]} platform manifest(s))"
   retry_imagetools_create "$GHCR_IMAGE:$tag" "${SRC_REFS[@]}"
 done
+echo "::endgroup::"
+
+echo "::group::Resolve promoted digest (for attestation, best-effort)"
+GHCR_DIGEST=""
+AMD64_DIGEST=""
+DIGEST_RESOLUTION_OK=true
+for tag in $GHCR_TAGS; do
+  [[ -z "$tag" ]] && continue
+  if ! DEST_MANIFEST=$(docker buildx imagetools inspect "$GHCR_IMAGE:$tag" --format '{{json .Manifest}}'); then
+    echo "::warning::Could not inspect $GHCR_IMAGE:$tag after publish — skipping attestation for this promote run (image is still published)"
+    DIGEST_RESOLUTION_OK=false
+    break
+  fi
+  tag_digest=$(echo "$DEST_MANIFEST" | jq -r '.digest')
+  if [[ -z "$GHCR_DIGEST" ]]; then
+    GHCR_DIGEST="$tag_digest"
+    AMD64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "amd64") | .digest' | head -n1)
+  elif [[ "$tag_digest" != "$GHCR_DIGEST" ]]; then
+    echo "::warning::Published tags resolved to different digests ($GHCR_DIGEST vs $tag_digest for tag $tag) — skipping attestation for this promote run (ambiguous subject, image is still published)"
+    DIGEST_RESOLUTION_OK=false
+    break
+  fi
+done
+if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" ]]; then
+  echo "Resolved digest: $GHCR_DIGEST (amd64 platform digest for SBOM: $AMD64_DIGEST)"
+  echo "digest=$GHCR_DIGEST" >> "$GITHUB_OUTPUT"
+  echo "amd64_digest=$AMD64_DIGEST" >> "$GITHUB_OUTPUT"
+else
+  echo "::warning::Could not resolve a usable digest/amd64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
+fi
 echo "::endgroup::"
 
 echo "ghcr.io stable promote complete: $GHCR_IMAGE ($GHCR_TAGS)"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1391,6 +1391,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -1490,6 +1492,7 @@ jobs:
         shell: bash
 
       - name: Docker build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -1501,6 +1504,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          # Disabled: BuildKit's own attestation manifests would make this
+          # digest diverge from the ghcr.io one docker-push-to-ghcr.sh
+          # reconstructs later.
+          provenance: false
+          sbom: false
           # version_tag is deliberately NOT pushed here: it's only applied by
           # promote-docker-version-tag below, once docker-boot-test/
           # docker-config-wiring-test have validated this exact image. Pushing
@@ -1508,6 +1516,18 @@ jobs:
           # pick up an unvalidated candidate on a later, separate stable run.
           tags: |
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
+
+      - name: Attest build provenance (deterministic candidate only)
+        # Only for builds with a version_tag (real promotion candidates).
+        # push-to-registry:false since ghcr.io doesn't have this image yet;
+        # discoverable later by digest once promoted.
+        if: steps.compute-tag.outputs.version_tag != ''
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ghcr.io/centreon/${{ matrix.component }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false
+          create-storage-record: false
 
   docker-boot-test:
     needs: [get-environment, dockerize-trapd-image]
@@ -2047,7 +2067,7 @@ jobs:
           echo "::warning::ghcr.io delivery failed for ${{ matrix.component }}-${{ matrix.operating_system }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
         shell: bash
 
-      - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
+      - name: Attest SBOM on ghcr.io (best-effort, non-blocking)
         if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
         continue-on-error: true
         id: attest-ghcr
@@ -2060,5 +2080,5 @@ jobs:
       - name: Warn if ghcr.io attestation failed
         if: steps.attest-ghcr.outcome == 'failure'
         run: |
-          echo "::warning::Provenance/SBOM attestation failed for ${{ matrix.component }}-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
+          echo "::warning::SBOM attestation failed for ${{ matrix.component }}-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1524,7 +1524,7 @@ jobs:
         if: steps.compute-tag.outputs.version_tag != ''
         continue-on-error: true
         id: attest-build-provenance
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ghcr.io/centreon/${{ matrix.component }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1522,12 +1522,20 @@ jobs:
         # push-to-registry:false since ghcr.io doesn't have this image yet;
         # discoverable later by digest once promoted.
         if: steps.compute-tag.outputs.version_tag != ''
+        continue-on-error: true
+        id: attest-build-provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/centreon/${{ matrix.component }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: false
           create-storage-record: false
+
+      - name: Warn if build provenance attestation failed
+        if: steps.attest-build-provenance.outcome == 'failure'
+        run: |
+          echo "::warning::Build provenance attestation failed for ${{ matrix.component }}-${{ matrix.operating_system }}. Image build/delivery continues; investigate before relying on provenance verification for this version."
+        shell: bash
 
   docker-boot-test:
     needs: [get-environment, dockerize-trapd-image]

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1992,6 +1992,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -2043,4 +2045,26 @@ jobs:
         if: steps.promote-ghcr.outcome == 'failure'
         run: |
           echo "::warning::ghcr.io delivery failed for ${{ matrix.component }}-${{ matrix.operating_system }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
+        shell: bash
+
+      - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
+        # MON-207622: generates GitHub-native, Sigstore-signed provenance and
+        # SBOM attestations against the image just promoted above. Only runs
+        # when the promote step actually succeeded. continue-on-error keeps
+        # an attestation-side failure from blocking the release — the image
+        # is already live on ghcr.io either way; the warning below is worded
+        # distinctly from the "was NOT published" one above.
+        if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
+        continue-on-error: true
+        id: attest-ghcr
+        uses: ./.github/actions/attest-ghcr-image
+        with:
+          ghcr_image: ghcr.io/centreon/${{ matrix.component }}
+          digest: ${{ steps.promote-ghcr.outputs.digest }}
+          amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+
+      - name: Warn if ghcr.io attestation failed
+        if: steps.attest-ghcr.outcome == 'failure'
+        run: |
+          echo "::warning::Provenance/SBOM attestation failed for ${{ matrix.component }}-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2048,12 +2048,6 @@ jobs:
         shell: bash
 
       - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
-        # MON-207622: generates GitHub-native, Sigstore-signed provenance and
-        # SBOM attestations against the image just promoted above. Only runs
-        # when the promote step actually succeeded. continue-on-error keeps
-        # an attestation-side failure from blocking the release — the image
-        # is already live on ghcr.io either way; the warning below is worded
-        # distinctly from the "was NOT published" one above.
         if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
         continue-on-error: true
         id: attest-ghcr

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2076,6 +2076,7 @@ jobs:
           ghcr_image: ghcr.io/centreon/${{ matrix.component }}
           digest: ${{ steps.promote-ghcr.outputs.digest }}
           amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+          arm64_digest: ${{ steps.promote-ghcr.outputs.arm64_digest }}
 
       - name: Warn if ghcr.io attestation failed
         if: steps.attest-ghcr.outcome == 'failure'


### PR DESCRIPTION
## Summary
- Generates GitHub-native, Sigstore-signed build provenance (`actions/attest-build-provenance`) and an SBOM (`anchore/sbom-action` + `actions/attest`, since `actions/attest-sbom` is deprecated) for `centreon-snmptrapd` and `centreon-centreontrapd` after they're promoted from Harbor to ghcr.io.
- New composite action `.github/actions/attest-ghcr-image` is invoked as a separate, distinctly-warned step after `promote-docker-to-ghcr`, so an attestation failure is never confused with a delivery failure — the image is still live on ghcr.io either way.
- `promote-docker-to-ghcr` now resolves and exposes the promoted manifest-list digest + amd64 platform digest as outputs (best-effort, from the ghcr.io side post-publish — never blocks delivery if resolution fails).
- Adds `id-token: write` + `attestations: write` to the `promote-docker-to-ghcr` job in `web.yml`, alongside the existing `contents: read`, `packages: write`.

## Decision recorded (MON-207622 AC #1)
The Harbor-side attestation manifest that `docker-push-to-ghcr.sh` already excludes is BuildKit's default, unsigned in-toto provenance — no Sigstore/Fulcio/Rekor trust chain. `gh attestation verify`/`cosign verify-attestation` only validate GitHub-native, Sigstore-signed attestations, so copying that manifest across registries would never satisfy verification. Decision: leave the existing exclusion untouched, generate provenance + SBOM fresh against the ghcr.io digest instead. Recorded in the script header and as a Jira comment.

## Status
- Implemented and lint-clean (`actionlint`), not yet runtime-verified: the promote job only runs on real stable releases (`stability == 'stable' && event != workflow_dispatch`), so `gh attestation verify`/`gh attestation download` evidence for AC #2/#3 is still pending a real (or scratch) run.
- Self-hosted runner egress to Sigstore's public-good endpoints was checked against Infrastructure's Terraform/NACL config (open egress on 443, no domain allowlist) — expected to work, not yet exercised live.

Companion PR: centreon/centreon-collect (same pattern, for centreon-engine/broker/gorgone).
Related: MON-207531 (original ghcr.io publish), MON-207622 (this ticket).