### PR TITLE
fix(ci): gate promote-docker-to-ghcr on on-prem releases

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2251,7 +2251,8 @@ jobs:
       github.event_name != 'workflow_dispatch' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      needs.get-environment.outputs.is_cloud == 'false'
     runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add `needs.get-environment.outputs.is_cloud == 'false'` to the `promote-docker-to-ghcr` job's `if:` condition in `web.yml`, matching the gating already used by `deliver-sources` in the same workflow.
- Without this, a cloud stable release publishes/moves public ghcr.io poller image tags (`centreon-snmptrapd`, `centreon-centreontrapd`) that no cloud install ever resolves to, and could regress what existing cloud pollers pull if a floating tag moves.
- Only an on-prem `26.10.x` (and later `YY.10.x`) stable release can now publish or move ghcr.io poller tags.

Companion change in centreon-collect (collect.yml + gorgone.yml): https://github.com/centreon/centreon-collect/pull/3683

Part 1 of MON-208333. Part 2 (reworking `install-poller`'s tag resolution so a cloud platform's generated install script pulls the previous on-prem major) is tracked separately and not included here.

Jira: https://centreon.atlassian.net/browse/MON-208333

## Test plan
- [ ] Workflow YAML parses (checked automatically by GitHub Actions on this PR)
- [ ] Next on-prem `26.10.x` stable promote still publishes `26.10.<patch>` / `26.10` to ghcr.io for `centreon-snmptrapd`, `centreon-centreontrapd`
- [ ] Next cloud stable promote creates/moves no ghcr.io tag for those images