### PR TITLE
fix(delivery): require the pulp environment inputs

### DIFF
--- a/.github/actions/package-delivery-pulp/action.yml
+++ b/.github/actions/package-delivery-pulp/action.yml
@@ -38,16 +38,13 @@ inputs:
     default: "true"
   pulp_url:
     description: "The pulp server api url"
-    required: false
-    default: "https://pulp-api.int.centreon.com"
+    required: true
   pulp_content_url:
     description: "The pulp server content url"
-    required: false
-    default: "https://packages.int.centreon.com"
+    required: true
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
-    required: false
-    default: "https://pulp.dev.centreon.io"
+    required: true
 
 runs:
   using: "composite"

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -30,16 +30,13 @@ inputs:
     default: "true"
   pulp_url:
     description: "The pulp server api url"
-    required: false
-    default: "https://pulp-api.int.centreon.com"
+    required: true
   pulp_content_url:
     description: "The pulp server content url"
-    required: false
-    default: "https://packages.int.centreon.com"
+    required: true
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
-    required: false
-    default: "https://pulp.dev.centreon.io"
+    required: true
 
 runs:
   using: "composite"

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -3,12 +3,10 @@ description: "Install pulp-cli and authenticate to pulp with a GitHub OIDC token
 inputs:
   pulp_url:
     description: "The pulp server api url"
-    required: false
-    default: "https://pulp-api.int.centreon.com"
+    required: true
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
-    required: false
-    default: "https://pulp.dev.centreon.io"
+    required: true
   domain:
     description: "Pulp Domain to operate in (DOMAIN_ENABLED). Pre-Domains repositories live in \"default\"."
     required: false


### PR DESCRIPTION
Related to: [MON-202540](https://centreon.atlassian.net/browse/MON-202540)

Same hardening as [delivery-tooling#310](https://github.com/centreon/delivery-tooling/pull/310)/[#312](https://github.com/centreon/delivery-tooling/pull/312), found while provisioning the prod pulp stack: the pulp actions carried hardcoded per-environment defaults (`pulp_url: https://pulp-api.int.centreon.com`, `pulp_content_url: https://packages.int.centreon.com` — a dead host — and `audience: https://pulp.dev.centreon.io`), so any call site missing an input would silently target the wrong environment.

The `pulp_url`, `pulp_content_url` and `audience` inputs of `setup-pulp-cli`, `package-delivery-pulp` and `promote-to-stable-pulp` lose their defaults and become **required**: callers wire the `PULP_API_URL` / `PULP_CONTENT_URL` / `PULP_OIDC_AUDIENCE` organization variables — which every call site in this repository already does (verified), so this is behavior-preserving here. The empty-audience guard and the `PULP_OIDC_AUDIENCE` export for the script token refreshes were already in place in this repository.

[MON-202540]: https://centreon.atlassian.net/browse/MON-202540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ