### PR TITLE
fix(install-poller): resolve poller image tag from previous on-prem major on cloud

### DIFF
--- a/centreon/install-poller/src/commands/docker.sh
+++ b/centreon/install-poller/src/commands/docker.sh
@@ -93,7 +93,7 @@ function _generateDotEnv() {
   local image_tag
   case "${STABILITY}" in
   stable)
-    image_tag="${major}"
+    image_tag="$(_pollerImageMajor)"
     ;;
   unstable)
     image_tag="develop"
@@ -140,6 +140,39 @@ EOF
 
   consoleInfo ".env written"
   logInfo ".env written"
+}
+
+# Whether a Centreon major version (e.g. 26.10) is an on-prem release.
+# On-prem majors always end in .10; anything else is a cloud release. Same
+# heuristic as get-environment.yml's cloud/on-prem detection and
+# uses_internal_repo() in centreon/unattended.sh (mirrored in
+# _usesInternalRepo, src/vm/packages.sh) — shared here so both the Docker and
+# VM install paths classify a major the same way.
+function _isOnPremMajor() {
+  [[ "${1}" == *.10 ]]
+}
+
+# The on-prem major this release's containerized pollers come from. On-prem
+# majors are used as-is. A cloud major pulls the nearest not-later on-prem
+# major, floored at 26.10 (MON-192897: no containerized poller exists before
+# that release). MON-208333.
+#
+# Unlike _usesInternalRepo (VM/RPM path), this doesn't just switch the
+# registry at the same major: RPM/DEB packages ARE published for cloud majors
+# (to an internal repo, per .github/actions/promote-to-stable), but poller
+# container images are only ever published for on-prem majors — so a cloud
+# major has to resolve to a *different*, older major here.
+function _pollerImageMajor() {
+  if _isOnPremMajor "${major}"; then
+    echo "${major}"
+    return
+  fi
+  local year=$((10#${major%%.*}))
+  local month=$((10#${major##*.}))
+  local onprem_year=${year}
+  [ "${month}" -lt 10 ] && onprem_year=$((year - 1))
+  [ "${onprem_year}" -lt 26 ] && onprem_year=26
+  printf "%02d.10" "${onprem_year}"
 }
 
 # Registry + repo (no tag) for one of the 5 poller component images, per

--- a/centreon/install-poller/src/commands/vm.sh
+++ b/centreon/install-poller/src/commands/vm.sh
@@ -28,8 +28,10 @@ function runVmInstall() {
     echo ""
     consoleTitle "Existing installation detected (major: ${installed_major:-unknown}):"
 
-    if [ -n "${installed_major}" ] && [ "${installed_major}" != "${major}" ]; then
-      consoleInfo "Major version change: ${installed_major} → ${major}"
+    local repo_major
+    repo_major=$(_vmRepoMajor)
+    if [ -n "${installed_major}" ] && [ "${installed_major}" != "${repo_major}" ]; then
+      consoleInfo "Major version change: ${installed_major} → ${repo_major}"
     fi
     _vmUpdateRepo
 

--- a/centreon/install-poller/src/vm/packages.sh
+++ b/centreon/install-poller/src/vm/packages.sh
@@ -92,7 +92,7 @@ function _vmInstallPowertools() {
 
 # Mirrors uses_internal_repo() in centreon/unattended.sh.
 function _usesInternalRepo() {
-  [ "${major##*.}" != "10" ]
+  ! _isOnPremMajor "${major}"
 }
 
 function _centreonRpmRepoUrl() {

--- a/centreon/install-poller/src/vm/packages.sh
+++ b/centreon/install-poller/src/vm/packages.sh
@@ -90,16 +90,33 @@ function _vmInstallPowertools() {
   esac
 }
 
+# The major to resolve VM package repo URLs against. For the stable channel, a
+# cloud major resolves to the previous on-prem major (same as
+# _pollerImageMajor for the Docker image tag, src/commands/docker.sh) so a
+# real customer install never needs internal repo access — RPM/DEB packages
+# for a cloud major are only ever published internally. testing/unstable stay
+# pinned to the actual major being validated: QA needs the real cloud
+# candidate build, not an older on-prem stand-in. MON-208333.
+function _vmRepoMajor() {
+  if [ "${STABILITY}" = "stable" ]; then
+    _pollerImageMajor
+  else
+    echo "${major}"
+  fi
+}
+
 # Mirrors uses_internal_repo() in centreon/unattended.sh.
 function _usesInternalRepo() {
-  ! _isOnPremMajor "${major}"
+  ! _isOnPremMajor "$(_vmRepoMajor)"
 }
 
 function _centreonRpmRepoUrl() {
+  local repo_major
+  repo_major=$(_vmRepoMajor)
   if _usesInternalRepo; then
-    echo "https://packages.centreon.com/rpm-standard-internal/${major}/el${_EL_MAJOR:-9}/centreon-${major}-internal.repo"
+    echo "https://packages.centreon.com/rpm-standard-internal/${repo_major}/el${_EL_MAJOR:-9}/centreon-${repo_major}-internal.repo"
   else
-    echo "https://packages.centreon.com/rpm-standard/${major}/el${_EL_MAJOR:-9}/centreon-${major}.repo"
+    echo "https://packages.centreon.com/rpm-standard/${repo_major}/el${_EL_MAJOR:-9}/centreon-${repo_major}.repo"
   fi
 }
 
@@ -132,6 +149,8 @@ function _vmConfigureRepoChannels() {
   else
     local codename
     codename=$(lsb_release -sc)
+    local repo_major
+    repo_major=$(_vmRepoMajor)
     local apt_root="apt-standard"
     _usesInternalRepo && apt_root="apt-standard-internal"
 
@@ -139,18 +158,18 @@ function _vmConfigureRepoChannels() {
           /etc/apt/sources.list.d/centreon-testing.list \
           /etc/apt/sources.list.d/centreon-unstable.list
 
-    echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-stable main" \
+    echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-stable main" \
       | tee /etc/apt/sources.list.d/centreon-stable.list > /dev/null
 
     if [ "${STABILITY}" = "testing" ] || [ "${STABILITY}" = "unstable" ]; then
       {
-        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-testing-hotfix main"
-        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-testing-release main"
+        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-testing-hotfix main"
+        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-testing-release main"
       } | tee /etc/apt/sources.list.d/centreon-testing.list > /dev/null
     fi
 
     if [ "${STABILITY}" = "unstable" ]; then
-      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-unstable main" \
+      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-unstable main" \
         | tee /etc/apt/sources.list.d/centreon-unstable.list > /dev/null
     fi
 
@@ -159,7 +178,7 @@ function _vmConfigureRepoChannels() {
 }
 
 function _vmInstallRepo() {
-  logInfo "Adding Centreon ${major} repository (stability: ${STABILITY})"
+  logInfo "Adding Centreon $(_vmRepoMajor) repository (stability: ${STABILITY})"
 
   if [ "${_PKG_COMMAND}" = "apt" ]; then
     consoleInfo "Adding Centreon repository (Debian)"
@@ -200,12 +219,14 @@ function _vmInstallPackages() {
 }
 
 function _vmUpdateRepo() {
-  consoleInfo "Updating Centreon repository to ${major} (stability: ${STABILITY})"
-  logInfo "Updating Centreon repository to ${major}, stability=${STABILITY}"
+  local repo_major
+  repo_major=$(_vmRepoMajor)
+  consoleInfo "Updating Centreon repository to ${repo_major} (stability: ${STABILITY})"
+  logInfo "Updating Centreon repository to ${repo_major}, stability=${STABILITY}"
 
   if [ "${_PKG_COMMAND}" = "dnf" ]; then
     rm -f /etc/yum.repos.d/centreon-*.repo
-    commandExitOnError "Cannot add Centreon ${major} repository" \
+    commandExitOnError "Cannot add Centreon ${repo_major} repository" \
       dnf config-manager --add-repo "$(_centreonRpmRepoUrl)"
     _vmConfigureRepoChannels
     dnf clean all


### PR DESCRIPTION
## Summary
- After part 1 (gating `promote-docker-to-ghcr` on `is_cloud == 'false'`), only on-prem `YY.10.x` stable releases publish poller container images to ghcr.io. A cloud release's generated `install.sh` was still resolving the Docker image tag from its own major, which will never exist there.
- Add `_pollerImageMajor()` in `install-poller/src/commands/docker.sh`: on-prem majors (ending in `.10`) are used as-is; a cloud major resolves to the nearest not-later on-prem major, floored at `26.10` (MON-192897 — no containerized poller exists before that release). `_generateDotEnv`'s `stable` branch now uses it instead of the bare `${major}`.
- **Same bug also affects VM/RPM installs — fixed here too (second commit):** RPM/DEB packages for a cloud major are only ever published to the internal repo (`rpm-standard-internal/<major>`, `apt-standard-internal`), never the public one, so a cloud `26.11` stable poller VM install pointed at `rpm-standard-internal/26.11/...` was just as unreachable as the ghcr.io image was. Add `_vmRepoMajor()` in `src/vm/packages.sh`: for the `stable` channel only, it resolves to `_pollerImageMajor()` (same previous-on-prem-major logic, always public since it's always an on-prem major); `testing`/`unstable` are untouched (QA needs the real cloud candidate build on the internal repo, not an older on-prem stand-in). `_usesInternalRepo()`, `_centreonRpmRepoUrl()`, the DEB `sources.list` construction, and the VM upgrade-detection message in `commands/vm.sh` all now resolve through it.
- Factored the shared `.10` on-prem/cloud predicate into `_isOnPremMajor()`, reused by `_usesInternalRepo()`.
- `install-poller/install.sh` is a gitignored local build artifact (regenerated via `just build` / CI's "Build install-poller script" step in `web.yml`), not committed — the fix flows through automatically at build time.

Part 2 of MON-208333, on top of the ghcr gate from part 1:
- https://github.com/centreon/centreon/pull/11509
- https://github.com/centreon/centreon-collect/pull/3683

Jira: https://centreon.atlassian.net/browse/MON-208333

## Test plan
- [x] `bash -n install.sh` on a locally rebuilt script: syntax OK
- [x] Traced `_pollerImageMajor()` against the ticket's examples: `26.11`→`26.10`, `27.03`→`26.10`, `27.11`→`27.10`, on-prem `26.10`→`26.10`, pre-26.10 cloud majors floor to `26.10`
- [x] Traced `_vmRepoMajor()`/`_usesInternalRepo()` across `stable`/`testing`/`unstable` for both cloud and on-prem majors: stable cloud → public repo at previous on-prem major; testing/unstable cloud → unchanged (internal, real cloud major); on-prem → unchanged either way
- [ ] Next cloud stable build: confirm the generated `install.sh` resolves the previous on-prem major (Docker tag and RPM/DEB repo) and pulls/installs successfully, unauthenticated/without internal access, from ghcr.io and the public `rpm-standard`/`apt-standard` repos
- [ ] Confirm testing/unstable VM/Docker installs are unaffected (still resolve to the real cloud candidate major, internal repo where applicable)