### PR TITLE
feat(ci): add provenance attestation and SBOM for ghcr.io poller images

### DIFF
--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,0 +1,67 @@
+name: "attest ghcr.io image (SBOM)"
+description: >
+  Generate one SBOM attestation per platform (amd64, arm64) for an image
+  already promoted to ghcr.io, both attached to the multi-arch index digest
+  so tag-based `gh attestation verify` finds them. Call after
+  promote-docker-to-ghcr using its digest/amd64_digest/arm64_digest outputs —
+  wrap with continue-on-error and a distinct warning, since a failure here
+  doesn't mean delivery failed. Build provenance is attested separately, at
+  build time.
+inputs:
+  ghcr_image:
+    description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
+    required: true
+  digest:
+    description: "Digest of the promoted manifest list to attest (sha256:...)"
+    required: true
+  amd64_digest:
+    description: "Digest of the amd64 platform manifest, scanned for its SBOM"
+    required: true
+  arm64_digest:
+    description: "Digest of the arm64 platform manifest, scanned for its SBOM"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate SBOM (amd64 platform manifest)
+      id: sbom-amd64
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: "${{ inputs.ghcr_image }}@${{ inputs.amd64_digest }}"
+        format: spdx-json
+        output-file: sbom-amd64.spdx.json
+        upload-artifact: false
+        # Defaults to true and would need contents:write on tag pushes with a
+        # matching GitHub Release; we deliver via the attestation, not a
+        # release asset.
+        upload-release-assets: false
+
+    - name: Attest SBOM (amd64)
+      # attest-sbom is deprecated in favor of attest
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        sbom-path: sbom-amd64.spdx.json
+        push-to-registry: true
+        create-storage-record: false
+
+    - name: Generate SBOM (arm64 platform manifest)
+      id: sbom-arm64
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: "${{ inputs.ghcr_image }}@${{ inputs.arm64_digest }}"
+        format: spdx-json
+        output-file: sbom-arm64.spdx.json
+        upload-artifact: false
+        upload-release-assets: false
+
+    - name: Attest SBOM (arm64)
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        sbom-path: sbom-arm64.spdx.json
+        push-to-registry: true
+        create-storage-record: false

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -7,7 +7,7 @@ description: >
   promote-to-stable-pulp.
 inputs:
   ghcr_image:
-    description: "Destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)"
+    description: "Destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)"
     required: true
   harbor_image:
     description: "Source image ref on Harbor, no tag"
@@ -30,6 +30,17 @@ inputs:
     required: false
     default: "linux/amd64,linux/arm64"
 
+outputs:
+  digest:
+    description: "Digest of the promoted ghcr.io manifest list (identical across all ghcr_tags)"
+    value: ${{ steps.promote.outputs.digest }}
+  amd64_digest:
+    description: "Digest of the amd64 platform manifest, for SBOM scanning"
+    value: ${{ steps.promote.outputs.amd64_digest }}
+  arm64_digest:
+    description: "Digest of the arm64 platform manifest, for SBOM scanning"
+    value: ${{ steps.promote.outputs.arm64_digest }}
+
 runs:
   using: "composite"
   steps:
@@ -45,6 +56,7 @@ runs:
         fi
 
     - name: Promote Harbor candidate to ghcr.io
+      id: promote
       shell: bash
       env:
         GHCR_IMAGE: ${{ inputs.ghcr_image }}

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -19,12 +19,22 @@
 # registries choke on committing a manifest that includes that attestation
 # subject). Harbor keeps full provenance; only the ghcr.io copy omits it.
 #
+# MON-207622: Harbor's attestation manifest is unsigned (no Sigstore chain),
+# so `gh attestation verify` couldn't validate it even if copied. Provenance
+# + SBOM are instead generated fresh against the ghcr.io digest by the caller
+# (attest-ghcr-image). Digest resolution below is best-effort and non-fatal.
+#
 # Expected env vars:
 #   GHCR_IMAGE   destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-snmptrapd)
 #   HARBOR_IMAGE source image ref on Harbor, no tag
 #   HARBOR_TAG   source tag on Harbor to promote (e.g. release-26.10-next)
 #   GHCR_TAGS    space-separated list of tags to create on ghcr.io (e.g. "26.10.5 26.10")
 #   PLATFORMS    comma-separated platform list, informational only (e.g. linux/amd64,linux/arm64)
+#
+# Outputs ($GITHUB_OUTPUT, best-effort — may be absent):
+#   digest       promoted manifest-list digest
+#   amd64_digest amd64 platform digest, for SBOM scanning
+#   arm64_digest arm64 platform digest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then
@@ -69,6 +79,39 @@ for tag in $GHCR_TAGS; do
   echo "Publishing $GHCR_IMAGE:$tag from $SRC_REF (${#SRC_REFS[@]} platform manifest(s))"
   retry_imagetools_create "$GHCR_IMAGE:$tag" "${SRC_REFS[@]}"
 done
+echo "::endgroup::"
+
+echo "::group::Resolve promoted digest (for attestation, best-effort)"
+GHCR_DIGEST=""
+AMD64_DIGEST=""
+ARM64_DIGEST=""
+DIGEST_RESOLUTION_OK=true
+for tag in $GHCR_TAGS; do
+  [[ -z "$tag" ]] && continue
+  if ! DEST_MANIFEST=$(docker buildx imagetools inspect "$GHCR_IMAGE:$tag" --format '{{json .Manifest}}'); then
+    echo "::warning::Could not inspect $GHCR_IMAGE:$tag after publish — skipping attestation for this promote run (image is still published)"
+    DIGEST_RESOLUTION_OK=false
+    break
+  fi
+  tag_digest=$(echo "$DEST_MANIFEST" | jq -r '.digest')
+  if [[ -z "$GHCR_DIGEST" ]]; then
+    GHCR_DIGEST="$tag_digest"
+    AMD64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "amd64") | .digest' | head -n1)
+    ARM64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "arm64") | .digest' | head -n1)
+  elif [[ "$tag_digest" != "$GHCR_DIGEST" ]]; then
+    echo "::warning::Published tags resolved to different digests ($GHCR_DIGEST vs $tag_digest for tag $tag) — skipping attestation for this promote run (ambiguous subject, image is still published)"
+    DIGEST_RESOLUTION_OK=false
+    break
+  fi
+done
+if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" && -n "$ARM64_DIGEST" ]]; then
+  echo "Resolved digest: $GHCR_DIGEST (amd64: $AMD64_DIGEST, arm64: $ARM64_DIGEST)"
+  echo "digest=$GHCR_DIGEST" >> "$GITHUB_OUTPUT"
+  echo "amd64_digest=$AMD64_DIGEST" >> "$GITHUB_OUTPUT"
+  echo "arm64_digest=$ARM64_DIGEST" >> "$GITHUB_OUTPUT"
+else
+  echo "::warning::Could not resolve a usable digest/amd64_digest/arm64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
+fi
 echo "::endgroup::"
 
 echo "ghcr.io stable promote complete: $GHCR_IMAGE ($GHCR_TAGS)"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1375,6 +1375,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -1474,6 +1476,7 @@ jobs:
         shell: bash
 
       - name: Docker build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -1485,6 +1488,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          # Disabled: BuildKit's own attestation manifests would make this
+          # digest diverge from the ghcr.io one docker-push-to-ghcr.sh
+          # reconstructs later.
+          provenance: false
+          sbom: false
           # version_tag is deliberately NOT pushed here: it's only applied by
           # promote-docker-version-tag below, once docker-boot-test/
           # docker-config-wiring-test have validated this exact image. Pushing
@@ -1492,6 +1500,26 @@ jobs:
           # pick up an unvalidated candidate on a later, separate stable run.
           tags: |
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.component }}-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
+
+      - name: Attest build provenance (deterministic candidate only)
+        # Only for builds with a version_tag (real promotion candidates).
+        # push-to-registry:false since ghcr.io doesn't have this image yet;
+        # discoverable later by digest once promoted.
+        if: steps.compute-tag.outputs.version_tag != ''
+        continue-on-error: true
+        id: attest-build-provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ghcr.io/centreon/${{ matrix.component }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false
+          create-storage-record: false
+
+      - name: Warn if build provenance attestation failed
+        if: steps.attest-build-provenance.outcome == 'failure'
+        run: |
+          echo "::warning::Build provenance attestation failed for ${{ matrix.component }}-${{ matrix.operating_system }}. Image build/delivery continues; investigate before relying on provenance verification for this version."
+        shell: bash
 
   docker-boot-test:
     needs: [get-environment, dockerize-trapd-image]
@@ -1977,6 +2005,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -2028,4 +2058,21 @@ jobs:
         if: steps.promote-ghcr.outcome == 'failure'
         run: |
           echo "::warning::ghcr.io delivery failed for ${{ matrix.component }}-${{ matrix.operating_system }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
+        shell: bash
+
+      - name: Attest SBOM on ghcr.io (best-effort, non-blocking)
+        if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
+        continue-on-error: true
+        id: attest-ghcr
+        uses: ./.github/actions/attest-ghcr-image
+        with:
+          ghcr_image: ghcr.io/centreon/${{ matrix.component }}
+          digest: ${{ steps.promote-ghcr.outputs.digest }}
+          amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+          arm64_digest: ${{ steps.promote-ghcr.outputs.arm64_digest }}
+
+      - name: Warn if ghcr.io attestation failed
+        if: steps.attest-ghcr.outcome == 'failure'
+        run: |
+          echo "::warning::SBOM attestation failed for ${{ matrix.component }}-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash


### PR DESCRIPTION
## Description
Backport of #11423 to `dev-26.10.x`.

Generates GitHub-native, Sigstore-signed build provenance (`actions/attest-build-provenance`) and an SBOM (`anchore/sbom-action` + `actions/attest`) for `centreon-snmptrapd` and `centreon-centreontrapd` after they're promoted from Harbor to ghcr.io. New composite action `.github/actions/attest-ghcr-image` runs as a separate, distinctly-warned step after `promote-docker-to-ghcr` so an attestation failure is never confused with a delivery failure. `promote-docker-to-ghcr` now resolves and exposes the promoted digest + amd64 platform digest as outputs (best-effort, never blocks delivery). Adds `id-token: write` + `attestations: write` to the `promote-docker-to-ghcr` job.

Ref: MON-207869

**Fixes** MON-207869

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?
Same testing procedure as #11423.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).