### PR TITLE
fix(ci): fail the Xray Test Plan lookup instead of creating a duplicate

### DIFF
--- a/.github/actions/xray-api-graphql/xray-graphql-call.sh
+++ b/.github/actions/xray-api-graphql/xray-graphql-call.sh
@@ -84,10 +84,14 @@ while :; do
     retryable="curl exited ${curl_status}"
   elif [[ "$HTTP_CODE" =~ ^5[0-9]{2}$ || "$HTTP_CODE" == "429" ]]; then
     retryable="HTTP $HTTP_CODE"
-  elif echo "$RESPONSE_JSON" | grep -q "503 ERROR"; then
-    retryable="Service Unavailable (503 ERROR)"
-  elif ! jq -e '.' >/dev/null 2>&1 <<<"$RESPONSE_JSON"; then
-    retryable="response is not valid JSON"
+  elif [[ ! "$HTTP_CODE" =~ ^4[0-9]{2}$ ]]; then
+    # Only a non-4xx body can hide a transient failure behind a 200; a client
+    # error is final and is reported with its status after the loop.
+    if echo "$RESPONSE_JSON" | grep -q "503 ERROR"; then
+      retryable="Service Unavailable (503 ERROR)"
+    elif ! jq -e '.' >/dev/null 2>&1 <<<"$RESPONSE_JSON"; then
+      retryable="response is not valid JSON"
+    fi
   fi
 
   if [[ -z "$retryable" ]]; then

--- a/.github/actions/xray-api-graphql/xray-graphql-call.sh
+++ b/.github/actions/xray-api-graphql/xray-graphql-call.sh
@@ -49,38 +49,73 @@ echo "GRAPHQL VARIABLES: $VARIABLES_JSON"
 # Read query
 QUERY=$(<"$GRAPHQL_FILE")
 
-# Execute GraphQL
-HTTP_CURL_CALL=$(curl -s -w "\n%{http_code}" -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $XRAY_TOKEN" \
-  -X POST \
-  -d "{\"query\": $(jq -Rs . <<< "$QUERY"), \"variables\": $VARIABLES_JSON}" \
-  https://xray.cloud.getxray.app/api/v2/graphql)
+# Execute GraphQL, retrying transient transport failures.
+# The API occasionally answers 5xx: a single failed attempt must not be reported
+# to the caller as a usable answer, so exhausted retries exit non-zero.
+MAX_ATTEMPTS="${XRAY_MAX_ATTEMPTS:-3}"
 
-# Extract HTTP code and response body
-HTTP_CODE=$(echo "$HTTP_CURL_CALL" | tail -n1)
-RESPONSE_JSON=$(echo "$HTTP_CURL_CALL" | sed '$d')
+# Validate before any arithmetic use: bash evaluates the *contents* of a variable
+# referenced inside (( )), so a malformed value would break the loop bounds.
+if [[ ! "$MAX_ATTEMPTS" =~ ^[1-9][0-9]{0,2}$ ]]; then
+  echo "ERROR: XRAY_MAX_ATTEMPTS must be a positive integer, got '${MAX_ATTEMPTS}'"
+  exit 1
+fi
+
+RETRY_DELAYS=(5 15)
+attempt=1
+
+while :; do
+  # Bound every attempt: without this a stalled connection hangs the job instead
+  # of becoming the retryable failure this loop exists to absorb.
+  curl_status=0
+  HTTP_CURL_CALL=$(curl -sS -w "\n%{http_code}" \
+    --connect-timeout 10 --max-time 60 \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${XRAY_TOKEN}" \
+    -X POST \
+    -d "{\"query\": $(jq -Rs . <<< "$QUERY"), \"variables\": ${VARIABLES_JSON}}" \
+    https://xray.cloud.getxray.app/api/v2/graphql) || curl_status=$?
+
+  HTTP_CODE=$(echo "$HTTP_CURL_CALL" | tail -n1)
+  RESPONSE_JSON=$(echo "$HTTP_CURL_CALL" | sed '$d')
+
+  retryable=""
+  if ((curl_status != 0)); then
+    retryable="curl exited ${curl_status}"
+  elif [[ "$HTTP_CODE" =~ ^5[0-9]{2}$ || "$HTTP_CODE" == "429" ]]; then
+    retryable="HTTP $HTTP_CODE"
+  elif echo "$RESPONSE_JSON" | grep -q "503 ERROR"; then
+    retryable="Service Unavailable (503 ERROR)"
+  elif ! jq -e '.' >/dev/null 2>&1 <<<"$RESPONSE_JSON"; then
+    retryable="response is not valid JSON"
+  fi
+
+  if [[ -z "$retryable" ]]; then
+    break
+  fi
+
+  if ((attempt >= MAX_ATTEMPTS)); then
+    echo "ERROR: Xray API call failed after $attempt attempt(s): $retryable"
+    echo "Response: $RESPONSE_JSON"
+    exit 1
+  fi
+
+  delay="${RETRY_DELAYS[$((attempt - 1))]:-15}"
+  echo "::warning::Xray API call failed ($retryable), retrying in ${delay}s (attempt $attempt/$MAX_ATTEMPTS)"
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done
 
 echo "HTTP_CODE: $HTTP_CODE"
 
-# Check for HTTP errors (4xx or 5xx)
-if [[ "$HTTP_CODE" =~ ^[45][0-9]{2}$ ]]; then
+# Client errors mean a malformed request or bad credentials: retrying will not help.
+if [[ "$HTTP_CODE" =~ ^4[0-9]{2}$ ]]; then
   echo "ERROR: HTTP $HTTP_CODE from Xray API"
   echo "Response: $RESPONSE_JSON"
   exit 1
 fi
 
-# Check for 503 error in response
-if echo "$RESPONSE_JSON" | grep -q "503 ERROR"; then
-  echo "Service Unavailable (503 ERROR) from Xray API"
-  exit 1
-fi
-
-# Validate + compact JSON
-if ! GET_RESPONSE=$(jq -c '.' <<<"$RESPONSE_JSON" 2>/dev/null); then
-  echo "ERROR: Response is not valid JSON"
-  echo "$RESPONSE_JSON"
-  exit 1
-fi
+GET_RESPONSE=$(jq -c '.' <<<"$RESPONSE_JSON")
 
 # GraphQL returns HTTP 200 even when the query fails; surface those errors here.
 graphql_errors=$(jq -c '.errors // empty' <<<"$GET_RESPONSE")

--- a/.github/workflows/xray-prepare-test-plan.yml
+++ b/.github/workflows/xray-prepare-test-plan.yml
@@ -80,7 +80,6 @@ jobs:
       # -------------------------------
       - name: Retrieve existing Test Plan
         id: retrieve-test-plan
-        continue-on-error: true
         uses: ./.github/actions/xray-api-graphql
         with:
           graphql_operation: 'get-test-plan'
@@ -88,22 +87,10 @@ jobs:
           xray_token: ${{ steps.generate-xray-token.outputs.xray_token }}
 
       # -------------------------------
-      # Handle retrieval failure
-      # -------------------------------
-      - name: Handle Test Plan retrieval failure
-        id: handle-retrieval-failure
-        if: steps.retrieve-test-plan.outcome == 'failure'
-        run: |
-          echo "::warning::Failed to retrieve Test Plan from Xray API"
-          echo "Will proceed with Test Plan creation"
-          echo "needs_create=true" >> "$GITHUB_OUTPUT"
-
-      # -------------------------------
       # Extract Test Plan key from response
       # -------------------------------
       - name: Extract Test Plan key
         id: extract-test-plan-key
-        if: steps.retrieve-test-plan.outcome == 'success'
         shell: bash
         run: |
           response='${{ steps.retrieve-test-plan.outputs.response }}'
@@ -112,11 +99,11 @@ jobs:
 
           total=$(echo "$response" | jq -r '.data.getTestPlans.total')
 
-          # Guard against a non-numeric total (e.g. GraphQL error) before the arithmetic test.
+          # An unreadable total means the lookup told us nothing. Creating a plan here
+          # would duplicate the one the campaign is already filling, so stop instead.
           if [[ ! "$total" =~ ^[0-9]+$ ]]; then
-              echo "::warning::Unexpected getTestPlans.total value '$total' (response may be an error) — will create a new Test Plan."
-              echo "needs_create=true" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "::error::Unexpected getTestPlans.total value '$total' - refusing to create a Test Plan on an inconclusive lookup."
+              exit 1
           fi
 
           if [[ "$total" -eq 0 ]]; then
@@ -125,25 +112,30 @@ jobs:
               exit 0
           fi
 
+          # Several plans share this summary: picking one would scatter the results.
+          if [[ "$total" -gt 1 ]]; then
+              echo "::error::The lookup matched $total Test Plans for this summary; results would be split across duplicates. Keep a single plan and delete the others."
+              echo "First match: $(echo "$response" | jq -r '.data.getTestPlans.results[0].jira.key // "unknown"')"
+              exit 1
+          fi
+
           jira_test_plan_key=$(echo "$response" | jq -r '.data.getTestPlans.results[0].jira.key // empty')
 
           if [[ -z "$jira_test_plan_key" ]]; then
-              echo "needs_create=true" >> "$GITHUB_OUTPUT"
-              echo "Test Plan found but key is empty, will create a new one."
-          else
-              echo "needs_create=false" >> "$GITHUB_OUTPUT"
-              echo "jira_test_plan_key=$jira_test_plan_key" >> "$GITHUB_OUTPUT"
-              echo "Found existing Test Plan with key: $jira_test_plan_key - will reuse it."
+              echo "::error::Test Plan found but its key is empty."
+              exit 1
           fi
+
+          echo "needs_create=false" >> "$GITHUB_OUTPUT"
+          echo "jira_test_plan_key=$jira_test_plan_key" >> "$GITHUB_OUTPUT"
+          echo "Found existing Test Plan with key: $jira_test_plan_key - will reuse it."
 
       # -------------------------------
       # Create Test Plan if needed
       # -------------------------------
       - name: Create Test Plan
         id: create-test-plan
-        if: |
-          (steps.extract-test-plan-key.outputs.needs_create == 'true') ||
-          (steps.handle-retrieval-failure.outputs.needs_create == 'true')
+        if: steps.extract-test-plan-key.outputs.needs_create == 'true'
         uses: ./.github/actions/xray-api-graphql
         with:
           graphql_operation: 'create-test-plan'
@@ -158,8 +150,7 @@ jobs:
         shell: bash
         run: |
           # Determine if we need to use CREATE or GET response
-          if [[ "${{ steps.extract-test-plan-key.outputs.needs_create }}" == "true" ]] || \
-             [[ "${{ steps.handle-retrieval-failure.outputs.needs_create }}" == "true" ]]; then
+          if [[ "${{ steps.extract-test-plan-key.outputs.needs_create }}" == "true" ]]; then
             RESPONSE='${{ steps.create-test-plan.outputs.response }}'
             echo "Using Test Plan from CREATE operation"
             jira_test_plan_key=$(jq -r '.data.createTestPlan.testPlan.jira.key // empty' <<< "$RESPONSE")


### PR DESCRIPTION
Fixes: [MON-208290](https://centreon.atlassian.net/browse/MON-208290)

The Xray Test Plan get-or-create looked up an existing plan with a single HTTP call, with no retry, in a step marked `continue-on-error`. Any transient API failure therefore fell through to the create branch: a 502 was read as "no Test Plan exists" and the job created a second plan, splitting the campaign results across duplicates.

## What changes

- `xray-graphql-call.sh` retries transient transport failures (5xx, 429, network errors, unparseable bodies) with a backoff before giving up. Client errors (4xx) and GraphQL application errors still fail immediately, since retrying will not help.
- Each attempt is bounded by `--connect-timeout 10 --max-time 60`, so a stalled connection becomes a retryable failure instead of hanging the job — without it the retry loop could never absorb the very failure mode it targets.
- `xray-prepare-test-plan.yml` no longer creates a Test Plan when the lookup is inconclusive: the job fails instead.
- A lookup matching more than one plan also fails, so pre-existing duplicates surface instead of silently scattering results.

## Context

Observed on 2026-09-01 on `release-26.10-next`: the `mbi` run got an HTTP 502 on `getTestPlans` and created MON-208161 while MON-208132 already existed. The 26.10 modules campaign then spread across both plans and had to be merged back by hand. The same defect had recurred since October 2024 — 15 summaries existed in several copies, up to 4.

Xray has been cleaned up beforehand, so the new duplicate guard cannot fail the job on current data: every summary the CI still generates now resolves to exactly one Test Plan.

## Verification

The script was exercised with a stubbed `curl` and a neutralised `sleep`: happy path, `500/500/200`, always-500, `429` then 200, `401` (not retried), transport error then 200, `503 ERROR` HTML body at HTTP 200, invalid JSON then 200, and GraphQL `errors` at 200 — all behave as intended, and every failure path exits non-zero without writing to `GITHUB_OUTPUT`. `XRAY_MAX_ATTEMPTS` was checked against the values that previously broke the loop bounds (`3s`, `abc`, `0`, `-1`, `2x`), which are now rejected with an explicit message.


[MON-208290]: https://centreon.atlassian.net/browse/MON-208290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ