### PR TITLE
fix(database): use the configured MySQL port

### DIFF
--- a/centreon/config.new/packages/doctrine.yaml
+++ b/centreon/config.new/packages/doctrine.yaml
@@ -18,15 +18,18 @@ doctrine:
         user: "%env(user)%"
         password: "%env(password)%"
         host: "%env(hostCentreon)%"
+        port: "%env(int:port)%"
       realtime:
         server_version: "%env(DATABASE_SERVER_VERSION)%"
         dbname: "%env(dbcstg)%"
         user: "%env(user)%"
         password: "%env(password)%"
         host: "%env(hostCentreon)%"
+        port: "%env(int:port)%"
       test_setup_default:
         server_version: "%env(DATABASE_SERVER_VERSION)%"
         dbname: "%env(db)%"
         user: "%env(user)%"
         password: "%env(password)%"
         host: "%env(hostCentreon)%"
+        port: "%env(int:port)%"

--- a/centreon/config.new/services/upgrade.php
+++ b/centreon/config.new/services/upgrade.php
@@ -56,6 +56,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '%env(password)%',
             '%env(db)%',
             '%env(dbcstg)%',
+            '%env(int:port)%',
         ]);
 
     $services->load('App\\Upgrade\\', __DIR__ . '/../../src/App/Upgrade');

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -9,7 +9,7 @@ parameters:
     api.header: "Api-Version"
     api.version.latest: "26.11"
     database_host: "%env(hostCentreon)%"
-    database_port: "%env(port)%"
+    database_port: "%env(int:port)%"
     database_db: "%env(db)%"
     database_dbstg: "%env(dbcstg)%"
     database_user: "%env(user)%"


### PR DESCRIPTION
## Summary

- The three `doctrine.dbal` connections did not declare `port`, so the PDO DSN had none and libmysql fell back to 3306.
- Same gap on the `ConnectionConfig` service of the `config.new` upgrade container.
- `env(port): '3306'` is kept: it only covers a missing env var, it was never the cause.

## Jira

Fixes: [MON-208039](https://centreon.atlassian.net/browse/MON-208039)

## Test plan

- [ ] With `$conf_centreon['port'] = "3340"`, `bin/console dbal:run-sql "SELECT 1"` returns a row.
- [ ] A non-admin user can list and edit BAM Business Views.
- [ ] A socket-based local install still works.
- [ ] `composer symfony:check && composer symfony:new:check` passes.


[MON-208039]: https://centreon.atlassian.net/browse/MON-208039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ