### PR TITLE
[Centreon Web] Update links to BA monitoring page 25.10

### DIFF
--- a/centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -122,6 +122,17 @@ class MonitoringResourceController extends AbstractController
     }
 
     /**
+     * Build uri to access the Business Activity monitoring page
+     *
+     * @param int $baId
+     * @return string
+     */
+    public function buildBaDetailsUri(int $baId): string
+    {
+        return $this->getBaseUri() . '/monitoring/bam/bas/' . $baId;
+    }
+
+    /**
      * Build uri to access service panel
      *
      * @param int $hostId

--- a/centreon/www/include/monitoring/downtime/listDowntime.php
+++ b/centreon/www/include/monitoring/downtime/listDowntime.php
@@ -295,10 +295,10 @@ for ($i = 0; ($data = $pearDBO->fetch($downtimesStatement)) !== false; $i++) {
 
     if (preg_match('/_Module_BAM_\d+/', $data['host_name'])) {
         $tab_downtime_svc[$i]['host_name'] = 'Module BAM';
-        $tab_downtime_svc[$i]['h_details_uri'] = './main.php?p=207&o=d&ba_id='
-            . $tab_service_bam[$data['service_description']]['id'];
-        $tab_downtime_svc[$i]['s_details_uri'] = './main.php?p=207&o=d&ba_id='
-            . $tab_service_bam[$data['service_description']]['id'];
+        $tab_downtime_svc[$i]['h_details_uri'] = $resourceController->buildBaDetailsUri(
+            (int) $tab_service_bam[$data['service_description']]['id']
+        );
+        $tab_downtime_svc[$i]['s_details_uri'] = $tab_downtime_svc[$i]['h_details_uri'];
         $tab_downtime_svc[$i]['service_description'] = $tab_service_bam[$data['service_description']]['name'];
         $tab_downtime_svc[$i]['downtime_type'] = 'SVC';
         if ($tab_downtime_svc[$i]['author_name'] === 'Centreon Broker BAM Module') {


### PR DESCRIPTION
## Summary
- Add `MonitoringResourceController::buildBaDetailsUri()` to build the redirection URI to a Business Activity's monitoring page (`/monitoring/bam/bas/{id}`).
- Update the downtime listing page to use this new method for Business Activity links instead of the legacy `main.php?p=207&o=d&ba_id=...` URL.

## Why
The centreon-bam module now relies on `buildBaDetailsUri()` to link Business Activities to their monitoring page across widgets, the BA tree, KPI listing, and reporting. This method needs to be available on `dev-25.10.x` for those changes to work correctly.

## Test plan
- [ ] Verify Business Activity links from the downtime listing page redirect to the correct monitoring page
- [ ] Verify centreon-bam e2e suites relying on BA monitoring links pass