### PR TITLE
fix(web): escape literal braces in $rg search values

### DIFF
--- a/centreon/src/Centreon/Infrastructure/RequestParameters/RegularExpressionSanitizer.php
+++ b/centreon/src/Centreon/Infrastructure/RequestParameters/RegularExpressionSanitizer.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Centreon\Infrastructure\RequestParameters;
+
+/**
+ * Makes a user provided regular expression usable by the SQL REGEXP operator.
+ *
+ * @package Centreon\Infrastructure\RequestParameters
+ */
+class RegularExpressionSanitizer
+{
+    /** A curly brace only opens a quantifier when it describes a {min} or a {min,max} interval. */
+    private const INTERVAL_QUANTIFIER = '/^\{\d+(?:,\d*)?\}/';
+
+    /**
+     * Makes a user provided regular expression acceptable to the SQL REGEXP operator.
+     *
+     * Today that means one thing: escaping the curly braces that do not delimit a {min,max}
+     * interval. PCRE tolerates such braces and reads them as literal characters, whereas the
+     * engine MySQL uses rejects the whole pattern, so searching for a resource whose name
+     * contains braces makes the query fail (error 3692 "Incorrect description of a {min,max}
+     * interval"). Escaped braces are literal for both engines, so the sanitized pattern keeps
+     * the exact same meaning.
+     *
+     * Braces are the only divergence measured between the two engines; further cases belong
+     * here rather than at the call sites.
+     *
+     * @param string $regularExpression
+     *
+     * @return string
+     */
+    public static function sanitize(string $regularExpression): string
+    {
+        $sanitized = '';
+
+        // Curly braces and backslashes are ASCII, so a multibyte character can never be mistaken
+        // for one of them: iterating over the bytes is safe here.
+        for ($index = 0, $length = strlen($regularExpression); $index < $length; ++$index) {
+            $character = $regularExpression[$index];
+
+            if ($character === '\\' && $index + 1 < $length) {
+                // An escape sequence is kept as it is.
+                $sanitized .= $character . $regularExpression[$index + 1];
+                ++$index;
+            } elseif (
+                $character === '{'
+                && preg_match(self::INTERVAL_QUANTIFIER, substr($regularExpression, $index), $matches) === 1
+            ) {
+                // A valid interval is kept as it is.
+                $sanitized .= $matches[0];
+                $index += strlen($matches[0]) - 1;
+            } elseif ($character === '{' || $character === '}') {
+                $sanitized .= '\\' . $character;
+            } else {
+                $sanitized .= $character;
+            }
+        }
+
+        return $sanitized;
+    }
+}

--- a/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -450,6 +450,7 @@ class SqlRequestParametersTranslator
                 }
                 try {
                     $mixedValue = str_replace('/', '\/', $mixedValue);
+                    $mixedValue = RegularExpressionSanitizer::sanitize($mixedValue);
                     preg_match('/' . $mixedValue . '/', '');
                     if (preg_last_error() !== PREG_NO_ERROR) {
                         throw new RequestParametersTranslatorException('Bad regex format \'' . $mixedValue . '\'', 0);

--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -30,6 +30,7 @@ use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Centreon\Domain\RequestParameters\RequestParameters;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
+use Centreon\Infrastructure\RequestParameters\RegularExpressionSanitizer;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Core\Common\Domain\Exception\CollectionException;
 use Core\Common\Domain\Exception\RepositoryException;
@@ -737,7 +738,9 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
             return null;
         }
 
-        $value = $nameParameter[RequestParameters::OPERATOR_REGEXP];
+        $value = RegularExpressionSanitizer::sanitize(
+            $nameParameter[RequestParameters::OPERATOR_REGEXP]
+        );
         $this->queryParameters->add(
             'serviceRegex',
             QueryParameter::string(':serviceRegex', $value)

--- a/centreon/tests/php/Centreon/Infrastructure/RequestParameters/RegularExpressionSanitizerTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/RequestParameters/RegularExpressionSanitizerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Centreon\Infrastructure\RequestParameters;
+
+use Centreon\Infrastructure\RequestParameters\RegularExpressionSanitizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class RegularExpressionSanitizerTest extends TestCase
+{
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function provideRegularExpressions(): array
+    {
+        return [
+            'literal braces of a resource name' => ['FR-WIZ_-_Wizernes_{Deroo}', 'FR-WIZ_-_Wizernes_\{Deroo\}'],
+            'lone opening brace' => ['host{01', 'host\{01'],
+            'lone closing brace' => ['host}01', 'host\}01'],
+            'empty braces' => ['host{}01', 'host\{\}01'],
+            'interval without a minimum' => ['host{,3}', 'host\{,3\}'],
+            'braces inside a character class' => ['[{}]', '[\{\}]'],
+            'exact interval' => ['ho{2}st', 'ho{2}st'],
+            'bounded interval' => ['ho{2,3}st', 'ho{2,3}st'],
+            'unbounded interval' => ['ho{2,}st', 'ho{2,}st'],
+            'interval followed by literal braces' => ['ho{2,3}st{Deroo}', 'ho{2,3}st\{Deroo\}'],
+            'already escaped braces' => ['host\{01\}', 'host\{01\}'],
+            'escaped brace followed by an interval' => ['host\{{2}', 'host\{{2}'],
+            'no brace at all' => ['^host.*$', '^host.*$'],
+            'multibyte characters' => ['Wizernes_éàü_{Deroo}', 'Wizernes_éàü_\{Deroo\}'],
+            'empty value' => ['', ''],
+        ];
+    }
+
+    /**
+     * The sanitized pattern must be exactly the expected one, and must still compile.
+     *
+     * @param string $regularExpression
+     * @param string $expected
+     */
+    #[DataProvider('provideRegularExpressions')]
+    public function testSanitize(string $regularExpression, string $expected): void
+    {
+        $sanitized = RegularExpressionSanitizer::sanitize($regularExpression);
+
+        $this->assertSame($expected, $sanitized);
+        $this->assertNotFalse(@preg_match('/' . $sanitized . '/', ''));
+        $this->assertSame(PREG_NO_ERROR, preg_last_error());
+    }
+}


### PR DESCRIPTION
## Description

Any listing search using the `$rg` operator answered HTTP 500 as soon as the searched value contained a curly brace, so every object whose name contains `{` or `}` was impossible to find.

`SqlRequestParametersTranslator` validates the pattern with **PCRE** (`preg_match`), then binds the raw value to the SQL `REGEXP` operator, which MySQL runs on **ICU**. The two engines disagree: PCRE reads `{Deroo}` as a literal and reports no error, ICU rejects the whole pattern. Validation therefore passes and the query blows up later at `execute()`, surfacing as an uncaught `PDOException`.

- `RegularExpressionSanitizer::sanitize()` escapes the braces that do not delimit a valid `{min}` / `{min,max}` interval. Escaped braces are literal for both engines, so the pattern keeps its exact meaning and genuine quantifiers are left untouched.
- It is applied at the two sites that bind a `$rg` value: the translator, and `DbReadDashboardPerformanceMetricRepository::addServiceRegexJoinClause()`, which binds its own value outside the translator.

Not limited to a matched pair: `a{b`, `a}b`, `a{}b` and `a{,3}b` all failed too (MySQL 3692 or 3688). I compared the two engines over every ASCII punctuation character alone and in context, 83 cases: braces are the only divergence, so the sanitizer stays deliberately narrow.

Measured on MySQL 8.4. A MariaDB stack uses PCRE for `REGEXP` and does not reproduce this.

**Known limitation, not introduced here:** a name containing a genuine interval is still read as a quantifier. Searching `App{1,2}` returns the object named `App{1,2}`, but also `App` and `Apppp`. Escaping it would break real quantifier searches; the wider issue is that the UI sends free text as a regex, which also makes `Paris (Nord)` match `Paris Nord`. Out of scope here.

Fixes: [MON-207738](https://centreon.atlassian.net/browse/MON-207738)

## How to test

1. Create a host group named `FR-WIZ_-_Wizernes_{Deroo}`.
2. `GET /centreon/api/latest/monitoring/hostgroups?search={"name":{"$rg":"FR-WIZ_-_Wizernes_{Deroo}"}}`
3. Expected **HTTP 200** with the group returned. Before: HTTP 500 and `SQLSTATE[HY000]: General error: 3692 Incorrect description of a {min,max} interval` in `prod.web.log`.
4. Same on `/monitoring/resources` and `/configuration/hosts/groups`.

Measured on a live stack, before and after:

| Case | Before | After |
|---|---|---|
| `{Deroo}` on `monitoring/hostgroups` | 500, error 3692 | 200, total=1 |
| `{` alone | 500, error 3692 | 200, total=1 |
| `}` alone | 500, error 3688 | 200, total=1 |
| `{Deroo}` on `monitoring/resources` | 500 | 200, total=1 |
| `{Deroo}` on `configuration/hosts/groups` | 500 | 200, total=1 |
| plain search | 200, total=2 | 200, total=2 |
| genuine quantifier `o{1,2}` | 200, total=1 | 200, total=1 |
| invalid regex `[01` | 500, refused | 500, refused |

The last two rows matter as much as the first five: the fix must not turn a quantifier into a literal, and must not make the validator blind.

Automated coverage: `RegularExpressionSanitizerTest` (15 cases — lone braces, empty braces, `{,3}`, braces inside a character class, already-escaped braces, valid intervals, multibyte).

## Links

Related: #11394 — sibling defect on the same theme (client errors answered as 500), fixed separately.

[MON-207738]: https://centreon.atlassian.net/browse/MON-207738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ