### PR TITLE
fix(agent-configuration): resolve engine config id from poller id in addBrokerDirective

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbWriteAgentConfigurationRepository.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbWriteAgentConfigurationRepository.php
@@ -246,7 +246,11 @@ class DbWriteAgentConfigurationRepository extends DatabaseRepository implements 
     public function addBrokerDirective(string $module, array $pollerIds): void
     {
         try {
-            $query = $this->connection->createQueryBuilder()->insert('`:db`.`cfg_nagios_broker_module`')
+            $findEngineConfigQuery = $this->translateDbName(
+                'SELECT nagios_id FROM `:db`.`cfg_nagios` WHERE nagios_server_id = :poller_id LIMIT 1'
+            );
+
+            $insertQuery = $this->connection->createQueryBuilder()->insert('`:db`.`cfg_nagios_broker_module`')
                 ->values(
                     [
                         'bk_mod_id' => ':bk_mod_id',
@@ -255,18 +259,30 @@ class DbWriteAgentConfigurationRepository extends DatabaseRepository implements 
                     ]
                 )->getQuery();
 
-            foreach ($pollerIds as $poller) {
-                $pollerId = $poller;
+            foreach ($pollerIds as $pollerId) {
+                $engineConfigId = $this->connection->fetchOne(
+                    $findEngineConfigQuery,
+                    QueryParameters::create([
+                        QueryParameter::int('poller_id', $pollerId),
+                    ])
+                );
+
+                if ($engineConfigId === false || $engineConfigId === null) {
+                    throw new \RuntimeException(
+                        sprintf('No engine configuration found for poller %d', $pollerId)
+                    );
+                }
+
                 $this->connection->insert(
-                    $this->translateDbName($query),
+                    $this->translateDbName($insertQuery),
                     QueryParameters::create([
                         QueryParameter::null('bk_mod_id'),
-                        QueryParameter::int('cfg_nagios_id', $pollerId),
+                        QueryParameter::int('cfg_nagios_id', (int) $engineConfigId),
                         QueryParameter::string('broker_module', $module),
                     ])
                 );
             }
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             throw new RepositoryException(
                 message: 'Error while adding broker directive in agent configuration',
                 context: ['pollerIds' => $pollerIds, 'broker_module' => $module],


### PR DESCRIPTION
Fixes: [MON-208325](https://centreon.atlassian.net/browse/MON-208325)

Backport of the `addBrokerDirective` fix to `dev-24.10.x`, originally introduced in [#10293](https://github.com/centreon/centreon/pull/10293) (develop).

`addBrokerDirective` used the poller id (`nagios_server.id`) directly as `cfg_nagios_id`, but these are two independent auto-increment sequences. Whenever they diverge for a given poller, the insert into `cfg_nagios_broker_module` fails with a foreign key violation.

This resolves `cfg_nagios.nagios_id` via `nagios_server_id` before inserting the broker directive.

[MON-208325]: https://centreon.atlassian.net/browse/MON-208325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ