### PR TITLE
fix(ci): handle delivery_type feature for debian delivery

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -25,6 +25,10 @@ inputs:
   is_cloud:
     description: "Release context (cloud or not cloud)"
     required: true
+  delivery_type:
+    description: "Delivery to feature or standard repository"
+    required: false
+    default: "standard"
 
 runs:
   using: "composite"
@@ -55,6 +59,7 @@ runs:
         IS_CLOUD: ${{ inputs.is_cloud }}
         RELEASE_TYPE: ${{ inputs.release_type }}
         STABILITY: ${{ inputs.stability }}
+        DELIVERY_TYPE: ${{ inputs.delivery_type }}
         ARTIFACTORY_TOKEN: ${{ inputs.artifactory_token }}
         DISTRIB_FAMILY: ${{ steps.parse-distrib.outputs.distrib_family }}
       run: |
@@ -67,11 +72,20 @@ runs:
         echo "[DEBUG] - is_cloud: $IS_CLOUD"
         echo "[DEBUG] - release_type: $RELEASE_TYPE"
         echo "[DEBUG] - stability: $STABILITY"
+        echo "[DEBUG] - delivery_type: $DELIVERY_TYPE"
 
         # Make sure all required inputs are NOT empty
         if [[ -z "$MODULE_NAME" || -z "$DISTRIB" || -z "$STABILITY" || -z "$VERSION" || -z "$IS_CLOUD" ]]; then
           echo "::error::some mandatory inputs are empty, please check the logs."
           exit 1
+        fi
+
+        # There is no apt feature repository: a feature delivery has no deb
+        # counterpart, so skip it instead of falling back to a testing delivery.
+        if [[ "$DELIVERY_TYPE" == "feature" ]]; then
+          echo "::warning::Feature (canary) delivery is not supported for deb packages: skipping delivery of $MODULE_NAME for $DISTRIB. RPM feature delivery is unaffected."
+          echo "Feature (canary) delivery is not supported for deb packages: \`$MODULE_NAME\` was **not** delivered for \`$DISTRIB\`." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
         fi
 
         if [[ "$STABILITY" != "testing" && "$STABILITY" != "unstable" ]]; then

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1311,6 +1311,7 @@ jobs:
           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 


### PR DESCRIPTION
if a PR has label feature-delivery + stability canary, it will not skip delivery, but it will try to create & delivery to a feature repository, however, these kind of repositories do not existe for debian, and since input delivery_type is not currently given to delivery-deb, it will fall into “testing delivery attempt” innstead