### PR TITLE
fix(poller): keep base URI in the install command

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -10075,7 +10075,7 @@ components:
           nullable: true
         installation_command:
           type: string
-          example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+          example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
           nullable: true
     Poller.CreatePollerInput:
       type: object
@@ -10110,7 +10110,7 @@ components:
         installation_command:
           description: 'Poller Installation Command'
           type: string
-          example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+          example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.InstallationCommandResource.jsonld:
       allOf:
         -
@@ -10121,7 +10121,7 @@ components:
             installation_command:
               description: 'Poller Installation Command'
               type: string
-              example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+              example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.jsonld:
       allOf:
         -
@@ -10146,5 +10146,5 @@ components:
               nullable: true
             installation_command:
               type: string
-              example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+              example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
               nullable: true

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\Poller;
 
+use App\MonitoringConfiguration\Domain\Model\UrlPath;
 use App\Shared\Domain\Assert\Assert as CentreonAssert;
 use Webmozart\Assert\Assert;
 
@@ -51,8 +52,6 @@ final readonly class CentralAddress
      */
     private const IP_LITERAL_PATTERN = '/^\[(?<host>[0-9A-Fa-f:.]+)\](?::(?<port>\d{1,5}))?$/';
     private const HOST_PORT_PATTERN = '/^(?<host>.+):(?<port>\d{1,5})$/';
-    private const BASE_PATH_PATTERN = '~^[A-Za-z0-9._\-]+(?:/[A-Za-z0-9._\-]+)*$~';
-    private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
     private const MIN_PORT = 1;
     private const MAX_PORT = 65535;
 
@@ -76,22 +75,14 @@ final readonly class CentralAddress
 
         $slashPosition = mb_strpos($normalized, '/');
         $authority = $slashPosition === false ? $normalized : mb_substr($normalized, 0, $slashPosition);
-        $basePath = $slashPosition === false ? null : mb_substr($normalized, $slashPosition + 1);
 
         [$host, $port] = $this->parseAuthority($authority);
-        if ($basePath !== null) {
-            Assert::regex(
-                $basePath,
-                self::BASE_PATH_PATTERN,
-                sprintf('[CentralAddress::value] The base path "%s" contains invalid characters', $basePath)
-            );
-            // "." and ".." match BASE_PATH_PATTERN but would make the generated URL
-            // resolve outside the configured base path.
-            Assert::false(
-                (bool) preg_match(self::DOT_SEGMENT_PATTERN, $basePath),
-                sprintf('[CentralAddress::value] The base path "%s" must not contain dot segments', $basePath)
-            );
-        }
+
+        // The separator is kept rather than skipped: UrlPath takes the canonical leading-slash
+        // form, so "host//path" reaches it as "//path" and is rejected as an empty segment.
+        $basePath = $slashPosition === false
+            ? null
+            : new UrlPath(mb_substr($normalized, $slashPosition), 'CentralAddress::value');
 
         $canonical = $this->canonicalize($host, $port, $basePath);
         // Bracketing a bare IPv6 host grows the value, and it is the canonical form that has to fit
@@ -99,7 +90,7 @@ final readonly class CentralAddress
         Assert::lengthBetween($canonical, self::MIN_LENGTH, self::MAX_LENGTH);
 
         $this->host = $host;
-        $this->basePath = $basePath;
+        $this->basePath = $basePath?->segments();
         $this->value = $canonical;
     }
 
@@ -165,7 +156,7 @@ final readonly class CentralAddress
         return $parsed;
     }
 
-    private function canonicalize(string $host, ?int $port, ?string $basePath): string
+    private function canonicalize(string $host, ?int $port, ?UrlPath $basePath): string
     {
         // An IPv6 literal only stands as a URL authority once bracketed: without brackets its
         // colons are read as the port separator.
@@ -175,6 +166,6 @@ final readonly class CentralAddress
 
         return $authority
             . ($port === null ? '' : ':' . $port)
-            . ($basePath === null ? '' : '/' . $basePath);
+            . ($basePath->value ?? '');
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
@@ -29,43 +29,45 @@ use Webmozart\Assert\Assert;
 /**
  * Client-visible entry point of the central server: hostname or IP address,
  * optional port, optional base path — e.g. "central.example.com",
- * "10.0.0.1:8443" or "orga.region.example.com/platform". Unlike PollerAddress,
- * it may carry a base path: on cloud platforms the whole application
- * (including /poller/install.sh) is served under the platform path. No scheme.
+ * "10.0.0.1:8443", "[2001:db8::1]:8443" or "orga.region.example.com/platform".
+ * Unlike PollerAddress, it may carry a base path: on cloud platforms the whole
+ * application (including /poller/install.sh) is served under the platform path.
+ * No scheme.
  *
  * Behind proxies and NAT, only the browser knows the client-reachable form of
- * this address, so the value is provided by the frontend and stored verbatim
- * (minus trailing slash).
+ * this address, so the value is provided by the frontend, then normalized.
  */
 final readonly class CentralAddress
 {
     public const MIN_LENGTH = 1;
     public const MAX_LENGTH = 255;
+
+    /**
+     * An IP-literal, the only form able to carry both an IPv6 host and a web port: the brackets
+     * are what tell the colons of the address from the port separator. Dots belong to the alphabet
+     * for the IPv4-mapped form ("::ffff:10.0.0.1"), and that alphabet is all a pattern can express
+     * — "[::::]" and "[10.0.0.1]" match it — so the capture goes through FILTER_VALIDATE_IP, which
+     * is what actually rejects a non-IPv6 between brackets.
+     */
+    private const IP_LITERAL_PATTERN = '/^\[(?<host>[0-9A-Fa-f:.]+)\](?::(?<port>\d{1,5}))?$/';
     private const HOST_PORT_PATTERN = '/^(?<host>.+):(?<port>\d{1,5})$/';
     private const BASE_PATH_PATTERN = '~^[A-Za-z0-9._\-]+(?:/[A-Za-z0-9._\-]+)*$~';
     private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
+    private const MIN_PORT = 1;
+    private const MAX_PORT = 65535;
 
     /**
-     * The admin input, verbatim minus surrounding whitespace and trailing slash: what gets
-     * persisted, echoed back by the API and quoted in error messages. Not a URL authority —
-     * use {@see $urlValue} for that.
+     * The canonical form of the address: what gets persisted, echoed back by the API and quoted in
+     * error messages. Also what must appear right after "scheme://", so an IPv6 host is bracketed
+     * here even when the admin typed it bare — a bare literal yields an authority curl cannot parse.
      */
     public string $value;
 
-    /** Authority host with the port stripped: hostname, IPv4, or unbracketed IPv6. */
+    /** Authority host, port and brackets stripped: hostname, IPv4, or bare IPv6. */
     public string $host;
 
     /** Base path without surrounding slashes ("platform", "base/path"), null when the address has none. */
     public ?string $basePath;
-
-    /**
-     * The address as it must appear right after "scheme://": web port and base path kept, an IPv6
-     * host bracketed.
-     *
-     * Assembled from the validated parts rather than reusing {@see $value}: a bare IPv6 literal
-     * there yields an authority curl cannot parse.
-     */
-    public string $urlValue;
 
     public function __construct(string $value)
     {
@@ -91,10 +93,14 @@ final readonly class CentralAddress
             );
         }
 
+        $canonical = $this->canonicalize($host, $port, $basePath);
+        // Bracketing a bare IPv6 host grows the value, and it is the canonical form that has to fit
+        // platform_topology.central_address.
+        Assert::lengthBetween($canonical, self::MIN_LENGTH, self::MAX_LENGTH);
+
         $this->host = $host;
         $this->basePath = $basePath;
-        $this->value = $normalized;
-        $this->urlValue = $this->buildUrlValue($host, $port, $basePath);
+        $this->value = $canonical;
     }
 
     /**
@@ -103,25 +109,30 @@ final readonly class CentralAddress
      * The host is kept rather than discarded because consumers that reach the central over a
      * protocol other than HTTP (the broker output, which dials its own port) need it bare.
      * They cannot re-derive it with parse_url(): on a scheme-less value it reports no host at all
-     * unless a port happens to be present. The port is what {@see $urlValue} puts back.
+     * unless a port happens to be present. The port is what {@see canonicalize()} puts back.
      *
      * @return array{0: string, 1: int|null}
      */
     private function parseAuthority(string $authority): array
     {
-        // A bare IP address (IPv4, or IPv6 whose colons would confuse port detection).
+        if (preg_match(self::IP_LITERAL_PATTERN, $authority, $matches, PREG_UNMATCHED_AS_NULL) === 1) {
+            Assert::true(
+                filter_var($matches['host'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false,
+                sprintf('[CentralAddress::value] "%s" is not a valid IPv6 address', $matches['host'])
+            );
+
+            return [$matches['host'], $this->parsePort($matches['port'])];
+        }
+
+        // A bare IP address (IPv4, or IPv6 whose colons would confuse port detection). An IPv6
+        // typed this way carries no port — its last group is indistinguishable from one — and
+        // canonicalize() brackets it back.
         if (filter_var($authority, FILTER_VALIDATE_IP) !== false) {
             return [$authority, null];
         }
 
         if (preg_match(self::HOST_PORT_PATTERN, $authority, $matches) === 1) {
-            $port = (int) $matches['port'];
-            Assert::range(
-                $port,
-                1,
-                65535,
-                sprintf('[CentralAddress::value] The port in "%s" is out of range', $authority)
-            );
+            $port = $this->parsePort($matches['port']);
             CentreonAssert::ipOrHostname($matches['host'], 'CentralAddress::value');
 
             return [$matches['host'], $port];
@@ -132,7 +143,29 @@ final readonly class CentralAddress
         return [$authority, null];
     }
 
-    private function buildUrlValue(string $host, ?int $port, ?string $basePath): string
+    /**
+     * @param string|null $port digits captured by the authority patterns, null when there is no port
+     */
+    private function parsePort(?string $port): ?int
+    {
+        if ($port === null) {
+            return null;
+        }
+
+        $parsed = (int) $port;
+        // The capture is interpolated rather than the whole authority: it holds nothing but digits,
+        // so the message cannot carry a "%" the assertion library re-expands.
+        Assert::range(
+            $parsed,
+            self::MIN_PORT,
+            self::MAX_PORT,
+            sprintf('[CentralAddress::value] The port "%s" is out of range', $port)
+        );
+
+        return $parsed;
+    }
+
+    private function canonicalize(string $host, ?int $port, ?string $basePath): string
     {
         // An IPv6 literal only stands as a URL authority once bracketed: without brackets its
         // colons are read as the port separator.

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddress.php
@@ -45,16 +45,27 @@ final readonly class CentralAddress
     private const BASE_PATH_PATTERN = '~^[A-Za-z0-9._\-]+(?:/[A-Za-z0-9._\-]+)*$~';
     private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
 
+    /**
+     * The admin input, verbatim minus surrounding whitespace and trailing slash: what gets
+     * persisted, echoed back by the API and quoted in error messages. Not a URL authority —
+     * use {@see $urlValue} for that.
+     */
     public string $value;
 
     /** Authority host with the port stripped: hostname, IPv4, or unbracketed IPv6. */
     public string $host;
 
-    /** Web port when the address carries one, null otherwise. Never a protocol port such as the broker's. */
-    public ?int $port;
-
     /** Base path without surrounding slashes ("platform", "base/path"), null when the address has none. */
     public ?string $basePath;
+
+    /**
+     * The address as it must appear right after "scheme://": web port and base path kept, an IPv6
+     * host bracketed.
+     *
+     * Assembled from the validated parts rather than reusing {@see $value}: a bare IPv6 literal
+     * there yields an authority curl cannot parse.
+     */
+    public string $urlValue;
 
     public function __construct(string $value)
     {
@@ -65,7 +76,7 @@ final readonly class CentralAddress
         $authority = $slashPosition === false ? $normalized : mb_substr($normalized, 0, $slashPosition);
         $basePath = $slashPosition === false ? null : mb_substr($normalized, $slashPosition + 1);
 
-        [$this->host, $this->port] = $this->parseAuthority($authority);
+        [$host, $port] = $this->parseAuthority($authority);
         if ($basePath !== null) {
             Assert::regex(
                 $basePath,
@@ -80,17 +91,19 @@ final readonly class CentralAddress
             );
         }
 
+        $this->host = $host;
         $this->basePath = $basePath;
         $this->value = $normalized;
+        $this->urlValue = $this->buildUrlValue($host, $port, $basePath);
     }
 
     /**
      * Validate the authority and split it into host + optional port.
      *
-     * The parts are kept rather than discarded because consumers that reach the central over a
-     * protocol other than HTTP (the broker output, which dials its own port) need the bare host.
+     * The host is kept rather than discarded because consumers that reach the central over a
+     * protocol other than HTTP (the broker output, which dials its own port) need it bare.
      * They cannot re-derive it with parse_url(): on a scheme-less value it reports no host at all
-     * unless a port happens to be present.
+     * unless a port happens to be present. The port is what {@see $urlValue} puts back.
      *
      * @return array{0: string, 1: int|null}
      */
@@ -117,5 +130,18 @@ final readonly class CentralAddress
         CentreonAssert::ipOrHostname($authority, 'CentralAddress::value');
 
         return [$authority, null];
+    }
+
+    private function buildUrlValue(string $host, ?int $port, ?string $basePath): string
+    {
+        // An IPv6 literal only stands as a URL authority once bracketed: without brackets its
+        // colons are read as the port separator.
+        $authority = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false
+            ? sprintf('[%s]', $host)
+            : $host;
+
+        return $authority
+            . ($port === null ? '' : ':' . $port)
+            . ($basePath === null ? '' : '/' . $basePath);
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
@@ -46,11 +46,12 @@ final readonly class CentralUrl
     private const HOST = '[A-Za-z0-9._\-]+';
 
     /**
-     * IPv6 needs a branch of its own: its brackets and colons fall outside HOST. The alphabet is
-     * all a pattern can express here — "[::::]" matches it — so the capture is handed to
-     * FILTER_VALIDATE_IP below.
+     * IPv6 needs a branch of its own: its brackets and colons fall outside HOST. Dots belong to the
+     * alphabet too, for the IPv4-mapped form ("::ffff:10.0.0.1"). That alphabet is all a pattern can
+     * express — "[::::]" and "[10.0.0.1]" match it — so the capture is handed to FILTER_VALIDATE_IP
+     * below, which is what actually separates an IPv6 literal from anything else in brackets.
      */
-    private const BRACKETED_IPV6 = '\[(?<ipv6>[0-9A-Fa-f:]+)\]';
+    private const BRACKETED_IPV6 = '\[(?<ipv6>[0-9A-Fa-f:.]+)\]';
 
     /** Web port, never a protocol port such as the broker's. Digit count only; the range is checked below. */
     private const PORT = '(?::(?<port>\d{1,5}))?';

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
@@ -65,9 +65,13 @@ final readonly class CentralUrl
      * An allowlist rather than an escape, and deliberately narrower than FILTER_VALIDATE_URL, which
      * accepts `$(id)` and backticks because they are legal RFC 3986 sub-delims. This is what makes
      * "safe to interpolate unquoted" checkable in a single place.
+     *
+     * "D" is what makes "$" the end of the subject rather than "before an optional trailing
+     * newline". The normalization below does not cover that: rtrim() runs on "/" after trim(), so
+     * a value ending in "\n/" comes back out of it with the newline restored.
      */
     private const PATTERN = '~^https?://(?:' . self::HOST . '|' . self::BRACKETED_IPV6 . ')'
-        . self::PORT . self::PATH . '$~';
+        . self::PORT . self::PATH . '$~D';
 
     public string $value;
 

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
@@ -57,7 +57,7 @@ final readonly class CentralUrl
     private const PORT = '(?::(?<port>\d{1,5}))?';
 
     /** The slash belongs to each segment, so an empty segment ("//") cannot pass. */
-    private const PATH = '(?:/[A-Za-z0-9._\-]+)*';
+    private const PATH = '(?:/' . UrlPath::SEGMENT . ')*';
 
     /**
      * Scheme, then authority with an optional web port, then path segments.
@@ -68,9 +68,6 @@ final readonly class CentralUrl
      */
     private const PATTERN = '~^https?://(?:' . self::HOST . '|' . self::BRACKETED_IPV6 . ')'
         . self::PORT . self::PATH . '$~';
-
-    /** Rejected for the same reason as in CentralAddress: they resolve outside the base path. */
-    private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
 
     public string $value;
 
@@ -85,7 +82,7 @@ final readonly class CentralUrl
         );
         // "." and ".." match the path part of PATTERN, so they need their own check.
         Assert::false(
-            (bool) preg_match(self::DOT_SEGMENT_PATTERN, $normalized),
+            (bool) preg_match(UrlPath::DOT_SEGMENT_PATTERN, $normalized),
             sprintf('[CentralUrl::value] The URL "%s" must not contain dot segments', $value)
         );
         // The two checks a character class cannot carry. CentralUrlFactory already builds this URL

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Model;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * Absolute HTTP(S) URL of the central web entry point, platform base URI included — e.g.
+ * "https://central.example.com", "http://10.0.0.1:8443/centreon" or "https://[2001:db8::1]/platform".
+ *
+ * The type exists so the guarantee travels with the value instead of being re-asserted by every
+ * consumer: this URL is interpolated unquoted, twice, into the `curl … | bash` one-liner an admin
+ * runs as root to install a poller. A scheme-less value there would download install.sh over plain
+ * HTTP, and anything carrying shell metacharacters would run as part of the command.
+ *
+ * Not a poller property: it is derived per request from a CentralAddress plus the current platform
+ * context (see CentralUrlFactory, the only intended producer), never persisted.
+ */
+final readonly class CentralUrl
+{
+    /** Hostname or IPv4 — indistinguishable here: both are letters, digits, dots and hyphens. */
+    private const HOST = '[A-Za-z0-9._\-]+';
+
+    /** IPv6 needs a branch of its own: its brackets and colons fall outside HOST. */
+    private const BRACKETED_IPV6 = '\[[0-9A-Fa-f:]+\]';
+
+    /** Web port, never a protocol port such as the broker's. Range checked by CentralAddress. */
+    private const PORT = '(?::\d{1,5})?';
+
+    /** The slash belongs to each segment, so an empty segment ("//") cannot pass. */
+    private const PATH = '(?:/[A-Za-z0-9._\-]+)*';
+
+    /**
+     * Scheme, then authority with an optional web port, then path segments.
+     *
+     * An allowlist rather than an escape, and deliberately narrower than FILTER_VALIDATE_URL, which
+     * accepts `$(id)` and backticks because they are legal RFC 3986 sub-delims. This is what makes
+     * "safe to interpolate unquoted" checkable in a single place.
+     */
+    private const PATTERN = '~^https?://(?:' . self::HOST . '|' . self::BRACKETED_IPV6 . ')'
+        . self::PORT . self::PATH . '$~';
+
+    /** Rejected for the same reason as in CentralAddress: they resolve outside the base path. */
+    private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
+
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        $normalized = rtrim(trim($value), '/');
+        Assert::regex(
+            $normalized,
+            self::PATTERN,
+            sprintf('[CentralUrl::value] "%s" is not an absolute HTTP(S) URL made of safe segments', $value)
+        );
+        // "." and ".." match the path part of PATTERN, so they need their own check.
+        Assert::false(
+            (bool) preg_match(self::DOT_SEGMENT_PATTERN, $normalized),
+            sprintf('[CentralUrl::value] The URL "%s" must not contain dot segments', $value)
+        );
+
+        $this->value = $normalized;
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/CentralUrl.php
@@ -39,14 +39,21 @@ use Webmozart\Assert\Assert;
  */
 final readonly class CentralUrl
 {
+    private const MIN_PORT = 1;
+    private const MAX_PORT = 65535;
+
     /** Hostname or IPv4 — indistinguishable here: both are letters, digits, dots and hyphens. */
     private const HOST = '[A-Za-z0-9._\-]+';
 
-    /** IPv6 needs a branch of its own: its brackets and colons fall outside HOST. */
-    private const BRACKETED_IPV6 = '\[[0-9A-Fa-f:]+\]';
+    /**
+     * IPv6 needs a branch of its own: its brackets and colons fall outside HOST. The alphabet is
+     * all a pattern can express here — "[::::]" matches it — so the capture is handed to
+     * FILTER_VALIDATE_IP below.
+     */
+    private const BRACKETED_IPV6 = '\[(?<ipv6>[0-9A-Fa-f:]+)\]';
 
-    /** Web port, never a protocol port such as the broker's. Range checked by CentralAddress. */
-    private const PORT = '(?::\d{1,5})?';
+    /** Web port, never a protocol port such as the broker's. Digit count only; the range is checked below. */
+    private const PORT = '(?::(?<port>\d{1,5}))?';
 
     /** The slash belongs to each segment, so an empty segment ("//") cannot pass. */
     private const PATH = '(?:/[A-Za-z0-9._\-]+)*';
@@ -69,9 +76,10 @@ final readonly class CentralUrl
     public function __construct(string $value)
     {
         $normalized = rtrim(trim($value), '/');
-        Assert::regex(
-            $normalized,
-            self::PATTERN,
+        // PREG_UNMATCHED_AS_NULL, or the branch that did not participate would come back as an
+        // empty string whenever a later group did — "" is not an absent capture.
+        Assert::true(
+            preg_match(self::PATTERN, $normalized, $matches, PREG_UNMATCHED_AS_NULL) === 1,
             sprintf('[CentralUrl::value] "%s" is not an absolute HTTP(S) URL made of safe segments', $value)
         );
         // "." and ".." match the path part of PATTERN, so they need their own check.
@@ -79,7 +87,46 @@ final readonly class CentralUrl
             (bool) preg_match(self::DOT_SEGMENT_PATTERN, $normalized),
             sprintf('[CentralUrl::value] The URL "%s" must not contain dot segments', $value)
         );
+        // The two checks a character class cannot carry. CentralUrlFactory already builds this URL
+        // from an equally validated CentralAddress, but the guarantee is meant to hold for the value
+        // itself, not for the path it happened to travel.
+        $this->assertIpv6IsWellFormed($matches['ipv6'] ?? null);
+        $this->assertPortIsInRange($matches['port'] ?? null);
 
         $this->value = $normalized;
+    }
+
+    /**
+     * @param string|null $ipv6 bracket contents, null when the authority is a hostname or an IPv4
+     */
+    private function assertIpv6IsWellFormed(?string $ipv6): void
+    {
+        if ($ipv6 === null) {
+            return;
+        }
+
+        // The capture is interpolated rather than $value: BRACKETED_IPV6 admits nothing but hex
+        // digits and colons, so the message cannot carry a "%" the assertion library re-expands.
+        Assert::true(
+            filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false,
+            sprintf('[CentralUrl::value] "%s" is not a valid IPv6 address', $ipv6)
+        );
+    }
+
+    /**
+     * @param string|null $port digits captured by PORT, null when the authority carries no port
+     */
+    private function assertPortIsInRange(?string $port): void
+    {
+        if ($port === null) {
+            return;
+        }
+
+        Assert::range(
+            (int) $port,
+            self::MIN_PORT,
+            self::MAX_PORT,
+            sprintf('[CentralUrl::value] The port "%s" is out of range', $port)
+        );
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/UrlPath.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/UrlPath.php
@@ -85,7 +85,9 @@ final readonly class UrlPath
         }
     }
 
-    /** The segments without their leading slash ("base/path"), null when the path is empty. */
+    /**
+     * The segments without their leading slash ("base/path"), null when the path is empty.
+     */
     public function segments(): ?string
     {
         return $this->value === '' ? null : mb_substr($this->value, 1);

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/UrlPath.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/UrlPath.php
@@ -42,8 +42,14 @@ final readonly class UrlPath
     /** The single definition of a safe segment. Public so composed patterns can interpolate it. */
     public const SEGMENT = '[A-Za-z0-9._\-]+';
 
-    /** The slash belongs to each segment, so an empty segment ("//") cannot pass. */
-    public const PATTERN = '~^(?:/' . self::SEGMENT . ')*$~';
+    /**
+     * The slash belongs to each segment, so an empty segment ("//") cannot pass.
+     *
+     * "D" is what makes "$" the end of the subject rather than "before an optional trailing
+     * newline": without it "/centreon\n" passes. CentralUrlFactory::baseUri() rtrims "/" alone,
+     * which leaves such a newline in place, so the guarantee above has to hold on its own.
+     */
+    public const PATTERN = '~^(?:/' . self::SEGMENT . ')*$~D';
 
     /** "." and ".." match PATTERN but resolve outside the path, so they need their own check. */
     public const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';

--- a/centreon/src/App/MonitoringConfiguration/Domain/Model/UrlPath.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Model/UrlPath.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Model;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * A URL path made of safe segments, in its canonical leading-slash form: "", "/centreon",
+ * "/base/path".
+ *
+ * The alphabet is deliberately narrower than RFC 3986. Such a path is interpolated unquoted
+ * into the `curl … | bash` one-liner an admin runs as root, so sub-delims a URL accepts
+ * ("$", "(", ")", backtick) are rejected here rather than escaped later.
+ *
+ * The type exists so that alphabet lives in one place: CentralAddress, CentralUrl and
+ * CentralUrlFactory each carried their own copy, and the copies had already drifted apart
+ * once.
+ */
+final readonly class UrlPath
+{
+    /** The single definition of a safe segment. Public so composed patterns can interpolate it. */
+    public const SEGMENT = '[A-Za-z0-9._\-]+';
+
+    /** The slash belongs to each segment, so an empty segment ("//") cannot pass. */
+    public const PATTERN = '~^(?:/' . self::SEGMENT . ')*$~';
+
+    /** "." and ".." match PATTERN but resolve outside the path, so they need their own check. */
+    public const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
+
+    /**
+     * The value as given, once validated: a leading slash on every segment, no trailing slash,
+     * "" for a root-mounted path. Nothing is normalized here on purpose, so a caller cannot have
+     * a malformed path quietly repaired into a valid one.
+     */
+    public string $value;
+
+    public function __construct(string $value, ?string $propertyPath = null)
+    {
+        $property = $propertyPath ?? 'UrlPath::value';
+
+        Assert::regex(
+            $value,
+            self::PATTERN,
+            sprintf('[%s] The path "%s" contains invalid characters', $property, $value)
+        );
+        Assert::false(
+            (bool) preg_match(self::DOT_SEGMENT_PATTERN, $value),
+            sprintf('[%s] The path "%s" must not contain dot segments', $property, $value)
+        );
+
+        $this->value = $value;
+    }
+
+    /**
+     * For callers that degrade instead of failing, such as a base URI dropped from a URL and
+     * logged rather than turned into an error response.
+     */
+    public static function tryFrom(string $value): ?self
+    {
+        try {
+            return new self($value);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /** The segments without their leading slash ("base/path"), null when the path is empty. */
+    public function segments(): ?string
+    {
+        return $this->value === '' ? null : mb_substr($this->value, 1);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Dto/CreatePollerInput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Dto/CreatePollerInput.php
@@ -28,6 +28,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Infrastructure\Validator\ExistingPollerToken;
+use App\MonitoringConfiguration\Infrastructure\Validator\ValidCentralAddress;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final readonly class CreatePollerInput
@@ -52,6 +53,7 @@ final readonly class CreatePollerInput
         #[Assert\NotBlank(normalizer: 'trim')]
         #[Assert\Length(min: CentralAddress::MIN_LENGTH, max: CentralAddress::MAX_LENGTH)]
         #[Assert\Regex(pattern: '~://~', match: false, message: 'This value must be an IP address or a hostname with an optional base path, without a protocol scheme.')]
+        #[ValidCentralAddress]
         public string $centralAddress,
     ) {
     }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/InstallationCommandResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/InstallationCommandResource.php
@@ -68,7 +68,7 @@ final class InstallationCommandResource
     public function __construct(
         #[ApiProperty(
             description: 'Poller Installation Command',
-            openapiContext: ['example' => 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
+            openapiContext: ['example' => 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
         )]
         #[Sensitive]
         public string $installationCommand,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
@@ -70,7 +70,7 @@ final class PollerResource
         public string $gorgoneCommunicationType,
 
         #[ApiProperty(
-            openapiContext: ['example' => 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
+            openapiContext: ['example' => 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>']
         )]
         #[Sensitive]
         public string $installationCommand = '',

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -37,6 +37,7 @@ use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Dto\CreatePollerInput;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\PollerResource;
+use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
 use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Security\Infrastructure\Security\CredentialUser;
 use App\Shared\Application\Command\CommandBus;
@@ -63,6 +64,7 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         private PollerRepository $pollerRepository,
         private PollerTokenRepository $pollerTokenRepository,
         private EngineSecretsRepository $engineSecretsRepository,
+        private CentralUrlFactory $centralUrlFactory,
         #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
         private bool $isCloudPlatform = false,
     ) {
@@ -109,8 +111,8 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
             $token,
             $appSecret,
             $salt,
+            $this->centralUrlFactory->create($centralAddress),
             $this->isCloudPlatform,
-            $centralAddress->value,
         );
 
         $resource = $this->transformer->transform($model);

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -85,6 +85,9 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         Assert::isInstanceOf($credentialUser, CredentialUser::class);
 
         $centralAddress = new CentralAddress($data->centralAddress);
+        // Resolved before the poller is persisted: an unusable platform base path fails the
+        // request, and doing it afterward would leave the poller created behind that failure.
+        $centralUrl = $this->centralUrlFactory->create($centralAddress);
 
         $command = new CreatePollerCommand(
             name: $pollerName,
@@ -111,7 +114,7 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
             $token,
             $appSecret,
             $salt,
-            $this->centralUrlFactory->create($centralAddress),
+            $centralUrl,
             $this->isCloudPlatform,
         );
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProvider.php
@@ -32,6 +32,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\InstallationCommandResource;
+use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
 use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Shared\Domain\Repository\EngineSecretsRepository;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -48,6 +49,7 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
         private PollerTokenRepository $pollerTokenRepository,
         private EngineSecretsRepository $engineSecretsRepository,
         private Security $security,
+        private CentralUrlFactory $centralUrlFactory,
         #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
         private bool $isCloudPlatform = false,
     ) {
@@ -77,8 +79,8 @@ final readonly class GetInstallationCommandProvider implements ProviderInterface
             $token,
             $this->engineSecretsRepository->getAppSecret(),
             $this->engineSecretsRepository->getSalt(),
+            $this->centralUrlFactory->create($poller->centralAddress),
             $this->isCloudPlatform,
-            $poller->centralAddress->value,
         );
 
         $installationCommand = $factory->generate();

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -31,6 +31,7 @@ use App\MonitoringConfiguration\Domain\Model\UrlPath;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Central URL for the poller install command: the address comes from the payload
@@ -106,19 +107,31 @@ final readonly class CentralUrlFactory
 
         // The base URI ends up in a command the admin runs in a shell, so it has to pass the
         // same segment rules as the rest of the URL.
-        $baseUri = UrlPath::tryFrom(rtrim($matches['baseUri'], '/'));
+        $rawBaseUri = rtrim($matches['baseUri'], '/');
+        $baseUri = UrlPath::tryFrom($rawBaseUri);
         if (! $baseUri instanceof UrlPath) {
-            $this->logDroppedBaseUri('unsafe path', $requestUri);
+            // Unlike an unrecognized entry point, this is a request the platform answers under a
+            // base path it cannot express. Dropping it would hand back a command that looks valid
+            // and 404s on install.sh, so the admin would chase the network or the token before
+            // suspecting the path.
+            Logger::create(LogChannelEnum::POLLER_INSTALL)->error(
+                'Central URL cannot carry the platform base URI',
+                ['reason' => 'unsafe path', 'request_uri' => $requestUri],
+            );
 
-            return '';
+            throw new BadRequestHttpException(sprintf(
+                'The platform base path "%s" cannot be used in a poller installation command.',
+                $rawBaseUri
+            ));
         }
 
         return $baseUri->value;
     }
 
     /**
-     * Without the base URI the command still looks valid but downloads install.sh from
-     * the wrong path, so the failure has to be traceable.
+     * An entry point this factory does not know about is not necessarily a platform served under a
+     * base path: a CLI or a test may reach the command generation with no request at all. The URL
+     * is built root-mounted, which is right for most platforms and traceable for the rest.
      */
     private function logDroppedBaseUri(string $reason, string $requestUri): void
     {

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure;
+
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Builds the URL a poller must use to reach the central: scheme, then the
+ * client-visible central address, then the base URI the web application is
+ * served under (e.g. "https://central.example.com/centreon").
+ *
+ * Only the address itself is client-provided: behind proxies and NAT, nothing
+ * server-side knows how the central is reachable. The base URI and the scheme
+ * are properties of this platform, so they are resolved from the current
+ * request instead of being taken from the payload — a bare address is the
+ * common case (the modal asks the admin for an address, and the upgrade
+ * populates existing pollers with the one already known to the platform).
+ */
+final readonly class CentralUrlFactory
+{
+    private const DEFAULT_SCHEME = 'https';
+
+    /**
+     * Every API route is mounted under "<base_uri>/api/<version>/", so whatever
+     * precedes it in the request URI is the base URI — empty when root-mounted.
+     */
+    private const ENTRY_POINT_PATTERN = '~^(?<baseUri>.*?)/api/(?:latest|beta|v\d+(?:\.\d+)?)/~';
+
+    /** Path segments only: the base URI ends up in a command the admin runs in a shell. */
+    private const SAFE_BASE_URI_PATTERN = '~^(?:/[A-Za-z0-9._\-]+)*$~';
+
+    public function __construct(
+        private RequestStack $requestStack,
+        #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
+        private bool $isCloudPlatform = false,
+    ) {
+    }
+
+    public function create(CentralAddress $centralAddress): string
+    {
+        $address = $centralAddress->value;
+
+        // On cloud the address already carries the platform path, taken from the
+        // browser location: appending the base URI would duplicate it.
+        if (! str_contains($address, '/')) {
+            $address .= $this->baseUri();
+        }
+
+        return sprintf('%s://%s', $this->scheme(), $address);
+    }
+
+    /**
+     * Cloud is always served over HTTPS. On-prem ships a plain-HTTP vhost until
+     * the admin configures SSL, so only the request tells which one it is —
+     * and the scheme drives whether the poller opens its Gorgone websocket over
+     * TLS, so guessing it wrong breaks the installation.
+     */
+    private function scheme(): string
+    {
+        if ($this->isCloudPlatform) {
+            return self::DEFAULT_SCHEME;
+        }
+
+        return $this->requestStack->getCurrentRequest()?->getScheme() ?? self::DEFAULT_SCHEME;
+    }
+
+    private function baseUri(): string
+    {
+        $requestUri = $this->requestStack->getCurrentRequest()?->getRequestUri() ?? '';
+
+        if (preg_match(self::ENTRY_POINT_PATTERN, $requestUri, $matches) !== 1) {
+            return '';
+        }
+
+        $baseUri = rtrim($matches['baseUri'], '/');
+
+        return preg_match(self::SAFE_BASE_URI_PATTERN, $baseUri) === 1 ? $baseUri : '';
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -82,14 +82,8 @@ final readonly class CentralUrlFactory
             return self::DEFAULT_SCHEME;
         }
 
-        // This kernel declares no trusted_proxies, so getScheme() cannot see through a
-        // TLS-terminating proxy. Honour the header to upgrade only: a spoofed value can
-        // make the command fail loudly, never downgrade a poller to plain HTTP.
-        $forwarded = $request->headers->get('X-Forwarded-Proto');
-        if (is_string($forwarded) && mb_strtolower(trim(explode(',', $forwarded)[0])) === self::DEFAULT_SCHEME) {
-            return self::DEFAULT_SCHEME;
-        }
-
+        // X-Forwarded-Proto is already resolved here, but only from the proxies
+        // config/packages/framework.yaml declares trusted.
         return $request->getScheme();
     }
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -42,9 +42,20 @@ final readonly class CentralUrlFactory
     private const DEFAULT_SCHEME = 'https';
 
     /**
-     * Entry points able to generate an install command, mirroring the paths Apache
-     * proxies to PHP-FPM (packaging/src/centreon-apache.conf): what precedes them
-     * in the request URI is the platform base URI.
+     * The two entry points able to generate an install command: the versioned API, and the legacy
+     * "copy installation command" script. What precedes them in the request URI is the platform
+     * base URI.
+     *
+     * Narrower than what Apache proxies to PHP-FPM on purpose: centreon-apache.conf also routes
+     * "authentication/" and every ".php" under www/, and widening this to match would let an
+     * unexpected request URI contribute a base URI to a command run as root. An unrecognized
+     * entry point is meant to drop the base URI, not to be added here.
+     *
+     * Request::getBaseUrl() would serve the API alone: api/index.php fakes SCRIPT_NAME so the
+     * kernel resolves "/centreon", while copyInstallCommand.php boots no kernel and yields
+     * ".../configServers/copyInstallCommand.php" instead. HttpUrlTrait::getBaseUri() covers both
+     * but sits outside App/, captures the request at injection time, and validates nothing it
+     * extracts.
      */
     private const ENTRY_POINT_PATTERN = '~^(?<baseUri>.*?)/(?:api/(?:latest|beta|v\d+(?:\.\d+)?)|include)/~';
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -23,34 +23,34 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Infrastructure;
 
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Builds the URL a poller must use to reach the central: scheme, then the
- * client-visible central address, then the base URI the web application is
- * served under (e.g. "https://central.example.com/centreon").
- *
- * Only the address itself is client-provided: behind proxies and NAT, nothing
- * server-side knows how the central is reachable. The base URI and the scheme
- * are properties of this platform, so they are resolved from the current
- * request instead of being taken from the payload — a bare address is the
- * common case (the modal asks the admin for an address, and the upgrade
- * populates existing pollers with the one already known to the platform).
+ * Central URL for the poller install command: the address comes from the payload
+ * (see CentralAddress), the scheme and base URI from the current request — they
+ * are properties of this platform, not of the payload.
  */
 final readonly class CentralUrlFactory
 {
     private const DEFAULT_SCHEME = 'https';
 
     /**
-     * Every API route is mounted under "<base_uri>/api/<version>/", so whatever
-     * precedes it in the request URI is the base URI — empty when root-mounted.
+     * Entry points able to generate an install command, mirroring the paths Apache
+     * proxies to PHP-FPM (packaging/src/centreon-apache.conf): what precedes them
+     * in the request URI is the platform base URI.
      */
-    private const ENTRY_POINT_PATTERN = '~^(?<baseUri>.*?)/api/(?:latest|beta|v\d+(?:\.\d+)?)/~';
+    private const ENTRY_POINT_PATTERN = '~^(?<baseUri>.*?)/(?:api/(?:latest|beta|v\d+(?:\.\d+)?)|include)/~';
 
     /** Path segments only: the base URI ends up in a command the admin runs in a shell. */
     private const SAFE_BASE_URI_PATTERN = '~^(?:/[A-Za-z0-9._\-]+)*$~';
+
+    /** Rejected for the same reason as in CentralAddress: they resolve outside the base path. */
+    private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
 
     public function __construct(
         private RequestStack $requestStack,
@@ -61,22 +61,15 @@ final readonly class CentralUrlFactory
 
     public function create(CentralAddress $centralAddress): string
     {
-        $address = $centralAddress->value;
+        // An address that already carries a base path — cloud, or pasted whole by the
+        // admin — must not get the platform one appended on top.
+        $path = $centralAddress->basePath === null ? $this->baseUri() : '';
 
-        // On cloud the address already carries the platform path, taken from the
-        // browser location: appending the base URI would duplicate it.
-        if (! str_contains($address, '/')) {
-            $address .= $this->baseUri();
-        }
-
-        return sprintf('%s://%s', $this->scheme(), $address);
+        return sprintf('%s://%s%s', $this->scheme(), $centralAddress->value, $path);
     }
 
     /**
-     * Cloud is always served over HTTPS. On-prem ships a plain-HTTP vhost until
-     * the admin configures SSL, so only the request tells which one it is —
-     * and the scheme drives whether the poller opens its Gorgone websocket over
-     * TLS, so guessing it wrong breaks the installation.
+     * On-prem may still be plain HTTP; the poller derives Gorgone's TLS and port from this scheme.
      */
     private function scheme(): string
     {
@@ -84,7 +77,20 @@ final readonly class CentralUrlFactory
             return self::DEFAULT_SCHEME;
         }
 
-        return $this->requestStack->getCurrentRequest()?->getScheme() ?? self::DEFAULT_SCHEME;
+        $request = $this->requestStack->getCurrentRequest();
+        if (! $request instanceof Request) {
+            return self::DEFAULT_SCHEME;
+        }
+
+        // This kernel declares no trusted_proxies, so getScheme() cannot see through a
+        // TLS-terminating proxy. Honour the header to upgrade only: a spoofed value can
+        // make the command fail loudly, never downgrade a poller to plain HTTP.
+        $forwarded = $request->headers->get('X-Forwarded-Proto');
+        if (is_string($forwarded) && mb_strtolower(trim(explode(',', $forwarded)[0])) === self::DEFAULT_SCHEME) {
+            return self::DEFAULT_SCHEME;
+        }
+
+        return $request->getScheme();
     }
 
     private function baseUri(): string
@@ -92,11 +98,33 @@ final readonly class CentralUrlFactory
         $requestUri = $this->requestStack->getCurrentRequest()?->getRequestUri() ?? '';
 
         if (preg_match(self::ENTRY_POINT_PATTERN, $requestUri, $matches) !== 1) {
+            $this->logDroppedBaseUri('unrecognized entry point', $requestUri);
+
             return '';
         }
 
         $baseUri = rtrim($matches['baseUri'], '/');
+        if (
+            preg_match(self::SAFE_BASE_URI_PATTERN, $baseUri) !== 1
+            || preg_match(self::DOT_SEGMENT_PATTERN, $baseUri) === 1
+        ) {
+            $this->logDroppedBaseUri('unsafe path', $requestUri);
 
-        return preg_match(self::SAFE_BASE_URI_PATTERN, $baseUri) === 1 ? $baseUri : '';
+            return '';
+        }
+
+        return $baseUri;
+    }
+
+    /**
+     * Without the base URI the command still looks valid but downloads install.sh from
+     * the wrong path, so the failure has to be traceable.
+     */
+    private function logDroppedBaseUri(string $reason, string $requestUri): void
+    {
+        Logger::create(LogChannelEnum::POLLER_INSTALL)->warning(
+            'Central URL built without the platform base URI',
+            ['reason' => $reason, 'request_uri' => $requestUri],
+        );
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -26,6 +26,7 @@ namespace App\MonitoringConfiguration\Infrastructure;
 use Adaptation\Log\Enum\LogChannelEnum;
 use Adaptation\Log\Logger;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
+use App\MonitoringConfiguration\Domain\Model\CentralUrl;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -59,13 +60,13 @@ final readonly class CentralUrlFactory
     ) {
     }
 
-    public function create(CentralAddress $centralAddress): string
+    public function create(CentralAddress $centralAddress): CentralUrl
     {
         // An address that already carries a base path — cloud, or pasted whole by the
         // admin — must not get the platform one appended on top.
         $path = $centralAddress->basePath === null ? $this->baseUri() : '';
 
-        return sprintf('%s://%s%s', $this->scheme(), $centralAddress->value, $path);
+        return new CentralUrl(sprintf('%s://%s%s', $this->scheme(), $centralAddress->urlValue, $path));
     }
 
     /**

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -107,7 +107,7 @@ final readonly class CentralUrlFactory
         // The base URI ends up in a command the admin runs in a shell, so it has to pass the
         // same segment rules as the rest of the URL.
         $baseUri = UrlPath::tryFrom(rtrim($matches['baseUri'], '/'));
-        if ($baseUri === null) {
+        if (! $baseUri instanceof UrlPath) {
             $this->logDroppedBaseUri('unsafe path', $requestUri);
 
             return '';

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -66,7 +66,7 @@ final readonly class CentralUrlFactory
         // admin — must not get the platform one appended on top.
         $path = $centralAddress->basePath === null ? $this->baseUri() : '';
 
-        return new CentralUrl(sprintf('%s://%s%s', $this->scheme(), $centralAddress->urlValue, $path));
+        return new CentralUrl(sprintf('%s://%s%s', $this->scheme(), $centralAddress->value, $path));
     }
 
     /**

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/CentralUrlFactory.php
@@ -27,6 +27,7 @@ use Adaptation\Log\Enum\LogChannelEnum;
 use Adaptation\Log\Logger;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Model\CentralUrl;
+use App\MonitoringConfiguration\Domain\Model\UrlPath;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -46,12 +47,6 @@ final readonly class CentralUrlFactory
      * in the request URI is the platform base URI.
      */
     private const ENTRY_POINT_PATTERN = '~^(?<baseUri>.*?)/(?:api/(?:latest|beta|v\d+(?:\.\d+)?)|include)/~';
-
-    /** Path segments only: the base URI ends up in a command the admin runs in a shell. */
-    private const SAFE_BASE_URI_PATTERN = '~^(?:/[A-Za-z0-9._\-]+)*$~';
-
-    /** Rejected for the same reason as in CentralAddress: they resolve outside the base path. */
-    private const DOT_SEGMENT_PATTERN = '~(?:^|/)\.{1,2}(?:/|$)~';
 
     public function __construct(
         private RequestStack $requestStack,
@@ -98,17 +93,16 @@ final readonly class CentralUrlFactory
             return '';
         }
 
-        $baseUri = rtrim($matches['baseUri'], '/');
-        if (
-            preg_match(self::SAFE_BASE_URI_PATTERN, $baseUri) !== 1
-            || preg_match(self::DOT_SEGMENT_PATTERN, $baseUri) === 1
-        ) {
+        // The base URI ends up in a command the admin runs in a shell, so it has to pass the
+        // same segment rules as the rest of the URL.
+        $baseUri = UrlPath::tryFrom(rtrim($matches['baseUri'], '/'));
+        if ($baseUri === null) {
             $this->logDroppedBaseUri('unsafe path', $requestUri);
 
             return '';
         }
 
-        return $baseUri;
+        return $baseUri->value;
     }
 
     /**

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -71,11 +71,16 @@ final readonly class PollerInstallationCommandFactory
 
     public function generate(): string
     {
-        // Only `name` is escaped with escapeshellarg(): it is the sole free-form,
-        // user-provided value. The other parameters are controlled and cannot carry
-        // shell metacharacters: pollerToken name+value are hex (bin2hex), uid is an int,
-        // pollerType is an enum, appSecret/salt are read verbatim from the engine context
-        // file, and centralUrl is a CentralUrl, whose allowlist rejects every shell
+        // Two free-form, user-provided values reach this line: the poller name and the
+        // poller token name. Only pollerName goes through escapeshellarg() — the token name
+        // is interpolated as is, and upstream bounds nothing but its length (NewToken, 255
+        // characters), so that part rests on an invariant nothing enforces. Read it as a
+        // description, not as a guarantee.
+        //
+        // The rest cannot carry shell metacharacters: the token value is base64 truncated to
+        // 64 characters (Encryption::generateRandomString), an alphabet that holds none; uid
+        // is an int; pollerType is an enum; appSecret/salt are read verbatim from the engine
+        // context file; and centralUrl is a CentralUrl, whose allowlist rejects every shell
         // metacharacter.
         $command = sprintf(
             'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -27,9 +27,9 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
+use App\MonitoringConfiguration\Domain\Model\CentralUrl;
 use App\MonitoringConfiguration\Domain\Model\PollerToken;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
-use Webmozart\Assert\Assert;
 
 final readonly class PollerInstallationCommandFactory
 {
@@ -40,17 +40,9 @@ final readonly class PollerInstallationCommandFactory
         private PollerToken $pollerToken,
         #[Sensitive] private string $appSecret,
         #[Sensitive] private string $salt,
-        private string $centralUrl,
+        private CentralUrl $centralUrl,
         private bool $isCloudPlatform = false,
     ) {
-        // The command interpolates centralUrl unquoted and never prepends a scheme, so a
-        // caller passing a bare address would emit a one-liner that curl downloads over
-        // plain HTTP before piping it into a root shell. Fail here instead.
-        Assert::regex(
-            $centralUrl,
-            '~^https?://~',
-            'The central URL must carry its scheme: build it with CentralUrlFactory.'
-        );
     }
 
     /**
@@ -62,7 +54,7 @@ final readonly class PollerInstallationCommandFactory
         PollerToken $pollerToken,
         string $appSecret,
         string $salt,
-        string $centralUrl,
+        CentralUrl $centralUrl,
         bool $isCloudPlatform = false,
     ): self {
         return new self(
@@ -83,17 +75,17 @@ final readonly class PollerInstallationCommandFactory
         // user-provided value. The other parameters are controlled and cannot carry
         // shell metacharacters: pollerToken name+value are hex (bin2hex), uid is an int,
         // pollerType is an enum, appSecret/salt are read verbatim from the engine context
-        // file, and centralUrl is asserted to be a scheme-bearing URL built from a
-        // validated CentralAddress.
+        // file, and centralUrl is a CentralUrl, whose allowlist rejects every shell
+        // metacharacter.
         $command = sprintf(
             'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
-            $this->centralUrl,
+            $this->centralUrl->value,
             $this->pollerToken->name,
             $this->pollerToken->value,
             $this->pollerUid->value,
             escapeshellarg($this->pollerName->value),
             $this->pollerType->value,
-            $this->centralUrl,
+            $this->centralUrl->value,
             $this->appSecret,
             $this->salt,
         );

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -39,8 +39,8 @@ final readonly class PollerInstallationCommandFactory
         private PollerToken $pollerToken,
         #[Sensitive] private string $appSecret,
         #[Sensitive] private string $salt,
+        private string $centralUrl,
         private bool $isCloudPlatform = false,
-        private string $centralUrl = '<CENTRAL_URL>',
     ) {
     }
 
@@ -53,8 +53,8 @@ final readonly class PollerInstallationCommandFactory
         PollerToken $pollerToken,
         string $appSecret,
         string $salt,
+        string $centralUrl,
         bool $isCloudPlatform = false,
-        string $centralUrl = '<CENTRAL_URL>',
     ): self {
         return new self(
             $poller->uid,
@@ -63,8 +63,8 @@ final readonly class PollerInstallationCommandFactory
             $pollerToken,
             $appSecret,
             $salt,
-            $isCloudPlatform,
             $centralUrl,
+            $isCloudPlatform,
         );
     }
 
@@ -73,10 +73,13 @@ final readonly class PollerInstallationCommandFactory
         // Only `name` is escaped with escapeshellarg(): it is the sole free-form,
         // user-provided value. The other parameters are controlled and cannot carry
         // shell metacharacters: pollerToken name+value are hex (bin2hex), uid is an int,
-        // pollerType is an enum, appSecret/salt are engine-generated, and centralUrl must be
-        // validated as an IP or hostname (PollerAddress) by every call site before reaching here.
+        // pollerType is an enum, appSecret/salt are engine-generated, and centralUrl is built
+        // by CentralUrlFactory from a validated CentralAddress by every call site.
+        //
+        // centralUrl already carries its scheme: the command must never prepend one, or an
+        // address that came in with a scheme would end up with two of them.
         $command = sprintf(
-            'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
+            'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
             $this->centralUrl,
             $this->pollerToken->name,
             $this->pollerToken->value,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -71,11 +71,11 @@ final readonly class PollerInstallationCommandFactory
 
     public function generate(): string
     {
-        // Two free-form, user-provided values reach this line: the poller name and the
-        // poller token name. Only pollerName goes through escapeshellarg() — the token name
-        // is interpolated as is, and upstream bounds nothing but its length (NewToken, 255
-        // characters), so that part rests on an invariant nothing enforces. Read it as a
-        // description, not as a guarantee.
+        // Two free-form, admin-provided values reach this line: the poller name and the
+        // poller token name. Upstream bounds nothing but their length (NewToken, 255
+        // characters), so both are quoted with escapeshellarg(). The token name and its
+        // value are quoted together, as the single --poller_token argument install.sh
+        // expects: it forwards the "name:value" pair verbatim to the Gorgone configuration.
         //
         // The rest cannot carry shell metacharacters: the token value is base64 truncated to
         // 64 characters (Encryption::generateRandomString), an alphabet that holds none; uid
@@ -83,10 +83,9 @@ final readonly class PollerInstallationCommandFactory
         // context file; and centralUrl is a CentralUrl, whose allowlist rejects every shell
         // metacharacter.
         $command = sprintf(
-            'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
+            'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
             $this->centralUrl->value,
-            $this->pollerToken->name,
-            $this->pollerToken->value,
+            escapeshellarg($this->pollerToken->name . ':' . $this->pollerToken->value),
             $this->pollerUid->value,
             escapeshellarg($this->pollerName->value),
             $this->pollerType->value,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactory.php
@@ -29,6 +29,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
 use App\MonitoringConfiguration\Domain\Model\PollerToken;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
+use Webmozart\Assert\Assert;
 
 final readonly class PollerInstallationCommandFactory
 {
@@ -42,6 +43,14 @@ final readonly class PollerInstallationCommandFactory
         private string $centralUrl,
         private bool $isCloudPlatform = false,
     ) {
+        // The command interpolates centralUrl unquoted and never prepends a scheme, so a
+        // caller passing a bare address would emit a one-liner that curl downloads over
+        // plain HTTP before piping it into a root shell. Fail here instead.
+        Assert::regex(
+            $centralUrl,
+            '~^https?://~',
+            'The central URL must carry its scheme: build it with CentralUrlFactory.'
+        );
     }
 
     /**
@@ -73,11 +82,9 @@ final readonly class PollerInstallationCommandFactory
         // Only `name` is escaped with escapeshellarg(): it is the sole free-form,
         // user-provided value. The other parameters are controlled and cannot carry
         // shell metacharacters: pollerToken name+value are hex (bin2hex), uid is an int,
-        // pollerType is an enum, appSecret/salt are engine-generated, and centralUrl is built
-        // by CentralUrlFactory from a validated CentralAddress by every call site.
-        //
-        // centralUrl already carries its scheme: the command must never prepend one, or an
-        // address that came in with a scheme would end up with two of them.
+        // pollerType is an enum, appSecret/salt are read verbatim from the engine context
+        // file, and centralUrl is asserted to be a scheme-bearing URL built from a
+        // validated CentralAddress.
         $command = sprintf(
             'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s:%s --uid %s --name %s --type %s --central_url %s --appsecret %s --salt %s',
             $this->centralUrl,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Validator/ValidCentralAddress.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Validator/ValidCentralAddress.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class ValidCentralAddress extends Constraint
+{
+    public string $message = 'This value must be an IP address or a hostname, with an optional port '
+        . 'and an optional base path. An IPv6 address must be enclosed in square brackets.';
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Validator/ValidCentralAddressValidator.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Validator/ValidCentralAddressValidator.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Validator;
+
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Turns a malformed central address into a 400 with an actionable message.
+ *
+ * The rules are not restated here: the value object is the single source of truth, and without this
+ * constraint its assertion would surface as an unmapped exception from the processor, which
+ * api_platform.yaml has no status for.
+ */
+final class ValidCentralAddressValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (! $constraint instanceof ValidCentralAddress) {
+            throw new UnexpectedTypeException($constraint, ValidCentralAddress::class);
+        }
+
+        // Emptiness is NotBlank's job, and reporting it twice would just clutter the response.
+        if (! is_string($value) || trim($value) === '') {
+            return;
+        }
+
+        try {
+            new CentralAddress($value);
+        } catch (\InvalidArgumentException) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}

--- a/centreon/src/App/Shared/Domain/Assert/Assert.php
+++ b/centreon/src/App/Shared/Domain/Assert/Assert.php
@@ -31,9 +31,13 @@ final class Assert
      * RFC 1123 hostname + underscore (allowed for NetBIOS / Active Directory names).
      * Labels: 1-63 chars, may start/end with alphanumeric or '_', '-' allowed in the middle.
      * Whole hostname: max 253 chars.
+     *
+     * "D" is what makes both "$" the end of the subject rather than "before an optional trailing
+     * newline": without it "host01\n" passes, and callers that interpolate the value they just
+     * validated — a URL authority, a configuration file, a shell command — inherit the newline.
      */
     private const HOSTNAME_PATTERN
-        = '/^(?=.{1,253}$)\w([\w-]{0,61}\w)?(\.\w([\w-]{0,61}\w)?)*$/';
+        = '/^(?=.{1,253}$)\w([\w-]{0,61}\w)?(\.\w([\w-]{0,61}\w)?)*$/D';
 
     public static function ipOrHostname(string $value, ?string $propertyPath = null): void
     {

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/GET -logout - Logout administrator - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: GET /logout - Logout administrator - HTTP 200
   type: http
-  seq: 12
+  seq: 13
 }
 
 get {

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created Docker poller - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created Docker poller - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: POST /clapi - Delete created Docker poller - HTTP 200
   type: http
-  seq: 11
+  seq: 12
 }
 
 post {

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created VM poller - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -clapi - Delete created VM poller - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: POST /clapi - Delete created VM poller - HTTP 200
   type: http
-  seq: 10
+  seq: 11
 }
 
 post {

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -login - Authenticate as super-admin for cleanup - HTTP 200.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -login - Authenticate as super-admin for cleanup - HTTP 200.bru
@@ -1,7 +1,7 @@
 meta {
   name: POST /login - Authenticate as super-admin for cleanup - HTTP 200
   type: http
-  seq: 9
+  seq: 10
 }
 
 post {

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create Docker poller returns installation command - HTTP 201.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Create Docker poller returns installation command - HTTP 201.bru
@@ -1,7 +1,7 @@
 meta {
   name: POST /pollers - Create Docker poller returns installation command - HTTP 201
   type: http
-  seq: 8
+  seq: 9
 }
 
 post {

--- a/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Malformed central address - HTTP 400.bru
+++ b/centreon/tests/api/web-api-workspace/collections/Poller_Configuration/Administrator profile/POST -pollers - Malformed central address - HTTP 400.bru
@@ -1,0 +1,30 @@
+meta {
+  name: POST /pollers - Malformed central address - HTTP 400
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrlWeb}}/configuration/pollers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "poller-bruno-bad-central-address",
+    "address": "1.2.3.7",
+    "poller_type": "vm",
+    "poller_token_name": "{{PollerTokenName}}",
+    "central_address": "central.example.com:70000"
+  }
+}
+
+assert {
+  res.status: eq 400
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddressTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddressTest.php
@@ -38,9 +38,27 @@ final class CentralAddressTest extends TestCase
 
         yield 'IPv4 address' => ['10.0.0.1', '10.0.0.1'];
 
-        yield 'IPv6 address' => ['2001:db8::1', '2001:db8::1'];
+        // A bare IPv6 literal is normalized to its bracketed form: that is what goes to the
+        // database and what must appear right after "scheme://".
+        yield 'bare IPv6 address' => ['2001:db8::1', '[2001:db8::1]'];
 
-        yield 'IPv6 address with base path' => ['2001:db8::1/platform', '2001:db8::1/platform'];
+        yield 'bare IPv6 address with base path' => ['2001:db8::1/platform', '[2001:db8::1]/platform'];
+
+        yield 'bracketed IPv6 address' => ['[2001:db8::1]', '[2001:db8::1]'];
+
+        yield 'bracketed IPv6 address with port' => ['[2001:db8::1]:8443', '[2001:db8::1]:8443'];
+
+        yield 'bracketed IPv6 address with port and base path' => [
+            '[2001:db8::1]:8443/platform',
+            '[2001:db8::1]:8443/platform',
+        ];
+
+        yield 'bracketed IPv6 address in upper case' => ['[2001:DB8::1]', '[2001:DB8::1]'];
+
+        // The IPv4-mapped form is an IPv6 address, dots included.
+        yield 'bare IPv4-mapped IPv6 address' => ['::ffff:10.0.0.1', '[::ffff:10.0.0.1]'];
+
+        yield 'bracketed IPv4-mapped IPv6 address with port' => ['[::ffff:10.0.0.1]:8443', '[::ffff:10.0.0.1]:8443'];
 
         yield 'hostname with port' => ['central.example.com:8443', 'central.example.com:8443'];
 
@@ -79,9 +97,17 @@ final class CentralAddressTest extends TestCase
 
         yield 'port out of range' => ['central.example.com:70000'];
 
-        // Known limitation: Assert::ipOrHostname rejects the brackets, so an IPv6 address
-        // cannot carry a web port.
-        yield 'bracketed IPv6 with port' => ['[2001:db8::1]:8443'];
+        // Bracket contents are only checked for their alphabet by IP_LITERAL_PATTERN.
+        yield 'bracketed non-address' => ['[::::]'];
+
+        yield 'bracketed IPv6 with too many groups' => ['[2001:db8:0:0:0:0:0:0:1]'];
+
+        // The brackets are reserved to IP-literals, so an IPv4 must not wear them.
+        yield 'bracketed IPv4' => ['[10.0.0.1]'];
+
+        yield 'bracketed IPv6 with port out of range' => ['[2001:db8::1]:70000'];
+
+        yield 'bracketed IPv6 with port zero' => ['[2001:db8::1]:0'];
 
         yield 'single-dot path segment' => ['central.example.com/.'];
 
@@ -95,52 +121,46 @@ final class CentralAddressTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{string, string, string|null, string}>
+     * The canonical value is covered by testAcceptsValidAddress; what matters here is that the
+     * host stays bare for the consumers dialing the central over another protocol.
+     *
+     * @return iterable<string, array{string, string, string|null}>
      */
     public static function authorityPartsProvider(): iterable
     {
-        yield 'hostname' => ['central.example.com', 'central.example.com', null, 'central.example.com'];
+        yield 'hostname' => ['central.example.com', 'central.example.com', null];
 
-        yield 'hostname with port' => [
-            'central.example.com:8443',
-            'central.example.com',
-            null,
-            'central.example.com:8443',
-        ];
+        yield 'hostname with port' => ['central.example.com:8443', 'central.example.com', null];
 
         yield 'hostname with base path' => [
             'orga.euwest1.example.com/platform',
             'orga.euwest1.example.com',
             'platform',
-            'orga.euwest1.example.com/platform',
         ];
 
         yield 'hostname with port and multi-segment base path' => [
             'central.example.com:8443/base/path',
             'central.example.com',
             'base/path',
-            'central.example.com:8443/base/path',
         ];
 
-        // An unbracketed IPv6 address must not have its last group mistaken for a port, and it
-        // only stands as a URL authority once bracketed.
-        yield 'IPv6 address' => ['2001:db8::1', '2001:db8::1', null, '[2001:db8::1]'];
+        // A bare IPv6 address must not have its last group mistaken for a port.
+        yield 'bare IPv6 address' => ['2001:db8::1', '2001:db8::1', null];
 
-        yield 'IPv6 address with base path' => [
-            '2001:db8::1/platform',
+        yield 'bare IPv6 address with base path' => ['2001:db8::1/platform', '2001:db8::1', 'platform'];
+
+        // The brackets belong to the authority, not to the host.
+        yield 'bracketed IPv6 address' => ['[2001:db8::1]', '2001:db8::1', null];
+
+        yield 'bracketed IPv6 address with port and base path' => [
+            '[2001:db8::1]:8443/platform',
             '2001:db8::1',
             'platform',
-            '[2001:db8::1]/platform',
         ];
 
-        yield 'IPv4 with base path' => ['10.0.0.1/centreon', '10.0.0.1', 'centreon', '10.0.0.1/centreon'];
+        yield 'IPv4 with base path' => ['10.0.0.1/centreon', '10.0.0.1', 'centreon'];
 
-        yield 'trailing slash is removed' => [
-            'central.example.com/platform/',
-            'central.example.com',
-            'platform',
-            'central.example.com/platform',
-        ];
+        yield 'trailing slash is removed' => ['central.example.com/platform/', 'central.example.com', 'platform'];
     }
 
     #[DataProvider('validAddressProvider')]
@@ -156,13 +176,11 @@ final class CentralAddressTest extends TestCase
         string $rawValue,
         string $expectedHost,
         ?string $expectedBasePath,
-        string $expectedUrlValue,
     ): void {
         $address = new CentralAddress($rawValue);
 
         self::assertSame($expectedHost, $address->host);
         self::assertSame($expectedBasePath, $address->basePath);
-        self::assertSame($expectedUrlValue, $address->urlValue);
     }
 
     #[DataProvider('invalidAddressProvider')]

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddressTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/Poller/CentralAddressTest.php
@@ -40,6 +40,8 @@ final class CentralAddressTest extends TestCase
 
         yield 'IPv6 address' => ['2001:db8::1', '2001:db8::1'];
 
+        yield 'IPv6 address with base path' => ['2001:db8::1/platform', '2001:db8::1/platform'];
+
         yield 'hostname with port' => ['central.example.com:8443', 'central.example.com:8443'];
 
         yield 'hostname with base path' => ['orga.euwest1.example.com/platform', 'orga.euwest1.example.com/platform'];
@@ -77,6 +79,10 @@ final class CentralAddressTest extends TestCase
 
         yield 'port out of range' => ['central.example.com:70000'];
 
+        // Known limitation: Assert::ipOrHostname rejects the brackets, so an IPv6 address
+        // cannot carry a web port.
+        yield 'bracketed IPv6 with port' => ['[2001:db8::1]:8443'];
+
         yield 'single-dot path segment' => ['central.example.com/.'];
 
         yield 'double-dot path segment' => ['central.example.com/..'];
@@ -89,34 +95,52 @@ final class CentralAddressTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{string, string, int|null, string|null}>
+     * @return iterable<string, array{string, string, string|null, string}>
      */
     public static function authorityPartsProvider(): iterable
     {
-        yield 'hostname' => ['central.example.com', 'central.example.com', null, null];
+        yield 'hostname' => ['central.example.com', 'central.example.com', null, 'central.example.com'];
 
-        yield 'hostname with port' => ['central.example.com:8443', 'central.example.com', 8443, null];
+        yield 'hostname with port' => [
+            'central.example.com:8443',
+            'central.example.com',
+            null,
+            'central.example.com:8443',
+        ];
 
         yield 'hostname with base path' => [
             'orga.euwest1.example.com/platform',
             'orga.euwest1.example.com',
-            null,
             'platform',
+            'orga.euwest1.example.com/platform',
         ];
 
         yield 'hostname with port and multi-segment base path' => [
             'central.example.com:8443/base/path',
             'central.example.com',
-            8443,
             'base/path',
+            'central.example.com:8443/base/path',
         ];
 
-        // An unbracketed IPv6 address must not have its last group mistaken for a port.
-        yield 'IPv6 address' => ['2001:db8::1', '2001:db8::1', null, null];
+        // An unbracketed IPv6 address must not have its last group mistaken for a port, and it
+        // only stands as a URL authority once bracketed.
+        yield 'IPv6 address' => ['2001:db8::1', '2001:db8::1', null, '[2001:db8::1]'];
 
-        yield 'IPv4 with base path' => ['10.0.0.1/centreon', '10.0.0.1', null, 'centreon'];
+        yield 'IPv6 address with base path' => [
+            '2001:db8::1/platform',
+            '2001:db8::1',
+            'platform',
+            '[2001:db8::1]/platform',
+        ];
 
-        yield 'trailing slash is removed' => ['central.example.com/platform/', 'central.example.com', null, 'platform'];
+        yield 'IPv4 with base path' => ['10.0.0.1/centreon', '10.0.0.1', 'centreon', '10.0.0.1/centreon'];
+
+        yield 'trailing slash is removed' => [
+            'central.example.com/platform/',
+            'central.example.com',
+            'platform',
+            'central.example.com/platform',
+        ];
     }
 
     #[DataProvider('validAddressProvider')]
@@ -131,14 +155,14 @@ final class CentralAddressTest extends TestCase
     public function testExposesTheAuthorityParts(
         string $rawValue,
         string $expectedHost,
-        ?int $expectedPort,
         ?string $expectedBasePath,
+        string $expectedUrlValue,
     ): void {
         $address = new CentralAddress($rawValue);
 
         self::assertSame($expectedHost, $address->host);
-        self::assertSame($expectedPort, $address->port);
         self::assertSame($expectedBasePath, $address->basePath);
+        self::assertSame($expectedUrlValue, $address->urlValue);
     }
 
     #[DataProvider('invalidAddressProvider')]

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
@@ -51,6 +51,8 @@ final class CentralUrlTest extends TestCase
 
         yield 'bracketed IPv6 with port' => ['https://[2001:db8::1]:8443', 'https://[2001:db8::1]:8443'];
 
+        yield 'bracketed IPv4-mapped IPv6' => ['https://[::ffff:10.0.0.1]', 'https://[::ffff:10.0.0.1]'];
+
         yield 'highest port' => ['https://central.example.com:65535', 'https://central.example.com:65535'];
 
         yield 'trailing slash is removed' => [
@@ -76,7 +78,7 @@ final class CentralUrlTest extends TestCase
 
         yield 'file scheme' => ['file:///etc/passwd'];
 
-        // What CentralAddress::$urlValue exists to prevent: curl cannot parse this authority.
+        // What CentralAddress canonicalization exists to prevent: curl cannot parse this authority.
         yield 'unbracketed IPv6' => ['https://2001:db8::1'];
 
         // A well-formed address, rejected by the pattern rather than by the IPv6 branch: without
@@ -87,6 +89,9 @@ final class CentralUrlTest extends TestCase
         yield 'bracketed non-address' => ['https://[::::]'];
 
         yield 'bracketed IPv6 with too many groups' => ['https://[2001:db8:0:0:0:0:0:0:1]'];
+
+        // The brackets are reserved to IP-literals, so a plain IPv4 must not wear them.
+        yield 'bracketed IPv4' => ['https://[10.0.0.1]'];
 
         // The pattern only counts the port digits.
         yield 'port zero' => ['https://central.example.com:0'];

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
@@ -125,6 +125,10 @@ final class CentralUrlTest extends TestCase
         yield 'single quote' => ["https://central.example.com/'"];
 
         yield 'embedded newline' => ["https://central.example.com\nid"];
+
+        // Normalization does not cover this one: rtrim() runs on "/" after trim(), so the newline
+        // is back in the value by the time the pattern sees it.
+        yield 'trailing newline restored by the slash trim' => ["https://central.example.com/centreon\n/"];
     }
 
     #[DataProvider('validUrlProvider')]

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Domain\Model;
+
+use App\MonitoringConfiguration\Domain\Model\CentralUrl;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CentralUrlTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function validUrlProvider(): iterable
+    {
+        yield 'https hostname' => ['https://central.example.com', 'https://central.example.com'];
+
+        yield 'http hostname' => ['http://central.example.com', 'http://central.example.com'];
+
+        yield 'hostname with port' => ['https://central.example.com:8443', 'https://central.example.com:8443'];
+
+        yield 'multi-segment base URI' => [
+            'https://central.example.com/base/path',
+            'https://central.example.com/base/path',
+        ];
+
+        yield 'IPv4 with port and base URI' => ['http://10.0.0.1:8443/centreon', 'http://10.0.0.1:8443/centreon'];
+
+        yield 'bracketed IPv6' => ['https://[2001:db8::1]/platform', 'https://[2001:db8::1]/platform'];
+
+        yield 'trailing slash is removed' => [
+            'https://central.example.com/platform/',
+            'https://central.example.com/platform',
+        ];
+
+        yield 'surrounding whitespace is trimmed' => ['  https://central.example.com  ', 'https://central.example.com'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidUrlProvider(): iterable
+    {
+        yield 'empty' => [''];
+
+        yield 'no scheme' => ['central.example.com'];
+
+        yield 'scheme-relative' => ['//central.example.com'];
+
+        yield 'unsupported scheme' => ['ftp://central.example.com'];
+
+        yield 'file scheme' => ['file:///etc/passwd'];
+
+        // What CentralAddress::$urlValue exists to prevent: curl cannot parse this authority.
+        yield 'unbracketed IPv6' => ['https://2001:db8::1'];
+
+        yield 'empty path segment' => ['https://central.example.com//platform'];
+
+        yield 'query string' => ['https://central.example.com/path?foo=bar'];
+
+        yield 'fragment' => ['https://central.example.com/path#anchor'];
+
+        yield 'inner whitespace' => ['https://central.example.com/pa th'];
+
+        yield 'single-dot path segment' => ['https://central.example.com/.'];
+
+        yield 'dot segment inside the path' => ['https://central.example.com/platform/../admin'];
+
+        // The value is interpolated unquoted into `curl … | bash`, so shell metacharacters are
+        // rejected rather than escaped.
+        yield 'command separator' => ['https://central.example.com;id'];
+
+        yield 'pipe' => ['https://central.example.com|id'];
+
+        yield 'background operator' => ['https://central.example.com&id'];
+
+        yield 'command substitution' => ['https://central.example.com/$(id)'];
+
+        yield 'backtick substitution' => ['https://central.example.com/`id`'];
+
+        yield 'single quote' => ["https://central.example.com/'"];
+
+        yield 'embedded newline' => ["https://central.example.com\nid"];
+    }
+
+    #[DataProvider('validUrlProvider')]
+    public function testAcceptsValidUrl(string $rawValue, string $expectedValue): void
+    {
+        $url = new CentralUrl($rawValue);
+
+        self::assertSame($expectedValue, $url->value);
+    }
+
+    #[DataProvider('invalidUrlProvider')]
+    public function testRejectsInvalidUrl(string $rawValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new CentralUrl($rawValue);
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/CentralUrlTest.php
@@ -49,6 +49,10 @@ final class CentralUrlTest extends TestCase
 
         yield 'bracketed IPv6' => ['https://[2001:db8::1]/platform', 'https://[2001:db8::1]/platform'];
 
+        yield 'bracketed IPv6 with port' => ['https://[2001:db8::1]:8443', 'https://[2001:db8::1]:8443'];
+
+        yield 'highest port' => ['https://central.example.com:65535', 'https://central.example.com:65535'];
+
         yield 'trailing slash is removed' => [
             'https://central.example.com/platform/',
             'https://central.example.com/platform',
@@ -74,6 +78,20 @@ final class CentralUrlTest extends TestCase
 
         // What CentralAddress::$urlValue exists to prevent: curl cannot parse this authority.
         yield 'unbracketed IPv6' => ['https://2001:db8::1'];
+
+        // A well-formed address, rejected by the pattern rather than by the IPv6 branch: without
+        // brackets the first colon is read as the port separator, and "db8" is not a port.
+        yield 'unbracketed IPv6 in long form with a path' => ['https://2001:db8:0:0:0:0:0:1/index.html'];
+
+        // Bracket contents are only checked for their alphabet by the pattern.
+        yield 'bracketed non-address' => ['https://[::::]'];
+
+        yield 'bracketed IPv6 with too many groups' => ['https://[2001:db8:0:0:0:0:0:0:1]'];
+
+        // The pattern only counts the port digits.
+        yield 'port zero' => ['https://central.example.com:0'];
+
+        yield 'port above the maximum' => ['https://central.example.com:99999'];
 
         yield 'empty path segment' => ['https://central.example.com//platform'];
 

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/UrlPathTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/UrlPathTest.php
@@ -80,6 +80,10 @@ final class UrlPathTest extends TestCase
         yield 'fragment' => ['/centreon#anchor'];
 
         yield 'embedded newline' => ["/centreon\nid"];
+
+        // "$" on its own would match right before this one, and CentralUrlFactory::baseUri() rtrims
+        // "/" alone, so the newline reaches the constructor intact.
+        yield 'trailing newline' => ["/centreon\n"];
     }
 
     /**

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/UrlPathTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Model/UrlPathTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Domain\Model;
+
+use App\MonitoringConfiguration\Domain\Model\UrlPath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class UrlPathTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function validPathProvider(): iterable
+    {
+        yield 'root-mounted platform' => [''];
+
+        yield 'single segment' => ['/centreon'];
+
+        yield 'multi-segment' => ['/base/path'];
+
+        yield 'dots inside a segment' => ['/index.php'];
+
+        yield 'underscore and hyphen' => ['/my_base-path'];
+
+        yield 'digits' => ['/v2'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidPathProvider(): iterable
+    {
+        // What CentralAddress relies on to keep rejecting "host//path".
+        yield 'empty segment' => ['//path'];
+
+        yield 'single-dot segment' => ['/.'];
+
+        yield 'double-dot segment' => ['/..'];
+
+        yield 'dot segment inside the path' => ['/platform/../admin'];
+
+        yield 'leading dot segment' => ['/./platform'];
+
+        // The value is interpolated unquoted into `curl … | bash`, so shell metacharacters are
+        // rejected rather than escaped.
+        yield 'command separator' => ['/centreon;id'];
+
+        yield 'pipe' => ['/centreon|id'];
+
+        yield 'command substitution' => ['/$(id)'];
+
+        yield 'backtick substitution' => ['/`id`'];
+
+        yield 'inner whitespace' => ['/base path'];
+
+        yield 'query string' => ['/centreon?foo=bar'];
+
+        yield 'fragment' => ['/centreon#anchor'];
+
+        yield 'embedded newline' => ["/centreon\nid"];
+    }
+
+    /**
+     * Nothing is repaired on the way in, so a caller cannot get a malformed path quietly turned
+     * into a valid one. Both forms are the callers' job to normalize before construction.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function unnormalizedPathProvider(): iterable
+    {
+        yield 'trailing slash' => ['/centreon/'];
+
+        yield 'no leading slash' => ['centreon'];
+    }
+
+    #[DataProvider('validPathProvider')]
+    public function testAcceptsValidPathVerbatim(string $rawValue): void
+    {
+        self::assertSame($rawValue, new UrlPath($rawValue)->value);
+    }
+
+    #[DataProvider('invalidPathProvider')]
+    public function testRejectsInvalidPath(string $rawValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new UrlPath($rawValue);
+    }
+
+    #[DataProvider('unnormalizedPathProvider')]
+    public function testRejectsRatherThanNormalizes(string $rawValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new UrlPath($rawValue);
+    }
+
+    /**
+     * CentralAddress passes its own property path so a base path failure keeps pointing at the
+     * address the admin typed, not at this type.
+     */
+    public function testReportsTheGivenPropertyPath(): void
+    {
+        $this->expectExceptionMessage('[CentralAddress::value] The path "/.." must not contain dot segments');
+
+        new UrlPath('/..', 'CentralAddress::value');
+    }
+
+    public function testExposesSegmentsWithoutTheLeadingSlash(): void
+    {
+        self::assertSame('base/path', new UrlPath('/base/path')->segments());
+    }
+
+    public function testExposesNoSegmentForAnEmptyPath(): void
+    {
+        self::assertNull(new UrlPath('')->segments());
+    }
+
+    public function testTryFromYieldsNullInsteadOfThrowing(): void
+    {
+        self::assertNull(UrlPath::tryFrom('/platform/../admin'));
+    }
+
+    public function testTryFromBuildsTheValueObjectWhenThePathIsValid(): void
+    {
+        self::assertSame('/centreon', UrlPath::tryFrom('/centreon')?->value);
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
@@ -46,6 +46,7 @@ use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Dto\CreatePollerInput;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller\CreatePollerProcessor;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller\ResourcePollerTransformer;
+use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
 use App\Security\Domain\Aggregate\Credential;
 use App\Security\Domain\Aggregate\CredentialIdentifier;
 use App\Security\Domain\Aggregate\UserId;
@@ -55,6 +56,7 @@ use App\Shared\Domain\Collection;
 use App\Shared\Domain\Repository\EngineSecretsRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 final class CreatePollerProcessorCommunicationTypeTest extends TestCase
 {
@@ -161,6 +163,7 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             pollerRepository: $pollerRepository,
             pollerTokenRepository: $pollerTokenRepository,
             engineSecretsRepository: $engineSecretsRepository,
+            centralUrlFactory: new CentralUrlFactory(new RequestStack(), $isCloudPlatform),
             isCloudPlatform: $isCloudPlatform,
         );
     }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php
@@ -56,7 +56,9 @@ use App\Shared\Domain\Collection;
 use App\Shared\Domain\Repository\EngineSecretsRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 final class CreatePollerProcessorCommunicationTypeTest extends TestCase
 {
@@ -102,8 +104,36 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
         self::assertSame('192.168.1.254', $capturedCommand->centralAddress->value);
     }
 
-    private function buildProcessor(bool $isCloudPlatform, ?object &$capturedCommand): CreatePollerProcessor
+    /**
+     * The central URL is resolved before the poller is persisted, so a platform base path that
+     * cannot go into the command fails the request instead of leaving a poller behind it.
+     */
+    public function testItCreatesNoPollerWhenThePlatformBaseUriIsUnusable(): void
     {
+        $capturedCommand = null;
+        $requestStack = new RequestStack();
+        $requestStack->push(
+            Request::create('https://central.example.com/centreon;id/api/latest/configuration/pollers')
+        );
+        $processor = $this->buildProcessor(
+            isCloudPlatform: false,
+            capturedCommand: $capturedCommand,
+            requestStack: $requestStack,
+        );
+
+        try {
+            $processor->process($this->buildInput(), new Post());
+            self::fail('An unusable platform base path must fail the request');
+        } catch (BadRequestHttpException) {
+            self::assertNull($capturedCommand, 'the poller must not have been created');
+        }
+    }
+
+    private function buildProcessor(
+        bool $isCloudPlatform,
+        ?object &$capturedCommand,
+        ?RequestStack $requestStack = null,
+    ): CreatePollerProcessor {
         $poller = new Poller(
             id: new PollerId(42),
             name: new PollerName('TestPoller'),
@@ -163,7 +193,7 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             pollerRepository: $pollerRepository,
             pollerTokenRepository: $pollerTokenRepository,
             engineSecretsRepository: $engineSecretsRepository,
-            centralUrlFactory: new CentralUrlFactory(new RequestStack(), $isCloudPlatform),
+            centralUrlFactory: new CentralUrlFactory($requestStack ?? new RequestStack(), $isCloudPlatform),
             isCloudPlatform: $isCloudPlatform,
         );
     }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
@@ -450,7 +450,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
         self::assertArrayHasKey('installation_command', $responseData);
         self::assertIsString($responseData['installation_command']);
         self::assertStringContainsString(
-            'https://staging.euwest1.centreon.click/funky-donkey/poller/install.sh',
+            'http://staging.euwest1.centreon.click/funky-donkey/poller/install.sh',
             $responseData['installation_command']
         );
     }
@@ -475,14 +475,39 @@ final class CreatePollerProcessorTest extends ApiTestCase
         self::assertArrayHasKey('installation_command', $responseData);
         self::assertIsString($responseData['installation_command']);
         self::assertStringContainsString(
-            'https://staging.euwest1.centreon.click/funky-donkey/poller/install.sh',
+            'http://staging.euwest1.centreon.click/funky-donkey/poller/install.sh',
             $responseData['installation_command']
         );
         self::assertStringNotContainsString('funky-donkey//', $responseData['installation_command']);
         self::assertStringContainsString(
-            '--central_url staging.euwest1.centreon.click/funky-donkey ',
+            '--central_url http://staging.euwest1.centreon.click/funky-donkey ',
             $responseData['installation_command']
         );
+    }
+
+    public function testCreatePollerReturnsCommandWithASingleSchemeOnBothUrls(): void
+    {
+        $this->login();
+
+        $response = $this->request('POST', '/api/latest/configuration/pollers', [
+            'json' => [
+                'name' => $this->uniqueName('SingleScheme'),
+                'poller_type' => 'vm',
+                'address' => '192.168.1.1',
+                'poller_token_name' => $this->tokenName,
+                'central_address' => '192.168.1.254',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        self::assertIsString($responseData['installation_command']);
+        $command = $responseData['installation_command'];
+
+        self::assertStringContainsString('curl -fsSL http://192.168.1.254/poller/install.sh', $command);
+        self::assertStringContainsString('--central_url http://192.168.1.254 ', $command);
+        self::assertSame(2, mb_substr_count($command, '://'));
     }
 
     private function uniqueName(string $prefix = 'Poller'): string

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
@@ -87,8 +87,8 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL http://192.168.1.1/poller/install.sh | bash -s -- --poller_token test-token-default:%s --uid %s --name %s --type %s --central_url http://192.168.1.1 --appsecret test-app-secret --salt test-salt',
-            $tokenValue,
+            'curl -fsSL http://192.168.1.1/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type %s --central_url http://192.168.1.1 --appsecret test-app-secret --salt test-salt',
+            escapeshellarg('test-token-default:' . $tokenValue),
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
             self::POLLER_TYPE,
@@ -108,8 +108,8 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL http://192.168.1.1/poller/install.sh | bash -s -- --poller_token named-token:%s --uid %s --name %s --type %s --central_url http://192.168.1.1 --appsecret test-app-secret --salt test-salt',
-            $namedTokenValue,
+            'curl -fsSL http://192.168.1.1/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type %s --central_url http://192.168.1.1 --appsecret test-app-secret --salt test-salt',
+            escapeshellarg('named-token:' . $namedTokenValue),
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
             self::POLLER_TYPE,

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
@@ -87,7 +87,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL https://192.168.1.1/poller/install.sh | bash -s -- --poller_token test-token-default:%s --uid %s --name %s --type %s --central_url 192.168.1.1 --appsecret test-app-secret --salt test-salt',
+            'curl -fsSL http://192.168.1.1/poller/install.sh | bash -s -- --poller_token test-token-default:%s --uid %s --name %s --type %s --central_url http://192.168.1.1 --appsecret test-app-secret --salt test-salt',
             $tokenValue,
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
@@ -108,7 +108,7 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
 
         $data = $response->toArray();
         $expected = sprintf(
-            'curl -fsSL https://192.168.1.1/poller/install.sh | bash -s -- --poller_token named-token:%s --uid %s --name %s --type %s --central_url 192.168.1.1 --appsecret test-app-secret --salt test-salt',
+            'curl -fsSL http://192.168.1.1/poller/install.sh | bash -s -- --poller_token named-token:%s --uid %s --name %s --type %s --central_url http://192.168.1.1 --appsecret test-app-secret --salt test-salt',
             $namedTokenValue,
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -31,6 +31,31 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class CentralUrlFactoryTest extends TestCase
 {
+    /** @var array<string> */
+    private array $trustedProxies = [];
+
+    private int $trustedHeaderSet = 0;
+
+    /**
+     * Request holds the trusted proxies statically, and the integration suite boots the
+     * kernel, which declares them process-wide: without this the scheme resolved here
+     * would depend on which tests ran before.
+     */
+    protected function setUp(): void
+    {
+        $this->trustedProxies = Request::getTrustedProxies();
+        $this->trustedHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
+    }
+
+    protected function tearDown(): void
+    {
+        /** @var int-mask-of<Request::HEADER_*> $trustedHeaderSet */
+        $trustedHeaderSet = $this->trustedHeaderSet;
+
+        Request::setTrustedProxies($this->trustedProxies, $trustedHeaderSet);
+    }
+
     public function testItAppendsThePlatformBaseUriToABareAddress(): void
     {
         $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
@@ -148,15 +173,14 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
-    public function testItUpgradesToHttpsWhenAProxyForwardsIt(): void
+    public function testItFollowsTheSchemeForwardedByATrustedProxy(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create(
+        $this->trustTheKernelProxies();
+
+        $factory = $this->createFactory(
             'http://central.example.com/centreon/api/latest/configuration/pollers',
-            server: ['HTTP_X_FORWARDED_PROTO' => 'https, http']
-        ));
-
-        $factory = new CentralUrlFactory($requestStack);
+            ['HTTP_X_FORWARDED_PROTO' => 'https, http']
+        );
 
         self::assertSame(
             'https://10.25.11.198/centreon',
@@ -164,15 +188,12 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
-    public function testItNeverDowngradesAnHttpsRequestToHttp(): void
+    public function testItIgnoresASchemeForwardedByAnUntrustedClient(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create(
+        $factory = $this->createFactory(
             'https://central.example.com/centreon/api/latest/configuration/pollers',
-            server: ['HTTP_X_FORWARDED_PROTO' => 'http']
-        ));
-
-        $factory = new CentralUrlFactory($requestStack);
+            ['HTTP_X_FORWARDED_PROTO' => 'http']
+        );
 
         self::assertSame(
             'https://10.25.11.198/centreon',
@@ -180,10 +201,27 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
-    private function createFactory(string $requestUrl): CentralUrlFactory
+    /**
+     * Mirrors what the kernel applies from config/packages/framework.yaml.
+     */
+    private function trustTheKernelProxies(): void
+    {
+        Request::setTrustedProxies(
+            ['127.0.0.1', 'REMOTE_ADDR'],
+            Request::HEADER_X_FORWARDED_FOR
+            | Request::HEADER_X_FORWARDED_HOST
+            | Request::HEADER_X_FORWARDED_PROTO
+            | Request::HEADER_X_FORWARDED_PORT
+        );
+    }
+
+    /**
+     * @param array<string, string> $server
+     */
+    private function createFactory(string $requestUrl, array $server = []): CentralUrlFactory
     {
         $requestStack = new RequestStack();
-        $requestStack->push(Request::create($requestUrl));
+        $requestStack->push(Request::create($requestUrl, server: $server));
 
         return new CentralUrlFactory($requestStack);
     }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -86,6 +86,30 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
+    public function testItKeepsTheWebPortOfABracketedIpv6Address(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://[2001:db8::1]:8443/centreon',
+            $factory->create(new CentralAddress('[2001:db8::1]:8443'))->value
+        );
+    }
+
+    /**
+     * The dots of an IPv4-mapped address used to fall outside the IPv6 alphabet CentralUrl accepts,
+     * so a value CentralAddress had canonicalized was rejected one step later.
+     */
+    public function testItBracketsAnIpv4MappedIpv6Address(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://[::ffff:10.0.0.1]/centreon',
+            $factory->create(new CentralAddress('::ffff:10.0.0.1'))->value
+        );
+    }
+
     public function testItBracketsAnIpv6AddressCarryingItsOwnBasePath(): void
     {
         $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -28,6 +28,7 @@ use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 final class CentralUrlFactoryTest extends TestCase
 {
@@ -175,9 +176,37 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
-    public function testItIgnoresABaseUriThatIsNotAPlainPath(): void
+    /**
+     * Dropping the base URI here would answer 200 with a command that 404s on install.sh, and the
+     * admin would only find out once they ran it.
+     */
+    public function testItRejectsABaseUriThatIsNotAPlainPath(): void
     {
         $factory = $this->createFactory('https://central.example.com/centreon;id/api/latest/configuration/pollers');
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('The platform base path "/centreon;id" cannot be used');
+
+        $factory->create(new CentralAddress('10.25.11.198'));
+    }
+
+    public function testItRejectsABaseUriContainingDotSegments(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/../api/latest/configuration/pollers');
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $factory->create(new CentralAddress('10.25.11.198'));
+    }
+
+    /**
+     * The counterpart of the two above: an entry point this factory does not know about carries no
+     * claim about a base path — a CLI or a test reaches it with no request at all — so the URL is
+     * built root-mounted rather than refused.
+     */
+    public function testItStillDropsTheBaseUriOfAnUnrecognizedEntryPoint(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon;id/authentication/login');
 
         self::assertSame(
             'https://10.25.11.198',
@@ -185,13 +214,17 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
-    public function testItIgnoresABaseUriContainingDotSegments(): void
+    /**
+     * The address carries its own base path, so the platform one is never read: an unusable request
+     * URI must not fail a payload that does not depend on it.
+     */
+    public function testItIgnoresAnUnusableBaseUriWhenTheAddressCarriesItsOwn(): void
     {
-        $factory = $this->createFactory('https://central.example.com/centreon/../api/latest/configuration/pollers');
+        $factory = $this->createFactory('https://central.example.com/centreon;id/api/latest/configuration/pollers');
 
         self::assertSame(
-            'https://10.25.11.198',
-            $factory->create(new CentralAddress('10.25.11.198'))->value
+            'https://10.25.11.198/platform',
+            $factory->create(new CentralAddress('10.25.11.198/platform'))->value
         );
     }
 

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -116,6 +116,70 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
+    public function testItIgnoresABaseUriContainingDotSegments(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/../api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://10.25.11.198',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItResolvesTheBaseUriFromTheLegacyEntryPoint(): void
+    {
+        $factory = $this->createFactory(
+            'https://central.example.com/centreon/include/configuration/configServers/copyInstallCommand.php?id=1'
+        );
+
+        self::assertSame(
+            'https://10.25.11.198/centreon',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItKeepsTheAddressBasePathOverThePlatformOne(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://10.0.0.1/custom',
+            $factory->create(new CentralAddress('10.0.0.1/custom'))
+        );
+    }
+
+    public function testItUpgradesToHttpsWhenAProxyForwardsIt(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create(
+            'http://central.example.com/centreon/api/latest/configuration/pollers',
+            server: ['HTTP_X_FORWARDED_PROTO' => 'https, http']
+        ));
+
+        $factory = new CentralUrlFactory($requestStack);
+
+        self::assertSame(
+            'https://10.25.11.198/centreon',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItNeverDowngradesAnHttpsRequestToHttp(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create(
+            'https://central.example.com/centreon/api/latest/configuration/pollers',
+            server: ['HTTP_X_FORWARDED_PROTO' => 'http']
+        ));
+
+        $factory = new CentralUrlFactory($requestStack);
+
+        self::assertSame(
+            'https://10.25.11.198/centreon',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
     private function createFactory(string $requestUrl): CentralUrlFactory
     {
         $requestStack = new RequestStack();

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure;
+
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
+use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class CentralUrlFactoryTest extends TestCase
+{
+    public function testItAppendsThePlatformBaseUriToABareAddress(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://10.25.11.198/centreon',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItKeepsThePortWhenAppendingTheBaseUri(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://central.example.com:8443/centreon',
+            $factory->create(new CentralAddress('central.example.com:8443'))
+        );
+    }
+
+    public function testItAppendsNothingWhenThePlatformIsRootMounted(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://10.25.11.198',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItDoesNotDuplicateABasePathAlreadyCarriedByTheAddress(): void
+    {
+        $factory = $this->createFactory('https://orga.euwest1.example.com/platform/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://orga.euwest1.example.com/platform',
+            $factory->create(new CentralAddress('orga.euwest1.example.com/platform'))
+        );
+    }
+
+    public function testItUsesTheSchemeOfTheCurrentRequest(): void
+    {
+        $factory = $this->createFactory('http://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'http://10.25.11.198/centreon',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItFallsBackToHttpsWithoutACurrentRequest(): void
+    {
+        $factory = new CentralUrlFactory(new RequestStack());
+
+        self::assertSame(
+            'https://10.25.11.198',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    public function testItAlwaysUsesHttpsOnCloudPlatforms(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(
+            Request::create('http://orga.euwest1.example.com/platform/api/latest/configuration/pollers')
+        );
+
+        $factory = new CentralUrlFactory($requestStack, isCloudPlatform: true);
+
+        self::assertSame(
+            'https://orga.euwest1.example.com/platform',
+            $factory->create(new CentralAddress('orga.euwest1.example.com/platform'))
+        );
+    }
+
+    public function testItIgnoresABaseUriThatIsNotAPlainPath(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon;id/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://10.25.11.198',
+            $factory->create(new CentralAddress('10.25.11.198'))
+        );
+    }
+
+    private function createFactory(string $requestUrl): CentralUrlFactory
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create($requestUrl));
+
+        return new CentralUrlFactory($requestStack);
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -62,7 +62,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198/centreon',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -72,7 +72,27 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://central.example.com:8443/centreon',
-            $factory->create(new CentralAddress('central.example.com:8443'))
+            $factory->create(new CentralAddress('central.example.com:8443'))->value
+        );
+    }
+
+    public function testItBracketsAnIpv6AddressSoCurlCanParseTheAuthority(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://[2001:db8::1]/centreon',
+            $factory->create(new CentralAddress('2001:db8::1'))->value
+        );
+    }
+
+    public function testItBracketsAnIpv6AddressCarryingItsOwnBasePath(): void
+    {
+        $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');
+
+        self::assertSame(
+            'https://[2001:db8::1]/platform',
+            $factory->create(new CentralAddress('2001:db8::1/platform'))->value
         );
     }
 
@@ -82,7 +102,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -92,7 +112,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://orga.euwest1.example.com/platform',
-            $factory->create(new CentralAddress('orga.euwest1.example.com/platform'))
+            $factory->create(new CentralAddress('orga.euwest1.example.com/platform'))->value
         );
     }
 
@@ -102,7 +122,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'http://10.25.11.198/centreon',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -112,7 +132,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -127,7 +147,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://orga.euwest1.example.com/platform',
-            $factory->create(new CentralAddress('orga.euwest1.example.com/platform'))
+            $factory->create(new CentralAddress('orga.euwest1.example.com/platform'))->value
         );
     }
 
@@ -137,7 +157,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -147,7 +167,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -159,7 +179,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198/centreon',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -169,7 +189,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.0.0.1/custom',
-            $factory->create(new CentralAddress('10.0.0.1/custom'))
+            $factory->create(new CentralAddress('10.0.0.1/custom'))->value
         );
     }
 
@@ -184,7 +204,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198/centreon',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 
@@ -197,7 +217,7 @@ final class CentralUrlFactoryTest extends TestCase
 
         self::assertSame(
             'https://10.25.11.198/centreon',
-            $factory->create(new CentralAddress('10.25.11.198'))
+            $factory->create(new CentralAddress('10.25.11.198'))->value
         );
     }
 

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/CentralUrlFactoryTest.php
@@ -207,6 +207,26 @@ final class CentralUrlFactoryTest extends TestCase
         );
     }
 
+    /**
+     * The invariant copyInstallCommand.php has to satisfy by declaring the trusted proxies
+     * itself: booting no kernel, nothing else declares them there, and a scheme resolved as
+     * http behind a TLS-terminating proxy would hand out an install.sh download in the clear.
+     */
+    public function testItFollowsTheForwardedSchemeFromTheLegacyEntryPoint(): void
+    {
+        $this->trustTheKernelProxies();
+
+        $factory = $this->createFactory(
+            'http://central.example.com/centreon/include/configuration/configServers/copyInstallCommand.php?id=1',
+            ['HTTP_X_FORWARDED_PROTO' => 'https']
+        );
+
+        self::assertSame(
+            'https://10.25.11.198/centreon',
+            $factory->create(new CentralAddress('10.25.11.198'))->value
+        );
+    }
+
     public function testItKeepsTheAddressBasePathOverThePlatformOne(): void
     {
         $factory = $this->createFactory('https://central.example.com/centreon/api/latest/configuration/pollers');

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
 
 final class PollerInstallationCommandFactoryTest extends TestCase
 {
-    private const CENTRAL_URL = 'centreon.example.com';
+    private const CENTRAL_URL = 'https://centreon.example.com/centreon';
     private const POLLER_TOKEN = 'my-secure-poller-token';
     private const APP_SECRET = 'my-app-secret';
     private const SALT = 'my-salt';
@@ -63,7 +63,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         $command = $factory->generate();
 
         self::assertStringContainsString('curl -fsSL', $command);
-        self::assertStringContainsString('https://' . self::CENTRAL_URL . '/poller/install.sh', $command);
+        self::assertStringContainsString(self::CENTRAL_URL . '/poller/install.sh', $command);
         self::assertStringContainsString('| bash -s --', $command);
     }
 
@@ -182,7 +182,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         );
 
         $expected = sprintf(
-            'curl -fsSL https://%s/poller/install.sh | bash -s -- --poller_token test-token:%s --uid %s --name %s --type vm --central_url %s --appsecret %s --salt %s',
+            'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token test-token:%s --uid %s --name %s --type vm --central_url %s --appsecret %s --salt %s',
             self::CENTRAL_URL,
             self::POLLER_TOKEN,
             self::POLLER_UID,
@@ -228,13 +228,14 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         $poller = $this->createPoller(PollerTypeEnum::Docker);
         $token = new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false);
 
-        // isCloudPlatform and centralUrl are intentionally omitted: their defaults are
-        // duplicated in both signatures, and this test pins them to the same values.
+        // isCloudPlatform is intentionally omitted: its default is duplicated in
+        // both signatures, and this test pins them to the same value.
         $fromPoller = PollerInstallationCommandFactory::fromPoller(
             poller: $poller,
             pollerToken: $token,
             appSecret: self::APP_SECRET,
             salt: self::SALT,
+            centralUrl: self::CENTRAL_URL,
         );
 
         $fromValueObjects = new PollerInstallationCommandFactory(
@@ -244,10 +245,10 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: $token,
             appSecret: self::APP_SECRET,
             salt: self::SALT,
+            centralUrl: self::CENTRAL_URL,
         );
 
         self::assertSame($fromPoller->generate(), $fromValueObjects->generate());
-        self::assertStringContainsString('--central_url <CENTRAL_URL>', $fromValueObjects->generate());
         self::assertStringNotContainsString('--cloud', $fromValueObjects->generate());
     }
 

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
@@ -78,7 +78,31 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
-        self::assertStringContainsString('--poller_token test-token:' . self::POLLER_TOKEN, $factory->generate());
+        self::assertStringContainsString(
+            '--poller_token ' . escapeshellarg('test-token:' . self::POLLER_TOKEN),
+            $factory->generate(),
+        );
+    }
+
+    public function testGenerateCommandQuotesATokenNameCarryingShellMetacharacters(): void
+    {
+        $factory = PollerInstallationCommandFactory::fromPoller(
+            poller: $this->createPoller(PollerTypeEnum::VM),
+            pollerToken: new PollerToken(name: 'token; rm -rf / #', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
+            appSecret: self::APP_SECRET,
+            salt: self::SALT,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
+        );
+
+        $command = $factory->generate();
+
+        // The name and the value stay a single argument, so nothing after the semicolon
+        // reaches the shell as a command of its own.
+        self::assertStringContainsString(
+            "--poller_token 'token; rm -rf / #:" . self::POLLER_TOKEN . "'",
+            $command,
+        );
+        self::assertStringEndsWith('--salt ' . self::SALT, $command);
     }
 
     public function testGenerateCommandContainsPollerUid(): void
@@ -183,9 +207,9 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         );
 
         $expected = sprintf(
-            'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token test-token:%s --uid %s --name %s --type vm --central_url %s --appsecret %s --salt %s',
+            'curl -fsSL %s/poller/install.sh | bash -s -- --poller_token %s --uid %s --name %s --type vm --central_url %s --appsecret %s --salt %s',
             self::CENTRAL_URL,
-            self::POLLER_TOKEN,
+            escapeshellarg('test-token:' . self::POLLER_TOKEN),
             self::POLLER_UID,
             escapeshellarg(self::POLLER_NAME),
             self::CENTRAL_URL,

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
@@ -36,6 +36,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\TrapConfiguration;
+use App\MonitoringConfiguration\Domain\Model\CentralUrl;
 use App\MonitoringConfiguration\Domain\Model\PollerToken;
 use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Shared\Domain\Collection;
@@ -57,7 +58,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         $command = $factory->generate();
@@ -74,7 +75,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--poller_token test-token:' . self::POLLER_TOKEN, $factory->generate());
@@ -87,7 +88,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--uid ' . self::POLLER_UID, $factory->generate());
@@ -100,7 +101,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--name ' . escapeshellarg(self::POLLER_NAME), $factory->generate());
@@ -113,7 +114,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--type vm', $factory->generate());
@@ -126,7 +127,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--type docker', $factory->generate());
@@ -139,7 +140,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--central_url ' . self::CENTRAL_URL, $factory->generate());
@@ -152,7 +153,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--appsecret ' . self::APP_SECRET, $factory->generate());
@@ -165,7 +166,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringContainsString('--salt ' . self::SALT, $factory->generate());
@@ -178,7 +179,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         $expected = sprintf(
@@ -203,7 +204,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             appSecret: self::APP_SECRET,
             salt: self::SALT,
             isCloudPlatform: true,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringEndsWith('--cloud', $factory->generate());
@@ -217,7 +218,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             appSecret: self::APP_SECRET,
             salt: self::SALT,
             isCloudPlatform: false,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertStringNotContainsString('--cloud', $factory->generate());
@@ -235,7 +236,7 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: $token,
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         $fromValueObjects = new PollerInstallationCommandFactory(
@@ -245,24 +246,11 @@ final class PollerInstallationCommandFactoryTest extends TestCase
             pollerToken: $token,
             appSecret: self::APP_SECRET,
             salt: self::SALT,
-            centralUrl: self::CENTRAL_URL,
+            centralUrl: new CentralUrl(self::CENTRAL_URL),
         );
 
         self::assertSame($fromPoller->generate(), $fromValueObjects->generate());
         self::assertStringNotContainsString('--cloud', $fromValueObjects->generate());
-    }
-
-    public function testItRejectsACentralUrlWithoutAScheme(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        PollerInstallationCommandFactory::fromPoller(
-            poller: $this->createPoller(PollerTypeEnum::VM),
-            pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
-            appSecret: self::APP_SECRET,
-            salt: self::SALT,
-            centralUrl: 'centreon.example.com/centreon',
-        );
     }
 
     private function createPoller(PollerTypeEnum $type): Poller

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/PollerInstallationCommandFactoryTest.php
@@ -252,6 +252,19 @@ final class PollerInstallationCommandFactoryTest extends TestCase
         self::assertStringNotContainsString('--cloud', $fromValueObjects->generate());
     }
 
+    public function testItRejectsACentralUrlWithoutAScheme(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        PollerInstallationCommandFactory::fromPoller(
+            poller: $this->createPoller(PollerTypeEnum::VM),
+            pollerToken: new PollerToken(name: 'test-token', value: self::POLLER_TOKEN, creationDate: new \DateTimeImmutable(), expirationDate: null, isRevoked: false),
+            appSecret: self::APP_SECRET,
+            salt: self::SALT,
+            centralUrl: 'centreon.example.com/centreon',
+        );
+    }
+
     private function createPoller(PollerTypeEnum $type): Poller
     {
         return new Poller(

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Validator/ValidCentralAddressValidatorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Validator/ValidCentralAddressValidatorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\Validator;
+
+use App\MonitoringConfiguration\Infrastructure\Validator\ValidCentralAddress;
+use App\MonitoringConfiguration\Infrastructure\Validator\ValidCentralAddressValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<ValidCentralAddressValidator>
+ */
+final class ValidCentralAddressValidatorTest extends ConstraintValidatorTestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function validAddressProvider(): iterable
+    {
+        yield 'hostname' => ['central.example.com'];
+
+        yield 'IPv4 with port and base path' => ['10.0.0.1:8443/centreon'];
+
+        yield 'bare IPv6' => ['2001:db8::1'];
+
+        yield 'bracketed IPv6 with port' => ['[2001:db8::1]:8443'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidAddressProvider(): iterable
+    {
+        yield 'malformed bracketed IPv6' => ['[::::]'];
+
+        yield 'bracketed IPv4' => ['[10.0.0.1]'];
+
+        yield 'port out of range' => ['central.example.com:70000'];
+
+        yield 'dot segment in the base path' => ['central.example.com/platform/../admin'];
+
+        yield 'shell metacharacter' => ['central.example.com;id'];
+    }
+
+    #[DataProvider('validAddressProvider')]
+    public function testValidAddressRaisesNoViolation(string $address): void
+    {
+        $this->validator->validate($address, new ValidCentralAddress());
+
+        $this->assertNoViolation();
+    }
+
+    #[DataProvider('invalidAddressProvider')]
+    public function testInvalidAddressRaisesViolation(string $address): void
+    {
+        $constraint = new ValidCentralAddress();
+        $this->validator->validate($address, $constraint);
+
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
+
+    /**
+     * Left to NotBlank, which already covers the field: reporting it twice would clutter the
+     * response with two violations for one mistake.
+     */
+    public function testEmptyValueIsSkipped(): void
+    {
+        $this->validator->validate('   ', new ValidCentralAddress());
+
+        $this->assertNoViolation();
+    }
+
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new ValidCentralAddressValidator();
+    }
+}

--- a/centreon/tests/php/App/Shared/Domain/Assert/AssertTest.php
+++ b/centreon/tests/php/App/Shared/Domain/Assert/AssertTest.php
@@ -64,6 +64,9 @@ class AssertTest extends TestCase
             'trailing hyphen' => ['bad-'],
             'label too long (64 chars)' => [str_repeat('a', 64)],
             'hostname too long (254 chars)' => [str_repeat('a', 254)],
+            // Both "$" of the pattern would match right before this one.
+            'trailing newline' => ["host01\n"],
+            'trailing newline on an FQDN' => ["host.example.com\n"],
         ];
     }
 

--- a/centreon/www/include/configuration/configServers/copyInstallCommand.php
+++ b/centreon/www/include/configuration/configServers/copyInstallCommand.php
@@ -41,6 +41,7 @@ use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Shared\Infrastructure\FsEngineSecretsRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 // Keep in sync with engine_context_path (config/services.yaml) and
 // upgrade.engine_context_path (config.new/services/upgrade.php): this endpoint
@@ -205,6 +206,15 @@ try {
     );
 
     sendJsonResponse(200, ['command' => $factory->generate()]);
+} catch (BadRequestHttpException $exception) {
+    // The one failure the admin can act on: the platform serves itself under a base path that
+    // cannot go into the command. listServers.ihtml puts this message straight in a toast, where
+    // the generic 500 below would say nothing about the cause.
+    Logger::create(LogChannelEnum::WEB)->error(
+        'Failed to generate poller installation command',
+        ['poller_id' => $pollerId, 'exception' => $exception],
+    );
+    sendJsonResponse(400, ['error' => $exception->getMessage()]);
 } catch (Throwable $exception) {
     Logger::create(LogChannelEnum::WEB)->error(
         'Failed to generate poller installation command',

--- a/centreon/www/include/configuration/configServers/copyInstallCommand.php
+++ b/centreon/www/include/configuration/configServers/copyInstallCommand.php
@@ -31,13 +31,16 @@ use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Adaptation\Log\Enum\LogChannelEnum;
 use Adaptation\Log\Logger;
-use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
 use App\MonitoringConfiguration\Domain\Model\PollerToken;
+use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
 use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Shared\Infrastructure\FsEngineSecretsRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 // Keep in sync with engine_context_path (config/services.yaml) and
 // upgrade.engine_context_path (config.new/services/upgrade.php): this endpoint
@@ -118,9 +121,9 @@ try {
 
     try {
         // central_address is written by the remote-server wizard without format validation;
-        // PollerAddress enforces the same IP-or-hostname invariant as the API endpoint,
-        // so no value able to alter the generated shell command can get through.
-        $centralAddress = new PollerAddress($poller['central_address']);
+        // CentralAddress enforces the same invariant as the API endpoint, so no value able
+        // to alter the generated shell command can get through.
+        $centralAddress = new CentralAddress($poller['central_address']);
     } catch (InvalidArgumentException) {
         sendJsonResponse(400, ['error' => 'Invalid central address configured for this poller']);
     }
@@ -157,6 +160,12 @@ try {
 
     $engineSecrets = new FsEngineSecretsRepository(ENGINE_CONTEXT_PATH);
 
+    // This endpoint does not boot the Symfony kernel, so the factory is built by hand
+    // over the current request: the scheme and the base URI must be resolved the same way
+    // as in the API, or the two commands diverge.
+    $requestStack = new RequestStack();
+    $requestStack->push(Request::createFromGlobals());
+
     $factory = new PollerInstallationCommandFactory(
         pollerUid: $pollerUid,
         pollerName: new PollerName($poller['name']),
@@ -165,7 +174,7 @@ try {
         appSecret: $engineSecrets->getAppSecret(),
         salt: $engineSecrets->getSalt(),
         isCloudPlatform: $isCloudPlatform,
-        centralUrl: $centralAddress->value,
+        centralUrl: (new CentralUrlFactory($requestStack, $isCloudPlatform))->create($centralAddress),
     );
 
     sendJsonResponse(200, ['command' => $factory->generate()]);

--- a/centreon/www/include/configuration/configServers/copyInstallCommand.php
+++ b/centreon/www/include/configuration/configServers/copyInstallCommand.php
@@ -47,6 +47,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 // deliberately does not boot the Symfony kernel, so it cannot read the parameter.
 const ENGINE_CONTEXT_PATH = '/etc/centreon-engine/engine-context.json';
 
+// Same reason, and same value as env(TRUSTED_PROXIES) in config/packages/framework.yaml:
+// keep both in sync, or the scheme this endpoint resolves drifts from the one the API
+// resolves for the very same platform.
+const DEFAULT_TRUSTED_PROXIES = '127.0.0.1,REMOTE_ADDR';
+
 header('Content-Type: application/json');
 // The response body carries the app secret, the salt and a live poller token.
 header('Cache-Control: no-store');
@@ -163,6 +168,28 @@ try {
     // This endpoint does not boot the Symfony kernel, so the factory is built by hand
     // over the current request: the scheme and the base URI must be resolved the same way
     // as in the API, or the two commands diverge.
+    //
+    // The trusted proxies come first, because that is what getScheme() reads
+    // x-forwarded-proto from. Booting no kernel means nothing has declared them, so a
+    // TLS-terminating proxy would be invisible here and the generated command would offer
+    // an http:// download piped into a root shell — app secret, salt and poller token
+    // travelling in the clear with it. setTrustedProxies() resolves the REMOTE_ADDR
+    // keyword itself; the header set mirrors trusted_headers in framework.yaml.
+    $trustedProxies = $_ENV['TRUSTED_PROXIES']
+        ?? $_SERVER['TRUSTED_PROXIES']
+        ?? getenv('TRUSTED_PROXIES');
+    if (! is_string($trustedProxies) || trim($trustedProxies) === '') {
+        $trustedProxies = DEFAULT_TRUSTED_PROXIES;
+    }
+
+    Request::setTrustedProxies(
+        array_values(array_filter(array_map('trim', explode(',', $trustedProxies)), 'strlen')),
+        Request::HEADER_X_FORWARDED_FOR
+        | Request::HEADER_X_FORWARDED_HOST
+        | Request::HEADER_X_FORWARDED_PROTO
+        | Request::HEADER_X_FORWARDED_PORT
+    );
+
     $requestStack = new RequestStack();
     $requestStack->push(Request::createFromGlobals());
 


### PR DESCRIPTION
## Description

The installation command generated by the *Create poller* modal and by
`GET /configuration/pollers/installation-command/{id}` dropped the base path the
web application is served under, so a central served under `/centreon` could not
be reached:

- neither the `install.sh` download URL nor `--central_url` carried the base URI;
- `--central_url` had no scheme at all, while `install.sh` derives TLS and the
  port from it (`CENTRAL_URL_SSL`), and the `curl` forced `https://` even on a
  platform served over plain HTTP.

The base URI and the scheme are properties of the platform, not of the payload:
a new `CentralUrlFactory` resolves them from the current request, while the
address itself stays client-provided — behind proxies and NAT, only the browser
knows how the central is reachable. Consequences:

- pollers whose `central_address` was populated by the upgrade (a bare address)
  are covered as well;
- no duplicated path when the address already carries one — the cloud modal sends
  host + base path from `window.location`;
- cloud always uses `https`, it is never served in plain HTTP;
- the command no longer prepends a hardcoded scheme, so the single-scheme fix
  from #11279 still holds.

### Review follow-up

Three changes came out of the review, all in the same area:

- **An unusable platform base path now fails the request** instead of being
  dropped with a log. Dropping it answered 200 with a command whose `install.sh`
  URL 404s, and nothing tied that failure to the base path. An unrecognized
  entry point or a request-less context (CLI, tests) still drops silently —
  neither carries a claim about a base path. Both entry points answer 400, the
  legacy one carrying the message so its toast shows the cause instead of a
  generic 500.
- **The URL is resolved before the poller is persisted**, so that refusal cannot
  leave a poller created behind an error response.
- **The path and URL patterns are anchored with the `D` modifier.** A bare `$`
  matches before a trailing newline, so `/centreon\n` passed validation in types
  whose documented contract is being safe to interpolate unquoted into the
  `curl … | bash` one-liner.

> [!IMPORTANT]
> The last item also fixes `App\Shared\Domain\Assert\Assert::HOSTNAME_PATTERN`,
> which is **outside the poller scope**: 13 callers use it (`Host`, `NewHost`,
> `VaultConfiguration`, `AuthenticationConditions`, `PollerAddress`,
> `CmaConfigurationParameters`, the platform topology…). Only values ending in a
> newline change behaviour, and the nine accepted forms of its own test provider
> are unaffected — but a value **already stored** with a trailing newline will now
> fail validation when one of those models is rebuilt from the database. That
> surfaces data the pattern should never have accepted rather than narrowing what
> counts as a valid hostname.

## How to test

1. Use a central served under a base path, over plain HTTP (e.g.
   `http://<central-ip>/centreon`).
2. Top banner → **Create poller** → fill in the poller name and address, enter
   `<central-ip>` as the central address (no scheme, no path), pick a token, then
   generate the install command.
3. The command must read
   `curl -fsSL http://<central-ip>/centreon/poller/install.sh …` and
   `--central_url http://<central-ip>/centreon`, with a single scheme on both.
4. Call `GET /centreon/api/latest/configuration/pollers/installation-command/{id}`
   for that poller: the command must be identical.
5. Run the command on a VM or a Docker host: the installation completes and the
   poller connects to Gorgone over PullWSS.
6. Repeat on a central served over HTTPS: both URLs must use `https`.
7. On a root-mounted central, both URLs must stay free of any base path.
8. Optional, and it needs an Apache alias: serve the platform under a base path
   holding a character outside `[A-Za-z0-9._-]` (e.g. `/mon+centreon`), then
   generate a command from both entry points. Each must answer 400 naming the
   base path, and `GET /configuration/pollers` must show no poller was created.
   Otherwise this case is covered by `CentralUrlFactoryTest` and
   `CreatePollerProcessorCommunicationTypeTest`.

## API

<details>
<summary>Example response</summary>

`GET /api/latest/configuration/pollers/installation-command/{id}`

```json
{
  "installation_command": "curl -fsSL https://central.example.com/centreon/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name 'my-poller' --type vm --central_url https://central.example.com/centreon --appsecret <app_secret> --salt <salt>"
}
```

</details>

## Links

### Jira ticket

Resolves: [MON-207433](https://centreon.atlassian.net/browse/MON-207433)

### PR Github

- Relates to: #11279 — introduced the single-scheme normalization this PR builds on


[MON-207433]: https://centreon.atlassian.net/browse/MON-207433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
