### PR TITLE
chore(deps): upgrade react-router to 7.18.2

### DIFF
--- a/centreon/package.json
+++ b/centreon/package.json
@@ -153,7 +153,7 @@
     "react-i18next": "^15.4.1",
     "react-material-ui-carousel": "^3.4.2",
     "react-resizable": "^3.0.5",
-    "react-router": "7.14.2",
+    "react-router": "7.18.2",
     "react-select": "^5.10.1",
     "react-spring": "^9.7.5",
     "string-argv": "^0.3.2",

--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -162,7 +162,7 @@
     "ramda": "0.30.1",
     "react-grid-layout": "^2.2.2",
     "react-resizable": "^3.0.5",
-    "react-router": "7.14.2",
+    "react-router": "7.18.2",
     "react-transition-group": "^4.4.5",
     "sanitize-html": "^2.14.0",
     "ulog": "^2.0.0-beta.19"

--- a/centreon/pnpm-lock.yaml
+++ b/centreon/pnpm-lock.yaml
@@ -200,8 +200,8 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
-        specifier: 7.14.2
-        version: 7.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 7.18.2
+        version: 7.18.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-select:
         specifier: ^5.10.1
         version: 5.10.1(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -675,8 +675,8 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
-        specifier: 7.14.2
-        version: 7.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 7.18.2
+        version: 7.18.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2148,84 +2148,72 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64-musl@2.3.11':
     resolution: {integrity: sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64-musl@2.3.9':
     resolution: {integrity: sha512-JOHyG2nl8XDpncbMazm1uBSi1dPX9VbQDOjKcfSVXTqajD0PsgodMOKyuZ/PkBu5Lw877sWMTGKfEfpM7jE7Cw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.10':
     resolution: {integrity: sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-arm64@2.3.11':
     resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-arm64@2.3.9':
     resolution: {integrity: sha512-BXBB6HbAgZI6T6QB8q6NSwIapVngqArP6K78BqkMerht7YjL6yWctqfeTnJm0qGF2bKBYFexslrbV+VTlM2E6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.10':
     resolution: {integrity: sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64-musl@2.3.11':
     resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64-musl@2.3.9':
     resolution: {integrity: sha512-FUkb/5beCIC2trpqAbW9e095X4vamdlju80c1ExSmhfdrojLZnWkah/XfTSixKb/dQzbAjpD7vvs6rWkJ+P07Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.10':
     resolution: {integrity: sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64@2.3.11':
     resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64@2.3.9':
     resolution: {integrity: sha512-PjYuv2WLmvf0WtidxAkFjlElsn0P6qcvfPijrqu1j+3GoW3XSQh3ywGu7gZ25J25zrYj3KEovUjvUZB55ATrGw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.10':
     resolution: {integrity: sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==}
@@ -12686,8 +12674,8 @@ packages:
     peerDependencies:
       react: '>= 16.3'
 
-  react-router@7.14.2:
-    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -29699,7 +29687,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  react-router@7.14.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router@7.18.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       cookie: 1.0.2
       react: 19.1.0


### PR DESCRIPTION
Fixes: [MON-207830](https://centreon.atlassian.net/browse/MON-207830)

Bumps `react-router` from 7.14.2 to **7.18.2**, staying within the 7.x line.

The previous bump (#11326) landed on 7.14.2, which has since been superseded — 7.18.2 is the current patched release on the 7.x branch. The modules-side counterpart is a separate PR under the same parent ticket ([MON-207829](https://centreon.atlassian.net/browse/MON-207829)).

## Changes
- `package.json` — react-router 7.14.2 → 7.18.2
- `packages/ui/package.json` (`@centreon/ui`) — same bump (it pins react-router directly)
- `pnpm-lock.yaml` — regenerated; resolves to 7.18.2 only

## Validation
- `pnpm install` clean — no 7.14.2 left in the tree
- `pnpm lint` (biome) clean — 1558 files
- `pnpm type-check` — no new errors (the 3 in `InstallationCommandButton.tsx` pre-exist on develop; that file is not in this diff)
- `pnpm build` (rspack prod) OK

react-router is a production dependency, so routing behaviour (nested/lazy routes, `useParams`/`useNavigate`/`useSearchParams`, module-federation route resolution) is exercised by the Cypress component + e2e suites in CI.

Supersedes the partial Dependabot PR #11204 (which does not cover `@centreon/ui`).

[MON-207830]: https://centreon.atlassian.net/browse/MON-207830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-207829]: https://centreon.atlassian.net/browse/MON-207829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ