### PR TITLE
enh(docker): build the web containers against the pulp dev packages host

### DIFF
--- a/.github/docker/centreon-web/alma10/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma10/Dockerfile.dependencies
@@ -4,6 +4,8 @@ ARG MAJOR_VERSION
 ARG PHP_VERSION=8.4
 ARG IS_CLOUD
 ARG STABILITY
+# packages host: the pulp dev stack serves the same legacy layout as production
+ARG PACKAGES_URL=https://packages-dev.int.centreon.com
 
 RUN bash -e <<EOF
 
@@ -21,9 +23,16 @@ dnf config-manager --set-enabled crb
 dnf install -y epel-release
 
 if [[ "${IS_CLOUD}" == "true" ]]; then
-  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard-internal/${MAJOR_VERSION}/el10/centreon-${MAJOR_VERSION}-internal.repo
+  dnf config-manager --add-repo ${PACKAGES_URL}/rpm-standard-internal/${MAJOR_VERSION}/el10/centreon-${MAJOR_VERSION}-internal.repo
 else
-  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${MAJOR_VERSION}/el10/centreon-${MAJOR_VERSION}.repo
+  dnf config-manager --add-repo ${PACKAGES_URL}/rpm-standard/${MAJOR_VERSION}/el10/centreon-${MAJOR_VERSION}.repo
+fi
+
+if [[ "${PACKAGES_URL}" != "https://packages.centreon.com" ]]; then
+  # the served .repo files carry production baseurls: point them at the same
+  # packages host this image is built against, and skip the gpg checks until
+  # that stack publishes its signing keys
+  sed -i -e "s|https://packages.centreon.com|${PACKAGES_URL}|g" -e "s|gpgcheck=1|gpgcheck=0|g" /etc/yum.repos.d/centreon-*.repo
 fi
 
 dnf config-manager --set-enabled 'centreon*'

--- a/.github/docker/centreon-web/alma9/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma9/Dockerfile.dependencies
@@ -4,6 +4,8 @@ ARG MAJOR_VERSION
 ARG PHP_VERSION=8.4
 ARG IS_CLOUD
 ARG STABILITY
+# packages host: the pulp dev stack serves the same legacy layout as production
+ARG PACKAGES_URL=https://packages-dev.int.centreon.com
 
 RUN bash -e <<EOF
 
@@ -21,9 +23,16 @@ dnf config-manager --set-enabled crb
 dnf install -y epel-release
 
 if [[ "${IS_CLOUD}" == "true" ]]; then
-  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard-internal/${MAJOR_VERSION}/el9/centreon-${MAJOR_VERSION}-internal.repo
+  dnf config-manager --add-repo ${PACKAGES_URL}/rpm-standard-internal/${MAJOR_VERSION}/el9/centreon-${MAJOR_VERSION}-internal.repo
 else
-  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${MAJOR_VERSION}/el9/centreon-${MAJOR_VERSION}.repo
+  dnf config-manager --add-repo ${PACKAGES_URL}/rpm-standard/${MAJOR_VERSION}/el9/centreon-${MAJOR_VERSION}.repo
+fi
+
+if [[ "${PACKAGES_URL}" != "https://packages.centreon.com" ]]; then
+  # the served .repo files carry production baseurls: point them at the same
+  # packages host this image is built against, and skip the gpg checks until
+  # that stack publishes its signing keys
+  sed -i -e "s|https://packages.centreon.com|${PACKAGES_URL}|g" -e "s|gpgcheck=1|gpgcheck=0|g" /etc/yum.repos.d/centreon-*.repo
 fi
 
 dnf config-manager --set-enabled 'centreon*'

--- a/.github/docker/centreon-web/trixie/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/trixie/Dockerfile.dependencies
@@ -4,6 +4,8 @@ ARG MAJOR_VERSION
 ARG PHP_VERSION=8.4
 ARG STABILITY
 ARG IS_CLOUD
+# packages host: the pulp dev stack serves the same legacy layout as production
+ARG PACKAGES_URL=https://packages-dev.int.centreon.com
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -39,18 +41,27 @@ if [[ "${PHP_VERSION}" != "8.4" ]]; then
   wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/php.gpg  > /dev/null 2>&1
 fi
 
-if [[ "${IS_CLOUD}" == "true" ]]; then
-  echo "deb https://packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
-else
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-stable main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+APT_OPTS=""
+if [[ "${PACKAGES_URL}" != "https://packages.centreon.com" ]]; then
+  # that stack does not publish its apt signing key yet
+  APT_OPTS=" [trusted=yes]"
 fi
-echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
-wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+
+if [[ "${IS_CLOUD}" == "true" ]]; then
+  echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-standard-internal/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+else
+  echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-stable main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
+  echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+  echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+  echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-standard/ \$VERSION_CODENAME-${MAJOR_VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+fi
+echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb\$APT_OPTS ${PACKAGES_URL}/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
+if [[ "${PACKAGES_URL}" == "https://packages.centreon.com" ]]; then
+  # artifactory-specific key endpoint; the sources above are [trusted=yes] otherwise
+  wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+fi
 
 if [[ "$STABILITY" == "testing" ]]; then
   for i in \$( ls /etc/apt/sources.list.d/centreon*unstable* ); do mv \$i \$i.disabled; done

--- a/.github/workflows/docker-web-dependencies.yml
+++ b/.github/workflows/docker-web-dependencies.yml
@@ -58,7 +58,8 @@ jobs:
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       github.event.pull_request.head.repo.fork != true
-    runs-on: ubuntu-24.04
+    # self-hosted: the images are built against an internal-only packages host
+    runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -934,7 +934,8 @@ jobs:
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   dockerize:
-    runs-on: ubuntu-24.04
+    # self-hosted: the image is built against an internal-only packages host
+    runs-on: centreon-ubuntu-22.04
     needs: [get-environment, changes, package]
     permissions:
       contents: read


### PR DESCRIPTION
Related to: [MON-202540](https://centreon.atlassian.net/browse/MON-202540)

**Draft** — validates that the docker images build against the pulp dev stack (`packages-dev.int.centreon.com`), which serves the same legacy URL layout as production.

- The three `Dockerfile.dependencies` (alma9, alma10, trixie) take a `PACKAGES_URL` build arg (**draft default: the pulp dev host**) used for every centreon repository configuration; the `centreon-web` image needs no change (it builds FROM the dependencies image and installs the freshly built packages against those repositories).
- rpm: the served `.repo` files carry production baseurls, so a non-production host rewrites them to itself and relaxes `gpgcheck` (the dev stack does not publish the production signing keys).
- deb: non-production hosts get `[trusted=yes]` (the pulp apt signing key is not published yet — known follow-up of MON-202540) and skip the artifactory-specific key endpoint.

This PR triggers the `docker-web-dependencies` build for the three distribs; the `centreon-web` image is then built by dispatching `web.yml` on this branch (it picks the branch-tagged dependencies image).

**Before a real merge**: flip the `PACKAGES_URL` default back to `https://packages.centreon.com` (or wire it as a workflow input) — the dev default is intentional for this draft.

[MON-202540]: https://centreon.atlassian.net/browse/MON-202540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ