### PR TITLE
enh(delivery): target jfrog artifactory through its native hostname

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -44,14 +44,14 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - if: inputs.delivery_type == 'feature'
       name: Create a rpm feature repository
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
         CENTREON_TECHNIQUE_PAT: ${{ inputs.centreon_technique_pat }}
@@ -97,7 +97,7 @@ runs:
     - name: Publish RPMs
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
         MODULE_NAME: ${{ inputs.module_name }}

--- a/.github/docker/centreon-web/trixie/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/trixie/Dockerfile.dependencies
@@ -50,7 +50,7 @@ fi
 echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
 echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
 echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
-wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://apt-key.centreon.com/ | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 if [[ "$STABILITY" == "testing" ]]; then
   for i in \$( ls /etc/apt/sources.list.d/centreon*unstable* ); do mv \$i \$i.disabled; done


### PR DESCRIPTION
Backport of #11446 to `release-29.01-next` (cherry-pick). Related to: [MON-207928](https://centreon.atlassian.net/browse/MON-207928)

Everything that writes to or reads from jfrog artifactory in CI targets its native hostname `https://centreon.jfrog.io` instead of `https://packages.centreon.com`, so artifactory deliveries keep working when `packages.centreon.com` switches to pulp. Client-facing URLs are untouched.

[MON-207928]: https://centreon.atlassian.net/browse/MON-207928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ