### PR TITLE
fix(web): answer 400 on invalid pagination params

### DIFF
--- a/centreon/.php-cs-fixer.conf.php
+++ b/centreon/.php-cs-fixer.conf.php
@@ -52,6 +52,7 @@ return [
             'tests/php/Centreon',
             'tests/php/CentreonLegacy',
             'tests/php/CentreonRemote',
+            'tests/php/EventSubscriber',
             'tests/php/mock',
             'tests/php/Security',
             'tests/php/Utility',

--- a/centreon/doc/php/logging.md
+++ b/centreon/doc/php/logging.md
@@ -148,6 +148,8 @@ Key points:
 > Uniform coverage is guaranteed not by this middleware but by the **processors registered globally on every channel** — see [§6](#6-http--security-processors-web-route-token). Any error, regardless of its entry point into Monolog, traverses `ExceptionFormatterProcessor` (shape `{exceptions: [{type, message, code, file, line, trace}, …]}`) and `WebProcessor` / `RouteProcessor` / `TokenProcessor` (HTTP / security enrichment).
 >
 > Assumed blind spots: dedicated channels in the `!exclude` list of `web_finger_crossed` (`event`, `doctrine`, `console`, `deprecation`, `authentication`, `token`, `password`, `plugin-pack-manager`, `upgrade`), the `console` channel in CLI, and PHP fatals before kernel boot (parse error, OOM).
+>
+> One more blind spot, by **level** rather than by channel: `web_finger_crossed` buffers with `action_level: error` and declares no `passthru_level`, so a buffered record that never triggers a flush is dropped when the buffer is cleared. Unless an `error` or higher record activates the handler later in the same request — in which case the buffer is flushed and the earlier records are written as context — a `warning` is not "a lower-priority line", it is **no line at all** in `prod.web.log`. Since `LegacyHttpExceptionListener` logs every 4xx at `warning` (only 5xx reach `critical`), client errors — malformed pagination, unknown sort column, rejected payload — normally leave no trace on the platform log and are diagnosed from the HTTP access log. This is deliberate: `prod.web.log` carries incidents, not client mistakes.
 
 The middleware emits a record on the Monolog `app` channel (Symfony default) for every dispatch:
 

--- a/centreon/phpstan.legacy.test.neon
+++ b/centreon/phpstan.legacy.test.neon
@@ -20,6 +20,7 @@ parameters:
         - tests/php/Centreon
         - tests/php/CentreonLegacy
         - tests/php/CentreonRemote
+        - tests/php/EventSubscriber
         - tests/php/mock
         - tests/php/Security
         - tests/php/Utility

--- a/centreon/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/centreon/src/EventSubscriber/CentreonEventSubscriber.php
@@ -42,6 +42,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\{ExceptionEvent, RequestEvent, ResponseEvent};
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -127,6 +128,7 @@ class CentreonEventSubscriber implements EventSubscriberInterface
      *
      * @param RequestEvent $request
      *
+     * @throws BadRequestHttpException when the "limit" or "page" parameter is not a valid integer
      * @throws \Exception
      */
     public function initRequestParameters(RequestEvent $request): void
@@ -138,7 +140,13 @@ class CentreonEventSubscriber implements EventSubscriberInterface
             FILTER_VALIDATE_INT
         );
         if ($limit === false) {
-            throw RequestParametersException::integer(RequestParameters::NAME_FOR_LIMIT);
+            $exception = RequestParametersException::integer(RequestParameters::NAME_FOR_LIMIT);
+
+            throw new BadRequestHttpException(
+                $exception->getMessage(),
+                previous: $exception,
+                code: Response::HTTP_BAD_REQUEST,
+            );
         }
         $this->requestParameters->setLimit($limit);
 
@@ -147,7 +155,13 @@ class CentreonEventSubscriber implements EventSubscriberInterface
             FILTER_VALIDATE_INT
         );
         if ($page === false) {
-            throw RequestParametersException::integer(RequestParameters::NAME_FOR_PAGE);
+            $exception = RequestParametersException::integer(RequestParameters::NAME_FOR_PAGE);
+
+            throw new BadRequestHttpException(
+                $exception->getMessage(),
+                previous: $exception,
+                code: Response::HTTP_BAD_REQUEST,
+            );
         }
         $this->requestParameters->setPage($page);
 

--- a/centreon/tests/php/App/Shared/Infrastructure/Legacy/Double/FakeHttpKernel.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Legacy/Double/FakeHttpKernel.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Legacy\Double;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Kernel events require an HttpKernelInterface; this double provides one without booting a kernel.
+ */
+final class FakeHttpKernel implements HttpKernelInterface
+{
+    public function handle(
+        Request $request,
+        int $type = HttpKernelInterface::MAIN_REQUEST,
+        bool $catch = true,
+    ): Response {
+        return new Response();
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Legacy/Double/RecordingLogger.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Legacy/Double/RecordingLogger.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Legacy\Double;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * @phpstan-type RecordTypeAlias array{level: string, message: string, context: array<int|string, mixed>}
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<RecordTypeAlias> */
+    private array $records = [];
+
+    /**
+     * @param array<int|string, mixed> $context
+     */
+    public function log(mixed $level, string|\Stringable $message, array $context = []): void
+    {
+        // Not an assert(): assertions are compiled out under
+        // zend.assertions=-1, which the repository does not pin, and a
+        // non-string level would then be recorded against the shape this
+        // double advertises.
+        if (! is_string($level)) {
+            throw new \LogicException(sprintf(
+                'Expected a PSR-3 string level, got "%s".',
+                get_debug_type($level),
+            ));
+        }
+
+        $this->records[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @return list<RecordTypeAlias>
+     */
+    public function records(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * @return RecordTypeAlias|null
+     */
+    public function lastRecord(): ?array
+    {
+        return $this->records === [] ? null : $this->records[array_key_last($this->records)];
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/Legacy/LegacyHttpExceptionListenerTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Legacy/LegacyHttpExceptionListenerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Legacy;
+
+use ApiPlatform\Validator\Exception\ValidationException;
+use App\Shared\Infrastructure\Legacy\LegacyHttpExceptionListener;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Tests\App\Shared\Infrastructure\Legacy\Double\FakeHttpKernel;
+use Tests\App\Shared\Infrastructure\Legacy\Double\RecordingLogger;
+
+final class LegacyHttpExceptionListenerTest extends TestCase
+{
+    public function testBadRequestIsAnsweredAsAClientError(): void
+    {
+        $logger = new RecordingLogger();
+        $domainCause = new \RuntimeException('The parameter "page" must be an integer');
+        $exception = new BadRequestHttpException(
+            $domainCause->getMessage(),
+            previous: $domainCause,
+            code: Response::HTTP_BAD_REQUEST,
+        );
+        $event = $this->createExceptionEvent($exception);
+
+        (new LegacyHttpExceptionListener([], $logger))($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertSame(
+            ['code' => Response::HTTP_BAD_REQUEST, 'message' => 'The parameter "page" must be an integer'],
+            json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR)
+        );
+        // The listener logs once and stops propagation, so Symfony's own
+        // ErrorListener never gets to log the same exception a second time.
+        self::assertCount(1, $logger->records());
+        $record = $logger->lastRecord();
+        self::assertNotNull($record);
+        self::assertSame(LogLevel::WARNING, $record['level']);
+        // The whole chain is handed to the logger: the processors report the
+        // original cause, not only the HTTP exception wrapping it.
+        self::assertSame($exception, $record['context']['exception'] ?? null);
+        self::assertSame($domainCause, $exception->getPrevious());
+    }
+
+    public function testExceptionWithoutHttpStatusIsAnsweredAsAServerError(): void
+    {
+        $logger = new RecordingLogger();
+        $event = $this->createExceptionEvent(new \RuntimeException('Something went wrong'));
+
+        (new LegacyHttpExceptionListener([], $logger))($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+        self::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        // The body carries the exception code, not the resolved status: an
+        // exception carrying none answers a 500 whose payload code stays 0.
+        self::assertSame(
+            ['code' => 0, 'message' => 'Something went wrong'],
+            json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR)
+        );
+        self::assertCount(1, $logger->records());
+        $record = $logger->lastRecord();
+        self::assertNotNull($record);
+        self::assertSame(LogLevel::CRITICAL, $record['level']);
+    }
+
+    public function testStatusIsReadFromTheApiPlatformMapping(): void
+    {
+        $logger = new RecordingLogger();
+        $event = $this->createExceptionEvent(new \RuntimeException('Nothing here'));
+
+        (new LegacyHttpExceptionListener([\RuntimeException::class => Response::HTTP_NOT_FOUND], $logger))($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+        self::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        // Status mapped to 404 while the payload code stays 0: the mapping
+        // alone cannot fix the body, which is why the thrown exception has to
+        // carry the status as its code too.
+        self::assertSame(
+            ['code' => 0, 'message' => 'Nothing here'],
+            json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR)
+        );
+        self::assertCount(1, $logger->records());
+        $record = $logger->lastRecord();
+        self::assertNotNull($record);
+        self::assertSame(LogLevel::WARNING, $record['level']);
+    }
+
+    public function testValidationExceptionIsLeftToItsOwnNormalizer(): void
+    {
+        $logger = new RecordingLogger();
+        $event = $this->createExceptionEvent(new ValidationException());
+
+        (new LegacyHttpExceptionListener([], $logger))($event);
+
+        self::assertNull($event->getResponse());
+        self::assertSame([], $logger->records());
+    }
+
+    private function createExceptionEvent(\Throwable $throwable): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            new FakeHttpKernel(),
+            Request::create('/api/latest/monitoring/resources'),
+            HttpKernelInterface::MAIN_REQUEST,
+            $throwable
+        );
+    }
+}

--- a/centreon/tests/php/EventSubscriber/CentreonEventSubscriberTest.php
+++ b/centreon/tests/php/EventSubscriber/CentreonEventSubscriberTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use Centreon\Application\ApiPlatform;
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\RequestParameters\RequestParameters;
+use Centreon\Domain\RequestParameters\RequestParametersException;
+use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
+use EventSubscriber\CentreonEventSubscriber;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Tests\EventSubscriber\Double\FakeHttpKernel;
+
+final class CentreonEventSubscriberTest extends TestCase
+{
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public static function provideMalformedPaginationParameters(): \Generator
+    {
+        yield 'non-numeric page' => ['page=abc', RequestParameters::NAME_FOR_PAGE];
+
+        yield 'empty page' => ['page=', RequestParameters::NAME_FOR_PAGE];
+
+        yield 'decimal page' => ['page=1.5', RequestParameters::NAME_FOR_PAGE];
+
+        yield 'array-shaped page' => ['page[]=1', RequestParameters::NAME_FOR_PAGE];
+
+        yield 'page beyond PHP_INT_MAX' => ['page=99999999999999999999', RequestParameters::NAME_FOR_PAGE];
+
+        yield 'non-numeric limit' => ['limit=abc', RequestParameters::NAME_FOR_LIMIT];
+
+        yield 'empty limit' => ['limit=', RequestParameters::NAME_FOR_LIMIT];
+
+        yield 'array-shaped limit' => ['limit[]=10', RequestParameters::NAME_FOR_LIMIT];
+    }
+
+    #[DataProvider('provideMalformedPaginationParameters')]
+    public function testInitRequestParametersRejectsNonIntegerPagination(
+        string $queryString,
+        string $rejectedParameter,
+    ): void {
+        try {
+            $this->createSubscriber(new RequestParameters())
+                ->initRequestParameters($this->createRequestEvent($queryString));
+            self::fail('A BadRequestHttpException was expected.');
+        } catch (BadRequestHttpException $exception) {
+            self::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+            self::assertSame(Response::HTTP_BAD_REQUEST, $exception->getCode());
+            self::assertSame(
+                RequestParametersException::integer($rejectedParameter)->getMessage(),
+                $exception->getMessage()
+            );
+            self::assertInstanceOf(RequestParametersException::class, $exception->getPrevious());
+        }
+    }
+
+    public function testInitRequestParametersAcceptsIntegerPageAndLimit(): void
+    {
+        $requestParameters = new RequestParameters();
+
+        $this->createSubscriber($requestParameters)
+            ->initRequestParameters($this->createRequestEvent('page=3&limit=50'));
+
+        self::assertSame(3, $requestParameters->getPage());
+        self::assertSame(50, $requestParameters->getLimit());
+    }
+
+    public function testInitRequestParametersFallsBackToTheDefaultPagination(): void
+    {
+        $requestParameters = new RequestParameters();
+
+        $this->createSubscriber($requestParameters)
+            ->initRequestParameters($this->createRequestEvent(''));
+
+        self::assertSame(RequestParameters::DEFAULT_PAGE, $requestParameters->getPage());
+        self::assertSame(RequestParameters::DEFAULT_LIMIT, $requestParameters->getLimit());
+    }
+
+    private function createSubscriber(RequestParameters $requestParameters): CentreonEventSubscriber
+    {
+        return new CentreonEventSubscriber(
+            $requestParameters,
+            new Security(new ServiceLocator([])),
+            new ApiPlatform(),
+            new Contact(),
+            new ExceptionLogger(new NullLogger()),
+            '26.11',
+            'Api-Version',
+            _CENTREON_PATH_ . 'www/locale',
+        );
+    }
+
+    private function createRequestEvent(string $queryString): RequestEvent
+    {
+        return new RequestEvent(
+            new FakeHttpKernel(),
+            Request::create('/api/latest/monitoring/resources?' . $queryString),
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+}

--- a/centreon/tests/php/EventSubscriber/Double/FakeHttpKernel.php
+++ b/centreon/tests/php/EventSubscriber/Double/FakeHttpKernel.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\EventSubscriber\Double;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Kernel events require an HttpKernelInterface; this double provides one without booting a kernel.
+ */
+final class FakeHttpKernel implements HttpKernelInterface
+{
+    public function handle(
+        Request $request,
+        int $type = HttpKernelInterface::MAIN_REQUEST,
+        bool $catch = true,
+    ): Response {
+        return new Response();
+    }
+}


### PR DESCRIPTION
## Description

An API request carrying a non-integer `page` or `limit` query parameter was answered with an HTTP 500 and logged as `request.CRITICAL`, so malformed client requests polluted the platform error alerting (1,162 entries in 9 days on a single production site). Invalid client input must be a 400.

- `initRequestParameters()` now throws a `BadRequestHttpException` carrying the 400 status, with the domain exception chained as `previous` so the log formatter still reports the original type.
- The exception reaches `LegacyHttpExceptionListener`, which reads the status from `HttpExceptionInterface`: the response becomes a 400 and the log level drops from `critical` to `warning`.
- `tests/php/EventSubscriber` is a new test directory, so it is declared in the php-cs-fixer and PHPStan legacy scopes (`.php-cs-fixer.conf.php`, `phpstan.legacy.test.neon`) to keep the added tests under analysis.
- `doc/php/logging.md` gains the blind spot this fix relies on: it listed the channels excluded from `prod.web.log` but not the level threshold — `web_finger_crossed` buffers with `action_level: error` and no `passthru_level`, so a `warning` leaves no line at all, which is what every 4xx becomes.

Two notes for the reviewer:

- Since the level is now `warning` and the `web_finger_crossed` handler has `action_level: error`, these requests no longer leave any line in `prod.web.log`. They remain visible in the Apache access logs. This is the intent of the ticket, not an oversight, and it aligns `page`/`limit` with `sort_by`, which already answered 400 at `warning` through the same listener. Worth noting the throw happens on `kernel.request` at priority 9, before the firewall at 8: prior to this fix any unauthenticated caller could force a `request.CRITICAL` entry and a buffer flush with a single `?page=abc`.
- A declarative alternative existed — mapping the exception in `api_platform.exception_to_status`. Throwing an HTTP-aware exception was preferred: it also fixes the `code` field of the response body, which the mapping would have left at 0.

Out of scope, spotted during review and tracked in [MON-207573](https://centreon.atlassian.net/browse/MON-207573): `?page=0` and `?page=-1` pass `FILTER_VALIDATE_INT`, produce `LIMIT -10, 10` and still answer 500 — with the raw SQL error message in the body; and `?sort_by[]=x` / `?search[]=x` raise a `TypeError` on the same code path.

## How to test

1. Call any non-migrated API endpoint with a malformed pagination parameter: `GET /centreon/api/latest/monitoring/resources?page=abc` (same with `limit=abc`).
2. Expected: **HTTP 400** with body `{"code":400,"message":"The parameter \"page\" must be an integer"}`. Before the fix: HTTP 500 with `{"code":0,...}`.
3. Check `/var/log/centreon/prod.web.log`: no `request.CRITICAL` entry and no stack trace for that request.
4. Nominal paging still works: `?page=3&limit=50` returns the third page.

Automated coverage: `tests/php/EventSubscriber/CentreonEventSubscriberTest.php` (rejected input and nominal case) and `tests/php/App/Shared/Infrastructure/Legacy/LegacyHttpExceptionListenerTest.php` (status code and log level per exception type).

## Links

### Jira ticket

Resolves: [MON-207983](https://centreon.atlassian.net/browse/MON-207983)

### PR Github

Backports: #11394


[MON-207573]: https://centreon.atlassian.net/browse/MON-207573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ