### PR TITLE
Poller profile docker-compose silently failed

### DIFF
--- a/.github/docker/centreon-web/alma10/entrypoint/container.d/80-register_pollers_background.sh
+++ b/.github/docker/centreon-web/alma10/entrypoint/container.d/80-register_pollers_background.sh
@@ -15,9 +15,9 @@ while true ; do
   fi
   case "$SQL_RESULT" in
     *id*)
-      echo "Reloading gorgoned to register new pollers."
-      if ! systemctl reload gorgoned; then
-        echo "Failed to reload gorgoned"
+      echo "Restarting gorgoned to register new pollers."
+      if ! systemctl restart gorgoned; then
+        echo "Failed to Restart gorgoned"
         continue
       fi
       i=0

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/80-register_pollers_background.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/80-register_pollers_background.sh
@@ -15,9 +15,9 @@ while true ; do
   fi
   case "$SQL_RESULT" in
     *id*)
-      echo "Reloading gorgoned to register new pollers."
-      if ! systemctl reload gorgoned; then
-        echo "Failed to reload gorgoned"
+      echo "Restarting gorgoned to register new pollers."
+      if ! systemctl restart gorgoned; then
+        echo "Failed to Restart gorgoned"
         continue
       fi
       i=0

--- a/.github/docker/centreon-web/trixie/entrypoint/container.d/80-register_pollers_background.sh
+++ b/.github/docker/centreon-web/trixie/entrypoint/container.d/80-register_pollers_background.sh
@@ -17,9 +17,9 @@ while true ; do
   fi
   case "$SQL_RESULT" in
     *id*)
-      echo "Reloading gorgoned to register new pollers."
-      if ! systemctl reload gorgoned; then
-        echo "Failed to reload gorgoned"
+      echo "Restarting gorgoned to register new pollers."
+      if ! systemctl restart gorgoned; then
+        echo "Failed to Restart gorgoned"
         continue
       fi
       i=0


### PR DESCRIPTION
## Description

While using poller profile the registration methode using a reload methode on gorgone, but gorgone not applying anny nodeRegistration on this methode, a restart will apply it properly

**Fixes**
`systemctl restart gorgoned` in entrypoint

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Run `docker compose --profile poller`. 
After a few seconds, the poller will show up in a running state in the GUI
