### PR TITLE
enh(openapi): regenerate the on-prem API doc as 3.1 and adopt the bare /api URL model

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: 'Centreon Web RestAPI'
   description: |
@@ -22,7 +22,7 @@ externalDocs:
   url: 'https://thewatch.centreon.com/'
 servers:
   -
-    url: '{protocol}://{server}:{port}/centreon/api/{version}'
+    url: '{protocol}://{server}:{port}/centreon'
     variables:
       protocol:
         enum:
@@ -36,105 +36,66 @@ servers:
       port:
         default: '80'
         description: 'Port used by HTTP server'
-      version:
-        default: v25.10
-        description: 'Version of the API'
 tags:
-  -
-    name: Acknowledgement
+  - name: Acknowledgement
     description: 'Endpoints to manage acknowledgements'
-  -
-    name: Administration
+  - name: Administration
     description: 'Endpoints to manage administration tasks'
-  -
-    name: Authentication
+  - name: Authentication
     description: 'Login and logout endpoints to retrieve authentication token'
-  -
-    name: Command
+  - name: Command
     description: "Resource 'Command' operations."
-  -
-    name: 'Contact group'
+  - name: 'Contact group'
     description: 'Endpoints to manage contact groups'
-  -
-    name: Downtime
+  - name: Downtime
     description: 'Endpoints to manage downtimes'
-  -
-    name: Gorgone
+  - name: Gorgone
     description: 'Endpoints to manage Gorgone'
-  -
-    name: Host
+  - name: Host
     description: 'Endpoints to manage hosts'
-  -
-    name: 'Host category'
+  - name: 'Host category'
     description: 'Endpoints to manage host categories'
-  -
-    name: 'Host group'
+  - name: 'Host group'
     description: 'Endpoints to manage host groups'
-  -
-    name: 'Meta service'
+  - name: 'Meta service'
     description: 'Endpoints to manage meta services'
-  -
-    name: 'Host severity'
-  -
-    name: 'Host template'
-  -
-    name: Media
-  -
-    name: 'Monitoring server'
-  -
-    name: Proxy
-  -
-    name: Service
-  -
-    name: 'Service group'
-  -
-    name: 'Service category'
+  - name: 'Host severity'
+  - name: 'Host template'
+  - name: Media
+  - name: 'Monitoring server'
+  - name: Proxy
+  - name: Service
+  - name: 'Service group'
+  - name: 'Service category'
     description: 'Endpoints to manage service categories'
-  -
-    name: Severity
+  - name: Severity
     description: 'Endpoints to manage severities'
-  -
-    name: 'Time period'
+  - name: 'Time period'
     description: 'Endpoints to manage time periods'
-  -
-    name: Topology
+  - name: Topology
     description: 'Endpoints to manage topologies'
-  -
-    name: GlobalMacroResource
-  -
-    name: ListPlugins
-  -
-    name: ServiceCategory
-  -
-    name: StandardMacroResource
-  -
-    name: ConnectorResource
-  -
-    name: Connector
+  - name: GlobalMacroResource
+  - name: ListPlugins
+  - name: ServiceCategory
+  - name: StandardMacroResource
+  - name: ConnectorResource
+  - name: Connector
     description: "Resource 'Connector' operations."
-  -
-    name: Plugin
+  - name: Plugin
     description: "Resource 'Plugin' operations."
-  -
-    name: 'Agent Configuration'
+  - name: 'Agent Configuration'
     description: "Resource 'Agent Configuration' operations."
-  -
-    name: 'Global Macro'
+  - name: 'Global Macro'
     description: "Resource 'Global Macro' operations."
-  -
-    name: Plugins
+  - name: Plugins
     description: "Resource 'Plugins' operations."
-  -
-    name: 'Service Category'
+  - name: 'Service Category'
     description: "Resource 'Service Category' operations."
-  -
-    name: 'Standard Macro'
+  - name: 'Standard Macro'
     description: "Resource 'Standard Macro' operations."
-  -
-    name: Poller
+  - name: Poller
     description: "Resource 'Poller' operations."
-  -
-    name: Upgrade
+  - name: Upgrade
     description: "Resource 'Upgrade' operations."
 security:
   -
@@ -142,7 +103,7 @@ security:
   -
     Cookie: []
 paths:
-  /login:
+  /api/login:
     post:
       tags:
         - Authentication
@@ -169,7 +130,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /logout:
+  /api/logout:
     get:
       tags:
         - Authentication
@@ -226,7 +187,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /authentication/providers/configurations:
+  /api/latest/authentication/providers/configurations:
     get:
       tags:
         - Authentication
@@ -247,8 +208,7 @@ paths:
       tags:
         - Authentication
       parameters:
-        -
-          $ref: '#/components/parameters/providerConfigurationName'
+        - $ref: '#/components/parameters/providerConfigurationName'
       summary: 'Authentication to provider'
       requestBody:
         required: true
@@ -272,7 +232,7 @@ paths:
                   redirect_uri: { type: string, example: '/centreon/main.php?p=50113&o=ldap' }
         '302':
           description: Found
-  /authentication/logout:
+  /api/latest/authentication/logout:
     get:
       tags:
         - Authentication
@@ -292,11 +252,11 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/additional-connector-configurations:
+  /api/latest/configuration/additional-connector-configurations:
     $ref: ./latest/onPremise/Configuration/AdditionalConnectorConfiguration/AddAndFindAccs.yaml
   '/configuration/additional-connector-configurations/{acc_id}':
     $ref: ./latest/onPremise/Configuration/AdditionalConnectorConfiguration/DeleteUpdateAndFindAcc.yaml
-  /configuration/agent-configurations:
+  /api/latest/configuration/agent-configurations:
     $ref: ./latest/onPremise/Configuration/AgentConfiguration/AddOrFindAc.yaml
   '/configuration/agent-configurations/{ac_id}':
     $ref: ./latest/onPremise/Configuration/AgentConfiguration/DeleteAndUpdateAndFindDetailAc.yaml
@@ -306,7 +266,3577 @@ paths:
     $ref: ./latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml
   '/configuration/broker/{broker_id}/outputs/{output_id}/file':
     $ref: ./latest/onPremise/Configuration/Broker/UpdateStreamConnectorFile.yaml
-  /configuration/commands:
+  /api/latest/configuration/graphs/templates:
+    $ref: ./latest/onPremise/Configuration/GraphTemplate/FindGraphTemplates.yaml
+  /api/latest/configuration/hosts/templates:
+    $ref: ./latest/onPremise/Configuration/HostTemplate/AddAndFindHostTemplates.yaml
+  '/configuration/hosts/templates/{host_template_id}':
+    $ref: ./latest/onPremise/Configuration/HostTemplate/DeleteAndPartialUpdateHostTemplate.yaml
+  /api/latest/configuration/hosts:
+    $ref: ./latest/onPremise/Configuration/Host/AddAndFindHosts.yaml
+  /api/latest/configuration/hosts/categories:
+    get:
+      operationId: FindHostCategories
+      tags:
+        - 'Host category'
+      summary: 'List host categories'
+      description: |
+        List of host category configurations
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * name
+        * alias
+        * is_activated
+        * hostgroup.name
+        * hostgroup.id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.Host.Category' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      operationId: AddHostCategory
+      tags:
+        - 'Host category'
+      summary: 'Create a host category'
+      description: |
+        Create a host category
+
+        This endpoint does NOT update the ACL rights with the new host category
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Configuration.Host.Category.Add'
+      responses:
+        '201':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/hosts/categories/{host_category_id}':
+    get:
+      operationId: FindHostCategory
+      tags:
+        - 'Host category'
+      summary: 'Get a host category'
+      description: |
+        Get a host category configuration
+      parameters:
+        - $ref: '#/components/parameters/HostCategoryId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Configuration.Host.Category'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      operationId: UpdateHostCategory
+      tags:
+        - 'Host category'
+      summary: 'Update a host category'
+      description: |
+        Update a host category
+      parameters:
+        - $ref: '#/components/parameters/HostCategoryId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Configuration.Host.Category.Add'
+      responses:
+        '204':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      operationId: DeleteHostCategory
+      tags:
+        - 'Host category'
+      summary: 'Delete a host category'
+      description: |
+        Delete a host category configuration
+      parameters:
+        - $ref: '#/components/parameters/HostCategoryId'
+      responses:
+        '204':
+          description: OK
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/hosts/{host_id}/services/deploy':
+    $ref: ./latest/onPremise/Configuration/Service/DeployServices.yaml
+  /api/latest/configuration/services/templates:
+    $ref: ./latest/onPremise/Configuration/ServiceTemplate/AddOneAndFindServiceTemplates.yaml
+  '/configuration/services/templates/{service_template_id}':
+    $ref: ./latest/onPremise/Configuration/ServiceTemplate/PartialUpdateAndDeleteServiceTemplate.yaml
+  '/configuration/services/{service_id}':
+    $ref: ./latest/onPremise/Configuration/Service/PartialUpdateAndDeleteService.yaml
+  /api/latest/configuration/services:
+    $ref: ./latest/onPremise/Configuration/Service/AddServiceAndFindServices.yaml
+  /api/latest/configuration/services/_delete:
+    $ref: ./latest/onPremise/Configuration/Service/DeleteServices.yaml
+  /api/latest/monitoring/services/categories:
+    get:
+      operationId: FindRealTimeServiceCategories
+      tags:
+        - 'Service category'
+      summary: 'List all real-time service categories'
+      description: |
+        List of all service categories in real-time context
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * host.id
+        * host.name
+        * host_group.id
+        * host_group.name
+        * host_category.id
+        * host_category.name
+        * service_group.id
+        * service_group.name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.Category' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/hosts/severities:
+    get:
+      operationId: FindHostSeverities
+      tags:
+        - 'Host severity'
+      summary: 'List all host severities'
+      description: |
+        List of all host severity configurations
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * alias
+        * level
+        * is_activated
+
+        Changes in 23.04 :
+
+        * `icon` was renamed `icon_id` and is no longer an object but the image ID
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.Host.Severity' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      operationId: AddHostSeverity
+      tags:
+        - 'Host severity'
+      summary: 'Create a host severity'
+      description: |
+        Create a host severity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: host-severity-name
+                alias:
+                  type: string
+                  example: host-severity-alias
+                level:
+                  type: integer
+                  example: 2
+                icon_id:
+                  type: integer
+                  example: 1
+      responses:
+        '201':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/hosts/severities/{host_severity_id}':
+    delete:
+      operationId: DeleteHostSeverity
+      tags:
+        - 'Host severity'
+      summary: 'Delete a host severity'
+      description: |
+        Delete a host severity configuration
+      parameters:
+        - $ref: '#/components/parameters/HostSeverityId'
+      responses:
+        '204':
+          description: OK
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      operationId: FindHostSeverity
+      tags:
+        - 'Host severity'
+      summary: 'Get a host severity'
+      description: |
+        Get a host severity configuration
+      parameters:
+        - $ref: '#/components/parameters/HostSeverityId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Configuration.Host.Severity'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      operationId: UpdateHostSeverity
+      tags:
+        - 'Host severity'
+      summary: 'Update a host severity'
+      description: |
+        Update a host severity
+      parameters:
+        - $ref: '#/components/parameters/HostSeverityId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Configuration.Host.Severity.Add'
+      responses:
+        '204':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/hosts/groups:
+    $ref: ./latest/onPremise/Configuration/HostGroup/AddAndFindHostGroups.yaml
+  '/configuration/hosts/groups/{hostgroup_id}':
+    $ref: ./latest/onPremise/Configuration/HostGroup/GetAndDeleteAndUpdateHostGroup.yaml
+  /api/latest/configuration/hosts/groups/_delete:
+    $ref: ./latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
+  /api/latest/configuration/hosts/groups/_enable:
+    $ref: ./latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
+  /api/latest/configuration/hosts/groups/_disable:
+    $ref: ./latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
+  /api/latest/configuration/hosts/groups/_duplicate:
+    $ref: ./latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
+  /api/latest/configuration/services/groups:
+    get:
+      operationId: FindServiceGroups
+      tags:
+        - 'Service group'
+      summary: 'List all service groups'
+      description: |
+        Return all service group configurations.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * alias
+        * is_activated
+        * host.id
+        * host.name
+        * hostgroup.id
+        * hostgroup.name
+        * hostcategory.id
+        * hostcategory.name
+        * servicecategory.id
+        * servicecategory.name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.Service.Group' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      operationId: AddServiceGroup
+      tags:
+        - 'Service group'
+      summary: 'Add a service group'
+      description: |
+        Add a new service group configuration.
+
+        Mandatory body properties are:
+
+        * name
+        * alias
+
+        `Since Centreon web 23.04`
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Configuration.Service.Group.Add'
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Configuration.Service.Group'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/services/groups/{servicegroup_id}':
+    delete:
+      operationId: DeleteServiceGroup
+      tags:
+        - 'Service group'
+      summary: 'Delete a service group'
+      description: |
+        `internal`
+
+        `Since Centreon web 23.04`
+
+        Delete service group.
+      parameters:
+        - $ref: '#/components/parameters/ServiceGroupId'
+      responses:
+        '204':
+          description: OK
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/services/severities:
+    $ref: ./latest/onPremise/Configuration/ServiceSeverity/AddAndFindServiceSeverities.yaml
+  '/configuration/services/severities/{service_severity_id}':
+    $ref: ./latest/onPremise/Configuration/ServiceSeverity/DeleteAndUpdateServiceSeverity.yaml
+  /api/latest/configuration/icons:
+    get:
+      operationId: centreon_application_configuration_icon_getIcons
+      tags:
+        - Icons
+      summary: 'List all icons'
+      description: |
+        List all icons from centreon configuration.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * name
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { type: object, properties: { id: { type: integer, description: 'id of the icon', example: 1 }, directory: { type: string, description: 'directory of the icon', example: ppm }, name: { type: string, description: 'name of the icon', example: operatingsystems-linux-snmp-linux-128.png }, url: { type: string, description: 'url to get the icon', example: /centreon/img/media/ppm/operatingsystems-linux-snmp-linux-128.png } } } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/medias:
+    $ref: ./latest/onPremise/Configuration/Media/AddAndFindMedia.yaml
+  /api/latest/configuration/media/folders:
+    $ref: ./latest/onPremise/Configuration/Media/FindImageFolders.yaml
+  '/configuration/medias/{media_id}/content':
+    $ref: ./latest/onPremise/Configuration/Media/UpdateMedia.yaml
+  /api/latest/configuration/proxy:
+    get:
+      operationId: configuration.proxy.getProxy
+      tags:
+        - Proxy
+      summary: 'Display the default configuration of the Centreon proxy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Configuration.Proxy'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      operationId: configuration.proxy.updateProxy
+      tags:
+        - Proxy
+      summary: 'Update the default configuration of the Centreon proxy'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Configuration.Proxy'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/monitoring-servers:
+    get:
+      operationId: configuration.monitoring-servers.findServer
+      tags:
+        - 'Monitoring server'
+      summary: 'List all monitoring servers configurations'
+      description: |
+        List all monitoring servers configurations.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * name
+          * is_localhost
+          * address
+          * is_activate
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.MonitoringServerMain' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/monitoring-servers/{monitoring_server_id}/generate':
+    get:
+      operationId: configuration_monitoring_server_generate
+      tags:
+        - 'Monitoring server'
+      summary: 'Generate the configuration of the monitoring server'
+      description: |
+        Generate and move the configuration files of the monitoring server
+      parameters:
+        - $ref: '#/components/parameters/MonitoringServerId'
+      responses:
+        '204':
+          description: 'Generation OK'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/monitoring-servers/{monitoring_server_id}/reload':
+    get:
+      operationId: configuration_monitoring_server_reload
+      tags:
+        - 'Monitoring server'
+      summary: 'Reload the configuration of the monitoring server'
+      description: |
+        Reload the configuration files of the monitoring server
+      parameters:
+        - $ref: '#/components/parameters/MonitoringServerId'
+      responses:
+        '204':
+          description: 'Reload OK'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/monitoring-servers/{monitoring_server_id}/generate-and-reload':
+    get:
+      operationId: configuration_monitoring_server_generate_and_reload
+      tags:
+        - 'Monitoring server'
+      summary: 'Generate and reload the configuration of the monitoring server'
+      description: |
+        Generate, move and reload the configuration files of the monitoring server
+      parameters:
+        - $ref: '#/components/parameters/MonitoringServerId'
+      responses:
+        '204':
+          description: 'Generation and reload OK'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/monitoring-servers/generate:
+    get:
+      operationId: configuration_monitoring_server_generate_all
+      tags:
+        - 'Monitoring server'
+      summary: 'Generate the configuration for all monitoring servers'
+      description: |
+        Generate and move the configuration files for all monitoring servers.
+
+        The process will stop at the first error.
+      responses:
+        '204':
+          description: 'Generation OK'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/monitoring-servers/reload:
+    get:
+      operationId: configuration_monitoring_server_reload_all
+      tags:
+        - 'Monitoring server'
+      summary: 'Reload the configuration for all monitoring servers'
+      description: |
+        Reload the configuration files for all monitoring servers.
+
+        The process will stop at the first error.
+      responses:
+        '204':
+          description: 'Reload OK'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/monitoring-servers/generate-and-reload:
+    get:
+      operationId: configuration_monitoring_server_generate_and_reload_all
+      tags:
+        - 'Monitoring server'
+      summary: 'Generate and reload the configuration for all monitoring servers'
+      description: |
+        Generate, move and reload the configuration files for all monitoring servers.
+
+        The process will stop at the first error.
+      responses:
+        '204':
+          description: 'Generation and reload OK'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/metaservices:
+    get:
+      operationId: centreon_application_find_meta_services_configurations
+      tags:
+        - 'Meta service'
+      summary: 'List all meta services configurations'
+      description: |
+        List all meta services configurations.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * name
+          * is_activate
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.MetaServices' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/metaservices/{meta_id}':
+    get:
+      operationId: centreon_application_find_meta_service_configuration
+      tags:
+        - 'Meta service'
+      summary: 'Get a meta service'
+      description: 'Get a meta service configuration by its id'
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Configuration.MetaServices'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/metaservices/{meta_id}/metrics':
+    get:
+      operationId: centreon_application_find_meta_service_metrics
+      tags:
+        - 'Meta service'
+      summary: 'List all meta service metrics'
+      description: |
+        List all meta services metrics from realtime.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * name
+          * service_description
+          * host_name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/MetaId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.MetaServiceMetric' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/hosts/{host_id}/notification-policy':
+    get:
+      operationId: configuration.host.notification-policy
+      tags:
+        - 'Notification Policy'
+      summary: 'Get notification policy of a host'
+      description: 'Return the notified contacts and contact groups of a host.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      responses:
+        '200':
+          description: 'Successful request'
+          content:
+            application/json:
+              schema:
+                $ref: ./latest/onPremise/Configuration/NotificationPolicy/Schema/NotificationPolicy.yaml
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/hosts/{host_id}/services/{service_id}/notification-policy':
+    get:
+      operationId: configuration.service.notification-policy
+      tags:
+        - 'Notification Policy'
+      summary: 'Get notification policy of a service'
+      description: 'Return the notified contacts and contact groups of a service.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '200':
+          description: 'Successful request'
+          content:
+            application/json:
+              schema:
+                $ref: ./latest/onPremise/Configuration/NotificationPolicy/Schema/NotificationPolicy.yaml
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/configuration/metaservices/{meta_id}/notification-policy':
+    get:
+      operationId: configuration.metaservice.notification-policy
+      tags:
+        - 'Notification Policy'
+      summary: 'Get notification policy of a meta service'
+      description: 'Return the notified contacts and contact groups of a meta service.'
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      responses:
+        '200':
+          description: 'Successful request'
+          content:
+            application/json:
+              schema:
+                $ref: ./latest/onPremise/Configuration/NotificationPolicy/Schema/NotificationPolicy.yaml
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/servers:
+    get:
+      operationId: centreon_application_find_real_time_monitoring_servers
+      tags:
+        - 'Monitoring server'
+      summary: 'List all real time monitoring servers'
+      description: |
+        List all monitoring servers configured and stored in real time.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * name
+          * running
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.Servers' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/users/acl/actions:
+    get:
+      operationId: centreon_application_user_getActionsAuthorization
+      tags:
+        - User
+      summary: 'List allowed actions'
+      description: 'List allowed actions of the current user.'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  host: { type: object, properties: { check: { type: boolean, description: 'if check is allowed on host', example: true }, acknowledgement: { type: boolean, description: 'if acknowledgement is allowed on host', example: true }, downtime: { type: boolean, description: 'if downtime is allowed on host', example: false } } }
+                  service: { type: object, properties: { check: { type: boolean, description: 'if check is allowed on service', example: true }, acknowledgement: { type: boolean, description: 'if acknowledgement is allowed on service', example: true }, downtime: { type: boolean, description: 'if downtime is allowed on service', example: false } } }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/timeperiods:
+    $ref: ./latest/onPremise/Configuration/TimePeriod/AddOneAndFindTimePeriods.yaml
+  '/configuration/timeperiods/{id}':
+    delete:
+      operationId: DeleteTimePeriod
+      tags:
+        - 'Time period'
+      summary: 'Delete a time period'
+      parameters:
+        -
+          in: path
+          name: id
+          description: 'ID of the time period to be deleted'
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '204':
+          description: 'Time period deleted'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      operationId: FindTimePeriod
+      tags:
+        - 'Time period'
+      summary: 'Get a time period'
+      parameters:
+        -
+          in: path
+          name: id
+          description: 'Time period ID'
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Configuration.TimePeriod'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      operationId: UpdateTimePeriod
+      tags:
+        - 'Time period'
+      summary: 'Update a time period'
+      parameters:
+        -
+          in: path
+          name: id
+          description: 'ID of the time period to be updated'
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Configuration.NewTimePeriod'
+      responses:
+        '204':
+          description: 'Time period updated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/users:
+    $ref: ./latest/onPremise/Configuration/Users/Users.yaml
+  /api/latest/configuration/users/current/parameters:
+    $ref: ./latest/onPremise/Configuration/Users/CurrentParameters.yaml
+  /api/latest/configuration/contacts/templates:
+    get:
+      operationId: centreon_application_configuration_contact_template_getContactTemplates
+      tags:
+        - User
+      summary: 'List contact templates'
+      description: 'List configured contact templates'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.ContactTemplate' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/configuration/contacts/groups:
+    $ref: ./latest/onPremise/Configuration/ContactGroup/FindContactGroups.yaml
+  /api/latest/configuration/dashboards:
+    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboards.yaml
+  '/configuration/dashboards/{dashboard_id}':
+    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.yaml
+  '/configuration/dashboards/{dashboard_id}/favorites':
+    $ref: ./latest/onPremise/Configuration/Dashboard/DeleteDashboardFromFavorites.yaml
+  /api/latest/configuration/dashboards/favorites:
+    $ref: ./latest/onPremise/Configuration/Dashboard/FavoriteDashboards.yaml
+  '/configuration/dashboards/{dashboard_id}/shares':
+    $ref: ./latest/onPremise/Configuration/Dashboard/ShareDashboard.yaml
+  '/configuration/dashboards/{dashboard_id}/access_rights/contacts/{contact_id}':
+    $ref: ./latest/onPremise/Configuration/Dashboard/DashboardShareContact.yaml
+  '/configuration/dashboards/{dashboard_id}/access_rights/contactgroups/{contact_group_id}':
+    $ref: ./latest/onPremise/Configuration/Dashboard/DashboardShareContactGroup.yaml
+  /api/latest/configuration/dashboards/contacts:
+    $ref: ./latest/onPremise/Configuration/Dashboard/Contacts.yaml
+  /api/latest/configuration/dashboards/contactgroups:
+    $ref: ./latest/onPremise/Configuration/Dashboard/ContactGroups.yaml
+  /api/latest/monitoring/dashboard/metrics/performances:
+    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsPerformances.yaml
+  /api/latest/monitoring/dashboard/metrics/performances/data:
+    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
+  /api/latest/monitoring/dashboard/metrics/top:
+    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsTop.yaml
+  /api/latest/monitoring/resources/hosts:
+    $ref: ./latest/onPremise/Realtime/Resources/FindResourcesByParent.yaml
+  /api/latest/configuration/access-groups:
+    get:
+      tags:
+        - 'Access Control'
+      summary: 'List access groups'
+      description: 'List access groups available for a user'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.AccessGroup' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/users/filters/{page_name}':
+    get:
+      tags:
+        - User
+      summary: 'List user filters by page'
+      description: |
+        `internal`
+
+        `Since Centreon web 20.04.6`
+
+        List user filters saved for a given page.
+      parameters:
+        - $ref: '#/components/parameters/FilterPageName'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/User.Filter' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - 'User filters'
+      summary: 'Add user filter'
+      description: |
+        `internal`
+
+        `Since Centreon web 20.04.6`
+
+        Add user filter for a given page.
+      parameters:
+        - $ref: '#/components/parameters/FilterPageName'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: 'filter name'
+                  example: 'my filter 1'
+                criterias:
+                  type: array
+                  description: 'list of filter criterias'
+                  items: { type: object, example: { type: text, name: field1, value: 'search value 1' } }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User.Filter'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/users/filters/{page_name}/{filter_id}':
+    get:
+      tags:
+        - User
+      summary: 'Detailed user filter'
+      description: |
+        `internal`
+
+        `Since Centreon web 20.04.6`
+
+        Get detailed information of a user filter for a given page.
+      parameters:
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User.Filter'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - 'User filters'
+      summary: 'Update user filter'
+      description: |
+        `internal`
+
+        `Since Centreon web 20.04.6`
+
+        Update user filter for a given page.
+      parameters:
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User.Filter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User.Filter'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - 'User filters'
+      summary: 'Patch user filter'
+      description: |
+        `internal`
+
+        `Since Centreon web 20.04.6`
+
+        Patch user filter order for a given page.
+      parameters:
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - order
+              properties:
+                order:
+                  type: integer
+                  description: 'filter order'
+                  example: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User.Filter'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - 'User filters'
+      summary: 'Delete user filter'
+      description: |
+        `internal`
+
+        `Since Centreon web 20.04.6`
+
+        Delete user filter for a given page.
+      parameters:
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
+      responses:
+        '204':
+          description: OK
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources:
+    get:
+      operationId: FindResources
+      tags:
+        - Resource
+      summary: 'List all resources including hosts and services'
+      x-remarks: |
+        The `meta.total` field may be approximate when the number of matching resources exceeds 1,000.
+        This is most common when a free-text search spans multiple columns (alias, address, information)
+        because no covering index is available for those columns. In that case `meta.is_approximate` is
+        `true` and `meta.total` is capped at 1,000. To retrieve the exact count, call
+        `GET /monitoring/resources/count` with `all_pages=true` and the same query parameters.
+      description: |
+        List all the resources in real-time monitoring : hosts and services.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * alias
+        * fqdn
+        * type
+        * status_code
+        * status
+        * action_url
+        * notes_label
+        * notes_url
+        * parent_name
+        * parent_status
+        * in_downtime
+        * acknowledged
+        * last_status_change
+        * tries
+        * last_check
+        * information
+        * monitoring_server_name
+        * status_types
+
+        Only for **searching**:
+
+        ---
+
+        * h.name
+        * h.alias
+        * h.address
+        * h.fqdn
+        * s.description
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/ResourceFilterType'
+        - $ref: '#/components/parameters/ResourceFilterState'
+        - $ref: '#/components/parameters/ResourceFilterStatus'
+        - $ref: '#/components/parameters/ResourceFilterHostgroupName'
+        - $ref: '#/components/parameters/ResourceFilterServicegroupName'
+        - $ref: '#/components/parameters/ResourceFilterServiceCategoryName'
+        - $ref: '#/components/parameters/ResourceFilterHostCategoryName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
+        - $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
+        - $ref: '#/components/parameters/ResourceFilterStatusTypes'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.ResourceMain' } }
+                  meta: { allOf: [{ $ref: '#/components/schemas/Meta' }, { type: object, properties: { is_approximate: { type: boolean, description: 'True when the result set exceeds 1,000 matching resources and the full count was not computed to avoid a costly full-table scan. meta.total is capped at 1,000. Call GET /monitoring/resources/count with all_pages=true and the same filters to retrieve the exact count.' } } }] }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources/count:
+    $ref: ./latest/onPremise/Realtime/Resources/CountResources.yaml
+  /api/latest/monitoring/resources/export:
+    $ref: ./latest/onPremise/Realtime/Resources/ExportResources.yaml
+  '/monitoring/resources/hosts/{host_id}':
+    get:
+      operationId: centreon_application_monitoring_resource_details_host
+      tags:
+        - Resource
+      summary: 'Get a Host resource type detail'
+      description: 'Return the full detail of a resource typed Host.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      responses:
+        '200':
+          description: 'Successful request'
+          content:
+            application/json:
+              schema:
+                $ref: ./latest/onPremise/Realtime/Resources/Schema/ResourceHostDetail.yaml
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/HostNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/resources/hosts/{host_id}/services/{service_id}':
+    get:
+      operationId: centreon_application_monitoring_resource_details_service
+      tags:
+        - Resource
+      summary: 'Get a Service resource type detail'
+      description: 'Return the full detail of a resource typed Service.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '200':
+          description: 'Successful request'
+          content:
+            application/json:
+              schema:
+                $ref: ./latest/onPremise/Realtime/Resources/Schema/ResourceServiceDetail.yaml
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundHostOrService'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hosts:
+    get:
+      operationId: centreon_application_monitoring_gethosts
+      tags:
+        - Host
+      summary: 'List all hosts'
+      description: |
+        List all the hosts in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * host.id
+        * host.name
+        * host.alias
+        * host.address
+        * host.state
+        * poller.id
+        * service.display_name
+        * host_group.id
+        * host.is_acknowledged
+        * host.downtime
+        * host.criticality
+      parameters:
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.HostMain' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}':
+    get:
+      operationId: centreon_application_monitoring_getonehost
+      tags:
+        - Host
+      summary: 'Get a host'
+      description: 'Return a single host with full details and some details about its services.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitoring.HostFull'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hosts/status:
+    $ref: ./latest/onPremise/Realtime/Hosts/FindHostsStatus.yaml
+  /api/latest/monitoring/services/status:
+    $ref: ./latest/onPremise/Realtime/Services/FindServicesStatus.yaml
+  /api/latest/monitoring/services:
+    get:
+      operationId: centreon_application_monitoring_getservices
+      tags:
+        - Service
+      summary: 'List all services'
+      description: |
+        List all the services in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * host.id
+        * host.name
+        * host.alias
+        * host.address
+        * host.state
+        * host_group.id
+        * service.display_name
+        * service.description
+        * service.is_acknowledged
+        * service.output
+        * service.state
+        * service_group.id
+        * poller.id
+        * service.downtime
+        * service.criticality
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.ServiceMain' }, { $ref: '#/components/schemas/Monitoring.ServiceWithHost' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/services/names:
+    get:
+      operationId: FindRealTimeUniqueServiceNames
+      tags:
+        - Service
+      summary: 'List all services unique names'
+      description: |
+        List all the services in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * name
+        * host.id
+        * host.name
+        * host_group.id
+        * host_group.name
+        * host_category.id
+        * host_category.name
+        * service_group.id
+        * service_group.name
+        * service_category.id
+        * service_category.name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { type: object, properties: { name: { type: string, example: Cpu } } } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services':
+    get:
+      operationId: centreon_application_monitoring_getservicesbyhost
+      tags:
+        - Service
+      summary: 'List services related to a host'
+      description: |
+        List all services related to a host in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * service.id
+        * service.description
+        * service.display_name
+        * service_group.id
+        * service.is_acknowledged
+        * service.state
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.ServiceMain' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}':
+    get:
+      operationId: centreon_application_monitoring_getoneservice
+      tags:
+        - Service
+      summary: 'Get a service'
+      description: 'Return a single service with full details.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitoring.ServiceFull'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/servicegroups':
+    get:
+      operationId: centreon_application_monitoring_getservicegroupsbyhostandservice
+      tags:
+        - 'Service group'
+      summary: 'Get service groups by host id and service id'
+      description: 'Return a list of service groups for host-service pair.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Monitoring.ServiceGroup'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/hostgroups':
+    get:
+      operationId: centreon_application_monitoring_gethostgroupsbyhost
+      tags:
+        - 'Host group'
+      summary: 'List all host groups by host id'
+      description: |
+        List all the host groups in real-time monitoring for a specific host.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * host.id
+        * host.name
+        * host.alias
+        * host.address
+        * host.display_name
+        * host.state
+        * poller.id
+        * service.display_name
+        * host_category.id
+        * host_category.name
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.HostGroup' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hosts/categories:
+    get:
+      tags:
+        - 'Host category'
+      summary: 'List all real-time host categories'
+      description: |
+        List of all host categories in real-time context
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * host_group.id
+        * host_group.name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.Category' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hostgroups:
+    get:
+      tags:
+        - 'Host group'
+      summary: 'List all host groups'
+      description: |
+        List all the host groups in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * host.id
+        * host.name
+        * host.alias
+        * host.address
+        * host.display_name
+        * host.state
+        * poller.id
+        * service.display_name
+        * host_category.id
+        * host_category.name
+      parameters:
+        - $ref: '#/components/parameters/ShowHost'
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.HostGroup' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/servicegroups:
+    get:
+      tags:
+        - 'Service group'
+      summary: 'List all service groups'
+      description: |
+        List all the service groups in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * name
+        * host.id
+        * host.name
+        * host.alias
+        * host.address
+        * host.display_name
+        * host.state
+        * poller.id
+        * service.id
+        * service.name
+        * service.display_name
+        * host_group.id
+        * host_group.name
+        * host_category.id
+        * host_category.name
+      parameters:
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/ShowHost'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.ServiceGroup' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/severities/service:
+    get:
+      tags:
+        - Severity
+      summary: 'List all service severities from the realtime'
+      description: |
+        List all the service severities in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * name
+        * level
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.Severity' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/severities/host:
+    get:
+      tags:
+        - Severity
+      summary: 'List all host severities from real-time data'
+      description: |
+        List all the host severities in real-time monitoring.
+
+        The available parameters to **search** / **sort_by** are:
+
+        * name
+        * level
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.Severity' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/acknowledgements:
+    get:
+      tags:
+        - Acknowledgement
+      summary: 'List all acknowledgements'
+      description: |
+        List all acknowledgements (host and service).
+
+        **Minimum API version:** 21.10
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * author_id
+        * comment
+        * entry_time
+        * deletion_time
+        * host_id
+        * service_id
+        * service.display_name
+        * is_notify_contacts
+        * is_persistent_comment
+        * is_sticky
+        * poller_id
+        * state
+        * type
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }, { $ref: '#/components/schemas/Acknowledgement.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources/acknowledgements:
+    delete:
+      tags:
+        - Acknowledgement
+      summary: 'Massively disacknowledge resources'
+      description: |
+        Remove/cancel acknowledgements on multiple resources (hosts and/or services) at once.
+
+        **Minimum API version:** 21.10
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Disacknowledge.Bulk'
+      responses:
+        '204':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/acknowledgements/{acknowledgement_id}':
+    get:
+      tags:
+        - Acknowledgement
+      summary: 'Display one acknowledgement'
+      description: |
+        Display one acknowledgement by its ID.
+
+        **Minimum API version:** 21.10
+
+        Returns either a host or service acknowledgement depending on the resource type.
+      parameters:
+        - $ref: '#/components/parameters/AcknowledgementId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Acknowledgement.Service'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hosts/acknowledgements:
+    get:
+      tags:
+        - Acknowledgement
+      summary: 'List all hosts acknowledgements'
+      description: |
+        List all host acknowledgements.
+
+        **Minimum API version:** 21.10
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * author_id
+        * comment
+        * entry_time
+        * deletion_time
+        * host_id
+        * is_notify_contacts
+        * is_persistent_comment
+        * is_sticky
+        * poller_id
+        * state
+        * type
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Acknowledgement
+      summary: 'Add an acknowledgement on multiple hosts'
+      description: |
+        Add an acknowledgement on multiple hosts at once.
+
+        **Minimum API version:** 21.10
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Hosts.Add'
+      responses:
+        '204':
+          description: 'Commands Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/services/acknowledgements:
+    get:
+      tags:
+        - Acknowledgement
+      summary: 'List all services acknowledgements'
+      description: |
+        List all service acknowledgements.
+
+        **Minimum API version:** 21.10
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * author_id
+        * comment
+        * entry_time
+        * deletion_time
+        * host_id
+        * service_id
+        * service.display_name
+        * is_notify_contacts
+        * is_persistent_comment
+        * is_sticky
+        * poller_id
+        * state
+        * type
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Acknowledgement
+      summary: 'Add an acknowledgement on multiple services'
+      description: |
+        Add an acknowledgement on multiple services at once.
+
+        **Minimum API version:** 21.10
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Services.Add'
+      responses:
+        '204':
+          description: 'Commands Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/acknowledgements':
+    get:
+      tags:
+        - Acknowledgement
+      summary: 'List all acknowledgements of a host'
+      description: |
+        List all acknowledgements for a specific host.
+
+        **Minimum API version:** 21.10
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * author_id
+        * comment
+        * entry_time
+        * deletion_time
+        * host_id
+        * is_notify_contacts
+        * is_persistent_comment
+        * is_sticky
+        * poller_id
+        * state
+        * type
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Acknowledgement
+      summary: 'Add an acknowledgement on chosen host'
+      description: |
+        Add an acknowledgement on a specific host.
+
+        **Minimum API version:** 21.10
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Host.Add'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Acknowledgement
+      summary: 'Cancel an acknowledgement on a host'
+      description: |
+        Remove/cancel the current acknowledgement on a host.
+
+        **Minimum API version:** 21.10
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/acknowledgements':
+    get:
+      tags:
+        - Acknowledgement
+      summary: 'List all acknowledgements of a service'
+      description: |
+        List all acknowledgements for a specific service.
+
+        **Minimum API version:** 21.10
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * author_id
+        * comment
+        * entry_time
+        * deletion_time
+        * host_id
+        * service_id
+        * service.display_name
+        * is_notify_contacts
+        * is_persistent_comment
+        * is_sticky
+        * poller_id
+        * state
+        * type
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Acknowledgement
+      summary: 'Add an acknowledgement on chosen service'
+      description: |
+        Add an acknowledgement on a specific service.
+
+        **Minimum API version:** 21.10
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Service.Add'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Acknowledgement
+      summary: 'Cancel an acknowledgement on a service'
+      description: |
+        Remove/cancel the current acknowledgement on a service.
+
+        **Minimum API version:** 21.10
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/metaservices/{meta_id}/acknowledgements':
+    get:
+      tags:
+        - Acknowledgement
+        - 'Meta service'
+      summary: 'List all acknowledgements of a metaservice'
+      description: |
+        List all acknowledgements for a specific metaservice.
+
+        **Minimum API version:** 21.10
+
+        The available parameters to **search** / **sort_by** are:
+        * id
+        * author_id
+        * comment
+        * entry_time
+        * deletion_time
+        * host_id
+        * service_id
+        * service.display_name
+        * is_notify_contacts
+        * is_persistent_comment
+        * is_sticky
+        * poller_id
+        * state
+        * type
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/MetaId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Acknowledgement
+        - 'Meta service'
+      summary: 'Add an acknowledgement on chosen metaservice'
+      description: |
+        Add an acknowledgement on a specific metaservice.
+
+        **Minimum API version:** 21.10
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Service.Add'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Acknowledgement
+        - 'Meta service'
+      summary: 'Cancel an acknowledgement on a metaservice'
+      description: |
+        Remove/cancel the current acknowledgement on a metaservice.
+
+        **Minimum API version:** 21.10
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/downtimes:
+    get:
+      tags:
+        - Downtime
+      summary: 'List all downtimes'
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      description: |
+        List all downtimes
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * entry_time
+          * is_cancelled
+          * comment
+          * deletion_time
+          * duration
+          * end_time
+          * is_fixed
+          * start_time
+          * host.id
+          * host.name
+          * host.alias
+          * host.address
+          * host.display_name
+          * host.state
+          * poller.id
+          * contact.id
+          * contact.name
+          * service.id
+          * service.display_name
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/downtimes/{downtime_id}':
+    get:
+      tags:
+        - Downtime
+      summary: 'Display one downtime'
+      description: 'Display one downtime.'
+      parameters:
+        - $ref: '#/components/parameters/DowntimeId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Downtime.Service'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Downtime
+      summary: 'Cancel a downtime'
+      description: 'Cancel a downtime.'
+      parameters:
+        - $ref: '#/components/parameters/DowntimeId'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hosts/downtimes:
+    get:
+      tags:
+        - Downtime
+      summary: 'List all hosts downtimes'
+      description: |
+        List all downtimes of hosts
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * entry_time
+        * is_cancelled
+        * comment
+        * deletion_time
+        * duration
+        * end_time
+        * is_fixed
+        * start_time
+        * contact.id
+        * contact.name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Host' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Downtime
+      summary: 'Add a downtime on multiple hosts'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Downtime.Hosts.Add'
+      responses:
+        '204':
+          description: 'Commands Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/services/downtimes:
+    get:
+      tags:
+        - Downtime
+      summary: 'List all services downtimes'
+      description: |
+        List all downtimes of services
+
+        The available parameters to **search** / **sort_by** are:
+
+        * id
+        * entry_time
+        * is_cancelled
+        * comment
+        * deletion_time
+        * duration
+        * end_time
+        * is_fixed
+        * start_time
+        * host.id
+        * host.name
+        * host.alias
+        * host.address
+        * host.display_name
+        * host.state
+        * poller.id
+        * contact.id
+        * contact.name
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Downtime
+      summary: 'Add a downtime on multiple services'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Downtime.Services.Add'
+      responses:
+        '204':
+          description: 'Commands Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/downtimes':
+    get:
+      tags:
+        - Downtime
+      summary: 'List all downtimes of a host'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      description: |
+        List all downtimes of a host.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * entry_time
+          * is_cancelled
+          * comment
+          * deletion_time
+          * duration
+          * end_time
+          * is_fixed
+          * start_time
+          * contact.id
+          * contact.name
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Host' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Downtime
+      summary: 'Add a downtime on a host'
+      description: 'Add a downtime on a host.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Downtime.Host.Add'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/downtimes':
+    get:
+      tags:
+        - Downtime
+      summary: 'List all downtimes of a service'
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      description: |
+        List all downtimes of a service.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * entry_time
+          * is_cancelled
+          * comment
+          * deletion_time
+          * duration
+          * end_time
+          * is_fixed
+          * start_time
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Downtime
+      summary: 'Add a downtime on a service'
+      description: 'Add a downtime on a service.'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Downtime.Service.Add'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/metaservices/{meta_id}/downtimes':
+    get:
+      tags:
+        - Downtime
+        - 'Meta service'
+      summary: 'List all downtimes of a metaservice'
+      parameters:
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/MetaId'
+      description: |
+        List all downtimes of a metaservice.
+
+        The available parameters to **search** / **sort_by** are:
+
+          * id
+          * entry_time
+          * is_cancelled
+          * comment
+          * deletion_time
+          * duration
+          * end_time
+          * is_fixed
+          * start_time
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Downtime
+        - 'Meta service'
+      summary: 'Add a downtime on a metaservice'
+      description: 'Add a downtime on a metaservice.'
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Downtime.Service.Add'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/hosts/check:
+    post:
+      tags:
+        - Check
+      summary: 'Check multiple hosts'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Check.Hosts'
+      responses:
+        '204':
+          description: 'Commands Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/services/check:
+    post:
+      tags:
+        - Check
+      summary: 'Check multiple services'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Check.Services'
+      responses:
+        '204':
+          description: 'Commands Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/check':
+    post:
+      tags:
+        - Check
+      summary: 'Check host'
+      description: 'Schedule immediate check on chosen host'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Check.Host'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Host not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/check':
+    post:
+      tags:
+        - Check
+      summary: 'Check service'
+      description: 'Schedule immediate check on chosen service'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Check.Service'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/metaservices/{meta_id}/check':
+    post:
+      tags:
+        - Check
+        - 'Meta service'
+      summary: 'Check metaservice'
+      description: 'Schedule immediate check on chosen metaservice'
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Check.Service'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources/check:
+    post:
+      tags:
+        - Check
+      summary: 'Check resources'
+      description: 'Schedule immediate check on chosen resources'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Check.Resources'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/submit':
+    post:
+      tags:
+        - Submit
+      summary: 'Submit a result to a single host'
+      description: 'Submit a result (check status, output and perfdata) to a single host'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitResult.Host'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Host not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/submit':
+    post:
+      tags:
+        - Submit
+      summary: 'Submit a result to a single service'
+      description: 'Submit a result (check status, output and perfdata) to a single service'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitResult.Service'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/metaservices/{meta_id}/submit':
+    post:
+      tags:
+        - Submit
+        - 'Meta service'
+      summary: 'Submit a result to a single metaservice'
+      description: 'Submit a result (check status, output and perfdata) to a single metaservice'
+      parameters:
+        - $ref: '#/components/parameters/MetaId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitResult.Service'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources/submit:
+    post:
+      tags:
+        - Submit
+      summary: 'Submit result to resources'
+      description: 'Submit a result (check status, output and perfdata) to resources'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitResult.Resources'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources/comments:
+    post:
+      tags:
+        - Comment
+      summary: 'Add comment to resources'
+      description: 'Add at least one comment to a single or to multiple resources'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Comment.Resources'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: 'Host or service not found'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/metrics':
+    $ref: ./latest/onPremise/Realtime/Metrics/FindMetricsByService.yaml
+  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/start/{start}/end/{end}':
+    get:
+      tags:
+        - Metrics
+      summary: 'Get service metrics'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/MetricStartDate'
+        - $ref: '#/components/parameters/MetricEndDate'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  global: { type: object, properties: { title: { type: string, description: 'title of the graph', example: 'graph title' }, start: { type: integer, description: 'timestamp of the start interval', example: 1594504800 }, end: { type: integer, description: 'timestamp of the end interval', example: 1594591200 }, vertical-label: { type: string, description: 'vertical label (should not be used cause multiple y-axis possible)', example: Value }, base: { type: string, description: 'base scale', example: '1024' }, width: { type: string, description: 'width of the graph (should not be used)', example: '550' }, height: { type: string, description: 'height of the graph (should not be used)', example: '140' }, lower-limit: { type: string, description: 'lower value of the graph', example: '0' }, scaled: { type: integer, description: 'if the graph needs to be automatically scaled', example: 1 }, multiple_services: { type: boolean, description: 'if multiple services are selected (always false)', example: false } } }
+                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, last_value: { type: number, nullable: true, description: 'last value', example: 5.0 }, minimum_value: { type: number, nullable: true, description: 'minimum value', example: 0.0 }, maximum_value: { type: number, nullable: true, description: 'maximum value', example: 10.0 }, average_value: { type: number, nullable: true, description: 'average value', example: 5.64 } } } }
+                  times: { type: array, items: { type: string, format: timestamp, description: 'timestamp of the tick' }, example: ['1594505100', '1594505400', '1594505700'] }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundHostOrService'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/status/start/{start}/end/{end}':
+    get:
+      tags:
+        - Metrics
+      summary: 'Get service status data'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/MetricStartDate'
+        - $ref: '#/components/parameters/MetricEndDate'
+      description: 'Get status data from a service between given interval'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  critical: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+                  warning: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+                  ok: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+                  unknown: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundHostOrService'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance':
+    get:
+      tags:
+        - Metrics
+      summary: 'Get service performance data'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        -
+          in: query
+          name: start
+          required: false
+          description: 'Start date of metrics (default date is 24 hours in the past)'
+          schema:
+            type: string
+            format: date-time
+            example: '2020-02-18T00:00:00'
+        -
+          in: query
+          name: end
+          required: false
+          description: 'End date of metrics (default date is current date)'
+          schema:
+            type: string
+            format: date-time
+            example: '2020-02-19T00:00:00'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  base: { type: string, description: 'base scale', example: 1024 }
+                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, format: float, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, minimum_value: { type: number, format: float, description: 'minimum value', example: 1.0 }, maximum_value: { type: number, format: float, description: 'maximum value', example: 1.0 } } } }
+                  times: { type: array, items: { type: string, format: timestamp, description: 'datetime of the tick' }, example: ['1690965300'] }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundHostOrService'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance/download':
+    get:
+      tags:
+        - Metrics
+      summary: 'Download performance data as csv file'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        -
+          in: query
+          name: start_date
+          required: true
+          description: 'Start date of metrics (date format should be in ISO 8601)'
+          schema:
+            type: string
+            format: date-time
+            example: '2022-01-01T00:00:22Z'
+        -
+          in: query
+          name: end
+          required: true
+          description: 'End date of metrics (date format should be in ISO 8601)'
+          schema:
+            type: string
+            format: date-time
+            example: '2023-01-01T00:00:00Z'
+      responses:
+        '200':
+          description: 'A CSV file containg performance data'
+          content:
+            application/force-download:
+              schema:
+                type: string
+                format: string
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/status':
+    get:
+      tags:
+        - Metrics
+      summary: 'Get service status data'
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        -
+          in: query
+          name: start
+          required: false
+          description: 'Start date of metrics (default date is 24 hours in the past)'
+          schema:
+            type: string
+            format: date-time
+            example: '2020-02-18T00:00:00'
+        -
+          in: query
+          name: end
+          required: false
+          description: 'End date of metrics (default date is current date)'
+          schema:
+            type: string
+            format: date-time
+            example: '2020-02-19T00:00:00'
+      description: 'Get status data from a service between given interval'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  critical: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+                  warning: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+                  ok: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+                  unknown: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundHostOrService'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/timeline':
+    get:
+      tags:
+        - Timeline
+      summary: 'Get host timeline'
+      description: |
+        List all events for a given host
+
+        The available parameters to **search** / **sort_by** are:
+
+        * type
+        * content
+        * date
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.TimelineEvent' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/timeline':
+    get:
+      tags:
+        - Timeline
+      summary: 'Get service timeline'
+      description: |
+        List all events for a given service
+
+        The available parameters to **search** / **sort_by** are:
+
+        * type
+        * content
+        * date
+      parameters:
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.TimelineEvent' } }
+                  meta: { $ref: '#/components/schemas/Meta' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/{metricName}':
+    $ref: ./latest/onPremise/Realtime/Metrics/FindSingleMetric.yaml
+  '/monitoring/metaService/{metaServiceId}/metrics/{metricName}':
+    $ref: ./latest/onPremise/Realtime/Metrics/FindSingleMetaMetric.yaml
+  /api/latest/monitoring/resources/acknowledge:
+    post:
+      tags:
+        - Acknowledgement
+      summary: 'Acknowledge multiple resources'
+      description: |
+        Add acknowledgements on multiple resources (hosts and/or services) at once.
+
+        **Minimum API version:** 21.10
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Acknowledgement.Bulk'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/monitoring/resources/downtime:
+    post:
+      tags:
+        - Downtime
+      summary: 'Set downtime for multiple resources'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Downtime.Bulk'
+      responses:
+        '204':
+          description: 'Command Sent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/platform:
+    patch:
+      tags:
+        - Platform
+      summary: 'Update a platform information'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Platform.Full'
+      responses:
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '204':
+          description: 'Platform updated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/platform/features:
+    $ref: ./latest/onPremise/Platform/Features.yaml
+  /api/latest/platform/versions:
+    $ref: ./latest/onPremise/Platform/Versions.yaml
+  /api/latest/platform/installation/status:
+    get:
+      tags:
+        - Platform
+      summary: 'Get centreon web versions'
+      description: 'Get installation status and available versions of centreon web'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - is_installed
+                  - has_upgrade_available
+                properties:
+                  is_installed: { type: boolean, description: 'Installation status of centreon web', example: true }
+                  has_upgrade_available: { type: boolean, description: "upgrade available or not\n", example: true }
+        '500':
+          description: 'centreon is not properly installed'
+  /api/latest/platform/topology:
+    post:
+      tags:
+        - Topology
+      summary: 'Register to platform topology'
+      description: 'Register a server to the platform topology'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Topology.Register'
+      responses:
+        '201':
+          description: OK
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      tags:
+        - Topology
+      summary: 'Get a platform topology'
+      description: 'Get a platform topology in Json Graph Format'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - graph
+                  - nodes
+                  - edges
+                properties:
+                  graph: { type: object, description: 'General informations about schema', properties: { label: { type: string, description: 'type of Json Graph', example: centreon-topology }, metadata: { type: object, properties: { version: { type: string, description: 'Version of the topology', example: 1.0.0 } } }, nodes: { type: object, minItems: 1, properties: { id: { properties: { type: { type: string, description: 'Server Type of a platform', example: central }, label: { type: string, description: 'logical name of a platform', example: Central }, metadata: { type: object, properties: { centreon-id: { type: string, description: 'id of a platform as known in centreon database', example: '1' }, hostname: { type: string, description: 'physical name of a platform', example: localhost.localdomain }, address: { type: string, description: 'address of a platform', example: 192.168.0.1 } } } } } } }, edges: { type: array, minItems: 0, items: { type: object, properties: { source: { type: string, description: 'children platform id as known in the topology', example: '91' }, relation: { type: string, description: 'broker communication type', example: peer_retention }, target: { type: string, description: 'parent platform id as known in the topology', example: '1' } } } } } }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/platform/topology/{poller_id}':
+    delete:
+      tags:
+        - Topology
+      parameters:
+        - $ref: '#/components/parameters/PollerId'
+      summary: 'Delete a Platform'
+      description: 'Delete a platform from the topology'
+      responses:
+        '204':
+          description: 'Platform deleted'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/gorgone/pollers/{poller_id}/responses/{token}':
+    get:
+      tags:
+        - Gorgone
+      parameters:
+        - $ref: '#/components/parameters/PollerId'
+        - $ref: '#/components/parameters/GorgoneToken'
+      summary: 'Gorgone poller responses token'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Gorgone.Response'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/gorgone/pollers/{poller_id}/commands/{command_name}':
+    post:
+      tags:
+        - Gorgone
+      parameters:
+        - $ref: '#/components/parameters/PollerId'
+        - $ref: '#/components/parameters/CommandName'
+      summary: 'Gorgone command on specific poller'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token: { type: string, description: 'Token used to retrieve the data linked to the command' }
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/administration/authentication/providers/local:
+    get:
+      tags:
+        - Administration
+      summary: 'get local provider configuration with password security policy'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationLocalProvider'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - Administration
+      summary: 'update local provider configuration'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationLocalProvider'
+      responses:
+        '204':
+          description: OK
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/administration/authentication/providers/openid:
+    $ref: ./latest/onPremise/Administration/Authentication/OpenIdProvider/OpenIdProvider.yaml
+  /api/latest/administration/authentication/providers/saml:
+    get:
+      tags:
+        - Administration
+      summary: 'Get SAML provider configuration'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadAuthenticationSAMLProvider'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - Administration
+      summary: 'Update SAML provider configuration'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WriteAuthenticationSAMLProvider'
+      responses:
+        '204':
+          description: 'Configuration updated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/administration/authentication/providers/web-sso:
+    get:
+      tags:
+        - Administration
+      summary: 'get web-sso provider configuration information'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationWebSSOProvider'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags:
+        - Administration
+      summary: 'update web-sso provider configuration'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationWebSSOProvider'
+      responses:
+        '204':
+          description: 'Configuration updated'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/administration/tokens:
+    $ref: ./latest/onPremise/Administration/Token/AddTokenAndFindTokens.yaml
+  '/administration/tokens/{token_name}':
+    $ref: ./latest/onPremise/Administration/Token/GetAndDeleteToken.yaml
+  '/administration/tokens/{token_name}/users/{user_id}':
+    $ref: ./latest/onPremise/Administration/Token/GetAndPartialUpdateAndDeleteTokenByUser.yaml
+  /api/latest/administration/parameters:
+    post:
+      tags:
+        - Administration
+      summary: 'Administration parameters'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  monitoring_default_downtime_duration: { type: integer, description: 'Default downtime duration', example: 3600 }
+                  monitoring_default_refresh_interval: { type: integer, description: 'Default monitoring refresh interval', example: 15 }
+                  monitoring_default_acknowledgement_persistent: { type: boolean, description: 'Default monitoring acknowledgement persistent option', example: true }
+                  monitoring_default_acknowledgement_sticky: { type: boolean, description: 'Default monitoring acknowledgement sticky option', example: true }
+                  monitoring_default_acknowledgement_notify: { type: boolean, description: 'Default monitoring acknowledgement notify option', example: true }
+                  monitoring_default_acknowledgement_force_active_checks: { type: boolean, description: 'Default monitoring acknowledgement force active checks option', example: true }
+                  monitoring_default_acknowledgement_with_services: { type: boolean, description: 'Default monitoring acknowledgement with services option', example: true }
+                  monitoring_default_downtime_fixed: { type: boolean, description: 'Default monitoring downtime fixed option', example: true }
+                  monitoring_default_downtime_with_services: { type: boolean, description: 'Default set downtimes on services attached to hosts option', example: true }
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /api/latest/administration/vaults/configurations:
+    $ref: ./latest/onPremise/Administration/Vault/VaultConfiguration.yaml
+  /api/configuration/commands:
     get:
       operationId: api_configurationcommands_get_collection
       tags:
@@ -423,7 +3953,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateCommandResource'
-          links: {  }
+          links: {}
         '400':
           description: 'Invalid input'
           content:
@@ -436,7 +3966,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
         '422':
           description: 'An error occurred'
           content:
@@ -449,7 +3979,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
+          links: {}
       summary: 'Creates a Command resource.'
       description: 'Creates a Command resource.'
       parameters: []
@@ -463,11 +3993,192 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateCommandResource'
         required: true
-  /configuration/graphs/templates:
-    $ref: ./latest/onPremise/Configuration/GraphTemplate/FindGraphTemplates.yaml
-  /configuration/connectors:
-    summary: Connectors
-    description: 'Endpoints to manage connectors'
+  /api/configuration/commands/_duplicate:
+    post:
+      operationId: api_configurationcommands_duplicate_post
+      tags:
+        - Command
+      responses:
+        '200':
+          description: 'A collection holding the duplication outcome for each requested command'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                properties:
+                  '@context': { type: string }
+                  '@id': { type: string }
+                  '@type': { type: string, example: Collection }
+                  totalItems: { type: integer }
+                  member: { type: array, items: { type: object, properties: { '@id': { type: string }, '@type': { type: string, example: DuplicateCommandResource }, command: { type: string, description: 'IRI of the duplicated command (absent when the duplication failed)' }, status: { type: integer }, message: { type: string } }, required: ['@id', '@type', status, message] } }
+              example:
+                '@context': /centreon/api/latest/contexts/Command
+                '@id': /centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8
+                '@type': Collection
+                totalItems: 2
+                member:
+                  - { '@id': /centreon/api/latest/.well-known/genid/c2afa2366f6f99491863, '@type': DuplicateCommandResource, command: /centreon/api/latest/configuration/commands/98, status: 204, message: 'Command duplicated successfully' }
+                  - { '@id': /centreon/api/latest/.well-known/genid/3fa305a034165257c384, '@type': DuplicateCommandResource, status: 404, message: 'Command with ID 99999 not found' }
+          links: {}
+        '400':
+          description: 'Invalid input — the request body failed validation'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code: { type: integer, example: 400 }
+                  message: { type: string, description: 'One line per violation, formatted as "[propertyPath] message"', example: "[ids] IDs array cannot be empty\n" }
+                required:
+                  - code
+                  - message
+        '403':
+          description: 'You are not allowed to duplicate commands'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code: { type: integer, example: 0 }
+                  message: { type: string, example: 'You are not allowed to duplicate commands' }
+                required:
+                  - code
+                  - message
+      summary: 'Duplicate a Command resource'
+      description: 'Duplicate a Command resource'
+      parameters: []
+      requestBody:
+        description: 'The new Command resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
+        required: true
+  '/api/configuration/commands/{id}':
+    get:
+      operationId: api_configurationcommands_id_get
+      tags:
+        - Command
+      responses:
+        '404':
+          description: 'Command resource not found'
+        '403':
+          description: 'You are not allowed to access this command'
+        '200':
+          description: 'Command resource'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Command.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Command'
+      summary: 'Retrieves a Command resource.'
+      description: 'Retrieves a Command resource.'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Command identifier'
+          required: true
+          deprecated: false
+          schema:
+            type: string
+          style: simple
+          explode: false
+    delete:
+      operationId: api_configurationcommands_id_delete
+      tags:
+        - Command
+      responses:
+        '404':
+          description: 'Command resource not found'
+        '403':
+          description: 'You are not allowed to delete this command'
+        '204':
+          description: 'Command resource deleted'
+      summary: 'Removes the Command resource.'
+      description: 'Removes the Command resource.'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Command identifier'
+          required: true
+          deprecated: false
+          schema:
+            type: string
+          style: simple
+          explode: false
+    patch:
+      operationId: api_configurationcommands_id_patch
+      tags:
+        - Command
+      responses:
+        '404':
+          description: 'Command resource not found'
+        '403':
+          description: 'You are not allowed to update this command'
+        '200':
+          description: 'Command resource updated'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Command.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Command'
+          links: {}
+        '400':
+          description: 'Invalid input'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+        '422':
+          description: 'An error occurred'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+          links: {}
+      summary: 'Updates the Command resource.'
+      description: 'Updates the Command resource.'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Command identifier'
+          required: true
+          deprecated: false
+          schema:
+            type: string
+          style: simple
+          explode: false
+      requestBody:
+        description: 'The updated Command resource'
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/Command.jsonMergePatch'
+        required: true
+  /api/configuration/connectors:
     get:
       operationId: api_configurationconnectors_get_collection
       tags:
@@ -500,7 +4211,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
       summary: 'Retrieves the collection of Connector resources.'
       description: 'Retrieves the collection of Connector resources.'
       parameters:
@@ -576,232 +4287,21 @@ paths:
             maximum: 30
           style: form
           explode: true
-  '/configuration/hosts/{host_id}':
-    $ref: ./latest/onPremise/Configuration/Host/GetAndDeleteAndPartialUpdateHost.yaml
-  /configuration/hosts/templates:
-    $ref: ./latest/onPremise/Configuration/HostTemplate/AddAndFindHostTemplates.yaml
-  '/configuration/hosts/templates/{host_template_id}':
-    $ref: ./latest/onPremise/Configuration/HostTemplate/DeleteAndPartialUpdateHostTemplate.yaml
-  /configuration/hosts:
-    $ref: ./latest/onPremise/Configuration/Host/AddAndFindHosts.yaml
-  /configuration/hosts/categories:
+  '/api/configuration/connectors/{id}':
     get:
-      operationId: FindHostCategories
+      operationId: api_configurationconnectors_id_get
       tags:
-        - 'Host category'
-      summary: 'List host categories'
-      description: |
-        List of host category configurations
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * name
-        * alias
-        * is_activated
-        * hostgroup.name
-        * hostgroup.id
+        - Connector
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.Host.Category' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      operationId: AddHostCategory
-      tags:
-        - 'Host category'
-      summary: 'Create a host category'
-      description: |
-        Create a host category
-
-        This endpoint does NOT update the ACL rights with the new host category
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Configuration.Host.Category.Add'
-      responses:
-        '201':
-          description: OK
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/categories/{host_category_id}':
-    get:
-      operationId: FindHostCategory
-      tags:
-        - 'Host category'
-      summary: 'Get a host category'
-      description: |
-        Get a host category configuration
-      parameters:
-        -
-          $ref: '#/components/parameters/HostCategoryId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Configuration.Host.Category'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      operationId: UpdateHostCategory
-      tags:
-        - 'Host category'
-      summary: 'Update a host category'
-      description: |
-        Update a host category
-      parameters:
-        -
-          $ref: '#/components/parameters/HostCategoryId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Configuration.Host.Category.Add'
-      responses:
-        '204':
-          description: OK
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    delete:
-      operationId: DeleteHostCategory
-      tags:
-        - 'Host category'
-      summary: 'Delete a host category'
-      description: |
-        Delete a host category configuration
-      parameters:
-        -
-          $ref: '#/components/parameters/HostCategoryId'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/{host_id}/services/deploy':
-    $ref: ./latest/onPremise/Configuration/Service/DeployServices.yaml
-  /configuration/services/categories:
-    get:
-      tags:
-        - 'Service category'
-      summary: 'List all service categories'
-      description: |
-        Return all service category configurations.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * alias
-        * is_activated
-        * host.id
-        * host.name
-        * hostgroup.id
-        * hostgroup.name
-        * hostcategory.id
-        * hostcategory.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/ServiceCategory' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      operationId: api_configurationservicescategories_post
-      tags:
-        - 'Service Category'
-      responses:
-        '409':
-          description: 'ServiceCategory resource already exists'
-        '201':
-          description: 'ServiceCategory resource created'
+          description: 'Connector resource'
           content:
             application/ld+json:
               schema:
-                $ref: '#/components/schemas/ServiceCategory.jsonld'
+                $ref: '#/components/schemas/Connector.jsonld'
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceCategory'
-          links: {  }
-        '400':
-          description: 'Invalid input'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
+                $ref: '#/components/schemas/Connector'
         '403':
           description: Forbidden
           content:
@@ -814,3455 +4314,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Creates a ServiceCategory resource.'
-      description: 'Creates a ServiceCategory resource.'
-      parameters: []
-      requestBody:
-        description: 'The new ServiceCategory resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/ServiceCategory'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ServiceCategory'
-        required: true
-  '/configuration/services/categories/{service_category_id}':
-    delete:
-      operationId: DeleteServiceCategory
-      tags:
-        - 'Service category'
-      summary: 'Delete a service category'
-      description: |
-        Delete a service category configuration
-      parameters:
-        -
-          $ref: '#/components/parameters/ServiceCategoryId'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
+          links: {}
         '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/services/templates:
-    $ref: ./latest/onPremise/Configuration/ServiceTemplate/AddOneAndFindServiceTemplates.yaml
-  '/configuration/services/templates/{service_template_id}':
-    $ref: ./latest/onPremise/Configuration/ServiceTemplate/PartialUpdateAndDeleteServiceTemplate.yaml
-  '/configuration/services/{service_id}':
-    $ref: ./latest/onPremise/Configuration/Service/PartialUpdateAndDeleteService.yaml
-  /configuration/services:
-    $ref: ./latest/onPremise/Configuration/Service/AddServiceAndFindServices.yaml
-  /configuration/services/_delete:
-    $ref: ./latest/onPremise/Configuration/Service/DeleteServices.yaml
-  /monitoring/services/categories:
-    get:
-      operationId: FindRealTimeServiceCategories
-      tags:
-        - 'Service category'
-      summary: 'List all real-time service categories'
-      description: |
-        List of all service categories in real-time context
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * host.id
-        * host.name
-        * host_group.id
-        * host_group.name
-        * host_category.id
-        * host_category.name
-        * service_group.id
-        * service_group.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.Category' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/hosts/severities:
-    get:
-      operationId: FindHostSeverities
-      tags:
-        - 'Host severity'
-      summary: 'List all host severities'
-      description: |
-        List of all host severity configurations
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * alias
-        * level
-        * is_activated
-
-        Changes in 23.04 :
-
-        * `icon` was renamed `icon_id` and is no longer an object but the image ID
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.Host.Severity' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      operationId: AddHostSeverity
-      tags:
-        - 'Host severity'
-      summary: 'Create a host severity'
-      description: |
-        Create a host severity
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              properties:
-                name:
-                  type: string
-                  example: host-severity-name
-                alias:
-                  type: string
-                  example: host-severity-alias
-                level:
-                  type: integer
-                  example: 2
-                icon_id:
-                  type: integer
-                  example: 1
-      responses:
-        '201':
-          description: OK
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/severities/{host_severity_id}':
-    delete:
-      operationId: DeleteHostSeverity
-      tags:
-        - 'Host severity'
-      summary: 'Delete a host severity'
-      description: |
-        Delete a host severity configuration
-      parameters:
-        -
-          $ref: '#/components/parameters/HostSeverityId'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    get:
-      operationId: FindHostSeverity
-      tags:
-        - 'Host severity'
-      summary: 'Get a host severity'
-      description: |
-        Get a host severity configuration
-      parameters:
-        -
-          $ref: '#/components/parameters/HostSeverityId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Configuration.Host.Severity'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      operationId: UpdateHostSeverity
-      tags:
-        - 'Host severity'
-      summary: 'Update a host severity'
-      description: |
-        Update a host severity
-      parameters:
-        -
-          $ref: '#/components/parameters/HostSeverityId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Configuration.Host.Severity.Add'
-      responses:
-        '204':
-          description: OK
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/hosts/groups:
-    $ref: ./latest/onPremise/Configuration/HostGroup/AddAndFindHostGroups.yaml
-  '/configuration/hosts/groups/{hostgroup_id}':
-    $ref: ./latest/onPremise/Configuration/HostGroup/GetAndDeleteAndUpdateHostGroup.yaml
-  /configuration/hosts/groups/_delete:
-    $ref: ./latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
-  /configuration/hosts/groups/_enable:
-    $ref: ./latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
-  /configuration/hosts/groups/_disable:
-    $ref: ./latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
-  /configuration/hosts/groups/_duplicate:
-    $ref: ./latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
-  /configuration/services/groups:
-    get:
-      operationId: FindServiceGroups
-      tags:
-        - 'Service group'
-      summary: 'List all service groups'
-      description: |
-        Return all service group configurations.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * alias
-        * is_activated
-        * host.id
-        * host.name
-        * hostgroup.id
-        * hostgroup.name
-        * hostcategory.id
-        * hostcategory.name
-        * servicecategory.id
-        * servicecategory.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.Service.Group' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      operationId: AddServiceGroup
-      tags:
-        - 'Service group'
-      summary: 'Add a service group'
-      description: |
-        Add a new service group configuration.
-
-        Mandatory body properties are:
-
-        * name
-        * alias
-
-        `Since Centreon web 23.04`
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Configuration.Service.Group.Add'
-      responses:
-        '201':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Configuration.Service.Group'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/services/groups/{servicegroup_id}':
-    delete:
-      operationId: DeleteServiceGroup
-      tags:
-        - 'Service group'
-      summary: 'Delete a service group'
-      description: |
-        `internal`
-
-        `Since Centreon web 23.04`
-
-        Delete service group.
-      parameters:
-        -
-          $ref: '#/components/parameters/ServiceGroupId'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/services/severities:
-    $ref: ./latest/onPremise/Configuration/ServiceSeverity/AddAndFindServiceSeverities.yaml
-  '/configuration/services/severities/{service_severity_id}':
-    $ref: ./latest/onPremise/Configuration/ServiceSeverity/DeleteAndUpdateServiceSeverity.yaml
-  /configuration/icons:
-    get:
-      operationId: centreon_application_configuration_icon_getIcons
-      tags:
-        - Icons
-      summary: 'List all icons'
-      description: |
-        List all icons from centreon configuration.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * name
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { type: object, properties: { id: { type: integer, description: 'id of the icon', example: 1 }, directory: { type: string, description: 'directory of the icon', example: ppm }, name: { type: string, description: 'name of the icon', example: operatingsystems-linux-snmp-linux-128.png }, url: { type: string, description: 'url to get the icon', example: /centreon/img/media/ppm/operatingsystems-linux-snmp-linux-128.png } } } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/medias:
-    $ref: ./latest/onPremise/Configuration/Media/AddAndFindMedia.yaml
-  /configuration/media/folders:
-    $ref: ./latest/onPremise/Configuration/Media/FindImageFolders.yaml
-  '/configuration/medias/{media_id}/content':
-    $ref: ./latest/onPremise/Configuration/Media/UpdateMedia.yaml
-  /configuration/proxy:
-    get:
-      operationId: configuration.proxy.getProxy
-      tags:
-        - Proxy
-      summary: 'Display the default configuration of the Centreon proxy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Configuration.Proxy'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      operationId: configuration.proxy.updateProxy
-      tags:
-        - Proxy
-      summary: 'Update the default configuration of the Centreon proxy'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Configuration.Proxy'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers:
-    get:
-      operationId: configuration.monitoring-servers.findServer
-      tags:
-        - 'Monitoring server'
-      summary: 'List all monitoring servers configurations'
-      description: |
-        List all monitoring servers configurations.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * name
-          * is_localhost
-          * address
-          * is_activate
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.MonitoringServerMain' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/monitoring-servers/{monitoring_server_id}/generate':
-    get:
-      operationId: configuration_monitoring_server_generate
-      tags:
-        - 'Monitoring server'
-      summary: 'Generate the configuration of the monitoring server'
-      description: |
-        Generate and move the configuration files of the monitoring server
-      parameters:
-        -
-          $ref: '#/components/parameters/MonitoringServerId'
-      responses:
-        '204':
-          description: 'Generation OK'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/monitoring-servers/{monitoring_server_id}/reload':
-    get:
-      operationId: configuration_monitoring_server_reload
-      tags:
-        - 'Monitoring server'
-      summary: 'Reload the configuration of the monitoring server'
-      description: |
-        Reload the configuration files of the monitoring server
-      parameters:
-        -
-          $ref: '#/components/parameters/MonitoringServerId'
-      responses:
-        '204':
-          description: 'Reload OK'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/monitoring-servers/{monitoring_server_id}/generate-and-reload':
-    get:
-      operationId: configuration_monitoring_server_generate_and_reload
-      tags:
-        - 'Monitoring server'
-      summary: 'Generate and reload the configuration of the monitoring server'
-      description: |
-        Generate, move and reload the configuration files of the monitoring server
-      parameters:
-        -
-          $ref: '#/components/parameters/MonitoringServerId'
-      responses:
-        '204':
-          description: 'Generation and reload OK'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers/generate:
-    get:
-      operationId: configuration_monitoring_server_generate_all
-      tags:
-        - 'Monitoring server'
-      summary: 'Generate the configuration for all monitoring servers'
-      description: |
-        Generate and move the configuration files for all monitoring servers.
-
-        The process will stop at the first error.
-      responses:
-        '204':
-          description: 'Generation OK'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers/reload:
-    get:
-      operationId: configuration_monitoring_server_reload_all
-      tags:
-        - 'Monitoring server'
-      summary: 'Reload the configuration for all monitoring servers'
-      description: |
-        Reload the configuration files for all monitoring servers.
-
-        The process will stop at the first error.
-      responses:
-        '204':
-          description: 'Reload OK'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers/generate-and-reload:
-    get:
-      operationId: configuration_monitoring_server_generate_and_reload_all
-      tags:
-        - 'Monitoring server'
-      summary: 'Generate and reload the configuration for all monitoring servers'
-      description: |
-        Generate, move and reload the configuration files for all monitoring servers.
-
-        The process will stop at the first error.
-      responses:
-        '204':
-          description: 'Generation and reload OK'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/metaservices:
-    get:
-      operationId: centreon_application_find_meta_services_configurations
-      tags:
-        - 'Meta service'
-      summary: 'List all meta services configurations'
-      description: |
-        List all meta services configurations.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * name
-          * is_activate
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.MetaServices' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/metaservices/{meta_id}':
-    get:
-      operationId: centreon_application_find_meta_service_configuration
-      tags:
-        - 'Meta service'
-      summary: 'Get a meta service'
-      description: 'Get a meta service configuration by its id'
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Configuration.MetaServices'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/metrics':
-    get:
-      operationId: centreon_application_find_meta_service_metrics
-      tags:
-        - 'Meta service'
-      summary: 'List all meta service metrics'
-      description: |
-        List all meta services metrics from realtime.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * name
-          * service_description
-          * host_name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/MetaId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.MetaServiceMetric' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/{host_id}/notification-policy':
-    get:
-      operationId: configuration.host.notification-policy
-      tags:
-        - 'Notification Policy'
-      summary: 'Get notification policy of a host'
-      description: 'Return the notified contacts and contact groups of a host.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      responses:
-        '200':
-          description: 'Successful request'
-          content:
-            application/json:
-              schema:
-                $ref: ./latest/onPremise/Configuration/NotificationPolicy/Schema/NotificationPolicy.yaml
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/{host_id}/services/{service_id}/notification-policy':
-    get:
-      operationId: configuration.service.notification-policy
-      tags:
-        - 'Notification Policy'
-      summary: 'Get notification policy of a service'
-      description: 'Return the notified contacts and contact groups of a service.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      responses:
-        '200':
-          description: 'Successful request'
-          content:
-            application/json:
-              schema:
-                $ref: ./latest/onPremise/Configuration/NotificationPolicy/Schema/NotificationPolicy.yaml
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/configuration/metaservices/{meta_id}/notification-policy':
-    get:
-      operationId: configuration.metaservice.notification-policy
-      tags:
-        - 'Notification Policy'
-      summary: 'Get notification policy of a meta service'
-      description: 'Return the notified contacts and contact groups of a meta service.'
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      responses:
-        '200':
-          description: 'Successful request'
-          content:
-            application/json:
-              schema:
-                $ref: ./latest/onPremise/Configuration/NotificationPolicy/Schema/NotificationPolicy.yaml
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/servers:
-    get:
-      operationId: centreon_application_find_real_time_monitoring_servers
-      tags:
-        - 'Monitoring server'
-      summary: 'List all real time monitoring servers'
-      description: |
-        List all monitoring servers configured and stored in real time.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * name
-          * running
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.Servers' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /users/acl/actions:
-    get:
-      operationId: centreon_application_user_getActionsAuthorization
-      tags:
-        - User
-      summary: 'List allowed actions'
-      description: 'List allowed actions of the current user.'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  host: { type: object, properties: { check: { type: boolean, description: 'if check is allowed on host', example: true }, acknowledgement: { type: boolean, description: 'if acknowledgement is allowed on host', example: true }, downtime: { type: boolean, description: 'if downtime is allowed on host', example: false } } }
-                  service: { type: object, properties: { check: { type: boolean, description: 'if check is allowed on service', example: true }, acknowledgement: { type: boolean, description: 'if acknowledgement is allowed on service', example: true }, downtime: { type: boolean, description: 'if downtime is allowed on service', example: false } } }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/timeperiods:
-    $ref: ./latest/onPremise/Configuration/TimePeriod/AddOneAndFindTimePeriods.yaml
-  '/configuration/timeperiods/{id}':
-    delete:
-      operationId: DeleteTimePeriod
-      tags:
-        - 'Time period'
-      summary: 'Delete a time period'
-      parameters:
-        -
-          in: path
-          name: id
-          description: 'ID of the time period to be deleted'
-          required: true
-          schema:
-            type: integer
-            format: int64
-            example: 1
-      responses:
-        '204':
-          description: 'Time period deleted'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    get:
-      operationId: FindTimePeriod
-      tags:
-        - 'Time period'
-      summary: 'Get a time period'
-      parameters:
-        -
-          in: path
-          name: id
-          description: 'Time period ID'
-          required: true
-          schema:
-            type: integer
-            format: int64
-            example: 1
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Configuration.TimePeriod'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      operationId: UpdateTimePeriod
-      tags:
-        - 'Time period'
-      summary: 'Update a time period'
-      parameters:
-        -
-          in: path
-          name: id
-          description: 'ID of the time period to be updated'
-          required: true
-          schema:
-            type: integer
-            format: int64
-            example: 1
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Configuration.NewTimePeriod'
-      responses:
-        '204':
-          description: 'Time period updated'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/users:
-    $ref: ./latest/onPremise/Configuration/Users/Users.yaml
-  /configuration/users/current/parameters:
-    $ref: ./latest/onPremise/Configuration/Users/CurrentParameters.yaml
-  /configuration/contacts/templates:
-    get:
-      operationId: centreon_application_configuration_contact_template_getContactTemplates
-      tags:
-        - User
-      summary: 'List contact templates'
-      description: 'List configured contact templates'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.ContactTemplate' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/contacts/groups:
-    $ref: ./latest/onPremise/Configuration/ContactGroup/FindContactGroups.yaml
-  /configuration/dashboards:
-    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboards.yaml
-  '/configuration/dashboards/{dashboard_id}':
-    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.yaml
-  '/configuration/dashboards/{dashboard_id}/favorites':
-    $ref: ./latest/onPremise/Configuration/Dashboard/DeleteDashboardFromFavorites.yaml
-  /configuration/dashboards/favorites:
-    $ref: ./latest/onPremise/Configuration/Dashboard/FavoriteDashboards.yaml
-  '/configuration/dashboards/{dashboard_id}/shares':
-    $ref: ./latest/onPremise/Configuration/Dashboard/ShareDashboard.yaml
-  '/configuration/dashboards/{dashboard_id}/access_rights/contacts/{contact_id}':
-    $ref: ./latest/onPremise/Configuration/Dashboard/DashboardShareContact.yaml
-  '/configuration/dashboards/{dashboard_id}/access_rights/contactgroups/{contact_group_id}':
-    $ref: ./latest/onPremise/Configuration/Dashboard/DashboardShareContactGroup.yaml
-  /configuration/dashboards/contacts:
-    $ref: ./latest/onPremise/Configuration/Dashboard/Contacts.yaml
-  /configuration/dashboards/contactgroups:
-    $ref: ./latest/onPremise/Configuration/Dashboard/ContactGroups.yaml
-  /monitoring/dashboard/metrics/performances:
-    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsPerformances.yaml
-  /monitoring/dashboard/metrics/performances/data:
-    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
-  /monitoring/dashboard/metrics/top:
-    $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsTop.yaml
-  /monitoring/resources/hosts:
-    $ref: ./latest/onPremise/Realtime/Resources/FindResourcesByParent.yaml
-  /configuration/access-groups:
-    get:
-      tags:
-        - 'Access Control'
-      summary: 'List access groups'
-      description: 'List access groups available for a user'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Configuration.AccessGroup' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/users/filters/{page_name}':
-    get:
-      tags:
-        - User
-      summary: 'List user filters by page'
-      description: |
-        `internal`
-
-        `Since Centreon web 20.04.6`
-
-        List user filters saved for a given page.
-      parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/User.Filter' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - 'User filters'
-      summary: 'Add user filter'
-      description: |
-        `internal`
-
-        `Since Centreon web 20.04.6`
-
-        Add user filter for a given page.
-      parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  description: 'filter name'
-                  example: 'my filter 1'
-                criterias:
-                  type: array
-                  description: 'list of filter criterias'
-                  items: { type: object, example: { type: text, name: field1, value: 'search value 1' } }
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User.Filter'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/users/filters/{page_name}/{filter_id}':
-    get:
-      tags:
-        - User
-      summary: 'Detailed user filter'
-      description: |
-        `internal`
-
-        `Since Centreon web 20.04.6`
-
-        Get detailed information of a user filter for a given page.
-      parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User.Filter'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      tags:
-        - 'User filters'
-      summary: 'Update user filter'
-      description: |
-        `internal`
-
-        `Since Centreon web 20.04.6`
-
-        Update user filter for a given page.
-      parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/User.Filter'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User.Filter'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    patch:
-      tags:
-        - 'User filters'
-      summary: 'Patch user filter'
-      description: |
-        `internal`
-
-        `Since Centreon web 20.04.6`
-
-        Patch user filter order for a given page.
-      parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - order
-              properties:
-                order:
-                  type: integer
-                  description: 'filter order'
-                  example: 1
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User.Filter'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    delete:
-      tags:
-        - 'User filters'
-      summary: 'Delete user filter'
-      description: |
-        `internal`
-
-        `Since Centreon web 20.04.6`
-
-        Delete user filter for a given page.
-      parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources:
-    get:
-      operationId: FindResources
-      tags:
-        - Resource
-      summary: 'List all resources including hosts and services'
-      x-remarks: |
-        The `meta.total` field may be approximate when the number of matching resources exceeds 1,000.
-        This is most common when a free-text search spans multiple columns (alias, address, information)
-        because no covering index is available for those columns. In that case `meta.is_approximate` is
-        `true` and `meta.total` is capped at 1,000. To retrieve the exact count, call
-        `GET /monitoring/resources/count` with `all_pages=true` and the same query parameters.
-      description: |
-        List all the resources in real-time monitoring : hosts and services.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * alias
-        * fqdn
-        * type
-        * status_code
-        * status
-        * action_url
-        * notes_label
-        * notes_url
-        * parent_name
-        * parent_status
-        * in_downtime
-        * acknowledged
-        * last_status_change
-        * tries
-        * last_check
-        * information
-        * monitoring_server_name
-        * status_types
-
-        Only for **searching**:
-
-        ---
-
-        * h.name
-        * h.alias
-        * h.address
-        * h.fqdn
-        * s.description
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/ResourceFilterType'
-        -
-          $ref: '#/components/parameters/ResourceFilterState'
-        -
-          $ref: '#/components/parameters/ResourceFilterStatus'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostgroupName'
-        -
-          $ref: '#/components/parameters/ResourceFilterServicegroupName'
-        -
-          $ref: '#/components/parameters/ResourceFilterServiceCategoryName'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostCategoryName'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostSeverityName'
-        -
-          $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
-        -
-          $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
-        -
-          $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
-        -
-          $ref: '#/components/parameters/ResourceFilterStatusTypes'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.ResourceMain' } }
-                  meta:
-                    allOf:
-                      - $ref: '#/components/schemas/Meta'
-                      - type: object
-                        properties:
-                          is_approximate:
-                            type: boolean
-                            description: 'True when the result set exceeds 1,000 matching resources and the full count was not computed to avoid a costly full-table scan. meta.total is capped at 1,000. Call GET /monitoring/resources/count with all_pages=true and the same filters to retrieve the exact count.'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/count:
-    $ref: ./latest/onPremise/Realtime/Resources/CountResources.yaml
-  /monitoring/resources/export:
-    $ref: ./latest/onPremise/Realtime/Resources/ExportResources.yaml
-  '/monitoring/resources/hosts/{host_id}':
-    get:
-      operationId: centreon_application_monitoring_resource_details_host
-      tags:
-        - Resource
-      summary: 'Get a Host resource type detail'
-      description: 'Return the full detail of a resource typed Host.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      responses:
-        '200':
-          description: 'Successful request'
-          content:
-            application/json:
-              schema:
-                $ref: ./latest/onPremise/Realtime/Resources/Schema/ResourceHostDetail.yaml
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/HostNotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/resources/hosts/{host_id}/services/{service_id}':
-    get:
-      operationId: centreon_application_monitoring_resource_details_service
-      tags:
-        - Resource
-      summary: 'Get a Service resource type detail'
-      description: 'Return the full detail of a resource typed Service.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      responses:
-        '200':
-          description: 'Successful request'
-          content:
-            application/json:
-              schema:
-                $ref: ./latest/onPremise/Realtime/Resources/Schema/ResourceServiceDetail.yaml
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFoundHostOrService'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts:
-    get:
-      operationId: centreon_application_monitoring_gethosts
-      tags:
-        - Host
-      summary: 'List all hosts'
-      description: |
-        List all the hosts in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.state
-        * poller.id
-        * service.display_name
-        * host_group.id
-        * host.is_acknowledged
-        * host.downtime
-        * host.criticality
-      parameters:
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.HostMain' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}':
-    get:
-      operationId: centreon_application_monitoring_getonehost
-      tags:
-        - Host
-      summary: 'Get a host'
-      description: 'Return a single host with full details and some details about its services.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Monitoring.HostFull'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/status:
-    $ref: ./latest/onPremise/Realtime/Hosts/FindHostsStatus.yaml
-  /monitoring/services/status:
-    $ref: ./latest/onPremise/Realtime/Services/FindServicesStatus.yaml
-  /monitoring/services:
-    get:
-      operationId: centreon_application_monitoring_getservices
-      tags:
-        - Service
-      summary: 'List all services'
-      description: |
-        List all the services in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.state
-        * host_group.id
-        * service.display_name
-        * service.description
-        * service.is_acknowledged
-        * service.output
-        * service.state
-        * service_group.id
-        * poller.id
-        * service.downtime
-        * service.criticality
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.ServiceMain' }, { $ref: '#/components/schemas/Monitoring.ServiceWithHost' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/names:
-    get:
-      operationId: FindRealTimeUniqueServiceNames
-      tags:
-        - Service
-      summary: 'List all services unique names'
-      description: |
-        List all the services in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * name
-        * host.id
-        * host.name
-        * host_group.id
-        * host_group.name
-        * host_category.id
-        * host_category.name
-        * service_group.id
-        * service_group.name
-        * service_category.id
-        * service_category.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { type: object, properties: { name: { type: string, example: Cpu } } } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services':
-    get:
-      operationId: centreon_application_monitoring_getservicesbyhost
-      tags:
-        - Service
-      summary: 'List services related to a host'
-      description: |
-        List all services related to a host in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * service.id
-        * service.description
-        * service.display_name
-        * service_group.id
-        * service.is_acknowledged
-        * service.state
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.ServiceMain' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}':
-    get:
-      operationId: centreon_application_monitoring_getoneservice
-      tags:
-        - Service
-      summary: 'Get a service'
-      description: 'Return a single service with full details.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Monitoring.ServiceFull'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/servicegroups':
-    get:
-      operationId: centreon_application_monitoring_getservicegroupsbyhostandservice
-      tags:
-        - 'Service group'
-      summary: 'Get service groups by host id and service id'
-      description: 'Return a list of service groups for host-service pair.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Monitoring.ServiceGroup'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/hostgroups':
-    get:
-      operationId: centreon_application_monitoring_gethostgroupsbyhost
-      tags:
-        - 'Host group'
-      summary: 'List all host groups by host id'
-      description: |
-        List all the host groups in real-time monitoring for a specific host.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.display_name
-        * host.state
-        * poller.id
-        * service.display_name
-        * host_category.id
-        * host_category.name
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.HostGroup' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/categories:
-    get:
-      tags:
-        - 'Host category'
-      summary: 'List all real-time host categories'
-      description: |
-        List of all host categories in real-time context
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * host_group.id
-        * host_group.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.Category' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hostgroups:
-    get:
-      tags:
-        - 'Host group'
-      summary: 'List all host groups'
-      description: |
-        List all the host groups in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.display_name
-        * host.state
-        * poller.id
-        * service.display_name
-        * host_category.id
-        * host_category.name
-      parameters:
-        -
-          $ref: '#/components/parameters/ShowHost'
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.HostGroup' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/servicegroups:
-    get:
-      tags:
-        - 'Service group'
-      summary: 'List all service groups'
-      description: |
-        List all the service groups in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.display_name
-        * host.state
-        * poller.id
-        * service.id
-        * service.name
-        * service.display_name
-        * host_group.id
-        * host_group.name
-        * host_category.id
-        * host_category.name
-      parameters:
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/ShowHost'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.ServiceGroup' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/severities/service:
-    get:
-      tags:
-        - Severity
-      summary: 'List all service severities from the realtime'
-      description: |
-        List all the service severities in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * name
-        * level
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.Severity' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/severities/host:
-    get:
-      tags:
-        - Severity
-      summary: 'List all host severities from real-time data'
-      description: |
-        List all the host severities in real-time monitoring.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * name
-        * level
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Monitoring.Severity' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/acknowledgements:
-    get:
-      tags:
-        - Acknowledgement
-      summary: 'List all acknowledgements'
-      description: |
-        List all acknowledgements (host and service).
-
-        **Minimum API version:** 21.10
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * author_id
-        * comment
-        * entry_time
-        * deletion_time
-        * host_id
-        * service_id
-        * service.display_name
-        * is_notify_contacts
-        * is_persistent_comment
-        * is_sticky
-        * poller_id
-        * state
-        * type
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }, { $ref: '#/components/schemas/Acknowledgement.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/acknowledgements:
-    delete:
-      tags:
-        - Acknowledgement
-      summary: 'Massively disacknowledge resources'
-      description: |
-        Remove/cancel acknowledgements on multiple resources (hosts and/or services) at once.
-
-        **Minimum API version:** 21.10
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Disacknowledge.Bulk'
-      responses:
-        '204':
-          description: OK
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/acknowledgements/{acknowledgement_id}':
-    get:
-      tags:
-        - Acknowledgement
-      summary: 'Display one acknowledgement'
-      description: |
-        Display one acknowledgement by its ID.
-
-        **Minimum API version:** 21.10
-
-        Returns either a host or service acknowledgement depending on the resource type.
-      parameters:
-        -
-          $ref: '#/components/parameters/AcknowledgementId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Acknowledgement.Service'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/acknowledgements:
-    get:
-      tags:
-        - Acknowledgement
-      summary: 'List all hosts acknowledgements'
-      description: |
-        List all host acknowledgements.
-
-        **Minimum API version:** 21.10
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * author_id
-        * comment
-        * entry_time
-        * deletion_time
-        * host_id
-        * is_notify_contacts
-        * is_persistent_comment
-        * is_sticky
-        * poller_id
-        * state
-        * type
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Acknowledgement
-      summary: 'Add an acknowledgement on multiple hosts'
-      description: |
-        Add an acknowledgement on multiple hosts at once.
-
-        **Minimum API version:** 21.10
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Hosts.Add'
-      responses:
-        '204':
-          description: 'Commands Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/acknowledgements:
-    get:
-      tags:
-        - Acknowledgement
-      summary: 'List all services acknowledgements'
-      description: |
-        List all service acknowledgements.
-
-        **Minimum API version:** 21.10
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * author_id
-        * comment
-        * entry_time
-        * deletion_time
-        * host_id
-        * service_id
-        * service.display_name
-        * is_notify_contacts
-        * is_persistent_comment
-        * is_sticky
-        * poller_id
-        * state
-        * type
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Acknowledgement
-      summary: 'Add an acknowledgement on multiple services'
-      description: |
-        Add an acknowledgement on multiple services at once.
-
-        **Minimum API version:** 21.10
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Services.Add'
-      responses:
-        '204':
-          description: 'Commands Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/acknowledgements':
-    get:
-      tags:
-        - Acknowledgement
-      summary: 'List all acknowledgements of a host'
-      description: |
-        List all acknowledgements for a specific host.
-
-        **Minimum API version:** 21.10
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * author_id
-        * comment
-        * entry_time
-        * deletion_time
-        * host_id
-        * is_notify_contacts
-        * is_persistent_comment
-        * is_sticky
-        * poller_id
-        * state
-        * type
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/HostId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Acknowledgement
-      summary: 'Add an acknowledgement on chosen host'
-      description: |
-        Add an acknowledgement on a specific host.
-
-        **Minimum API version:** 21.10
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Host.Add'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    delete:
-      tags:
-        - Acknowledgement
-      summary: 'Cancel an acknowledgement on a host'
-      description: |
-        Remove/cancel the current acknowledgement on a host.
-
-        **Minimum API version:** 21.10
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/acknowledgements':
-    get:
-      tags:
-        - Acknowledgement
-      summary: 'List all acknowledgements of a service'
-      description: |
-        List all acknowledgements for a specific service.
-
-        **Minimum API version:** 21.10
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * author_id
-        * comment
-        * entry_time
-        * deletion_time
-        * host_id
-        * service_id
-        * service.display_name
-        * is_notify_contacts
-        * is_persistent_comment
-        * is_sticky
-        * poller_id
-        * state
-        * type
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Acknowledgement
-      summary: 'Add an acknowledgement on chosen service'
-      description: |
-        Add an acknowledgement on a specific service.
-
-        **Minimum API version:** 21.10
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Service.Add'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    delete:
-      tags:
-        - Acknowledgement
-      summary: 'Cancel an acknowledgement on a service'
-      description: |
-        Remove/cancel the current acknowledgement on a service.
-
-        **Minimum API version:** 21.10
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/acknowledgements':
-    get:
-      tags:
-        - Acknowledgement
-        - 'Meta service'
-      summary: 'List all acknowledgements of a metaservice'
-      description: |
-        List all acknowledgements for a specific metaservice.
-
-        **Minimum API version:** 21.10
-
-        The available parameters to **search** / **sort_by** are:
-        * id
-        * author_id
-        * comment
-        * entry_time
-        * deletion_time
-        * host_id
-        * service_id
-        * service.display_name
-        * is_notify_contacts
-        * is_persistent_comment
-        * is_sticky
-        * poller_id
-        * state
-        * type
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/MetaId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Acknowledgement.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Acknowledgement
-        - 'Meta service'
-      summary: 'Add an acknowledgement on chosen metaservice'
-      description: |
-        Add an acknowledgement on a specific metaservice.
-
-        **Minimum API version:** 21.10
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Service.Add'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    delete:
-      tags:
-        - Acknowledgement
-        - 'Meta service'
-      summary: 'Cancel an acknowledgement on a metaservice'
-      description: |
-        Remove/cancel the current acknowledgement on a metaservice.
-
-        **Minimum API version:** 21.10
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/downtimes:
-    get:
-      tags:
-        - Downtime
-      summary: 'List all downtimes'
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      description: |
-        List all downtimes
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * entry_time
-          * is_cancelled
-          * comment
-          * deletion_time
-          * duration
-          * end_time
-          * is_fixed
-          * start_time
-          * host.id
-          * host.name
-          * host.alias
-          * host.address
-          * host.display_name
-          * host.state
-          * poller.id
-          * contact.id
-          * contact.name
-          * service.id
-          * service.display_name
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/downtimes/{downtime_id}':
-    get:
-      tags:
-        - Downtime
-      summary: 'Display one downtime'
-      description: 'Display one downtime.'
-      parameters:
-        -
-          $ref: '#/components/parameters/DowntimeId'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Downtime.Service'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    delete:
-      tags:
-        - Downtime
-      summary: 'Cancel a downtime'
-      description: 'Cancel a downtime.'
-      parameters:
-        -
-          $ref: '#/components/parameters/DowntimeId'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/downtimes:
-    get:
-      tags:
-        - Downtime
-      summary: 'List all hosts downtimes'
-      description: |
-        List all downtimes of hosts
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * entry_time
-        * is_cancelled
-        * comment
-        * deletion_time
-        * duration
-        * end_time
-        * is_fixed
-        * start_time
-        * contact.id
-        * contact.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Host' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Downtime
-      summary: 'Add a downtime on multiple hosts'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Downtime.Hosts.Add'
-      responses:
-        '204':
-          description: 'Commands Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/downtimes:
-    get:
-      tags:
-        - Downtime
-      summary: 'List all services downtimes'
-      description: |
-        List all downtimes of services
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * entry_time
-        * is_cancelled
-        * comment
-        * deletion_time
-        * duration
-        * end_time
-        * is_fixed
-        * start_time
-        * host.id
-        * host.name
-        * host.alias
-        * host.address
-        * host.display_name
-        * host.state
-        * poller.id
-        * contact.id
-        * contact.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Downtime
-      summary: 'Add a downtime on multiple services'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Downtime.Services.Add'
-      responses:
-        '204':
-          description: 'Commands Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/downtimes':
-    get:
-      tags:
-        - Downtime
-      summary: 'List all downtimes of a host'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      description: |
-        List all downtimes of a host.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * entry_time
-          * is_cancelled
-          * comment
-          * deletion_time
-          * duration
-          * end_time
-          * is_fixed
-          * start_time
-          * contact.id
-          * contact.name
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Host' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Downtime
-      summary: 'Add a downtime on a host'
-      description: 'Add a downtime on a host.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Downtime.Host.Add'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/downtimes':
-    get:
-      tags:
-        - Downtime
-      summary: 'List all downtimes of a service'
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      description: |
-        List all downtimes of a service.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * entry_time
-          * is_cancelled
-          * comment
-          * deletion_time
-          * duration
-          * end_time
-          * is_fixed
-          * start_time
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Downtime
-      summary: 'Add a downtime on a service'
-      description: 'Add a downtime on a service.'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Downtime.Service.Add'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/downtimes':
-    get:
-      tags:
-        - Downtime
-        - 'Meta service'
-      summary: 'List all downtimes of a metaservice'
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/MetaId'
-      description: |
-        List all downtimes of a metaservice.
-
-        The available parameters to **search** / **sort_by** are:
-
-          * id
-          * entry_time
-          * is_cancelled
-          * comment
-          * deletion_time
-          * duration
-          * end_time
-          * is_fixed
-          * start_time
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { allOf: [{ $ref: '#/components/schemas/Downtime.Service' }] } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      tags:
-        - Downtime
-        - 'Meta service'
-      summary: 'Add a downtime on a metaservice'
-      description: 'Add a downtime on a metaservice.'
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Downtime.Service.Add'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/check:
-    post:
-      tags:
-        - Check
-      summary: 'Check multiple hosts'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Check.Hosts'
-      responses:
-        '204':
-          description: 'Commands Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/check:
-    post:
-      tags:
-        - Check
-      summary: 'Check multiple services'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Check.Services'
-      responses:
-        '204':
-          description: 'Commands Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/check':
-    post:
-      tags:
-        - Check
-      summary: 'Check host'
-      description: 'Schedule immediate check on chosen host'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Check.Host'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: 'Host not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/check':
-    post:
-      tags:
-        - Check
-      summary: 'Check service'
-      description: 'Schedule immediate check on chosen service'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Check.Service'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/check':
-    post:
-      tags:
-        - Check
-        - 'Meta service'
-      summary: 'Check metaservice'
-      description: 'Schedule immediate check on chosen metaservice'
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Check.Service'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/check:
-    post:
-      tags:
-        - Check
-      summary: 'Check resources'
-      description: 'Schedule immediate check on chosen resources'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Check.Resources'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/submit':
-    post:
-      tags:
-        - Submit
-      summary: 'Submit a result to a single host'
-      description: 'Submit a result (check status, output and perfdata) to a single host'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitResult.Host'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: 'Host not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/submit':
-    post:
-      tags:
-        - Submit
-      summary: 'Submit a result to a single service'
-      description: 'Submit a result (check status, output and perfdata) to a single service'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitResult.Service'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/submit':
-    post:
-      tags:
-        - Submit
-        - 'Meta service'
-      summary: 'Submit a result to a single metaservice'
-      description: 'Submit a result (check status, output and perfdata) to a single metaservice'
-      parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitResult.Service'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/submit:
-    post:
-      tags:
-        - Submit
-      summary: 'Submit result to resources'
-      description: 'Submit a result (check status, output and perfdata) to resources'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitResult.Resources'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/comments:
-    post:
-      tags:
-        - Comment
-      summary: 'Add comment to resources'
-      description: 'Add at least one comment to a single or to multiple resources'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Comment.Resources'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          description: 'Host or service not found'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics':
-    $ref: ./latest/onPremise/Realtime/Metrics/FindMetricsByService.yaml
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/start/{start}/end/{end}':
-    get:
-      tags:
-        - Metrics
-      summary: 'Get service metrics'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          $ref: '#/components/parameters/MetricStartDate'
-        -
-          $ref: '#/components/parameters/MetricEndDate'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  global: { type: object, properties: { title: { type: string, description: 'title of the graph', example: 'graph title' }, start: { type: integer, description: 'timestamp of the start interval', example: 1594504800 }, end: { type: integer, description: 'timestamp of the end interval', example: 1594591200 }, vertical-label: { type: string, description: 'vertical label (should not be used cause multiple y-axis possible)', example: Value }, base: { type: string, description: 'base scale', example: '1024' }, width: { type: string, description: 'width of the graph (should not be used)', example: '550' }, height: { type: string, description: 'height of the graph (should not be used)', example: '140' }, lower-limit: { type: string, description: 'lower value of the graph', example: '0' }, scaled: { type: integer, description: 'if the graph needs to be automatically scaled', example: 1 }, multiple_services: { type: boolean, description: 'if multiple services are selected (always false)', example: false } } }
-                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, last_value: { type: number, nullable: true, description: 'last value', example: 5.0 }, minimum_value: { type: number, nullable: true, description: 'minimum value', example: 0.0 }, maximum_value: { type: number, nullable: true, description: 'maximum value', example: 10.0 }, average_value: { type: number, nullable: true, description: 'average value', example: 5.64 } } } }
-                  times: { type: array, items: { type: string, format: timestamp, description: 'timestamp of the tick' }, example: ['1594505100', '1594505400', '1594505700'] }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFoundHostOrService'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/status/start/{start}/end/{end}':
-    get:
-      tags:
-        - Metrics
-      summary: 'Get service status data'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          $ref: '#/components/parameters/MetricStartDate'
-        -
-          $ref: '#/components/parameters/MetricEndDate'
-      description: 'Get status data from a service between given interval'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  critical: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-                  warning: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-                  ok: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-                  unknown: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFoundHostOrService'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance':
-    get:
-      tags:
-        - Metrics
-      summary: 'Get service performance data'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          in: query
-          name: start
-          required: false
-          description: 'Start date of metrics (default date is 24 hours in the past)'
-          schema:
-            type: string
-            format: date-time
-            example: '2020-02-18T00:00:00'
-        -
-          in: query
-          name: end
-          required: false
-          description: 'End date of metrics (default date is current date)'
-          schema:
-            type: string
-            format: date-time
-            example: '2020-02-19T00:00:00'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  base: { type: string, description: 'base scale', example: 1024 }
-                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, format: float, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, minimum_value: { type: number, format: float, description: 'minimum value', example: 1.0 }, maximum_value: { type: number, format: float, description: 'maximum value', example: 1.0 } } } }
-                  times: { type: array, items: { type: string, format: timestamp, description: 'datetime of the tick' }, example: ['1690965300'] }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFoundHostOrService'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance/download':
-    get:
-      tags:
-        - Metrics
-      summary: 'Download performance data as csv file'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          in: query
-          name: start_date
-          required: true
-          description: 'Start date of metrics (date format should be in ISO 8601)'
-          schema:
-            type: string
-            format: date-time
-            example: '2022-01-01T00:00:22Z'
-        -
-          in: query
-          name: end
-          required: true
-          description: 'End date of metrics (date format should be in ISO 8601)'
-          schema:
-            type: string
-            format: date-time
-            example: '2023-01-01T00:00:00Z'
-      responses:
-        '200':
-          description: 'A CSV file containg performance data'
-          content:
-            application/force-download:
-              schema:
-                type: string
-                format: string
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/status':
-    get:
-      tags:
-        - Metrics
-      summary: 'Get service status data'
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          in: query
-          name: start
-          required: false
-          description: 'Start date of metrics (default date is 24 hours in the past)'
-          schema:
-            type: string
-            format: date-time
-            example: '2020-02-18T00:00:00'
-        -
-          in: query
-          name: end
-          required: false
-          description: 'End date of metrics (default date is current date)'
-          schema:
-            type: string
-            format: date-time
-            example: '2020-02-19T00:00:00'
-      description: 'Get status data from a service between given interval'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  critical: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-                  warning: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-                  ok: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-                  unknown: { type: array, items: { type: object, properties: { start: { type: string, description: 'start time (timestamp)', example: '1581987121' }, end: { type: string, description: 'end time (timestamp)', example: '1581987181' } } } }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFoundHostOrService'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/timeline':
-    get:
-      tags:
-        - Timeline
-      summary: 'Get host timeline'
-      description: |
-        List all events for a given host
-
-        The available parameters to **search** / **sort_by** are:
-
-        * type
-        * content
-        * date
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.TimelineEvent' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/timeline':
-    get:
-      tags:
-        - Timeline
-      summary: 'Get service timeline'
-      description: |
-        List all events for a given service
-
-        The available parameters to **search** / **sort_by** are:
-
-        * type
-        * content
-        * date
-      parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/Monitoring.TimelineEvent' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/{metricName}':
-    $ref: ./latest/onPremise/Realtime/Metrics/FindSingleMetric.yaml
-  '/monitoring/metaService/{metaServiceId}/metrics/{metricName}':
-    $ref: ./latest/onPremise/Realtime/Metrics/FindSingleMetaMetric.yaml
-  /monitoring/resources/acknowledge:
-    post:
-      tags:
-        - Acknowledgement
-      summary: 'Acknowledge multiple resources'
-      description: |
-        Add acknowledgements on multiple resources (hosts and/or services) at once.
-
-        **Minimum API version:** 21.10
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Acknowledgement.Bulk'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/downtime:
-    post:
-      tags:
-        - Downtime
-      summary: 'Set downtime for multiple resources'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Downtime.Bulk'
-      responses:
-        '204':
-          description: 'Command Sent'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /platform:
-    patch:
-      tags:
-        - Platform
-      summary: 'Update a platform information'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Platform.Full'
-      responses:
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '204':
-          description: 'Platform updated'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /platform/features:
-    $ref: ./latest/onPremise/Platform/Features.yaml
-  /platform/versions:
-    $ref: ./latest/onPremise/Platform/Versions.yaml
-  /platform/updates:
-    $ref: ./latest/onPremise/Administration/Update/updates.yaml
-    post:
-      operationId: api_platformupdates_post
-      tags:
-        - Upgrade
-      responses:
-        '204':
-          description: 'Upgrade resource created'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Upgrade.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Upgrade'
-          links: {  }
-        '400':
-          description: 'Invalid input'
+          description: 'Not found'
           content:
             application/ld+json:
               schema:
@@ -4273,322 +4327,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
-        '403':
-          description: Forbidden
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Creates a Upgrade resource.'
-      description: 'Creates a Upgrade resource.'
-      parameters: []
-      requestBody:
-        description: 'The new Upgrade resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/Upgrade'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Upgrade'
-        required: true
-  /platform/installation/status:
-    get:
-      tags:
-        - Platform
-      summary: 'Get centreon web versions'
-      description: 'Get installation status and available versions of centreon web'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - is_installed
-                  - has_upgrade_available
-                properties:
-                  is_installed: { type: boolean, description: 'Installation status of centreon web', example: true }
-                  has_upgrade_available: { type: boolean, description: "upgrade available or not\n", example: true }
-        '500':
-          description: 'centreon is not properly installed'
-  /platform/topology:
-    post:
-      tags:
-        - Topology
-      summary: 'Register to platform topology'
-      description: 'Register a server to the platform topology'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Topology.Register'
-      responses:
-        '201':
-          description: OK
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    get:
-      tags:
-        - Topology
-      summary: 'Get a platform topology'
-      description: 'Get a platform topology in Json Graph Format'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - graph
-                  - nodes
-                  - edges
-                properties:
-                  graph: { type: object, description: 'General informations about schema', properties: { label: { type: string, description: 'type of Json Graph', example: centreon-topology }, metadata: { type: object, properties: { version: { type: string, description: 'Version of the topology', example: 1.0.0 } } }, nodes: { type: object, minItems: 1, properties: { id: { properties: { type: { type: string, description: 'Server Type of a platform', example: central }, label: { type: string, description: 'logical name of a platform', example: Central }, metadata: { type: object, properties: { centreon-id: { type: string, description: 'id of a platform as known in centreon database', example: '1' }, hostname: { type: string, description: 'physical name of a platform', example: localhost.localdomain }, address: { type: string, description: 'address of a platform', example: 192.168.0.1 } } } } } } }, edges: { type: array, minItems: 0, items: { type: object, properties: { source: { type: string, description: 'children platform id as known in the topology', example: '91' }, relation: { type: string, description: 'broker communication type', example: peer_retention }, target: { type: string, description: 'parent platform id as known in the topology', example: '1' } } } } } }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/platform/topology/{poller_id}':
-    delete:
-      tags:
-        - Topology
+          links: {}
+      summary: 'Retrieves a Connector resource.'
+      description: 'Retrieves a Connector resource.'
       parameters:
         -
-          $ref: '#/components/parameters/PollerId'
-      summary: 'Delete a Platform'
-      description: 'Delete a platform from the topology'
-      responses:
-        '204':
-          description: 'Platform deleted'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/gorgone/pollers/{poller_id}/responses/{token}':
-    get:
-      tags:
-        - Gorgone
-      parameters:
-        -
-          $ref: '#/components/parameters/PollerId'
-        -
-          $ref: '#/components/parameters/GorgoneToken'
-      summary: 'Gorgone poller responses token'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Gorgone.Response'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  '/gorgone/pollers/{poller_id}/commands/{command_name}':
-    post:
-      tags:
-        - Gorgone
-      parameters:
-        -
-          $ref: '#/components/parameters/PollerId'
-        -
-          $ref: '#/components/parameters/CommandName'
-      summary: 'Gorgone command on specific poller'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  token: { type: string, description: 'Token used to retrieve the data linked to the command' }
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /administration/authentication/providers/local:
-    get:
-      tags:
-        - Administration
-      summary: 'get local provider configuration with password security policy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuthenticationLocalProvider'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      tags:
-        - Administration
-      summary: 'update local provider configuration'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationLocalProvider'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /administration/authentication/providers/openid:
-    $ref: ./latest/onPremise/Administration/Authentication/OpenIdProvider/OpenIdProvider.yaml
-  /administration/authentication/providers/saml:
-    get:
-      tags:
-        - Administration
-      summary: 'Get SAML provider configuration'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReadAuthenticationSAMLProvider'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      tags:
-        - Administration
-      summary: 'Update SAML provider configuration'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/WriteAuthenticationSAMLProvider'
-      responses:
-        '204':
-          description: 'Configuration updated'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /administration/authentication/providers/web-sso:
-    get:
-      tags:
-        - Administration
-      summary: 'get web-sso provider configuration information'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuthenticationWebSSOProvider'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      tags:
-        - Administration
-      summary: 'update web-sso provider configuration'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationWebSSOProvider'
-      responses:
-        '204':
-          description: 'Configuration updated'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /administration/tokens:
-    $ref: ./latest/onPremise/Administration/Token/AddTokenAndFindTokens.yaml
-  '/administration/tokens/{token_name}':
-    $ref: ./latest/onPremise/Administration/Token/GetAndDeleteToken.yaml
-  '/administration/tokens/{token_name}/users/{user_id}':
-    $ref: ./latest/onPremise/Administration/Token/GetAndPartialUpdateAndDeleteTokenByUser.yaml
-  /administration/parameters:
-    post:
-      tags:
-        - Administration
-      summary: 'Administration parameters'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  monitoring_default_downtime_duration: { type: integer, description: 'Default downtime duration', example: 3600 }
-                  monitoring_default_refresh_interval: { type: integer, description: 'Default monitoring refresh interval', example: 15 }
-                  monitoring_default_acknowledgement_persistent: { type: boolean, description: 'Default monitoring acknowledgement persistent option', example: true }
-                  monitoring_default_acknowledgement_sticky: { type: boolean, description: 'Default monitoring acknowledgement sticky option', example: true }
-                  monitoring_default_acknowledgement_notify: { type: boolean, description: 'Default monitoring acknowledgement notify option', example: true }
-                  monitoring_default_acknowledgement_force_active_checks: { type: boolean, description: 'Default monitoring acknowledgement force active checks option', example: true }
-                  monitoring_default_acknowledgement_with_services: { type: boolean, description: 'Default monitoring acknowledgement with services option', example: true }
-                  monitoring_default_downtime_fixed: { type: boolean, description: 'Default monitoring downtime fixed option', example: true }
-                  monitoring_default_downtime_with_services: { type: boolean, description: 'Default set downtimes on services attached to hosts option', example: true }
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /administration/vaults/configurations:
-    $ref: ./latest/onPremise/Administration/Vault/VaultConfiguration.yaml
-  /configuration/global-macros:
-    summary: 'global macros'
-    description: 'global macros configuration'
+          name: id
+          in: path
+          description: 'Connector identifier'
+          required: true
+          deprecated: false
+          schema:
+            type: string
+          style: simple
+          explode: false
+  /api/configuration/global-macros:
     get:
       operationId: api_configurationglobal-macros_get_collection
       tags:
@@ -4621,7 +4374,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
       summary: 'Retrieves the collection of GlobalMacro resources.'
       description: 'Retrieves the collection of GlobalMacro resources.'
       parameters:
@@ -4673,9 +4426,48 @@ paths:
             maximum: 30
           style: form
           explode: true
-  /configuration/plugins:
-    summary: plugins
-    description: 'plugins configuration'
+  '/api/configuration/plugins/{plugin_name}':
+    get:
+      operationId: api_configurationplugins_plugin_name_get
+      tags:
+        - Plugin
+      responses:
+        '200':
+          description: 'Plugin resource'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Plugin.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+        '404':
+          description: 'Not found'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Retrieves a Plugin resource.'
+      description: 'Retrieves a Plugin resource.'
+      parameters:
+        -
+          name: plugin_name
+          in: path
+          description: 'Plugin identifier'
+          required: true
+          deprecated: false
+          schema:
+            type: string
+          style: simple
+          explode: false
+  /api/configuration/plugins:
     get:
       operationId: api_configurationplugins_get_collection
       tags:
@@ -4723,9 +4515,193 @@ paths:
             maximum: 30
           style: form
           explode: true
-  /configuration/standard-macros:
-    summary: 'standard macros'
-    description: 'standard macros configuration'
+  /api/configuration/pollers:
+    post:
+      operationId: api_configurationpollers_post
+      tags:
+        - Poller
+      responses:
+        '400':
+          description: 'Invalid input (e.g. unknown poller token name)'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+        '409':
+          description: 'Poller resource already exists'
+        '503':
+          description: 'Engine secrets are not available'
+        '201':
+          description: 'Poller resource created'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Poller.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Poller'
+          links: {}
+        '422':
+          description: 'An error occurred'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+          links: {}
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Creates a Poller resource.'
+      description: 'Creates a Poller resource.'
+      parameters: []
+      requestBody:
+        description: 'The new Poller resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/Poller.CreatePollerInput'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Poller.CreatePollerInput'
+        required: true
+  '/api/configuration/pollers/installation-command/{id}':
+    get:
+      operationId: api_configurationpollersinstallation-command_id_get
+      tags:
+        - Poller
+      responses:
+        '404':
+          description: 'Poller or poller token not found'
+        '403':
+          description: 'You are not allowed to access this resource'
+        '503':
+          description: 'Engine secrets are not available'
+        '200':
+          description: 'InstallationCommandResource resource'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Poller.InstallationCommandResource.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Poller.InstallationCommandResource'
+      summary: 'Retrieves a poller installation command'
+      description: 'Retrieves a poller installation command'
+      parameters:
+        -
+          name: token-name
+          in: query
+          description: 'Name of the poller token to embed in the installation command. When omitted, the first valid poller token is used.'
+          required: false
+          deprecated: false
+          schema:
+            type: string
+          style: form
+          explode: true
+        -
+          name: id
+          in: path
+          description: 'Id of the poller for which to generate the installation command.'
+          required: true
+          deprecated: false
+          schema:
+            type: integer
+          style: simple
+          explode: false
+  /api/configuration/services/categories:
+    post:
+      operationId: api_configurationservicescategories_post
+      tags:
+        - 'Service Category'
+      responses:
+        '409':
+          description: 'ServiceCategory resource already exists'
+        '201':
+          description: 'ServiceCategory resource created'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ServiceCategory.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceCategory'
+          links: {}
+        '400':
+          description: 'Invalid input'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+        '422':
+          description: 'An error occurred'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+          links: {}
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Creates a ServiceCategory resource.'
+      description: 'Creates a ServiceCategory resource.'
+      parameters: []
+      requestBody:
+        description: 'The new ServiceCategory resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/ServiceCategory'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceCategory'
+        required: true
+  /api/configuration/standard-macros:
     get:
       operationId: api_configurationstandard-macros_get_collection
       tags:
@@ -4797,83 +4773,22 @@ paths:
             maximum: 30
           style: form
           explode: true
-  '/configuration/commands/{id}':
-    summary: 'operations on a specific command resource'
-    description: 'operations on a specific command resource'
-    get:
-      operationId: api_configurationcommands_id_get
+  /api/platform/updates:
+    post:
+      operationId: api_platformupdates_post
       tags:
-        - Command
+        - Upgrade
       responses:
-        '404':
-          description: 'Command resource not found'
-        '403':
-          description: 'You are not allowed to access this command'
-        '200':
-          description: 'Command resource'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Command.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Command'
-      summary: 'Retrieves a Command resource.'
-      description: 'Retrieves a Command resource.'
-      parameters:
-        -
-          name: id
-          in: path
-          description: 'Command identifier'
-          required: true
-          deprecated: false
-          schema:
-            type: string
-          style: simple
-          explode: false
-    delete:
-      operationId: api_configurationcommands_id_delete
-      tags:
-        - Command
-      responses:
-        '404':
-          description: 'Command resource not found'
-        '403':
-          description: 'You are not allowed to delete this command'
         '204':
-          description: 'Command resource deleted'
-      summary: 'Removes the Command resource.'
-      description: 'Removes the Command resource.'
-      parameters:
-        -
-          name: id
-          in: path
-          description: 'Command identifier'
-          required: true
-          deprecated: false
-          schema:
-            type: string
-          style: simple
-          explode: false
-    patch:
-      operationId: api_configurationcommands_id_patch
-      tags:
-        - Command
-      responses:
-        '404':
-          description: 'Command resource not found'
-        '403':
-          description: 'You are not allowed to update this command'
-        '200':
-          description: 'Command resource updated'
+          description: 'Upgrade resource created'
           content:
             application/ld+json:
               schema:
-                $ref: '#/components/schemas/Command.jsonld'
+                $ref: '#/components/schemas/Upgrade.jsonld'
             application/json:
               schema:
-                $ref: '#/components/schemas/Command'
-          links: {  }
+                $ref: '#/components/schemas/Upgrade'
+          links: {}
         '400':
           description: 'Invalid input'
           content:
@@ -4886,7 +4801,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
         '422':
           description: 'An error occurred'
           content:
@@ -4899,110 +4814,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
-      summary: 'Updates the Command resource.'
-      description: 'Updates the Command resource.'
-      parameters:
-        -
-          name: id
-          in: path
-          description: 'Command identifier'
-          required: true
-          deprecated: false
-          schema:
-            type: string
-          style: simple
-          explode: false
-      requestBody:
-        description: 'The updated Command resource'
-        content:
-          application/merge-patch+json:
-            schema:
-              $ref: '#/components/schemas/Command.jsonMergePatch'
-        required: true
-  /configuration/commands/_duplicate:
-    summary: 'duplicate a Command resource'
-    description: 'duplicate a Command resource'
-    post:
-      operationId: api_configurationcommands_duplicate_post
-      tags:
-        - Command
-      responses:
-        '200':
-          description: 'A collection holding the duplication outcome for each requested command'
-          content:
-            application/ld+json:
-              schema:
-                type: object
-                properties:
-                  '@context': { type: string }
-                  '@id': { type: string }
-                  '@type': { type: string, example: Collection }
-                  totalItems: { type: integer }
-                  member: { type: array, items: { type: object, properties: { '@id': { type: string }, '@type': { type: string, example: DuplicateCommandResource }, command: { type: string, description: 'IRI of the duplicated command (absent when the duplication failed)' }, status: { type: integer }, message: { type: string } }, required: ['@id', '@type', status, message] } }
-              example:
-                '@context': /centreon/api/latest/contexts/Command
-                '@id': /centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8
-                '@type': Collection
-                totalItems: 2
-                member:
-                  - { '@id': /centreon/api/latest/.well-known/genid/c2afa2366f6f99491863, '@type': DuplicateCommandResource, command: /centreon/api/latest/configuration/commands/98, status: 204, message: 'Command duplicated successfully' }
-                  - { '@id': /centreon/api/latest/.well-known/genid/3fa305a034165257c384, '@type': DuplicateCommandResource, status: 404, message: 'Command with ID 99999 not found' }
-          links: {  }
-        '400':
-          description: 'Invalid input — the request body failed validation'
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code: { type: integer, example: 400 }
-                  message: { type: string, description: 'One line per violation, formatted as "[propertyPath] message"', example: "[ids] IDs array cannot be empty\n" }
-                required:
-                  - code
-                  - message
-        '403':
-          description: 'You are not allowed to duplicate commands'
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code: { type: integer, example: 0 }
-                  message: { type: string, example: 'You are not allowed to duplicate commands' }
-                required:
-                  - code
-                  - message
-      summary: 'Duplicate a Command resource'
-      description: 'Duplicate a Command resource'
-      parameters: []
-      requestBody:
-        description: 'The new Command resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
-        required: true
-  '/configuration/connectors/{id}':
-    summary: 'operations on a specific connector resource'
-    description: 'operations on a specific Connector resource'
-    get:
-      operationId: api_configurationconnectors_id_get
-      tags:
-        - Connector
-      responses:
-        '200':
-          description: 'Connector resource'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Connector.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Connector'
+          links: {}
         '403':
           description: Forbidden
           content:
@@ -5015,77 +4827,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
-        '404':
-          description: 'Not found'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Retrieves a Connector resource.'
-      description: 'Retrieves a Connector resource.'
-      parameters:
-        -
-          name: id
-          in: path
-          description: 'Connector identifier'
-          required: true
-          deprecated: false
-          schema:
-            type: string
-          style: simple
-          explode: false
-  '/configuration/plugins/{plugin_name}':
-    summary: 'operations on a specific plugin resource'
-    description: 'operations on a specific plugin resource'
-    get:
-      operationId: api_configurationplugins_plugin_name_get
-      tags:
-        - Plugin
-      responses:
-        '200':
-          description: 'Plugin resource'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Plugin.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Plugin'
-        '404':
-          description: 'Not found'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Retrieves a Plugin resource.'
-      description: 'Retrieves a Plugin resource.'
-      parameters:
-        -
-          name: plugin_name
-          in: path
-          description: 'Plugin identifier'
-          required: true
-          deprecated: false
-          schema:
-            type: string
-          style: simple
-          explode: false
-  '/configuration/agent-configurations/installation-command/{pollerId}':
+          links: {}
+      summary: 'Creates a Upgrade resource.'
+      description: 'Creates a Upgrade resource.'
+      parameters: []
+      requestBody:
+        description: 'The new Upgrade resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/Upgrade'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Upgrade'
+        required: true
+  '/api/configuration/agent-configurations/installation-command/{pollerId}':
     get:
       operationId: api_configurationagent-configurationsinstallation-command_pollerId_get
       tags:
@@ -5115,118 +4871,6 @@ paths:
           deprecated: false
           schema:
             type: string
-          style: simple
-          explode: false
-  /configuration/pollers:
-    post:
-      operationId: api_configurationpollers_post
-      tags:
-        - Poller
-      responses:
-        '409':
-          description: 'Poller resource already exists'
-        '201':
-          description: 'Poller resource created'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Poller.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Poller'
-          links: {  }
-        '400':
-          description: 'Invalid input'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
-        '403':
-          description: Forbidden
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Creates a Poller resource.'
-      description: 'Creates a Poller resource.'
-      parameters: []
-      requestBody:
-        description: 'The new Poller resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/Poller.CreatePollerInput'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Poller.CreatePollerInput'
-        required: true
-  '/configuration/pollers/installation-command/{id}':
-    get:
-      operationId: api_configurationpollersinstallation-command_id_get
-      tags:
-        - Poller
-      responses:
-        '404':
-          description: 'Poller not found'
-        '403':
-          description: 'You are not allowed to access this resource'
-        '200':
-          description: 'InstallationCommandResource resource'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Poller.InstallationCommandResource.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Poller.InstallationCommandResource'
-      summary: 'Retrieves a poller installation command'
-      description: 'Retrieves a poller installation command'
-      parameters:
-        -
-          name: token-name
-          in: query
-          description: 'Name of the poller token to embed in the installation command. When omitted, the first valid poller token is used.'
-          required: false
-          deprecated: false
-          schema:
-            type: string
-          style: form
-          explode: true
-        -
-          name: id
-          in: path
-          description: 'Id of the poller for which to generate the installation command.'
-          required: true
-          deprecated: false
-          schema:
-            type: integer
           style: simple
           explode: false
 components:
@@ -6055,8 +5699,7 @@ components:
                   priority: { type: number, description: 'priority of the role', example: 1 }
     ReadAuthenticationSAMLProvider:
       allOf:
-        -
-          $ref: '#/components/schemas/AuthenticationSAMLProvider'
+        - $ref: '#/components/schemas/AuthenticationSAMLProvider'
         -
           properties:
             groups_mapping:
@@ -6073,8 +5716,7 @@ components:
                   items: { type: object, properties: { claim_value: { type: string, description: 'Authorization claim value', example: scope }, access_group: { type: object, description: 'Access group', properties: { id: { type: integer, description: 'Access group ID', example: 1 }, name: { type: string, description: 'Access group name', example: Default } } } } }
     WriteAuthenticationSAMLProvider:
       allOf:
-        -
-          $ref: '#/components/schemas/AuthenticationSAMLProvider'
+        - $ref: '#/components/schemas/AuthenticationSAMLProvider'
         -
           properties:
             groups_mapping:
@@ -6263,8 +5905,7 @@ components:
                 type: object
                 properties:
                   id: { type: integer, description: 'ID of the extra period', example: 1 }
-              -
-                $ref: '#/components/schemas/Configuration.TimePeriod.ExtraTimePeriod'
+              - $ref: '#/components/schemas/Configuration.TimePeriod.ExtraTimePeriod'
     Configuration.TimePeriod.days:
       type: object
       properties:
@@ -6431,8 +6072,7 @@ components:
           description: 'Indicates whether this host severity is enabled or not'
     Configuration.Host.Template:
       allOf:
-        -
-          $ref: '#/components/schemas/Configuration.Host.Template.Add'
+        - $ref: '#/components/schemas/Configuration.Host.Template.Add'
         -
           properties:
             id:
@@ -6678,8 +6318,7 @@ components:
           description: 'Indicates whether the host template is activated or not'
     Configuration.Service.Group:
       allOf:
-        -
-          $ref: '#/components/schemas/Configuration.Service.Group.Add'
+        - $ref: '#/components/schemas/Configuration.Service.Group.Add'
         -
           properties:
             id:
@@ -7147,8 +6786,7 @@ components:
       type: object
       nullable: true
       allOf:
-        -
-          $ref: '#/components/schemas/Acknowledgement.Host'
+        - $ref: '#/components/schemas/Acknowledgement.Host'
         -
           type: object
           nullable: true
@@ -7160,8 +6798,7 @@ components:
               example: 5
     Acknowledgement.Host.Add:
       allOf:
-        -
-          $ref: '#/components/schemas/Acknowledgement.Service.Add'
+        - $ref: '#/components/schemas/Acknowledgement.Service.Add'
         -
           type: object
           properties:
@@ -7173,10 +6810,8 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Acknowledgement.Host.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Acknowledgement.Host.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Acknowledgement.Service.Add:
       type: object
       properties:
@@ -7200,14 +6835,11 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Acknowledgement.Service.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Acknowledgement.Service.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Downtime.Host.Add:
       allOf:
-        -
-          $ref: '#/components/schemas/Downtime.Service.Add'
+        - $ref: '#/components/schemas/Downtime.Service.Add'
         -
           type: object
           properties:
@@ -7219,10 +6851,8 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Downtime.Host.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Downtime.Host.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Downtime.Service.Add:
       type: object
       properties:
@@ -7250,10 +6880,8 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Downtime.Service.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Downtime.Service.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Downtime.Host:
       type: object
       properties:
@@ -7322,8 +6950,7 @@ components:
           example: true
     Downtime.Service:
       allOf:
-        -
-          $ref: '#/components/schemas/Downtime.Host'
+        - $ref: '#/components/schemas/Downtime.Host'
         -
           type: object
           properties:
@@ -7378,22 +7005,17 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Check.Host'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Check.Host'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Check.Service:
       allOf:
-        -
-          $ref: '#/components/schemas/Check.Host'
+        - $ref: '#/components/schemas/Check.Host'
     Check.Services:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Check.Service'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Check.Service'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Check.Resources:
       type: object
       properties:
@@ -7901,10 +7523,8 @@ components:
           example: All
         host:
           allOf:
-            -
-              $ref: '#/components/schemas/Monitoring.HostMin'
-            -
-              $ref: '#/components/schemas/Monitoring.HostWithService'
+            - $ref: '#/components/schemas/Monitoring.HostMin'
+            - $ref: '#/components/schemas/Monitoring.HostWithService'
     Monitoring.HostMin:
       type: object
       properties:
@@ -7936,8 +7556,7 @@ components:
           example: 0
     Monitoring.HostFull:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.HostMain'
+        - $ref: '#/components/schemas/Monitoring.HostMain'
         -
           type: object
           properties:
@@ -8041,10 +7660,8 @@ components:
                   allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }]
     Monitoring.HostMain:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.HostMin'
-        -
-          $ref: '#/components/schemas/Monitoring.HostWithService'
+        - $ref: '#/components/schemas/Monitoring.HostMin'
+        - $ref: '#/components/schemas/Monitoring.HostWithService'
         -
           type: object
           properties:
@@ -8235,8 +7852,7 @@ components:
           example: 0
     Monitoring.ServiceMain:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.ServiceMin'
+        - $ref: '#/components/schemas/Monitoring.ServiceMin'
         -
           type: object
           properties:
@@ -8292,8 +7908,7 @@ components:
               example: '2h 3m'
     Monitoring.ServiceFull:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.ServiceMain'
+        - $ref: '#/components/schemas/Monitoring.ServiceMain'
         -
           type: object
           properties:
@@ -8398,8 +8013,7 @@ components:
                 $ref: '#/components/schemas/Downtime.Service'
             acknowledgement:
               allOf:
-                -
-                  $ref: '#/components/schemas/Acknowledgement.Service'
+                - $ref: '#/components/schemas/Acknowledgement.Service'
               type: object
               nullable: true
             flapping:
@@ -8699,8 +8313,7 @@ components:
         '@context':
           readOnly: true
           oneOf:
-            -
-              type: string
+            - type: string
             -
               type: object
               properties:
@@ -8756,65 +8369,74 @@ components:
       description: 'A representation of common errors.'
       properties:
         title:
-          type: string
           readOnly: true
           description: 'A short, human-readable summary of the problem.'
-          nullable: true
+          type:
+            - string
+            - 'null'
         detail:
-          type: string
           readOnly: true
           description: 'A human-readable explanation specific to this occurrence of the problem.'
-          nullable: true
+          type:
+            - string
+            - 'null'
         status:
-          type: number
-          default: 400
-          example:
+          type:
+            - integer
+            - 'null'
+          examples:
             - 404
-          nullable: true
+          default: 400
         instance:
-          type: string
           readOnly: true
           description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.'
-          nullable: true
+          type:
+            - string
+            - 'null'
         type:
           readOnly: true
           description: 'A URI reference that identifies the problem type'
           type: string
     Error.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
             title:
               readOnly: true
               description: 'A short, human-readable summary of the problem.'
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             detail:
               readOnly: true
               description: 'A human-readable explanation specific to this occurrence of the problem.'
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             status:
-              type: number
-              example: 404
+              type:
+                - integer
+                - 'null'
+              examples:
+                - 404
               default: 400
-              nullable: true
             instance:
               readOnly: true
               description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.'
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             type:
               readOnly: true
               description: 'A URI reference that identifies the problem type'
               type: string
             description:
               readOnly: true
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
       description: 'A representation of common errors.'
     GlobalMacroResource:
       type: object
@@ -8938,14 +8560,14 @@ components:
           maxLength: 255
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         is_activated:
           type: boolean
     ServiceCategory.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -8958,8 +8580,9 @@ components:
               maxLength: 255
               type: string
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             is_activated:
               type: boolean
     StandardMacroResource:
@@ -9038,10 +8661,11 @@ components:
             id: 1
             name: 'SSH Connector'
         comment:
-          type: string
           description: 'Additional information about the command'
+          type:
+            - string
+            - 'null'
           example: 'This command is used to check the HTTP service'
-          nullable: true
     Command.DuplicateCommandInput:
       type: object
       description: ''
@@ -9066,8 +8690,7 @@ components:
             type: integer
     Command.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9117,9 +8740,10 @@ components:
                 name: 'SSH Connector'
             comment:
               description: 'Additional information about the command'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This command is used to check the HTTP service'
-              nullable: true
     Connector:
       type: object
       properties:
@@ -9134,18 +8758,18 @@ components:
           type: string
           example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
         description:
-          type: string
           description: 'The connector description'
+          type:
+            - string
+            - 'null'
           example: 'Connector using SSH to connect to remote hosts'
-          nullable: true
         is_activated:
           description: 'Indicates whether the connector is activated'
           type: boolean
           example: true
     Connector.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9161,9 +8785,10 @@ components:
               example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
             description:
               description: 'The connector description'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'Connector using SSH to connect to remote hosts'
-              nullable: true
             is_activated:
               description: 'Indicates whether the connector is activated'
               type: boolean
@@ -9234,14 +8859,14 @@ components:
           type: string
           example: /usr/lib64/nagios/plugins/negate
         description:
-          type: string
           description: 'description of plugin'
+          type:
+            - string
+            - 'null'
           example: 'This is the help description of the plugin.'
-          nullable: true
     Plugin.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9255,9 +8880,10 @@ components:
               example: /usr/lib64/nagios/plugins/negate
             description:
               description: 'description of plugin'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This is the help description of the plugin.'
-              nullable: true
     Command.jsonMergePatch:
       type: object
       properties:
@@ -9306,10 +8932,11 @@ components:
             id: 1
             name: 'SSH Connector'
         comment:
-          type: string
           description: 'Additional information about the command'
+          type:
+            - string
+            - 'null'
           example: 'This command is used to check the HTTP service'
-          nullable: true
     ConstraintViolation:
       type: object
       description: 'Unprocessable entity'
@@ -9348,17 +8975,18 @@ components:
           readOnly: true
           type: string
         title:
-          type: string
           readOnly: true
-          nullable: true
+          type:
+            - string
+            - 'null'
         instance:
-          type: string
           readOnly: true
-          nullable: true
+          type:
+            - string
+            - 'null'
     ConstraintViolation.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9389,12 +9017,14 @@ components:
               type: string
             title:
               readOnly: true
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             instance:
               readOnly: true
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
       description: 'Unprocessable entity'
     CreateCommandResource:
       type: object
@@ -9425,19 +9055,20 @@ components:
           description: 'Indicates whether the command can be executed through a shell'
           type: boolean
         connector:
-          type: string
+          type:
+            - string
+            - 'null'
           format: iri-reference
           example: 'https://example.com/'
-          nullable: true
         comment:
-          type: string
           description: 'Additional information about the command'
+          type:
+            - string
+            - 'null'
           example: 'This command is used to check the HTTP service'
-          nullable: true
     CreateCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9467,23 +9098,26 @@ components:
               description: 'Indicates whether the command can be executed through a shell'
               type: boolean
             connector:
-              type: string
+              type:
+                - string
+                - 'null'
               format: iri-reference
               example: 'https://example.com/'
-              nullable: true
             comment:
               description: 'Additional information about the command'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This command is used to check the HTTP service'
-              nullable: true
     DuplicateCommandResource:
       type: object
       properties:
         command:
-          type: string
+          type:
+            - string
+            - 'null'
           format: iri-reference
           example: 'https://example.com/'
-          nullable: true
         status:
           description: 'The status of the duplication operation'
           type: integer
@@ -9503,16 +9137,16 @@ components:
             type: integer
     DuplicateCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
             command:
-              type: string
+              type:
+                - string
+                - 'null'
               format: iri-reference
               example: 'https://example.com/'
-              nullable: true
             status:
               description: 'The status of the duplication operation'
               type: integer
@@ -9557,8 +9191,7 @@ components:
         - expression
     Global.Macro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9595,8 +9228,7 @@ components:
             - expression
     HydraCollectionBaseSchema:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraCollectionBaseSchemaNoPagination'
+        - $ref: '#/components/schemas/HydraCollectionBaseSchemaNoPagination'
         -
           type: object
           properties:
@@ -9609,16 +9241,16 @@ components:
                 '@type':
                   type: string
                 first:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 last:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 previous:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 next:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
               example:
                 '@id': string
@@ -9649,15 +9281,14 @@ components:
                 properties:
                   '@type': { type: string }
                   variable: { type: string }
-                  property: { type: string, nullable: true }
+                  property: { type: [string, 'null'] }
                   required: { type: boolean }
     HydraItemBaseSchema:
       type: object
       properties:
         '@context':
           oneOf:
-            -
-              type: string
+            - type: string
             -
               type: object
               properties:
@@ -9690,8 +9321,7 @@ components:
           example: 'curl -fsSL https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/[PF_VERSION]-latest/agent/installer/scripts_linux/install_cma.sh -o install_cma.sh && sudo chmod +x install_cma.sh && sudo ./install_cma.sh -e "[poller IP/DNS]:[PORT]" -f "[centreon_storage.instances.cma_certificate_sha]" -N "[centreon_storage.cma_certificate_cn]"'
     InstallationCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9749,8 +9379,7 @@ components:
           type: boolean
     ListCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9801,15 +9430,15 @@ components:
         - name
       properties:
         name:
-          type: string
           maxLength: 255
           description: 'Name of plugin'
+          type:
+            - string
+            - 'null'
           example: negate
-          nullable: true
     Plugins.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           required:
@@ -9818,9 +9447,10 @@ components:
             name:
               maxLength: 255
               description: 'Name of plugin'
-              type: string
+              type:
+                - string
+                - 'null'
               example: negate
-              nullable: true
     Service.Category:
       type: object
       properties:
@@ -9839,8 +9469,7 @@ components:
           type: boolean
     Service.Category.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9868,8 +9497,7 @@ components:
           nullable: true
     Standard.Macro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9883,29 +9511,33 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
+          type:
+            - string
+            - 'null'
           example: $USER1$
-          nullable: true
         expression:
-          type: string
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
-          nullable: true
         comment:
-          type: string
           maxLength: 255
           description: 'Additional information about the macro'
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
-          nullable: true
         is_password:
           type: boolean
         is_activated:
@@ -9915,35 +9547,38 @@ components:
         - expression
     GlobalMacro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
               minLength: 1
               maxLength: 255
               pattern: '^(\$.*\$)$'
               description: 'Name of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: $USER1$
-              nullable: true
             expression:
               minLength: 1
               maxLength: 255
               description: 'Expression (value) of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: /usr/lib64/nagios/plugins
-              nullable: true
             comment:
               maxLength: 255
               description: 'Additional information about the macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This macro is used to define the path of plugins'
-              nullable: true
             is_password:
               type: boolean
             is_activated:
@@ -9998,8 +9633,7 @@ components:
           type: string
     Poller.jsonld-poller.read:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10029,32 +9663,33 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     StandardMacro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
     Upgrade:
       type: object
     Upgrade.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
-        -
-          type: object
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
+        - type: object
     Poller:
       type: object
       properties:
@@ -10065,18 +9700,18 @@ components:
         address:
           type: string
         central_address:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         id:
           type: integer
-          nullable: true
         uid:
           type: string
-          nullable: true
+        gorgone_communication_type:
+          type: string
         installation_command:
           type: string
-          example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
-          nullable: true
+          example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.CreatePollerInput:
       type: object
       properties:
@@ -10092,6 +9727,7 @@ components:
         address:
           minLength: 1
           maxLength: 255
+          pattern: '^(((?!://).)*)$'
           type: string
         poller_token_name:
           minLength: 1
@@ -10100,8 +9736,10 @@ components:
         central_address:
           minLength: 1
           maxLength: 255
+          pattern: '^(((?!://).)*)$'
           type: string
       required:
+        - address
         - poller_token_name
         - central_address
     Poller.InstallationCommandResource:
@@ -10110,22 +9748,20 @@ components:
         installation_command:
           description: 'Poller Installation Command'
           type: string
-          example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+          example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.InstallationCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
             installation_command:
               description: 'Poller Installation Command'
               type: string
-              example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+              example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10136,15 +9772,15 @@ components:
             address:
               type: string
             central_address:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             id:
               type: integer
-              nullable: true
             uid:
               type: string
-              nullable: true
+            gorgone_communication_type:
+              type: string
             installation_command:
               type: string
-              example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
-              nullable: true
+              example: 'curl -fsSL https://<url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'


### PR DESCRIPTION
Regenerate centreon-api.yaml with the 3.1 command and align paths with #11078:
- migrated API Platform endpoints keep the canonical bare /api prefix
- login/logout use the canonical bare /api (exposed by centreon_authentication_bare_api)
- the 9 stale prefix-less generated paths are removed
- the 84 remaining legacy hand-authored paths are prefixed with /api/latest
- server base becomes {...}/centreon; relabel to openapi 3.1.0
No duplicate operationIds; regeneration is idempotent.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>